### PR TITLE
fix(query): cannot unset global setting if has same session setting

### DIFF
--- a/src/query/management/src/setting/setting_api.rs
+++ b/src/query/management/src/setting/setting_api.rs
@@ -28,5 +28,5 @@ pub trait SettingApi: Sync + Send {
     async fn get_setting(&self, name: &str, seq: MatchSeq) -> Result<SeqV<UserSetting>>;
 
     // Drop the setting by name.
-    async fn drop_setting(&self, name: &str, seq: MatchSeq) -> Result<()>;
+    async fn try_drop_setting(&self, name: &str, seq: MatchSeq) -> Result<()>;
 }

--- a/src/query/management/tests/it/setting.rs
+++ b/src/query/management/tests/it/setting.rs
@@ -86,7 +86,7 @@ async fn test_set_setting() -> Result<()> {
 
     // Drop setting.
     {
-        mgr.drop_setting("max_threads", MatchSeq::GE(1)).await?;
+        mgr.try_drop_setting("max_threads", MatchSeq::GE(1)).await?;
     }
 
     // Get settings.
@@ -103,8 +103,10 @@ async fn test_set_setting() -> Result<()> {
 
     // Drop setting not exists.
     {
-        let res = mgr.drop_setting("max_threads_not", MatchSeq::GE(1)).await;
-        assert!(res.is_err());
+        let res = mgr
+            .try_drop_setting("max_threads_not", MatchSeq::GE(1))
+            .await;
+        assert!(res.is_ok());
     }
 
     Ok(())

--- a/src/query/service/src/interpreters/interpreter_unsetting.rs
+++ b/src/query/service/src/interpreters/interpreter_unsetting.rs
@@ -54,12 +54,11 @@ impl Interpreter for UnSettingInterpreter {
                 // To be compatible with some drivers
                 "sql_mode" | "autocommit" => (false, String::from("")),
                 setting => {
-                    if matches!(settings.get_setting_level(setting)?, Global) {
-                        self.ctx
-                            .get_shard_settings()
-                            .try_drop_global_setting(setting)
-                            .await?;
-                    }
+                    self.ctx
+                        .get_shard_settings()
+                        .try_drop_global_setting(setting)
+                        .await?;
+
                     let default_val = {
                         if setting == "max_memory_usage" {
                             let conf = GlobalConfig::instance();

--- a/src/query/settings/src/settings_global.rs
+++ b/src/query/settings/src/settings_global.rs
@@ -51,7 +51,7 @@ impl Settings {
 
         UserApiProvider::instance()
             .get_setting_api_client(&self.tenant)?
-            .drop_setting(key, MatchSeq::GE(1))
+            .try_drop_setting(key, MatchSeq::GE(1))
             .await
     }
 

--- a/src/query/users/src/user_setting.rs
+++ b/src/query/users/src/user_setting.rs
@@ -38,7 +38,7 @@ impl UserApiProvider {
     pub async fn drop_setting(&self, tenant: &str, name: &str) -> Result<()> {
         let setting_api_provider = self.get_setting_api_client(tenant)?;
         setting_api_provider
-            .drop_setting(name, MatchSeq::GE(1))
+            .try_drop_setting(name, MatchSeq::GE(1))
             .await
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(query): cannot unset global setting if has same session setting

Closes #issue
