### PR TITLE
refactor: Remove HTTP timeout after OpenDAL timeout layer added

### DIFF
--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -281,13 +281,6 @@ fn init_s3_operator(cfg: &StorageS3Config) -> Result<impl Builder> {
             .unwrap_or(30);
         builder = builder.connect_timeout(Duration::from_secs(connect_timeout));
 
-        // Timeout default to 120s.
-        let timeout = env::var("_DATABEND_INTERNAL_TIMEOUT")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(120);
-        builder = builder.timeout(Duration::from_secs(timeout));
-
         builder
     };
 

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -2948,7 +2948,7 @@ async fn remove_table_copied_files(
     Ok(n)
 }
 
-/// List the copied file identies belonging to a table.
+/// List the copied file identities belonging to a table.
 async fn list_table_copied_files(
     kv_api: &impl kvapi::KVApi<Error = MetaError>,
     table_id: u64,

--- a/src/meta/app/src/storage/storage_params.rs
+++ b/src/meta/app/src/storage/storage_params.rs
@@ -322,7 +322,7 @@ pub struct StorageS3Config {
     pub role_arn: String,
     /// The ExternalId that used for AssumeRole.
     pub external_id: String,
-    /// Allow anonymous access to S3 if credentail not loaded.
+    /// Allow anonymous access to S3 if credential not loaded.
     pub allow_anonymous: bool,
 }
 

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -485,7 +485,7 @@ pub struct RaftConfig {
     #[clap(long, default_value = "")]
     pub sled_tree_prefix: String,
 
-    /// Tne node name. If the user specifies a name, the user-supplied name is used,
+    /// The node name. If the user specifies a name, the user-supplied name is used,
     /// if not, the default name is used
     #[clap(long, default_value = "foo_cluster")]
     pub cluster_name: String,

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -636,7 +636,7 @@ pub enum PatternType {
     PatternStr,
     // e.g. '%rrow'
     StartOfPercent,
-    // e.g. 'Arro%'
+    // e.g. 'Arrow%'
     EndOfPercent,
     // e.g. '%Arrow%'
     SurroundByPercent,

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
@@ -19,7 +19,7 @@ use common_hashtable::RowPtr;
 use crate::pipelines::processors::transforms::hash_join::desc::JOIN_MAX_BLOCK_SIZE;
 
 /// ProbeState used for probe phase of hash join.
-/// We may need some reuseable state for probe phase.
+/// We may need some reusable state for probe phase.
 pub struct ProbeState {
     pub(crate) probe_indexes: Vec<(u32, u32)>,
     pub(crate) build_indexes: Vec<RowPtr>,

--- a/src/query/sharing-endpoint/README.md
+++ b/src/query/sharing-endpoint/README.md
@@ -54,7 +54,7 @@ share_endpoint_address = "127.0.0.1:13003" # receive shared information from ope
 
 ### How to share a table?
 
-For the tenant who wants to share the table `tabl1` from database `db1` to tenant `vendor`
+For the tenant who wants to share the table `table1` from database `db1` to tenant `vendor`
 
 ```sql
 CREATE SHARE myshare;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The timeout for the entire HTTP request is not needed after OpenDAL timeout layer has been added. Besides, this timeout didn't take the body size into consideration which could lead to connection retry.