### PR TITLE
chore: remove take_string_types

### DIFF
--- a/src/query/expression/src/kernels/take_compact.rs
+++ b/src/query/expression/src/kernels/take_compact.rs
@@ -24,7 +24,6 @@ use crate::types::decimal::DecimalColumn;
 use crate::types::map::KvColumnBuilder;
 use crate::types::nullable::NullableColumn;
 use crate::types::number::NumberColumn;
-use crate::types::string::StringColumn;
 use crate::types::AnyType;
 use crate::types::ArgType;
 use crate::types::ArrayType;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR
Remove `take_string_types` and replace it by `take_compact_arg_types`.

Closes #issue
