### PR TITLE
chore: try fix outer join

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -268,7 +268,7 @@ impl JoinHashTable {
             // Acquire write lock in current scope
             let mut chunks = self.row_space.chunks.write();
             if self.need_outer_scan() {
-                let outer_scan_bitmap = unsafe { &mut *self.outer_scan_bitmap.get() };
+                let mut outer_scan_bitmap = self.outer_scan_bitmap.write();
                 outer_scan_bitmap.push(MutableBitmap::from_len_zeroed(chunk.num_rows()));
             }
             chunks.push(chunk);

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state_impl.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state_impl.rs
@@ -479,7 +479,7 @@ impl HashJoinState for JoinHashTable {
     }
 
     fn generate_outer_scan_task(&self) -> Result<()> {
-        let outer_scan_bitmap = unsafe { &mut *self.outer_scan_bitmap.get() };
+        let outer_scan_bitmap = self.outer_scan_bitmap.read();
         let bitmap_num = outer_scan_bitmap.len();
         if bitmap_num == 0 {
             return Ok(());
@@ -524,7 +524,7 @@ impl HashJoinState for JoinHashTable {
             .iter()
             .fold(0, |acc, chunk| acc + chunk.num_rows());
 
-        let outer_scan_bitmap = unsafe { &mut *self.outer_scan_bitmap.get() };
+        let outer_scan_bitmap = self.outer_scan_bitmap.read();
         let interrupt = self.interrupt.clone();
         let chunk_index = task;
         if interrupt.load(Ordering::Relaxed) {
@@ -603,7 +603,7 @@ impl HashJoinState for JoinHashTable {
             .iter()
             .fold(0, |acc, chunk| acc + chunk.num_rows());
 
-        let outer_scan_bitmap = unsafe { &mut *self.outer_scan_bitmap.get() };
+        let outer_scan_bitmap = self.outer_scan_bitmap.read();
         let interrupt = self.interrupt.clone();
         let chunk_index = task;
         if interrupt.load(Ordering::Relaxed) {
@@ -651,7 +651,7 @@ impl HashJoinState for JoinHashTable {
             .iter()
             .fold(0, |acc, chunk| acc + chunk.num_rows());
 
-        let outer_scan_bitmap = unsafe { &mut *self.outer_scan_bitmap.get() };
+        let outer_scan_bitmap = self.outer_scan_bitmap.read();
         let interrupt = self.interrupt.clone();
         let chunk_index = task;
         if interrupt.load(Ordering::Relaxed) {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/join_hash_table.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/join_hash_table.rs
@@ -105,7 +105,7 @@ pub struct JoinHashTable {
     pub(crate) probe_schema: DataSchemaRef,
     pub(crate) interrupt: Arc<AtomicBool>,
     /// OuterScan bitmap
-    pub(crate) outer_scan_bitmap: Arc<SyncUnsafeCell<Vec<MutableBitmap>>>,
+    pub(crate) outer_scan_bitmap: Arc<RwLock<Vec<MutableBitmap>>>,
     /// Finalize tasks
     pub(crate) build_worker_num: Arc<AtomicU32>,
     pub(crate) finalize_tasks: Arc<RwLock<VecDeque<(usize, usize)>>>,
@@ -175,7 +175,7 @@ impl JoinHashTable {
             row_ptrs: RwLock::new(vec![]),
             probe_schema: probe_data_schema,
             interrupt: Arc::new(AtomicBool::new(false)),
-            outer_scan_bitmap: Arc::new(SyncUnsafeCell::new(Vec::new())),
+            outer_scan_bitmap: Arc::new(RwLock::new(Vec::new())),
             build_worker_num: Arc::new(AtomicU32::new(0)),
             finalize_tasks: Arc::new(RwLock::new(VecDeque::new())),
             outer_scan_tasks: Arc::new(RwLock::new(VecDeque::new())),

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_anti_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_anti_join.rs
@@ -40,8 +40,6 @@ impl JoinHashTable {
         let local_build_indexes = &mut probe_state.build_indexes;
         let local_build_indexes_ptr = local_build_indexes.as_mut_ptr();
 
-        let outer_scan_bitmap = unsafe { &mut *self.outer_scan_bitmap.get() };
-
         for (i, key) in keys_iter.enumerate() {
             let (mut match_count, mut incomplete_ptr) = self.probe_key(
                 hash_table,
@@ -63,8 +61,11 @@ impl JoinHashTable {
                         ));
                     }
 
-                    for row_ptr in local_build_indexes.iter() {
-                        outer_scan_bitmap[row_ptr.chunk_index].set(row_ptr.row_index, true);
+                    {
+                        let mut outer_scan_bitmap = self.outer_scan_bitmap.write();
+                        for row_ptr in local_build_indexes.iter() {
+                            outer_scan_bitmap[row_ptr.chunk_index].set(row_ptr.row_index, true);
+                        }
                     }
 
                     occupied = 0;
@@ -92,6 +93,7 @@ impl JoinHashTable {
             }
         }
 
+        let mut outer_scan_bitmap = self.outer_scan_bitmap.write();
         for row_ptr in local_build_indexes.iter().take(occupied) {
             outer_scan_bitmap[row_ptr.chunk_index].set(row_ptr.row_index, true);
         }
@@ -126,7 +128,6 @@ impl JoinHashTable {
         let num_rows = data_blocks
             .iter()
             .fold(0, |acc, chunk| acc + chunk.num_rows());
-        let outer_scan_bitmap = unsafe { &mut *self.outer_scan_bitmap.get() };
 
         for (i, key) in keys_iter.enumerate() {
             let (mut match_count, mut incomplete_ptr) = self.probe_key(
@@ -168,10 +169,12 @@ impl JoinHashTable {
                         )?;
 
                         if all_true {
+                            let mut outer_scan_bitmap = self.outer_scan_bitmap.write();
                             for row_ptr in local_build_indexes.iter() {
                                 outer_scan_bitmap[row_ptr.chunk_index].set(row_ptr.row_index, true);
                             }
                         } else if !all_false {
+                            let mut outer_scan_bitmap = self.outer_scan_bitmap.write();
                             // Safe to unwrap.
                             let validity = bm.unwrap();
                             let mut idx = 0;
@@ -232,10 +235,12 @@ impl JoinHashTable {
             )?;
 
             if all_true {
+                let mut outer_scan_bitmap = self.outer_scan_bitmap.write();
                 for row_ptr in local_build_indexes.iter().take(occupied) {
                     outer_scan_bitmap[row_ptr.chunk_index].set(row_ptr.row_index, true);
                 }
             } else if !all_false {
+                let mut outer_scan_bitmap = self.outer_scan_bitmap.write();
                 // Safe to unwrap.
                 let validity = bm.unwrap();
                 let mut idx = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR
Temporarily use `RWLock` to replace `SyncUnsafeCell`.

Closes #issue
