### PR TITLE
feat: Bump OpenDAL to 0.37.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5939,15 +5939,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.8",
+ "rustls 0.21.0",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -7222,9 +7222,9 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3555168d4cc9a83c332e1416ff00e3be36a6d78447dff472829962afbc91bb3d"
+checksum = "6a37de9fe637d53550bf3f76d5c731f69cb6f9685ada6afd390ada98994a3f91"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -8611,9 +8611,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04f5fccb94d61c154f0d8520ec42e79afdc145f4b1a392faa269874995fda66"
+checksum = "b6cb65eb3405f9c2de5c18bfc37338d6bbdb2c35eb8eb0e946208cbb564e4833"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8642,9 +8642,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -8663,14 +8663,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.8",
+ "rustls 0.21.0",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.0",
  "tokio-util",
  "tower-service",
  "trust-dns-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ members = [
 [workspace.dependencies]
 # databend maintains:
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
-opendal = { version = "0.36", features = [
+opendal = { version = "0.37", features = [
     "layers-tracing",
     "layers-metrics",
     "services-ipfs",

--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -43,6 +43,7 @@ use opendal::layers::ImmutableIndexLayer;
 use opendal::layers::LoggingLayer;
 use opendal::layers::MetricsLayer;
 use opendal::layers::RetryLayer;
+use opendal::layers::TimeoutLayer;
 use opendal::layers::TracingLayer;
 use opendal::raw::HttpClient;
 use opendal::services;
@@ -94,6 +95,15 @@ pub fn build_operator<B: Builder>(builder: B) -> Result<Operator> {
         // storage operator so that all underlying storage operations
         // will send to storage runtime.
         .layer(RuntimeLayer::new(GlobalIORuntime::instance().inner()))
+        .layer(
+            TimeoutLayer::new()
+                // Return timeout error if the operation failed to finish in
+                // 60s
+                .with_timeout(Duration::from_secs(60))
+                // Return timeout error if the request speed is less than
+                // 1 KiB/s.
+                .with_speed(1024),
+        )
         // Add retry
         .layer(RetryLayer::new().with_jitter())
         // Add metrics

--- a/src/common/storage/src/runtime_layer.rs
+++ b/src/common/storage/src/runtime_layer.rs
@@ -12,23 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
 use std::io::SeekFrom;
 use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::LazyLock;
 use std::task::Context;
 use std::task::Poll;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use common_base::base::tokio::pin;
 use common_base::base::tokio::runtime::Handle;
-use common_base::base::tokio::select;
 use common_base::base::tokio::task::JoinHandle;
-use common_base::base::tokio::time;
 use common_base::runtime::TrackedFuture;
 use futures::ready;
 use futures::Future;
@@ -51,16 +45,7 @@ use opendal::raw::RpList;
 use opendal::raw::RpRead;
 use opendal::raw::RpStat;
 use opendal::raw::RpWrite;
-use opendal::Error;
-use opendal::ErrorKind;
 use opendal::Result;
-
-static READ_TIMEOUT: LazyLock<u64> = LazyLock::new(|| {
-    env::var("_DATABEND_INTERNAL_READ_TIMEOUT")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(30)
-});
 
 /// # TODO
 ///
@@ -127,22 +112,7 @@ impl<A: Accessor> LayeredAccessor for RuntimeAccessor<A> {
         let op = self.inner.clone();
         let path = path.to_string();
 
-        let future = async move {
-            let sleep = time::sleep(Duration::from_secs(*READ_TIMEOUT));
-            pin!(sleep);
-
-            #[allow(unused_assignments)]
-            let mut res = None;
-            select! {
-                _ = &mut sleep => {
-                    res = Some(Err(Error::new(ErrorKind::Unexpected, "operation timed out while reading").set_temporary()));
-                }
-                v = op.read(&path, args) => {
-                    res = Some(v);
-                }
-            }
-            res.unwrap()
-        };
+        let future = async move { op.read(&path, args).await };
 
         let future = TrackedFuture::create(future);
         self.runtime


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Bump OpenDAL to 0.37.0

Release note: https://github.com/apache/incubator-opendal/releases/tag/v0.37.0

Notable changes to databend:

- feat: Implement Timeout Layer
- fix(core): Don't wake up operator futures while not ready