### PR TITLE
chore(planner): Minor refactor property derivation

### DIFF
--- a/src/query/sql/src/planner/optimizer/cascades/cascade.rs
+++ b/src/query/sql/src/planner/optimizer/cascades/cascade.rs
@@ -92,7 +92,7 @@ impl CascadesOptimizer {
         self.find_optimal_plan(root_index)
     }
 
-    pub fn insert_from_transform_state(
+    pub(crate) fn insert_from_transform_state(
         &mut self,
         group_index: IndexType,
         state: TransformResult,
@@ -104,6 +104,15 @@ impl CascadesOptimizer {
         Ok(())
     }
 
+    /// Insert a new `SExpr` into the memo. This will recursively insert all of its children.
+    /// When inserting a new expression, we will first check if it is already in the memo. If it is,
+    /// we will return the existing group index. Otherwise, we will create a new group and return
+    /// its index.
+    /// Currently, we can only check if the inserted expression is already in the memo by its
+    /// `SExpr::original_group` field, which is set by the `PatternExtractor` when extracting
+    /// candidates from memo. But sometimes, it's possible to insert the generated expression
+    /// into a existed group, we'd better find a way to do this in the future to reduce duplicated
+    /// groups.
     fn insert_expression(&mut self, group_index: IndexType, expression: &SExpr) -> Result<()> {
         self.memo.insert(Some(group_index), expression.clone())?;
 

--- a/src/query/sql/src/planner/optimizer/group.rs
+++ b/src/query/sql/src/planner/optimizer/group.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_exception::ErrorCode;
 use common_exception::Result;
 
@@ -41,23 +43,23 @@ impl GroupState {
 /// `Group` is a set of logically equivalent relational expressions represented with `MExpr`.
 #[derive(Clone)]
 pub struct Group {
-    pub group_index: IndexType,
-    pub m_exprs: Vec<MExpr>,
+    pub(crate) group_index: IndexType,
+    pub(crate) m_exprs: Vec<MExpr>,
 
     /// Relational property shared by expressions in a same `Group`
-    pub relational_prop: RelationalProperty,
+    pub(crate) relational_prop: Arc<RelationalProperty>,
 
     /// Stat info shared by expressions in a same `Group`
-    pub stat_info: StatInfo,
+    pub(crate) stat_info: Arc<StatInfo>,
 
-    pub state: GroupState,
+    pub(crate) state: GroupState,
 }
 
 impl Group {
     pub fn create(
         index: IndexType,
-        relational_prop: RelationalProperty,
-        stat_info: StatInfo,
+        relational_prop: Arc<RelationalProperty>,
+        stat_info: Arc<StatInfo>,
     ) -> Self {
         Group {
             group_index: index,

--- a/src/query/sql/src/planner/optimizer/m_expr.rs
+++ b/src/query/sql/src/planner/optimizer/m_expr.rs
@@ -33,15 +33,15 @@ use crate::IndexType;
 #[derive(Clone)]
 pub struct MExpr {
     // index of current `Group`
-    pub group_index: IndexType,
+    pub(crate) group_index: IndexType,
     // index of current `MExpr` within a `Group`
-    pub index: IndexType,
+    pub(crate) index: IndexType,
 
-    pub plan: Arc<RelOperator>,
-    pub children: Vec<IndexType>,
+    pub(crate) plan: Arc<RelOperator>,
+    pub(crate) children: Vec<IndexType>,
 
     // Disable rules for current `MExpr`
-    pub applied_rules: AppliedRules,
+    pub(crate) applied_rules: AppliedRules,
 }
 
 impl MExpr {

--- a/src/query/sql/src/planner/optimizer/memo.rs
+++ b/src/query/sql/src/planner/optimizer/memo.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -37,7 +38,7 @@ pub struct Memo {
 
     /// Hash table for detecting duplicated expressions.
     /// The entry is `(plan, children) -> (group_index, m_expr_index)`.
-    pub m_expr_lookup_table: HashMap<(RelOperator, Vec<IndexType>), (IndexType, IndexType)>,
+    pub m_expr_lookup_table: HashMap<(Arc<RelOperator>, Vec<IndexType>), (IndexType, IndexType)>,
 }
 
 impl Memo {
@@ -84,7 +85,7 @@ impl Memo {
 
         if let Some((group_index, _)) = self
             .m_expr_lookup_table
-            .get(&((*s_expr.plan).clone(), children_group.clone()))
+            .get(&(s_expr.plan.clone(), children_group.clone()))
         {
             // If the expression already exists, return the group index of the existing expression
             return Ok(*group_index);
@@ -126,7 +127,7 @@ impl Memo {
 
     pub fn insert_m_expr(&mut self, group_index: IndexType, m_expr: MExpr) -> Result<()> {
         self.m_expr_lookup_table.insert(
-            ((*m_expr.plan).clone(), m_expr.children.clone()),
+            (m_expr.plan.clone(), m_expr.children.clone()),
             (m_expr.group_index, m_expr.index),
         );
         self.group_mut(group_index)?.insert(m_expr)
@@ -138,7 +139,11 @@ impl Memo {
             .ok_or_else(|| ErrorCode::Internal(format!("Group index {} not found", index)))
     }
 
-    fn add_group(&mut self, relational_prop: RelationalProperty, stat_info: StatInfo) -> IndexType {
+    fn add_group(
+        &mut self,
+        relational_prop: Arc<RelationalProperty>,
+        stat_info: Arc<StatInfo>,
+    ) -> IndexType {
         let group_index = self.groups.len();
         let group = Group::create(group_index, relational_prop, stat_info);
         self.groups.push(group);

--- a/src/query/sql/src/planner/optimizer/property/builder.rs
+++ b/src/query/sql/src/planner/optimizer/property/builder.rs
@@ -44,7 +44,7 @@ impl<'a> RelExpr<'a> {
         Self::MExpr { expr: m_expr, memo }
     }
 
-    pub fn derive_relational_prop(&self) -> Result<RelationalProperty> {
+    pub fn derive_relational_prop(&self) -> Result<Arc<RelationalProperty>> {
         match self {
             RelExpr::SExpr { expr } => {
                 if let Some(rel_prop) = expr.rel_prop.lock().unwrap().as_ref() {
@@ -58,7 +58,7 @@ impl<'a> RelExpr<'a> {
         }
     }
 
-    pub fn derive_relational_prop_child(&self, index: usize) -> Result<RelationalProperty> {
+    pub fn derive_relational_prop_child(&self, index: usize) -> Result<Arc<RelationalProperty>> {
         match self {
             RelExpr::SExpr { expr } => {
                 let child = expr.child(index)?;
@@ -72,7 +72,7 @@ impl<'a> RelExpr<'a> {
     }
 
     // Derive cardinality and statistics
-    pub fn derive_cardinality(&self) -> Result<StatInfo> {
+    pub fn derive_cardinality(&self) -> Result<Arc<StatInfo>> {
         match self {
             RelExpr::SExpr { expr } => {
                 if let Some(stat_info) = expr.stat_info.lock().unwrap().as_ref() {
@@ -86,7 +86,7 @@ impl<'a> RelExpr<'a> {
         }
     }
 
-    pub(crate) fn derive_cardinality_child(&self, index: IndexType) -> Result<StatInfo> {
+    pub(crate) fn derive_cardinality_child(&self, index: IndexType) -> Result<Arc<StatInfo>> {
         match self {
             RelExpr::SExpr { expr } => {
                 let child = expr.child(index)?;

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/agg_index/query_rewrite.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/agg_index/query_rewrite.rs
@@ -844,7 +844,7 @@ fn push_down_index_scan(s_expr: &SExpr, agg_info: AggIndexInfo) -> Result<SExpr>
         RelOperator::Scan(scan) => {
             let mut new_scan = scan.clone();
             new_scan.agg_index = Some(agg_info);
-            s_expr.replace_plan(new_scan.into())
+            s_expr.replace_plan(Arc::new(new_scan.into()))
         }
         _ => {
             let child = push_down_index_scan(s_expr.child(0)?, agg_info)?;

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/extract_or_predicates.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/extract_or_predicates.rs
@@ -32,8 +32,10 @@ pub fn rewrite_predicates(s_expr: &SExpr) -> Result<Vec<ScalarExpr>> {
             ScalarExpr::FunctionCall(func) if func.func_name == "or" => {
                 for join_child in join.children().iter() {
                     let rel_expr = RelExpr::with_s_expr(join_child);
-                    let used_columns = rel_expr.derive_relational_prop()?.used_columns;
-                    if let Some(predicate) = extract_or_predicate(&func.arguments, &used_columns)? {
+                    let prop = rel_expr.derive_relational_prop()?;
+                    if let Some(predicate) =
+                        extract_or_predicate(&func.arguments, &prop.used_columns)?
+                    {
                         new_predicates.push(predicate)
                     }
                 }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/filter_join/outer_join_to_inner_join.rs
@@ -38,8 +38,14 @@ pub fn outer_to_inner(s_expr: &SExpr) -> Result<SExpr> {
             crate::optimizer::ConstraintSet::new(&mut filter.predicates)
         {
             let join_expr = RelExpr::with_s_expr(s_expr.child(0)?);
-            let left_columns = join_expr.derive_relational_prop_child(0)?.output_columns;
-            let right_columns = join_expr.derive_relational_prop_child(1)?.output_columns;
+            let left_columns = join_expr
+                .derive_relational_prop_child(0)?
+                .output_columns
+                .clone();
+            let right_columns = join_expr
+                .derive_relational_prop_child(1)?
+                .output_columns
+                .clone();
 
             let eliminate_left_null = left_columns
                 .iter()

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_constant.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_constant.rs
@@ -187,7 +187,7 @@ impl Rule for RuleFoldConstant {
             _ => unreachable!(),
         }
         if &new_plan != s_expr.plan() {
-            state.add_result(s_expr.replace_plan(new_plan));
+            state.add_result(s_expr.replace_plan(Arc::new(new_plan)));
         }
         Ok(())
     }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_fold_count_aggregate.rs
@@ -88,8 +88,8 @@ impl Rule for RuleFoldCountAggregate {
 
         if let (true, column_stats, Some(table_card)) = (
             is_simple_count,
-            input_stat_info.statistics.column_stats,
-            input_stat_info.statistics.precise_cardinality,
+            &input_stat_info.statistics.column_stats,
+            &input_stat_info.statistics.precise_cardinality,
         ) {
             let mut scalars = agg.aggregate_functions;
             for item in scalars.iter_mut() {
@@ -97,7 +97,7 @@ impl Rule for RuleFoldCountAggregate {
                     if agg_func.args.is_empty() {
                         item.scalar = ScalarExpr::ConstantExpr(ConstantExpr {
                             span: item.scalar.span(),
-                            value: Scalar::Number(NumberScalar::UInt64(table_card)),
+                            value: Scalar::Number(NumberScalar::UInt64(*table_card)),
                         });
                     } else if let ScalarExpr::BoundColumnRef(col) = &agg_func.args[0] {
                         if let Some(card) = column_stats.get(&col.column.index) {

--- a/src/query/sql/src/planner/optimizer/rule/transform/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/rule/transform/rule_eager_aggregation.rs
@@ -803,7 +803,7 @@ impl Rule for RuleEagerAggregation {
                         )),
                         Arc::new(join_expr.child(1)?.clone()),
                     ]))])
-                    .replace_plan(eager_groupby_count_count_sum.try_into()?)
+                    .replace_plan(Arc::new(eager_groupby_count_count_sum.try_into()?))
             } else {
                 eval_scalar_expr
                     .replace_children(vec![Arc::new(join_expr.replace_children(vec![
@@ -827,7 +827,7 @@ impl Rule for RuleEagerAggregation {
                             )),
                         )),
                     ]))])
-                    .replace_plan(eager_groupby_count_count_sum.try_into()?)
+                    .replace_plan(Arc::new(eager_groupby_count_count_sum.try_into()?))
             });
 
             // Apply eager split on d and d^1.
@@ -889,7 +889,7 @@ impl Rule for RuleEagerAggregation {
                             )),
                         )),
                     ]))])
-                    .replace_plan(eager_split_count_sum.try_into()?),
+                    .replace_plan(Arc::new(eager_split_count_sum.try_into()?)),
             );
         } else if can_push_down[d] && eager_aggregations[d ^ 1].is_empty() {
             // (1) Try to apply eager group-by on d.
@@ -1121,7 +1121,7 @@ impl Rule for RuleEagerAggregation {
                                 )),
                             )),
                         ]))])
-                        .replace_plan(eager_count_sum.try_into()?)
+                        .replace_plan(Arc::new(eager_count_sum.try_into()?))
                 } else {
                     eval_scalar_expr
                         .replace_children(vec![Arc::new(join_expr.replace_children(vec![
@@ -1134,7 +1134,7 @@ impl Rule for RuleEagerAggregation {
                             )),
                             Arc::new(join_expr.child(1)?.clone()),
                         ]))])
-                        .replace_plan(eager_count_sum.try_into()?)
+                        .replace_plan(Arc::new(eager_count_sum.try_into()?))
                 });
 
                 // Apply double eager on d and d^1.
@@ -1176,7 +1176,7 @@ impl Rule for RuleEagerAggregation {
                                 )),
                             )),
                         ]))])
-                        .replace_plan(double_eager_count_sum.try_into()?)
+                        .replace_plan(Arc::new(double_eager_count_sum.try_into()?))
                 } else {
                     eval_scalar_expr
                         .replace_children(vec![Arc::new(join_expr.replace_children(vec![
@@ -1204,7 +1204,7 @@ impl Rule for RuleEagerAggregation {
                                 )),
                             )),
                         ]))])
