### PR TITLE
feat: make explain delete work

### DIFF
--- a/src/query/sql/src/planner/format/display_plan.rs
+++ b/src/query/sql/src/planner/format/display_plan.rs
@@ -15,12 +15,22 @@
 use std::sync::Arc;
 
 use common_exception::Result;
+use common_expression::types::DataType;
+use common_expression::types::NumberDataType;
+use common_expression::ROW_ID_COL_NAME;
 
 use crate::optimizer::SExpr;
+use crate::plans::BoundColumnRef;
+use crate::plans::DeletePlan;
+use crate::plans::EvalScalar;
 use crate::plans::Filter;
 use crate::plans::Plan;
 use crate::plans::RelOperator;
+use crate::plans::ScalarItem;
 use crate::plans::Scan;
+use crate::ColumnBinding;
+use crate::ScalarExpr;
+use crate::Visibility;
 
 impl Plan {
     pub fn format_indent(&self) -> Result<String> {
@@ -107,45 +117,7 @@ impl Plan {
             // Insert
             Plan::Insert(insert) => Ok(format!("{:?}", insert)),
             Plan::Replace(replace) => Ok(format!("{:?}", replace)),
-            Plan::Delete(delete) => {
-                let mut predicates = vec![];
-                if let Some(selection) = &delete.selection {
-                   predicates.push(selection.clone());
-                }
-                let filter = RelOperator::Filter(Filter {
-                    predicates,
-                    is_having: false,
-                });
-                let s_expr = if let Some(subquery_desc) = &delete.subquery_desc {
-                    SExpr::create_unary(
-                        Arc::new(filter),
-                        Arc::new(subquery_desc.input_expr.clone()),
-                    )
-                } else {
-                    let table_index = delete
-                        .metadata
-                        .read()
-                        .get_table_index(
-                            Some(delete.database_name.as_str()),
-                            delete.table_name.as_str(),
-                        )
-                        .unwrap();
-                    let scan = RelOperator::Scan(Scan {
-                        table_index,
-                        columns: Default::default(),
-                        push_down_predicates: None,
-                        limit: None,
-                        order_by: None,
-                        prewhere: None,
-                        agg_index: None,
-                        statistics: Default::default(),
-                    });
-                    let scan_expr = SExpr::create_leaf(Arc::new(scan));
-                    SExpr::create_unary(Arc::new(filter), Arc::new(scan_expr))
-                };
-                let res = s_expr.to_format_tree(&delete.metadata).format_pretty()?;
-                Ok(format!("DeletePlan:\n{res}"))
-            }
+            Plan::Delete(delete) => format_delete(delete),
             Plan::Update(update) => Ok(format!("{:?}", update)),
 
             // Stages
@@ -202,4 +174,63 @@ impl Plan {
             Plan::DescDatamaskPolicy(p) => Ok(format!("{:?}", p)),
         }
     }
+}
+
+fn format_delete(delete: &DeletePlan) -> Result<String> {
+    let table_index = delete
+        .metadata
+        .read()
+        .get_table_index(
+            Some(delete.database_name.as_str()),
+            delete.table_name.as_str(),
+        )
+        .unwrap();
+    let s_expr = if let Some(subquery_desc) = &delete.subquery_desc {
+        let row_id_column_binding = ColumnBinding {
+            database_name: Some(delete.database_name.clone()),
+            table_name: Some(delete.table_name.clone()),
+            column_position: None,
+            table_index: Some(table_index),
+            column_name: ROW_ID_COL_NAME.to_string(),
+            index: subquery_desc.index,
+            data_type: Box::new(DataType::Number(NumberDataType::UInt64)),
+            visibility: Visibility::InVisible,
+            virtual_computed_expr: None,
+        };
+        SExpr::create_unary(
+            Arc::new(RelOperator::EvalScalar(EvalScalar {
+                items: vec![ScalarItem {
+                    scalar: ScalarExpr::BoundColumnRef(BoundColumnRef {
+                        span: None,
+                        column: row_id_column_binding,
+                    }),
+                    index: 0,
+                }],
+            })),
+            Arc::new(subquery_desc.input_expr.clone()),
+        )
+    } else {
+        let scan = RelOperator::Scan(Scan {
+            table_index,
+            columns: Default::default(),
+            push_down_predicates: None,
+            limit: None,
+            order_by: None,
+            prewhere: None,
+            agg_index: None,
+            statistics: Default::default(),
+        });
+        let scan_expr = SExpr::create_leaf(Arc::new(scan));
+        let mut predicates = vec![];
+        if let Some(selection) = &delete.selection {
+            predicates.push(selection.clone());
+        }
+        let filter = RelOperator::Filter(Filter {
+            predicates,
+            is_having: false,
+        });
+        SExpr::create_unary(Arc::new(filter), Arc::new(scan_expr))
+    };
+    let res = s_expr.to_format_tree(&delete.metadata).format_pretty()?;
+    Ok(format!("DeletePlan:\n{res}"))
 }

--- a/src/query/sql/src/planner/plans/delete.rs
+++ b/src/query/sql/src/planner/plans/delete.rs
@@ -19,15 +19,20 @@ use crate::IndexType;
 use crate::MetadataRef;
 
 #[derive(Clone, Debug)]
+pub struct SubqueryDesc {
+    // The s_expr is a plan tree after decorrelation subquery
+    pub input_expr: SExpr,
+    // `_row_id`'s index
+    pub index: IndexType,
+    pub outer_columns: ColumnSet,
+}
+
+#[derive(Clone, Debug)]
 pub struct DeletePlan {
     pub catalog_name: String,
     pub database_name: String,
     pub table_name: String,
     pub metadata: MetadataRef,
     pub selection: Option<ScalarExpr>,
-    // The case: selection is subquery
-    pub input_expr: Option<SExpr>,
-    // `_row_id`'s index
-    pub index: Option<IndexType>,
-    pub outer_columns: Option<ColumnSet>,
+    pub subquery_desc: Option<SubqueryDesc>,
 }

--- a/src/query/sql/src/planner/plans/mod.rs
+++ b/src/query/sql/src/planner/plans/mod.rs
@@ -50,6 +50,7 @@ pub use copy::*;
 pub use data_mask::*;
 pub use ddl::*;
 pub use delete::DeletePlan;
+pub use delete::SubqueryDesc;
 pub use dummy_table_scan::DummyTableScan;
 pub use eval_scalar::*;
 pub use exchange::*;

--- a/tests/sqllogictests/suites/mode/standalone/explain/delete.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/delete.test
@@ -1,0 +1,54 @@
+statement ok
+drop table if exists t1
+
+statement ok
+drop table if exists t2
+
+statement ok
+create table t1 (a int)
+
+statement ok
+create table t2(b int)
+
+statement ok
+insert into t1 values(1), (2), (3), (8);
+
+statement ok
+insert into t2 values(2), (3);
+
+query T
+explain delete from t1 where a in (select b from t2);
+----
+DeletePlan:
+EvalScalar
+├── scalars: [t1._row_id (#2)]
+└── Filter
+    ├── filters: [3 (#3)]
+    └── HashJoin: RIGHT MARK
+        ├── equi conditions: [eq(t1.a (#0), CAST(subquery_1 (#1) AS Int32))]
+        ├── non-equi conditions: []
+        ├── LogicalGet
+        │   ├── table: default.default.t1
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── EvalScalar
+            ├── scalars: [t2.b (#1)]
+            └── LogicalGet
+                ├── table: default.default.t2
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+
+query T
+explain delete from t1 where a > 2;
+----
+DeletePlan:
+Filter
+├── filters: [gt(t1.a (#0), 2)]
+└── LogicalGet
+    ├── table: default.default.t1
+    ├── filters: []
+    ├── order by: []
+    └── limit: NONE


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Before:
```
mysql> explain delete from t1 where a in (select b from t2) and a < 2;
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| DeletePlan { catalog_name: "default", database_name: "default", table_name: "t1", metadata: RwLock { data: Metadata { tables: [TableEntry { catalog: "default", database: "default", name: "t1", index: 0, .. }, TableEntry { catalog: "default", database: "default", name: "t2", index: 1, .. }], columns: [BaseTableColumn(BaseTableColumn { table_index: 0, column_index: 0, column_name: "a", column_position: Some(1), data_type: Number(Int32), path_indices: None, leaf_index: Some(0) }), BaseTableColumn(BaseTableColumn { table_index: 1, column_index: 1, column_name: "b", column_position: Some(1), data_type: Number(Int32), path_indices: None, leaf_index: Some(0) })], lazy_columns: {}, agg_indexes: {} } }, selection: Some(FunctionCall(FunctionCall { span: Some(53..56), func_name: "and", params: [], arguments: [SubqueryExpr(SubqueryExpr { span: Some(35..51), typ: Any, subquery: SExpr { plan: EvalScalar(EvalScalar { items: [ScalarItem { scalar: BoundColumnRef(BoundColumnRef { span: Some(42..43), column: ColumnBinding { database_name: Some("default"), table_name: Some("t2"), column_position: Some(1), table_index: Some(1), column_name: "b", index: 1, data_type: Number(Int32), visibility: Visible } }), index: 1 }] }), children: [SExpr { plan: Scan(Scan { table_index: 1, columns: {1}, push_down_predicates: None, limit: None, order_by: None, prewhere: None, agg_index: None, statistics: Statistics { statistics: Some(TableStatistics { num_rows: Some(2), data_size: Some(8), data_size_compressed: Some(197), index_size: Some(276) }), col_stats: {1: Some(ColumnStatistics { min: Number(2_i32), max: Number(3_i32), null_count: 0, number_of_distinct_values: 2 })} } }), children: [], original_group: None, rel_prop: Mutex { data: Some(RelationalProperty { output_columns: {1}, outer_columns: {}, used_columns: {1} }), poisoned: false, .. }, stat_info: Mutex { data: None, poisoned: false, .. }, applied_rules: AppliedRules { rules: RuleSet { rules: RoaringBitmap<[]> } } }], original_group: None, rel_prop: Mutex { data: Some(RelationalProperty { output_columns: {1}, outer_columns: {}, used_columns: {1} }), poisoned: false, .. }, stat_info: Mutex { data: None, poisoned: false, .. }, applied_rules: AppliedRules { rules: RuleSet { rules: RoaringBitmap<[]> } } }, child_expr: Some(BoundColumnRef(BoundColumnRef { span: Some(29..30), column: ColumnBinding { database_name: Some("default"), table_name: Some("t1"), column_position: Some(1), table_index: Some(0), column_name: "a", index: 0, data_type: Number(Int32), visibility: Visible } })), compare_op: Some(Equal), output_column: ColumnBinding { database_name: Some("default"), table_name: Some("t2"), column_position: Some(1), table_index: Some(1), column_name: "b", index: 1, data_type: Number(Int32), visibility: Visible }, projection_index: None, data_type: Number(Int32), outer_columns: {} }), FunctionCall(FunctionCall { span: Some(59..60), func_name: "lt", params: [], arguments: [BoundColumnRef(BoundColumnRef { span: Some(57..58), column: ColumnBinding { database_name: Some("default"), table_name: Some("t1"), column_position: Some(1), table_index: Some(0), column_name: "a", index: 0, data_type: Number(Int32), visibility: Visible } }), ConstantExpr(ConstantExpr { span: Some(61..62), value: Number(2_u8) })] })] })), input_expr: None, index: None, child_expr: None } |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
Now: see tests

Closes #issue
