### PR TITLE
fix: support named window in expression.

### DIFF
--- a/src/query/sql/src/planner/binder/bind_context.rs
+++ b/src/query/sql/src/planner/binder/bind_context.rs
@@ -17,6 +17,7 @@ use std::hash::Hash;
 
 use common_ast::ast::Query;
 use common_ast::ast::TableAlias;
+use common_ast::ast::WindowSpec;
 use common_catalog::plan::InternalColumn;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -172,6 +173,8 @@ pub struct BindContext {
     /// If true, the query is planning for aggregate index.
     /// It's used to avoid infinite loop.
     pub planning_agg_index: bool,
+
+    pub window_definitions: DashMap<String, WindowSpec>,
 }
 
 #[derive(Clone, Debug)]
@@ -194,6 +197,7 @@ impl BindContext {
             srfs: DashMap::new(),
             expr_context: ExprContext::default(),
             planning_agg_index: false,
+            window_definitions: DashMap::new(),
         }
     }
 
@@ -210,6 +214,7 @@ impl BindContext {
             srfs: DashMap::new(),
             expr_context: ExprContext::default(),
             planning_agg_index: false,
+            window_definitions: DashMap::new(),
         }
     }
 

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -653,6 +653,7 @@ impl Binder {
             srfs: Default::default(),
             expr_context: ExprContext::default(),
             planning_agg_index: false,
+            window_definitions: DashMap::new(),
         };
         let (s_expr, mut new_bind_context) = self
             .bind_query(&mut new_bind_context, &cte_info.query)

--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -15,6 +15,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use common_ast::ast::WindowDefinition;
+use common_ast::ast::WindowSpec;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_exception::Span;
@@ -62,6 +64,127 @@ impl Binder {
             Arc::new(window_plan.into()),
             Arc::new(child),
         ))
+    }
+
+    pub(super) fn analyze_window_definition(
+        &self,
+        bind_context: &mut BindContext,
+        window_list: &Option<Vec<WindowDefinition>>,
+    ) -> Result<()> {
+        if window_list.is_none() {
+            return Ok(());
+        }
+        let window_list = window_list.as_ref().unwrap();
+        let (window_specs, mut resolved_window_specs) =
+            self.extract_window_definitions(window_list.as_slice())?;
+
+        let window_definitions = dashmap::DashMap::with_capacity(window_specs.len());
+
+        for (name, spec) in window_specs.iter() {
+            let new_spec = Self::rewrite_inherited_window_spec(
+                spec,
+                &window_specs,
+                &mut resolved_window_specs,
+            )?;
+            window_definitions.insert(name.clone(), new_spec);
+        }
+        bind_context.window_definitions = window_definitions;
+        Ok(())
+    }
+
+    fn extract_window_definitions(
+        &self,
+        window_list: &[WindowDefinition],
+    ) -> Result<(HashMap<String, WindowSpec>, HashMap<String, WindowSpec>)> {
+        let mut window_specs = HashMap::new();
+        let mut resolved_window_specs = HashMap::new();
+        for window in window_list {
+            window_specs.insert(window.name.name.clone(), window.spec.clone());
+            if window.spec.existing_window_name.is_none() {
+                resolved_window_specs.insert(window.name.name.clone(), window.spec.clone());
+            }
+        }
+        Ok((window_specs, resolved_window_specs))
+    }
+
+    fn rewrite_inherited_window_spec(
+        window_spec: &WindowSpec,
+        window_list: &HashMap<String, WindowSpec>,
+        resolved_window: &mut HashMap<String, WindowSpec>,
+    ) -> Result<WindowSpec> {
+        if window_spec.existing_window_name.is_some() {
+            let referenced_name = window_spec
+                .existing_window_name
+                .as_ref()
+                .unwrap()
+                .name
+                .clone();
+            // check if spec is resolved first, so that we no need to resolve again.
+            let referenced_window_spec = {
+                resolved_window.get(&referenced_name).unwrap_or(
+                    window_list
+                        .get(&referenced_name)
+                        .ok_or_else(|| ErrorCode::SyntaxException("Referenced window not found"))?,
+                )
+            }
+            .clone();
+
+            let resolved_spec = match referenced_window_spec.existing_window_name.clone() {
+                Some(_) => Self::rewrite_inherited_window_spec(
+                    &referenced_window_spec,
+                    window_list,
+                    resolved_window,
+                )?,
+                None => referenced_window_spec.clone(),
+            };
+
+            // add to resolved.
+            resolved_window.insert(referenced_name, resolved_spec.clone());
+
+            // check semantic
+            if !window_spec.partition_by.is_empty() {
+                return Err(ErrorCode::SemanticError(
+                    "WINDOW specification with named WINDOW reference cannot specify PARTITION BY",
+                ));
+            }
+            if !window_spec.order_by.is_empty() && !resolved_spec.order_by.is_empty() {
+                return Err(ErrorCode::SemanticError(
+                    "Cannot specify ORDER BY if referenced named WINDOW specifies ORDER BY",
+                ));
+            }
+            if resolved_spec.window_frame.is_some() {
+                return Err(ErrorCode::SemanticError(
+                    "Cannot reference named WINDOW containing frame specification",
+                ));
+            }
+
+            // resolve referenced window
+            let mut partition_by = window_spec.partition_by.clone();
+            if !resolved_spec.partition_by.is_empty() {
+                partition_by = resolved_spec.partition_by.clone();
+            }
+
+            let mut order_by = window_spec.order_by.clone();
+            if order_by.is_empty() && !resolved_spec.order_by.is_empty() {
+                order_by = resolved_spec.order_by.clone();
+            }
+
+            let mut window_frame = window_spec.window_frame.clone();
+            if window_frame.is_none() && resolved_spec.window_frame.is_some() {
+                window_frame = resolved_spec.window_frame;
+            }
+
+            // replace with new window spec
+            let new_window_spec = WindowSpec {
+                existing_window_name: None,
+                partition_by,
+                order_by,
+                window_frame,
+            };
+            Ok(new_window_spec)
+        } else {
+            Ok(window_spec.clone())
+        }
     }
 }
 
