### PR TITLE
feat: new window function `nth_value`.

### DIFF
--- a/src/query/functions/src/lib.rs
+++ b/src/query/functions/src/lib.rs
@@ -35,7 +35,7 @@ pub fn is_builtin_function(name: &str) -> bool {
 #[ctor]
 pub static BUILTIN_FUNCTIONS: FunctionRegistry = builtin_functions();
 
-pub const GENERAL_WINDOW_FUNCTIONS: [&str; 10] = [
+pub const GENERAL_WINDOW_FUNCTIONS: [&str; 11] = [
     "row_number",
     "rank",
     "dense_rank",
@@ -46,6 +46,7 @@ pub const GENERAL_WINDOW_FUNCTIONS: [&str; 10] = [
     "first",
     "last_value",
     "last",
+    "nth_value",
 ];
 
 fn builtin_functions() -> FunctionRegistry {

--- a/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
@@ -141,9 +141,9 @@ impl WindowFunctionInfo {
             WindowFunction::Rank => Self::Rank,
             WindowFunction::DenseRank => Self::DenseRank,
             WindowFunction::PercentRank => Self::PercentRank,
-            WindowFunction::Lag(lag) => {
-                let new_arg = schema.index_of(&lag.arg.to_string())?;
-                let new_default = match &lag.default {
+            WindowFunction::LagLead(ll) => {
+                let new_arg = schema.index_of(&ll.arg.to_string())?;
+                let new_default = match &ll.default {
                     LagLeadDefault::Null => LagLeadDefault::Null,
                     LagLeadDefault::Index(i) => {
                         let offset = schema.index_of(&i.to_string())?;
@@ -152,25 +152,9 @@ impl WindowFunctionInfo {
                 };
                 Self::Lag(WindowFuncLagLeadImpl {
                     arg: new_arg,
-                    offset: lag.sig.offset,
+                    offset: ll.sig.offset,
                     default: new_default,
-                    return_type: lag.sig.return_type.clone(),
-                })
-            }
-            WindowFunction::Lead(lead) => {
-                let new_arg = schema.index_of(&lead.arg.to_string())?;
-                let new_default = match &lead.default {
-                    LagLeadDefault::Null => LagLeadDefault::Null,
-                    LagLeadDefault::Index(i) => {
-                        let offset = schema.index_of(&i.to_string())?;
-                        LagLeadDefault::Index(offset)
-                    }
-                };
-                Self::Lead(WindowFuncLagLeadImpl {
-                    arg: new_arg,
-                    offset: lead.sig.offset,
-                    default: new_default,
-                    return_type: lead.sig.return_type.clone(),
+                    return_type: ll.sig.return_type.clone(),
                 })
             }
             WindowFunction::FirstValue(func) => {

--- a/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
@@ -93,7 +93,6 @@ impl Drop for WindowFuncAggImpl {
 #[derive(Clone)]
 pub struct WindowFuncLagLeadImpl {
     pub arg: usize,
-    pub offset: u64,
     pub default: LagLeadDefault,
     pub return_type: DataType,
 }
@@ -149,17 +148,16 @@ impl WindowFunctionInfo {
                 };
                 Self::LagLead(WindowFuncLagLeadImpl {
                     arg: new_arg,
-                    offset: ll.sig.offset,
                     default: new_default,
-                    return_type: ll.sig.return_type.clone(),
+                    return_type: ll.return_type.clone(),
                 })
             }
             WindowFunction::NthValue(func) => {
                 let new_arg = schema.index_of(&func.arg.to_string())?;
                 Self::NthValue(WindowFuncNthValueImpl {
-                    n: func.sig.n,
+                    n: func.n,
                     arg: new_arg,
-                    return_type: func.sig.return_type.clone(),
+                    return_type: func.return_type.clone(),
                 })
             }
         })

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -300,8 +300,7 @@ pub enum WindowFunction {
     Rank,
     DenseRank,
     PercentRank,
-    Lag(LagLeadFunctionDesc),
-    Lead(LagLeadFunctionDesc),
+    LagLead(LagLeadFunctionDesc),
     FirstValue(FirstLastFunctionDesc),
     LastValue(FirstLastFunctionDesc),
 }
@@ -314,7 +313,7 @@ impl WindowFunction {
                 Ok(DataType::Number(NumberDataType::UInt64))
             }
             WindowFunction::PercentRank => Ok(DataType::Number(NumberDataType::Float64)),
-            WindowFunction::Lag(f) | WindowFunction::Lead(f) => Ok(f.sig.return_type.clone()),
+            WindowFunction::LagLead(f) => Ok(f.sig.return_type.clone()),
             WindowFunction::FirstValue(f) | WindowFunction::LastValue(f) => {
                 Ok(f.sig.return_type.clone())
             }
@@ -330,8 +329,8 @@ impl Display for WindowFunction {
             WindowFunction::Rank => write!(f, "rank"),
             WindowFunction::DenseRank => write!(f, "dense_rank"),
             WindowFunction::PercentRank => write!(f, "percent_rank"),
-            WindowFunction::Lag(_) => write!(f, "lag"),
-            WindowFunction::Lead(_) => write!(f, "lead"),
+            WindowFunction::LagLead(lag_lead) if lag_lead.sig.is_lag => write!(f, "lag"),
+            WindowFunction::LagLead(_) => write!(f, "lead"),
             WindowFunction::FirstValue(_) => write!(f, "first_value"),
             WindowFunction::LastValue(_) => write!(f, "last_value"),
         }
@@ -859,7 +858,7 @@ pub struct LagLeadFunctionDesc {
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LagLeadFunctionSignature {
-    pub name: String,
+    pub is_lag: bool,
     pub arg: DataType,
     pub offset: u64,
     pub default: Option<DataType>,

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -301,8 +301,7 @@ pub enum WindowFunction {
     DenseRank,
     PercentRank,
     LagLead(LagLeadFunctionDesc),
-    FirstValue(FirstLastFunctionDesc),
-    LastValue(FirstLastFunctionDesc),
+    NthValue(NthValueFunctionDesc),
 }
 
 impl WindowFunction {
@@ -314,9 +313,7 @@ impl WindowFunction {
             }
             WindowFunction::PercentRank => Ok(DataType::Number(NumberDataType::Float64)),
             WindowFunction::LagLead(f) => Ok(f.sig.return_type.clone()),
-            WindowFunction::FirstValue(f) | WindowFunction::LastValue(f) => {
-                Ok(f.sig.return_type.clone())
-            }
+            WindowFunction::NthValue(f) => Ok(f.sig.return_type.clone()),
         }
     }
 }
@@ -331,8 +328,7 @@ impl Display for WindowFunction {
             WindowFunction::PercentRank => write!(f, "percent_rank"),
             WindowFunction::LagLead(lag_lead) if lag_lead.sig.is_lag => write!(f, "lag"),
             WindowFunction::LagLead(_) => write!(f, "lead"),
-            WindowFunction::FirstValue(_) => write!(f, "first_value"),
-            WindowFunction::LastValue(_) => write!(f, "last_value"),
+            WindowFunction::NthValue(_) => write!(f, "nth_value"),
         }
     }
 }
@@ -866,16 +862,15 @@ pub struct LagLeadFunctionSignature {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct FirstLastFunctionDesc {
-    pub sig: FirstLastFunctionSignature,
+pub struct NthValueFunctionDesc {
+    pub sig: NthValueFunctionSignature,
     pub output_column: IndexType,
     pub arg: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct FirstLastFunctionSignature {
-    pub name: String,
-    pub arg: DataType,
+pub struct NthValueFunctionSignature {
+    pub n: Option<u64>,
     pub return_type: DataType,
 }
 

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -312,8 +312,8 @@ impl WindowFunction {
                 Ok(DataType::Number(NumberDataType::UInt64))
             }
             WindowFunction::PercentRank => Ok(DataType::Number(NumberDataType::Float64)),
-            WindowFunction::LagLead(f) => Ok(f.sig.return_type.clone()),
-            WindowFunction::NthValue(f) => Ok(f.sig.return_type.clone()),
+            WindowFunction::LagLead(f) => Ok(f.return_type.clone()),
+            WindowFunction::NthValue(f) => Ok(f.return_type.clone()),
         }
     }
 }
@@ -326,7 +326,7 @@ impl Display for WindowFunction {
             WindowFunction::Rank => write!(f, "rank"),
             WindowFunction::DenseRank => write!(f, "dense_rank"),
             WindowFunction::PercentRank => write!(f, "percent_rank"),
-            WindowFunction::LagLead(lag_lead) if lag_lead.sig.is_lag => write!(f, "lag"),
+            WindowFunction::LagLead(lag_lead) if lag_lead.is_lag => write!(f, "lag"),
             WindowFunction::LagLead(_) => write!(f, "lead"),
             WindowFunction::NthValue(_) => write!(f, "nth_value"),
         }
@@ -846,31 +846,17 @@ pub enum LagLeadDefault {
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LagLeadFunctionDesc {
-    pub sig: LagLeadFunctionSignature,
-    pub output_column: IndexType,
+    pub is_lag: bool,
+    pub offset: u64,
     pub arg: usize,
+    pub return_type: DataType,
     pub default: LagLeadDefault,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct LagLeadFunctionSignature {
-    pub is_lag: bool,
-    pub arg: DataType,
-    pub offset: u64,
-    pub default: Option<DataType>,
-    pub return_type: DataType,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct NthValueFunctionDesc {
-    pub sig: NthValueFunctionSignature,
-    pub output_column: IndexType,
-    pub arg: usize,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct NthValueFunctionSignature {
     pub n: Option<u64>,
+    pub arg: usize,
     pub return_type: DataType,
 }
 

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -58,7 +58,6 @@ use super::Filter;
 use super::HashJoin;
 use super::Limit;
 use super::NthValueFunctionDesc;
-use super::NthValueFunctionSignature;
 use super::ProjectSet;
 use super::RowFetch;
 use super::Sort;
@@ -73,7 +72,6 @@ use crate::executor::FragmentKind;
 use crate::executor::IEJoin;
 use crate::executor::LagLeadDefault;
 use crate::executor::LagLeadFunctionDesc;
-use crate::executor::LagLeadFunctionSignature;
 use crate::executor::PhysicalPlan;
 use crate::executor::RuntimeFilterSource;
 use crate::executor::SortDesc;
@@ -1277,17 +1275,9 @@ impl PhysicalPlanBuilder {
                     },
                 };
                 WindowFunction::LagLead(LagLeadFunctionDesc {
-                    sig: LagLeadFunctionSignature {
-                        is_lag: lag_lead.is_lag,
-                        arg: lag_lead.arg.data_type()?,
-                        offset: lag_lead.offset,
-                        default: match lag_lead.default.as_ref().map(|d| d.data_type()) {
-                            None => None,
-                            Some(d) => Some(d?),
-                        },
-                        return_type: *lag_lead.return_type.clone(),
-                    },
-                    output_column: w.index,
+                    is_lag: lag_lead.is_lag,
+                    offset: lag_lead.offset,
+                    return_type: *lag_lead.return_type.clone(),
                     arg: if let ScalarExpr::BoundColumnRef(col) = *lag_lead.arg.clone() {
                         Ok(col.column.index)
                     } else {
@@ -1300,11 +1290,8 @@ impl PhysicalPlanBuilder {
             }
 
             WindowFuncType::NthValue(func) => WindowFunction::NthValue(NthValueFunctionDesc {
-                sig: NthValueFunctionSignature {
-                    n: func.n,
-                    return_type: *func.return_type.clone(),
-                },
-                output_column: w.index,
+                n: func.n,
+                return_type: *func.return_type.clone(),
                 arg: if let ScalarExpr::BoundColumnRef(col) = &*func.arg {
                     Ok(col.column.index)
                 } else {

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -55,10 +55,10 @@ use super::AggregatePartial;
 use super::EvalScalar;
 use super::Exchange as PhysicalExchange;
 use super::Filter;
-use super::FirstLastFunctionDesc;
-use super::FirstLastFunctionSignature;
 use super::HashJoin;
 use super::Limit;
+use super::NthValueFunctionDesc;
+use super::NthValueFunctionSignature;
 use super::ProjectSet;
 use super::RowFetch;
 use super::Sort;
@@ -1299,10 +1299,9 @@ impl PhysicalPlanBuilder {
                 })
             }
 
-            WindowFuncType::FirstValue(func) => WindowFunction::FirstValue(FirstLastFunctionDesc {
-                sig: FirstLastFunctionSignature {
-                    name: "first_value".to_string(),
-                    arg: func.arg.data_type()?,
+            WindowFuncType::NthValue(func) => WindowFunction::NthValue(NthValueFunctionDesc {
+                sig: NthValueFunctionSignature {
+                    n: func.n,
                     return_type: *func.return_type.clone(),
                 },
                 output_column: w.index,
@@ -1310,24 +1309,7 @@ impl PhysicalPlanBuilder {
                     Ok(col.column.index)
                 } else {
                     Err(ErrorCode::Internal(
-                        "Window's first_value function argument must be a BoundColumnRef"
-                            .to_string(),
-                    ))
-                }?,
-            }),
-            WindowFuncType::LastValue(func) => WindowFunction::LastValue(FirstLastFunctionDesc {
-                sig: FirstLastFunctionSignature {
-                    name: "last_value".to_string(),
-                    arg: func.arg.data_type()?,
-                    return_type: *func.return_type.clone(),
-                },
-                output_column: w.index,
-                arg: if let ScalarExpr::BoundColumnRef(col) = &*func.arg {
-                    Ok(col.column.index)
-                } else {
-                    Err(ErrorCode::Internal(
-                        "Window's last_value function argument must be a BoundColumnRef"
-                            .to_string(),
+                        "Window's nth_value function argument must be a BoundColumnRef".to_string(),
                     ))
                 }?,
             }),

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -40,9 +40,9 @@ use crate::plans::AggregateMode;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
 use crate::plans::EvalScalar;
-use crate::plans::FirstLastFunction;
 use crate::plans::FunctionCall;
 use crate::plans::LagLeadFunction;
+use crate::plans::NthValueFunction;
 use crate::plans::ScalarExpr;
 use crate::plans::ScalarItem;
 use crate::plans::WindowFunc;
@@ -184,16 +184,10 @@ impl<'a> AggregateRewriter<'a> {
                             return_type: ll.return_type.clone(),
                         })
                     }
-                    WindowFuncType::FirstValue(func) => {
+                    WindowFuncType::NthValue(func) => {
                         let new_arg = self.visit(&func.arg)?;
-                        WindowFuncType::FirstValue(FirstLastFunction {
-                            arg: Box::new(new_arg),
-                            return_type: func.return_type.clone(),
-                        })
-                    }
-                    WindowFuncType::LastValue(func) => {
-                        let new_arg = self.visit(&func.arg)?;
-                        WindowFuncType::LastValue(FirstLastFunction {
+                        WindowFuncType::NthValue(NthValueFunction {
+                            n: func.n,
                             arg: Box::new(new_arg),
                             return_type: func.return_type.clone(),
                         })

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -169,32 +169,19 @@ impl<'a> AggregateRewriter<'a> {
                             return_type: agg.return_type.clone(),
                         })
                     }
-                    WindowFuncType::Lag(lag) => {
-                        let new_arg = self.visit(&lag.arg)?;
-                        let new_default = match lag.default.clone().map(|d| self.visit(&d)) {
+                    WindowFuncType::LagLead(ll) => {
+                        let new_arg = self.visit(&ll.arg)?;
+                        let new_default = match ll.default.clone().map(|d| self.visit(&d)) {
                             None => None,
                             Some(d) => Some(Box::new(d?)),
                         };
 
-                        WindowFuncType::Lag(LagLeadFunction {
+                        WindowFuncType::LagLead(LagLeadFunction {
+                            is_lag: ll.is_lag,
                             arg: Box::new(new_arg),
-                            offset: lag.offset,
+                            offset: ll.offset,
                             default: new_default,
-                            return_type: lag.return_type.clone(),
-                        })
-                    }
-                    WindowFuncType::Lead(lead) => {
-                        let new_arg = self.visit(&lead.arg)?;
-                        let new_default = match lead.default.clone().map(|d| self.visit(&d)) {
-                            None => None,
-                            Some(d) => Some(Box::new(d?)),
-                        };
-
-                        WindowFuncType::Lead(LagLeadFunction {
-                            arg: Box::new(new_arg),
-                            offset: lead.offset,
-                            default: new_default,
-                            return_type: lead.return_type.clone(),
+                            return_type: ll.return_type.clone(),
                         })
                     }
                     WindowFuncType::FirstValue(func) => {

--- a/src/query/sql/src/planner/binder/scalar_common.rs
+++ b/src/query/sql/src/planner/binder/scalar_common.rs
@@ -175,7 +175,7 @@ pub fn prune_by_children(scalar: &ScalarExpr, columns: &HashSet<ScalarExpr>) -> 
                 WindowFuncType::Aggregate(agg) => {
                     agg.args.iter().all(|arg| prune_by_children(arg, columns))
                 }
-                WindowFuncType::Lag(f) | WindowFuncType::Lead(f) => {
+                WindowFuncType::LagLead(f) => {
                     if let Some(default) = &f.default {
                         prune_by_children(&f.arg, columns) & prune_by_children(default, columns)
                     } else {

--- a/src/query/sql/src/planner/binder/scalar_common.rs
+++ b/src/query/sql/src/planner/binder/scalar_common.rs
@@ -182,9 +182,7 @@ pub fn prune_by_children(scalar: &ScalarExpr, columns: &HashSet<ScalarExpr>) -> 
                         prune_by_children(&f.arg, columns)
                     }
                 }
-                WindowFuncType::FirstValue(f) | WindowFuncType::LastValue(f) => {
-                    prune_by_children(&f.arg, columns)
-                }
+                WindowFuncType::NthValue(f) => prune_by_children(&f.arg, columns),
                 _ => false,
             };
             flag || scalar

--- a/src/query/sql/src/planner/binder/scalar_visitor.rs
+++ b/src/query/sql/src/planner/binder/scalar_visitor.rs
@@ -65,7 +65,7 @@ pub trait ScalarVisitor: Sized {
                                                 stack.push(RecursionProcessing::Call(arg));
                                             }
                                         }
-                                        WindowFuncType::Lag(f) | WindowFuncType::Lead(f) => {
+                                        WindowFuncType::LagLead(f) => {
                                             stack.push(RecursionProcessing::Call(&f.arg));
                                             if let Some(default) = &f.default {
                                                 stack.push(RecursionProcessing::Call(default));

--- a/src/query/sql/src/planner/binder/scalar_visitor.rs
+++ b/src/query/sql/src/planner/binder/scalar_visitor.rs
@@ -71,8 +71,7 @@ pub trait ScalarVisitor: Sized {
                                                 stack.push(RecursionProcessing::Call(default));
                                             }
                                         }
-                                        WindowFuncType::FirstValue(f)
-                                        | WindowFuncType::LastValue(f) => {
+                                        WindowFuncType::NthValue(f) => {
                                             stack.push(RecursionProcessing::Call(&f.arg));
                                         }
                                         _ => {}

--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -24,9 +24,9 @@ use crate::optimizer::SExpr;
 use crate::plans::AggregateFunction;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
-use crate::plans::FirstLastFunction;
 use crate::plans::FunctionCall;
 use crate::plans::LagLeadFunction;
+use crate::plans::NthValueFunction;
 use crate::plans::ScalarExpr;
 use crate::plans::ScalarItem;
 use crate::plans::Window;
@@ -258,16 +258,10 @@ impl<'a> WindowRewriter<'a> {
                     return_type: ll.return_type.clone(),
                 })
             }
-            WindowFuncType::FirstValue(func) => {
+            WindowFuncType::NthValue(func) => {
                 let new_arg = self.visit(&func.arg)?;
-                WindowFuncType::FirstValue(FirstLastFunction {
-                    arg: Box::new(new_arg),
-                    return_type: func.return_type.clone(),
-                })
-            }
-            WindowFuncType::LastValue(func) => {
-                let new_arg = self.visit(&func.arg)?;
-                WindowFuncType::LastValue(FirstLastFunction {
+                WindowFuncType::NthValue(NthValueFunction {
+                    n: func.n,
                     arg: Box::new(new_arg),
                     return_type: func.return_type.clone(),
                 })

--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -246,26 +246,16 @@ impl<'a> WindowRewriter<'a> {
                     return_type: agg.return_type.clone(),
                 })
             }
-            WindowFuncType::Lag(lag) => {
+            WindowFuncType::LagLead(ll) => {
                 let (new_arg, new_default) =
-                    self.replace_lag_lead_args(&mut agg_args, &window_func_name, lag)?;
+                    self.replace_lag_lead_args(&mut agg_args, &window_func_name, ll)?;
 
-                WindowFuncType::Lag(LagLeadFunction {
+                WindowFuncType::LagLead(LagLeadFunction {
+                    is_lag: ll.is_lag,
                     arg: Box::new(new_arg),
-                    offset: lag.offset,
+                    offset: ll.offset,
                     default: new_default,
-                    return_type: lag.return_type.clone(),
-                })
-            }
-            WindowFuncType::Lead(lead) => {
-                let (new_arg, new_default) =
-                    self.replace_lag_lead_args(&mut agg_args, &window_func_name, lead)?;
-
-                WindowFuncType::Lead(LagLeadFunction {
-                    arg: Box::new(new_arg),
-                    offset: lead.offset,
-                    default: new_default,
-                    return_type: lead.return_type.clone(),
+                    return_type: ll.return_type.clone(),
                 })
             }
             WindowFuncType::FirstValue(func) => {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/derive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/derive_filter.rs
@@ -144,7 +144,7 @@ fn replace_column(scalar: &mut ScalarExpr, col_to_scalar: &HashMap<&IndexType, &
                         replace_column(default, col_to_scalar);
                     }
                 }
-                WindowFuncType::FirstValue(f) | WindowFuncType::LastValue(f) => {
+                WindowFuncType::NthValue(f) => {
                     replace_column(&mut f.arg, col_to_scalar);
                 }
                 _ => {}

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/derive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/derive_filter.rs
@@ -138,7 +138,7 @@ fn replace_column(scalar: &mut ScalarExpr, col_to_scalar: &HashMap<&IndexType, &
                         replace_column(arg, col_to_scalar);
                     }
                 }
-                WindowFuncType::Lag(f) | WindowFuncType::Lead(f) => {
+                WindowFuncType::LagLead(f) => {
                     replace_column(&mut f.arg, col_to_scalar);
                     if let Some(ref mut default) = &mut f.default {
                         replace_column(default, col_to_scalar);

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_eval_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_eval_scalar.rs
@@ -27,9 +27,9 @@ use crate::plans::AggregateFunction;
 use crate::plans::CastExpr;
 use crate::plans::EvalScalar;
 use crate::plans::Filter;
-use crate::plans::FirstLastFunction;
 use crate::plans::FunctionCall;
 use crate::plans::LagLeadFunction;
+use crate::plans::NthValueFunction;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 use crate::plans::ScalarExpr;
@@ -130,16 +130,10 @@ impl RulePushDownFilterEvalScalar {
                             return_type: ll.return_type.clone(),
                         })
                     }
-                    WindowFuncType::FirstValue(func) => {
+                    WindowFuncType::NthValue(func) => {
                         let new_arg = Self::replace_predicate(&func.arg, items)?;
-                        WindowFuncType::FirstValue(FirstLastFunction {
-                            arg: Box::new(new_arg),
-                            return_type: func.return_type.clone(),
-                        })
-                    }
-                    WindowFuncType::LastValue(func) => {
-                        let new_arg = Self::replace_predicate(&func.arg, items)?;
-                        WindowFuncType::LastValue(FirstLastFunction {
+                        WindowFuncType::NthValue(NthValueFunction {
+                            n: func.n,
                             arg: Box::new(new_arg),
                             return_type: func.return_type.clone(),
                         })

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_eval_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_eval_scalar.rs
@@ -112,9 +112,9 @@ impl RulePushDownFilterEvalScalar {
                             display_name: agg.display_name.clone(),
                         })
                     }
-                    WindowFuncType::Lag(lag) => {
-                        let new_arg = Self::replace_predicate(&lag.arg, items)?;
-                        let new_default = match lag
+                    WindowFuncType::LagLead(ll) => {
+                        let new_arg = Self::replace_predicate(&ll.arg, items)?;
+                        let new_default = match ll
                             .default
                             .clone()
                             .map(|d| Self::replace_predicate(&d, items))
@@ -122,28 +122,12 @@ impl RulePushDownFilterEvalScalar {
                             None => None,
                             Some(d) => Some(Box::new(d?)),
                         };
-                        WindowFuncType::Lag(LagLeadFunction {
+                        WindowFuncType::LagLead(LagLeadFunction {
+                            is_lag: ll.is_lag,
                             arg: Box::new(new_arg),
-                            offset: lag.offset,
+                            offset: ll.offset,
                             default: new_default,
-                            return_type: lag.return_type.clone(),
-                        })
-                    }
-                    WindowFuncType::Lead(lead) => {
-                        let new_arg = Self::replace_predicate(&lead.arg, items)?;
-                        let new_default = match lead
-                            .default
-                            .clone()
-                            .map(|d| Self::replace_predicate(&d, items))
-                        {
-                            None => None,
-                            Some(d) => Some(Box::new(d?)),
-                        };
-                        WindowFuncType::Lead(LagLeadFunction {
-                            arg: Box::new(new_arg),
-                            offset: lead.offset,
-                            default: new_default,
-                            return_type: lead.return_type.clone(),
+                            return_type: ll.return_type.clone(),
                         })
                     }
                     WindowFuncType::FirstValue(func) => {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
@@ -24,9 +24,9 @@ use crate::plans::AggregateFunction;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
 use crate::plans::Filter;
-use crate::plans::FirstLastFunction;
 use crate::plans::FunctionCall;
 use crate::plans::LagLeadFunction;
+use crate::plans::NthValueFunction;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 use crate::plans::Scan;
@@ -151,18 +151,11 @@ impl RulePushDownFilterScan {
                             return_type: ll.return_type.clone(),
                         })
                     }
-                    WindowFuncType::FirstValue(func) => {
+                    WindowFuncType::NthValue(func) => {
                         let new_arg =
                             Self::replace_view_column(&func.arg, table_entries, column_entries)?;
-                        WindowFuncType::FirstValue(FirstLastFunction {
-                            arg: Box::new(new_arg),
-                            return_type: func.return_type.clone(),
-                        })
-                    }
-                    WindowFuncType::LastValue(func) => {
-                        let new_arg =
-                            Self::replace_view_column(&func.arg, table_entries, column_entries)?;
-                        WindowFuncType::LastValue(FirstLastFunction {
+                        WindowFuncType::NthValue(NthValueFunction {
+                            n: func.n,
                             arg: Box::new(new_arg),
                             return_type: func.return_type.clone(),
                         })

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
@@ -133,38 +133,22 @@ impl RulePushDownFilterScan {
                             display_name: agg.display_name.clone(),
                         })
                     }
-                    WindowFuncType::Lag(lag) => {
+                    WindowFuncType::LagLead(ll) => {
                         let new_arg =
-                            Self::replace_view_column(&lag.arg, table_entries, column_entries)?;
+                            Self::replace_view_column(&ll.arg, table_entries, column_entries)?;
                         let new_default =
-                            match lag.default.clone().map(|d| {
+                            match ll.default.clone().map(|d| {
                                 Self::replace_view_column(&d, table_entries, column_entries)
                             }) {
                                 None => None,
                                 Some(d) => Some(Box::new(d?)),
                             };
-                        WindowFuncType::Lag(LagLeadFunction {
+                        WindowFuncType::LagLead(LagLeadFunction {
+                            is_lag: ll.is_lag,
                             arg: Box::new(new_arg),
-                            offset: lag.offset,
+                            offset: ll.offset,
                             default: new_default,
-                            return_type: lag.return_type.clone(),
-                        })
-                    }
-                    WindowFuncType::Lead(lead) => {
-                        let new_arg =
-                            Self::replace_view_column(&lead.arg, table_entries, column_entries)?;
-                        let new_default =
-                            match lead.default.clone().map(|d| {
-                                Self::replace_view_column(&d, table_entries, column_entries)
-                            }) {
-                                None => None,
-                                Some(d) => Some(Box::new(d?)),
-                            };
-                        WindowFuncType::Lead(LagLeadFunction {
-                            arg: Box::new(new_arg),
-                            offset: lead.offset,
-                            default: new_default,
-                            return_type: lead.return_type.clone(),
+                            return_type: ll.return_type.clone(),
                         })
                     }
                     WindowFuncType::FirstValue(func) => {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_union.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_union.rs
@@ -179,30 +179,18 @@ fn replace_column_binding(
                         .collect::<Result<Vec<_>>>()?,
                     return_type: arg.return_type,
                 }),
-                WindowFuncType::Lag(lag) => {
-                    let new_arg = replace_column_binding(index_pairs, *lag.arg)?;
-                    let new_default = match &lag.default {
+                WindowFuncType::LagLead(ll) => {
+                    let new_arg = replace_column_binding(index_pairs, *ll.arg)?;
+                    let new_default = match &ll.default {
                         None => None,
                         Some(d) => Some(Box::new(replace_column_binding(index_pairs, *d.clone())?)),
                     };
-                    WindowFuncType::Lag(LagLeadFunction {
+                    WindowFuncType::LagLead(LagLeadFunction {
+                        is_lag: ll.is_lag,
                         arg: Box::new(new_arg),
-                        offset: lag.offset,
+                        offset: ll.offset,
                         default: new_default,
-                        return_type: lag.return_type.clone(),
-                    })
-                }
-                WindowFuncType::Lead(lead) => {
-                    let new_arg = replace_column_binding(index_pairs, *lead.arg)?;
-                    let new_default = match &lead.default {
-                        None => None,
-                        Some(d) => Some(Box::new(replace_column_binding(index_pairs, *d.clone())?)),
-                    };
-                    WindowFuncType::Lead(LagLeadFunction {
-                        arg: Box::new(new_arg),
-                        offset: lead.offset,
-                        default: new_default,
-                        return_type: lead.return_type.clone(),
+                        return_type: ll.return_type.clone(),
                     })
                 }
                 WindowFuncType::FirstValue(func) => {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_union.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_union.rs
@@ -26,9 +26,9 @@ use crate::plans::AggregateFunction;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
 use crate::plans::Filter;
-use crate::plans::FirstLastFunction;
 use crate::plans::FunctionCall;
 use crate::plans::LagLeadFunction;
+use crate::plans::NthValueFunction;
 use crate::plans::PatternPlan;
 use crate::plans::RelOp;
 use crate::plans::ScalarExpr;
@@ -193,16 +193,10 @@ fn replace_column_binding(
                         return_type: ll.return_type.clone(),
                     })
                 }
-                WindowFuncType::FirstValue(func) => {
+                WindowFuncType::NthValue(func) => {
                     let new_arg = replace_column_binding(index_pairs, *func.arg)?;
-                    WindowFuncType::FirstValue(FirstLastFunction {
-                        arg: Box::new(new_arg),
-                        return_type: func.return_type.clone(),
-                    })
-                }
-                WindowFuncType::LastValue(func) => {
-                    let new_arg = replace_column_binding(index_pairs, *func.arg)?;
-                    WindowFuncType::LastValue(FirstLastFunction {
+                    WindowFuncType::NthValue(NthValueFunction {
+                        n: func.n,
                         arg: Box::new(new_arg),
                         return_type: func.return_type.clone(),
                     })

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -362,7 +362,13 @@ pub struct LagLeadFunction {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct FirstLastFunction {
+pub struct NthValueFunction {
+    /// The nth row of the window frame (couting from 1).
+    ///
+    /// - Some(1): `first_value`
+    /// - Some(n): `nth_value`
+    /// - None: `last_value`
+    pub n: Option<u64>,
     pub arg: Box<ScalarExpr>,
     pub return_type: Box<DataType>,
 }

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -353,6 +353,8 @@ pub struct AggregateFunction {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct LagLeadFunction {
+    /// Is `lag` or `lead`.
+    pub is_lag: bool,
     pub arg: Box<ScalarExpr>,
     pub offset: u64,
     pub default: Option<Box<ScalarExpr>>,

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -363,7 +363,7 @@ pub struct LagLeadFunction {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct NthValueFunction {
-    /// The nth row of the window frame (couting from 1).
+    /// The nth row of the window frame (counting from 1).
     ///
     /// - Some(1): `first_value`
     /// - Some(n): `nth_value`

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1157,7 +1157,7 @@ impl<'a> TypeChecker<'a> {
 
         match func_name {
             "lag" | "lead" => {
-                self.resolve_laglead_window_function(func_name, &arguments, &arg_types)
+                self.resolve_lag_lead_window_function(func_name, &arguments, &arg_types)
                     .await
             }
             "first_value" | "first" | "last_value" | "last" | "nth_value" => {
@@ -1171,7 +1171,7 @@ impl<'a> TypeChecker<'a> {
     }
 
     #[async_backtrace::framed]
-    async fn resolve_laglead_window_function(
+    async fn resolve_lag_lead_window_function(
         &mut self,
         func_name: &str,
         args: &[ScalarExpr],

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -76,6 +76,7 @@ use crate::plans::CastExpr;
 use crate::plans::ComparisonOp;
 use crate::plans::ConstantExpr;
 use crate::plans::FunctionCall;
+use crate::plans::LagLeadFunction;
 use crate::plans::ScalarExpr;
 use crate::plans::SubqueryExpr;
 use crate::plans::SubqueryType;
@@ -1080,25 +1081,25 @@ impl<'a> TypeChecker<'a> {
                     end_bound: WindowFuncFrameBound::Following(None),
                 });
             }
-            WindowFuncType::Lag(lag) => {
+            WindowFuncType::LagLead(lag_lead) if lag_lead.is_lag => {
                 return Ok(WindowFuncFrame {
                     units: WindowFuncFrameUnits::Rows,
                     start_bound: WindowFuncFrameBound::Preceding(Some(Scalar::Number(
-                        NumberScalar::UInt64(lag.offset),
+                        NumberScalar::UInt64(lag_lead.offset),
                     ))),
                     end_bound: WindowFuncFrameBound::Preceding(Some(Scalar::Number(
-                        NumberScalar::UInt64(lag.offset),
+                        NumberScalar::UInt64(lag_lead.offset),
                     ))),
                 });
             }
-            WindowFuncType::Lead(lead) => {
+            WindowFuncType::LagLead(lag_lead) => {
                 return Ok(WindowFuncFrame {
                     units: WindowFuncFrameUnits::Rows,
                     start_bound: WindowFuncFrameBound::Following(Some(Scalar::Number(
-                        NumberScalar::UInt64(lead.offset),
+                        NumberScalar::UInt64(lag_lead.offset),
                     ))),
                     end_bound: WindowFuncFrameBound::Following(Some(Scalar::Number(
-                        NumberScalar::UInt64(lead.offset),
+                        NumberScalar::UInt64(lag_lead.offset),
                     ))),
                 });
             }
@@ -1158,8 +1159,8 @@ impl<'a> TypeChecker<'a> {
                 self.resolve_laglead_window_function(func_name, &arguments, &arg_types)
                     .await
             }
-            "first_value" | "first" | "last_value" | "last" => {
-                self.resolve_firstlast_window_function(func_name, &arguments, &arg_types)
+            "first_value" | "first" | "last_value" | "last" | "nth_value" => {
+                self.resolve_nth_value_window_function(func_name, &arguments, &arg_types)
                     .await
             }
             _ => Err(ErrorCode::UnknownFunction(format!(
@@ -1226,17 +1227,17 @@ impl<'a> TypeChecker<'a> {
             })
             .transpose()?;
 
-        WindowFuncType::get_general_window_func(
-            func_name,
-            args[0].clone(),
-            offset,
-            cast_default,
-            return_type,
-        )
+        Ok(WindowFuncType::LagLead(LagLeadFunction {
+            is_lag: func_name == "lag",
+            arg: Box::new(args[0].clone()),
+            offset: offset.unwrap_or(1),
+            default: cast_default.map(Box::new),
+            return_type: Box::new(return_type),
+        }))
     }
 
     #[async_backtrace::framed]
-    async fn resolve_firstlast_window_function(
+    async fn resolve_nth_value_window_function(
         &mut self,
         func_name: &str,
         args: &[ScalarExpr],

--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -417,6 +417,71 @@ sales 1 4
 sales 3 4
 sales 4 4
 
+# nth_value
+query III
+SELECT depname, empno,
+	nth_value(empno, 2) OVER (
+		PARTITION BY depname ORDER BY empno ASC
+		ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+		) fv
+FROM empsalary
+ORDER BY 1, 2
+----
+develop	7	8
+develop	8	9
+develop	9	10
+develop	10	11
+develop	11	NULL
+personnel	2	5
+personnel	5	NULL
+sales	1	3
+sales	3	4
+sales	4	NULL
+
+statement ok
+DROP VIEW IF EXISTS empno_nulls
+
+statement ok
+CREATE VIEW empno_nulls AS
+SELECT depname, case empno % 2 when 1 then empno else NULL end as empno, salary, enroll_date
+FROM empsalary
+
+query III
+SELECT depname, empno,
+	nth_value(empno, 2) OVER (
+		PARTITION BY depname ORDER BY empno ASC NULLS FIRST
+		ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+		) fv
+FROM empno_nulls
+ORDER BY 1, 2 NULLS FIRST
+----
+develop	NULL	NULL
+develop	NULL	7
+develop	7	9
+develop	9	11
+develop	11	NULL
+personnel	NULL	5
+personnel	5	NULL
+sales	NULL	1
+sales	1	3
+sales	3	NULL
+
+statement error
+SELECT depname, empno,
+	nth_value(empno) OVER (
+		PARTITION BY depname ORDER BY empno ASC
+		ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+		) fv
+FROM empsalary
+
+statement error
+SELECT depname, empno,
+	nth_value(empno, 2, 3) OVER (
+		PARTITION BY depname ORDER BY empno ASC
+		ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+		) fv
+FROM empsalary
+
 # min/max/avg
 query TIIR
 SELECT depname, min(salary) OVER (PARTITION BY depname ORDER BY salary, empno) m1, max(salary) OVER (PARTITION BY depname ORDER BY salary, empno) m2, AVG(salary) OVER (PARTITION BY depname ORDER BY salary, empno) m3 FROM empsalary ORDER BY depname, empno

--- a/tests/sqllogictests/suites/query/window_function/window_wisconsin.test
+++ b/tests/sqllogictests/suites/query/window_function/window_wisconsin.test
@@ -128,3 +128,9 @@ NULL
 NULL
 3
 NULL
+
+statement ok
+USE default
+
+statement ok
+DROP DATABASE test_window_wisconsin


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Support new window function `nth_value`.
- Unify `lead` and `lag` into one structure.
- Unify `first_value`, `last_value` and `nth_value` into one structure.
- Remove useless data structures.

Tracking in #11148
