### PR TITLE
chore(executor): Add a switch to enable profiling in cluster mode

### DIFF
--- a/src/common/profile/src/span.rs
+++ b/src/common/profile/src/span.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -36,7 +37,7 @@ pub struct ProfSpanSet<K = u32> {
 }
 
 impl<K> ProfSpanSet<K>
-where K: std::hash::Hash + Eq
+where K: std::hash::Hash + Eq + PartialEq + Clone + Debug
 {
     pub fn update(&mut self, key: K, span: ProfSpan) {
         let entry = self.spans.entry(key).or_insert_with(ProfSpan::default);

--- a/src/query/service/src/api/rpc/packets/packet_executor.rs
+++ b/src/query/service/src/api/rpc/packets/packet_executor.rs
@@ -36,6 +36,8 @@ pub struct QueryFragmentsPlanPacket {
     pub changed_settings: HashMap<String, ChangeValue>,
     // We send nodes info for each node. This is a bad choice
     pub executors_info: HashMap<String, Arc<NodeInfo>>,
+    /// Enable profiling for this query
+    pub enable_profiling: bool,
 }
 
 impl QueryFragmentsPlanPacket {
@@ -46,6 +48,7 @@ impl QueryFragmentsPlanPacket {
         executors_info: HashMap<String, Arc<NodeInfo>>,
         changed_settings: HashMap<String, ChangeValue>,
         request_executor: String,
+        enable_profiling: bool,
     ) -> QueryFragmentsPlanPacket {
         QueryFragmentsPlanPacket {
             query_id,
@@ -54,6 +57,7 @@ impl QueryFragmentsPlanPacket {
             executors_info,
             changed_settings,
             request_executor,
+            enable_profiling,
         }
     }
 }

--- a/src/query/service/src/interpreters/interpreter_explain.rs
+++ b/src/query/service/src/interpreters/interpreter_explain.rs
@@ -264,7 +264,7 @@ impl ExplainInterpreter {
 
         let root_fragment = Fragmenter::try_create(ctx.clone())?.build_fragment(&plan)?;
 
-        let mut fragments_actions = QueryFragmentsActions::create(ctx.clone());
+        let mut fragments_actions = QueryFragmentsActions::create(ctx.clone(), false);
         root_fragment.get_actions(ctx, &mut fragments_actions)?;
 
         let display_string = fragments_actions.display_indent(&metadata).to_string();

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -240,7 +240,7 @@ impl Interpreter for InsertInterpreter {
                 let mut build_res = if !insert_select_plan.is_distributed_plan() {
                     build_local_pipeline(&self.ctx, &insert_select_plan, false).await
                 } else {
-                    build_distributed_pipeline(&self.ctx, &insert_select_plan).await
+                    build_distributed_pipeline(&self.ctx, &insert_select_plan, false).await
                 }?;
 
                 table.commit_insertion(

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -1186,6 +1186,7 @@ impl PipelineBuilder {
         let build_res = exchange_manager.get_fragment_source(
             &exchange_source.query_id,
             exchange_source.source_fragment_id,
+            self.enable_profiling,
             self.exchange_injector.clone(),
         )?;
 

--- a/src/query/service/src/schedulers/fragments/query_fragment_actions.rs
+++ b/src/query/service/src/schedulers/fragments/query_fragment_actions.rs
@@ -107,13 +107,15 @@ impl QueryFragmentActions {
 
 pub struct QueryFragmentsActions {
     ctx: Arc<QueryContext>,
+    enable_profiling: bool,
     pub fragments_actions: Vec<QueryFragmentActions>,
 }
 
 impl QueryFragmentsActions {
-    pub fn create(ctx: Arc<QueryContext>) -> QueryFragmentsActions {
+    pub fn create(ctx: Arc<QueryContext>, enable_profiling: bool) -> QueryFragmentsActions {
         QueryFragmentsActions {
             ctx,
+            enable_profiling,
             fragments_actions: Vec::new(),
         }
     }
@@ -183,6 +185,7 @@ impl QueryFragmentsActions {
             nodes_info.clone(),
             changed_settings.clone(),
             cluster.local_id(),
+            self.enable_profiling,
         );
 
         for (executor, fragments) in fragments_packets.into_iter() {
@@ -196,6 +199,7 @@ impl QueryFragmentsActions {
                 executors_info,
                 changed_settings.clone(),
                 cluster.local_id(),
+                self.enable_profiling,
             ));
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR only adds a switch to enable profiling in cluster mode. It will be used to allow for distributed query profiling in the following work.