-                        .replace_plan(double_eager_count_sum.try_into()?)
+                        .replace_plan(Arc::new(double_eager_count_sum.try_into()?))
                 });
             }
         }
@@ -1227,19 +1227,19 @@ impl Rule for RuleEagerAggregation {
                 .replace_children(vec![Arc::new(
                     final_agg_partial_expr
                         .replace_children(vec![Arc::new(join_exprs[idx].clone())])
-                        .replace_plan(final_agg_partials[idx].clone().try_into()?),
+                        .replace_plan(Arc::new(final_agg_partials[idx].clone().try_into()?)),
                 )])
-                .replace_plan(final_agg_finals[idx].clone().try_into()?);
+                .replace_plan(Arc::new(final_agg_finals[idx].clone().try_into()?));
             let mut result = if has_sort {
                 eval_scalar_expr
                     .replace_children(vec![Arc::new(
                         sort_expr.replace_children(vec![Arc::new(temp_final_agg_expr)]),
                     )])
-                    .replace_plan(final_eval_scalars[idx].clone().try_into()?)
+                    .replace_plan(Arc::new(final_eval_scalars[idx].clone().try_into()?))
             } else {
                 eval_scalar_expr
                     .replace_children(vec![Arc::new(temp_final_agg_expr)])
-                    .replace_plan(final_eval_scalars[idx].clone().try_into()?)
+                    .replace_plan(Arc::new(final_eval_scalars[idx].clone().try_into()?))
             };
             result.set_applied_rule(&self.id);
             state.add_result(result);

--- a/src/query/sql/src/planner/optimizer/runtime_filter/mod.rs
+++ b/src/query/sql/src/planner/optimizer/runtime_filter/mod.rs
@@ -67,7 +67,7 @@ fn wrap_runtime_filter_source(
     );
     let mut join: Join = s_expr.plan().clone().try_into()?;
     join.contain_runtime_filter = true;
-    let s_expr = s_expr.replace_plan(RelOperator::Join(join));
+    let s_expr = s_expr.replace_plan(Arc::new(RelOperator::Join(join)));
     Ok(s_expr.replace_children(vec![Arc::new(probe_side), Arc::new(build_side)]))
 }
 

