### PR TITLE
ci: Bump rust to latest toolchain

### DIFF
--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -186,7 +186,7 @@ function install_sccache {
 			arch="aarch64"
 			;;
 		esac
-		download_version="v0.4.1"
+		download_version="v0.5.3"
 		download_target="sccache-${download_version}-${arch}-unknown-linux-musl"
 		SCCACHE_RELEASE="https://github.com/mozilla/sccache/releases/"
 		curl -fLo sccache.tar.gz "${SCCACHE_RELEASE}/download/${download_version}/${download_target}.tar.gz"

--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-03-10"
+channel = "nightly-2023-06-09"
 components = ["rustfmt", "clippy", "rust-src", "miri", "rust-analyzer"]

--- a/scripts/setup/rust-tools.txt
+++ b/scripts/setup/rust-tools.txt
@@ -1,4 +1,4 @@
-cargo-audit@0.17.5
+cargo-audit@0.17.6
 cargo-machete@0.5.0
 taplo-cli@0.8.0
-typos-cli@1.14.8
+typos-cli@1.15.0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Bump rust to latest toolchain