@@ -469,7 +592,7 @@ impl<'a> WindowRewriter<'a> {
 }
 
 impl Binder {
-    /// Analyze =windows in select clause, this will rewrite window functions.
+    /// Analyze windows in select clause, this will rewrite window functions.
     /// See [`WindowRewriter`] for more details.
     pub(crate) fn analyze_window(
         &mut self,

--- a/tests/sqllogictests/suites/query/window_function/window_in_expr.test
+++ b/tests/sqllogictests/suites/query/window_function/window_in_expr.test
@@ -1,0 +1,52 @@
+statement ok
+CREATE DATABASE IF NOT EXISTS test_window_in_expr
+
+statement ok
+USE test_window_in_expr
+
+statement ok
+DROP TABLE IF EXISTS t1
+
+statement ok
+CREATE TABLE t1(a int)
+
+statement ok
+INSERT INTO t1 VALUES (1),(1),(1),(3),(3),(5),(5)
+
+query II
+select a, 1 + sum(a) over (partition by a) from t1;
+----
+1 4
+1 4
+1 4
+3 7
+3 7
+5 11
+5 11
+
+query IIII
+select 
+    a, 
+    1 + sum(a) over w, 
+    2 + sum(a) over w1, 
+    3 + sum(a) over w2 
+from t1 
+window 
+    w as (partition by a), 
+    w2 as (w1 rows current row), 
+    w1 as (w order by a) 
+order by a
+----
+1 4 5 4
+1 4 5 4
+1 4 5 4
+3 7 8 6
+3 7 8 6
+5 11 12 8
+5 11 12 8
+
+statement ok
+USE default
+
+statement ok
+DROP DATABASE test_window_in_expr


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

In the past implementation, we rewritten window reference clause into window spec clause in the select list with the named window map. However, we only rewrite the top level of the expression. E.g. `select rank() over w` will be rewritten, but `select 1 + rank() over w` will not be rewritten, which will lead to panic during `type_check`. 

The modifications in this PR:

- Add the missing `explain syntax` for named window.
- Put named window map into bind context. We can refer to bind context during `type_check`. It will reduce many duplicate codes.
- Add tests of window functions in expressions.

Fix part of #11593