--- a/src/query/sql/src/planner/optimizer/s_expr.rs
+++ b/src/query/sql/src/planner/optimizer/s_expr.rs
@@ -47,10 +47,10 @@ pub struct SExpr {
     /// Since `SExpr` is `Send + Sync`, we use `Mutex` to protect
     /// the cache.
     #[educe(Hash(ignore), PartialEq(ignore), Eq(ignore))]
-    pub(crate) rel_prop: Arc<Mutex<Option<RelationalProperty>>>,
+    pub(crate) rel_prop: Arc<Mutex<Option<Arc<RelationalProperty>>>>,
 
     #[educe(Hash(ignore), PartialEq(ignore), Eq(ignore))]
-    pub(crate) stat_info: Arc<Mutex<Option<StatInfo>>>,
+    pub(crate) stat_info: Arc<Mutex<Option<Arc<StatInfo>>>>,
 
     /// A bitmap to record applied rules on current SExpr, to prevent
     /// redundant transformations.
@@ -62,8 +62,8 @@ impl SExpr {
         plan: Arc<RelOperator>,
         children: impl IntoIterator<Item = Arc<SExpr>>,
         original_group: Option<IndexType>,
-        rel_prop: Option<RelationalProperty>,
-        stat_info: Option<StatInfo>,
+        rel_prop: Option<Arc<RelationalProperty>>,
+        stat_info: Option<Arc<StatInfo>>,
     ) -> Self {
         SExpr {
             plan,
@@ -170,12 +170,12 @@ impl SExpr {
         }
     }
 
-    pub fn replace_plan(&self, plan: RelOperator) -> Self {
+    pub fn replace_plan(&self, plan: Arc<RelOperator>) -> Self {
         Self {
-            plan: Arc::new(plan),
+            plan,
             original_group: self.original_group,
-            rel_prop: self.rel_prop.clone(),
-            stat_info: self.stat_info.clone(),
+            rel_prop: Arc::new(Mutex::new(None)),
+            stat_info: Arc::new(Mutex::new(None)),
             applied_rules: self.applied_rules.clone(),
             children: self.children.clone(),
         }

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -146,7 +146,7 @@ impl Operator for Aggregate {
         Ok(required)
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
 
         // Derive output columns
@@ -167,18 +167,18 @@ impl Operator for Aggregate {
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(input_prop.used_columns);
+        used_columns.extend(input_prop.used_columns.clone());
 
-        Ok(RelationalProperty {
+        Ok(Arc::new(RelationalProperty {
             output_columns,
             outer_columns,
             used_columns,
-        })
+        }))
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         let stat_info = rel_expr.derive_cardinality_child(0)?;
-        let (cardinality, mut statistics) = (stat_info.cardinality, stat_info.statistics);
+        let (cardinality, mut statistics) = (stat_info.cardinality, stat_info.statistics.clone());
         let cardinality = if self.group_items.is_empty() {
             // Scalar aggregation
             1.0
@@ -221,12 +221,12 @@ impl Operator for Aggregate {
         } else {
             None
         };
-        Ok(StatInfo {
+        Ok(Arc::new(StatInfo {
             cardinality,
             statistics: Statistics {
                 precise_cardinality,
                 column_stats: statistics.column_stats,
             },
-        })
+        }))
     }
 }

--- a/src/query/sql/src/planner/plans/dummy_table_scan.rs
+++ b/src/query/sql/src/planner/plans/dummy_table_scan.rs
@@ -24,6 +24,7 @@ use crate::optimizer::RelExpr;
 use crate::optimizer::RelationalProperty;
 use crate::optimizer::StatInfo;
 use crate::optimizer::Statistics;
+use crate::DUMMY_COLUMN_INDEX;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DummyTableScan;
@@ -42,12 +43,12 @@ impl Operator for DummyTableScan {
     fn derive_relational_prop(
         &self,
         _rel_expr: &crate::optimizer::RelExpr,
-    ) -> Result<RelationalProperty> {
-        Ok(RelationalProperty {
-            output_columns: ColumnSet::new(),
+    ) -> Result<Arc<RelationalProperty>> {
+        Ok(Arc::new(RelationalProperty {
+            output_columns: ColumnSet::from([DUMMY_COLUMN_INDEX]),
             outer_columns: ColumnSet::new(),
             used_columns: ColumnSet::new(),
-        })
+        }))
     }
 
     fn derive_physical_prop(
@@ -59,14 +60,14 @@ impl Operator for DummyTableScan {
         })
     }
 
-    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> Result<StatInfo> {
-        Ok(StatInfo {
+    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
+        Ok(Arc::new(StatInfo {
             cardinality: 1.0,
             statistics: Statistics {
                 precise_cardinality: Some(1),
                 column_stats: Default::default(),
             },
-        })
+        }))
     }
 
     fn compute_required_prop_child(

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -70,17 +70,17 @@ impl Operator for EvalScalar {
         Ok(required.clone())
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
 
         // Derive output columns
-        let mut output_columns = input_prop.output_columns;
+        let mut output_columns = input_prop.output_columns.clone();
         for item in self.items.iter() {
             output_columns.insert(item.index);
         }
 
         // Derive outer columns
-        let mut outer_columns = input_prop.outer_columns;
+        let mut outer_columns = input_prop.outer_columns.clone();
         for item in self.items.iter() {
             let used_columns = item.scalar.used_columns();
             let outer = used_columns
@@ -93,16 +93,16 @@ impl Operator for EvalScalar {
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(input_prop.used_columns);
+        used_columns.extend(input_prop.used_columns.clone());
 
-        Ok(RelationalProperty {
+        Ok(Arc::new(RelationalProperty {
             output_columns,
             outer_columns,
             used_columns,
-        })
+        }))
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         rel_expr.derive_cardinality_child(0)
     }
 }

--- a/src/query/sql/src/planner/plans/exchange.rs
+++ b/src/query/sql/src/planner/plans/exchange.rs
@@ -40,7 +40,7 @@ impl Operator for Exchange {
         RelOp::Exchange
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         rel_expr.derive_relational_prop_child(0)
     }
 
@@ -55,7 +55,7 @@ impl Operator for Exchange {
         })
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         rel_expr.derive_cardinality_child(0)
     }
 

--- a/src/query/sql/src/planner/plans/limit.rs
+++ b/src/query/sql/src/planner/plans/limit.rs
@@ -54,28 +54,22 @@ impl Operator for Limit {
         Ok(required)
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
-        let input_prop = rel_expr.derive_relational_prop_child(0)?;
-
-        Ok(RelationalProperty {
-            output_columns: input_prop.output_columns,
-            outer_columns: input_prop.outer_columns,
-            used_columns: input_prop.used_columns,
-        })
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
+        rel_expr.derive_relational_prop_child(0)
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         let stat_info = rel_expr.derive_cardinality_child(0)?;
         let cardinality = match self.limit {
             Some(limit) if (limit as f64) < stat_info.cardinality => limit as f64,
             _ => stat_info.cardinality,
         };
-        Ok(StatInfo {
+        Ok(Arc::new(StatInfo {
             cardinality,
             statistics: Statistics {
                 precise_cardinality: None,
                 column_stats: Default::default(),
             },
-        })
+        }))
     }
 }

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -45,11 +45,11 @@ pub trait Operator {
         false
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty>;
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>>;
 
     fn derive_physical_prop(&self, rel_expr: &RelExpr) -> Result<PhysicalProperty>;
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo>;
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>>;
 
     fn compute_required_prop_child(
         &self,
@@ -121,7 +121,7 @@ impl Operator for RelOperator {
         }
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         match self {
             RelOperator::Scan(rel_op) => rel_op.derive_relational_prop(rel_expr),
             RelOperator::Join(rel_op) => rel_op.derive_relational_prop(rel_expr),
@@ -159,7 +159,7 @@ impl Operator for RelOperator {
         }
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         match self {
             RelOperator::Scan(rel_op) => rel_op.derive_cardinality(rel_expr),
             RelOperator::Join(rel_op) => rel_op.derive_cardinality(rel_expr),

--- a/src/query/sql/src/planner/plans/pattern.rs
+++ b/src/query/sql/src/planner/plans/pattern.rs
@@ -42,7 +42,7 @@ impl Operator for PatternPlan {
     fn derive_relational_prop(
         &self,
         _rel_expr: &RelExpr,
-    ) -> common_exception::Result<RelationalProperty> {
+    ) -> common_exception::Result<Arc<RelationalProperty>> {
         Err(ErrorCode::Internal(
             "Cannot derive relational property for pattern plan",
         ))
@@ -57,7 +57,7 @@ impl Operator for PatternPlan {
         ))
     }
 
-    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> common_exception::Result<StatInfo> {
+    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> common_exception::Result<Arc<StatInfo>> {
         Err(ErrorCode::Internal(
             "Cannot derive cardinality for pattern plan",
         ))

--- a/src/query/sql/src/planner/plans/project_set.rs
+++ b/src/query/sql/src/planner/plans/project_set.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
 use std::sync::Arc;
 
 use common_catalog::table_context::TableContext;
@@ -52,12 +53,12 @@ impl Operator for ProjectSet {
     fn derive_relational_prop(
         &self,
         rel_expr: &RelExpr,
-    ) -> common_exception::Result<RelationalProperty> {
-        let mut child_prop = rel_expr.derive_relational_prop_child(0)?;
+    ) -> common_exception::Result<Arc<RelationalProperty>> {
+        let mut child_prop = rel_expr.derive_relational_prop_child(0)?.as_ref().clone();
         for srf in &self.srfs {
             child_prop.output_columns.insert(srf.index);
         }
-        Ok(child_prop)
+        Ok(Arc::new(child_prop))
     }
 
     fn derive_physical_prop(
@@ -67,11 +68,11 @@ impl Operator for ProjectSet {
         rel_expr.derive_physical_prop_child(0)
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> common_exception::Result<StatInfo> {
-        let mut input_stat = rel_expr.derive_cardinality_child(0)?;
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> common_exception::Result<Arc<StatInfo>> {
+        let mut input_stat = rel_expr.derive_cardinality_child(0)?.deref().clone();
         // ProjectSet is set-returning functions, precise_cardinality set None
         input_stat.statistics.precise_cardinality = None;
-        Ok(input_stat)
+        Ok(Arc::new(input_stat))
     }
 
     fn compute_required_prop_child(

--- a/src/query/sql/src/planner/plans/runtime_filter_source.rs
+++ b/src/query/sql/src/planner/plans/runtime_filter_source.rs
@@ -69,33 +69,33 @@ impl Operator for RuntimeFilterSource {
         RelOp::RuntimeFilterSource
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let left_prop = rel_expr.derive_relational_prop_child(0)?;
         // Derive output columns
         let output_columns = left_prop.output_columns.clone();
         // Derive outer columns
-        let outer_columns = left_prop.outer_columns;
+        let outer_columns = left_prop.outer_columns.clone();
 
-        Ok(RelationalProperty {
+        Ok(Arc::new(RelationalProperty {
             output_columns,
             outer_columns,
             used_columns: self.used_columns()?,
-        })
+        }))
     }
 
     fn derive_physical_prop(&self, _rel_expr: &RelExpr) -> Result<PhysicalProperty> {
         todo!()
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         let stat_info = rel_expr.derive_cardinality_child(0)?;
-        Ok(StatInfo {
+        Ok(Arc::new(StatInfo {
             cardinality: stat_info.cardinality,
             statistics: Statistics {
                 precise_cardinality: None,
-                column_stats: stat_info.statistics.column_stats,
+                column_stats: stat_info.statistics.column_stats.clone(),
             },
-        })
+        }))
     }
 
     fn compute_required_prop_child(

--- a/src/query/sql/src/planner/plans/scan.rs
+++ b/src/query/sql/src/planner/plans/scan.rs
@@ -147,12 +147,12 @@ impl Operator for Scan {
         RelOp::Scan
     }
 
-    fn derive_relational_prop(&self, _rel_expr: &RelExpr) -> Result<RelationalProperty> {
-        Ok(RelationalProperty {
+    fn derive_relational_prop(&self, _rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
+        Ok(Arc::new(RelationalProperty {
             output_columns: self.columns.clone(),
             outer_columns: Default::default(),
             used_columns: self.used_columns(),
-        })
+        }))
     }
 
     fn derive_physical_prop(&self, _rel_expr: &RelExpr) -> Result<PhysicalProperty> {
@@ -161,7 +161,7 @@ impl Operator for Scan {
         })
     }
 
-    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, _rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         let used_columns = self.used_columns();
 
         let num_rows = self
@@ -238,13 +238,13 @@ impl Operator for Scan {
         } else {
             None
         };
-        Ok(StatInfo {
+        Ok(Arc::new(StatInfo {
             cardinality,
             statistics: OpStatistics {
                 precise_cardinality,
                 column_stats,
             },
-        })
+        }))
     }
 
     // Won't be invoked at all, since `PhysicalScan` is leaf node

--- a/src/query/sql/src/planner/plans/sort.rs
+++ b/src/query/sql/src/planner/plans/sort.rs
@@ -61,11 +61,11 @@ impl Operator for Sort {
         Ok(required)
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         rel_expr.derive_relational_prop_child(0)
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         rel_expr.derive_cardinality_child(0)
     }
 }

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -108,7 +108,7 @@ impl Operator for Window {
         Ok(required)
     }
 
-    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<RelationalProperty> {
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
 
         // Derive output columns
@@ -123,16 +123,16 @@ impl Operator for Window {
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(input_prop.used_columns);
+        used_columns.extend(input_prop.used_columns.clone());
 
-        Ok(RelationalProperty {
+        Ok(Arc::new(RelationalProperty {
             output_columns,
             outer_columns,
             used_columns,
-        })
+        }))
     }
 
-    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<StatInfo> {
+    fn derive_cardinality(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
         let input_stat_info = rel_expr.derive_cardinality_child(0)?;
         let cardinality = if self.partition_by.is_empty() {
             // Scalar aggregation
@@ -164,13 +164,13 @@ impl Operator for Window {
         } else {
             None
         };
-        Ok(StatInfo {
+        Ok(Arc::new(StatInfo {
             cardinality,
             statistics: Statistics {
                 precise_cardinality,
-                column_stats: input_stat_info.statistics.column_stats,
+                column_stats: input_stat_info.statistics.column_stats.clone(),
             },
-        })
+        }))
     }
 }
 

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1828,7 +1828,7 @@ impl<'a> TypeChecker<'a> {
             projection_index: None,
             data_type: data_type.clone(),
             typ,
-            outer_columns: rel_prop.outer_columns,
+            outer_columns: rel_prop.outer_columns.clone(),
         };
 
         let data_type = subquery_expr.data_type();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Use `Arc` to store relational properties to reduce clone
- Expand `Pattern` into complete `SExpr` in `PatternExtractor`
