### PR TITLE
chore: state combinator wraps the whole function.

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_function_factory.rs
+++ b/src/query/functions/src/aggregates/aggregate_function_factory.rs
@@ -229,6 +229,9 @@ impl AggregateFunctionFactory {
                     }
                     Some(nested_desc) => {
                         *features = nested_desc.features.clone();
+                        if suffix == "_state" {
+                            features.returns_default_when_only_null = true;
+                        }
                         return (desc.creator)(
                             nested_name,
                             params,

--- a/tests/sqllogictests/suites/query/02_function/02_0000_function_aggregate_state
+++ b/tests/sqllogictests/suites/query/02_function/02_0000_function_aggregate_state
@@ -1,10 +1,9 @@
 query T
-select length(max_state(number)) from numbers(100);
+select length(max_state(number)), typeof(max_state(number)) from numbers(100);
 ----
-2
+3 VARCHAR
 
 query I
-select length(sum_state(number)) from numbers(10000);
+select length(sum_state(number)), typeof(max_state(number)) from numbers(10000);
 ----
-5
-
+6 VARCHAR


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

We need to hold a complete (nested) aggregation function in the state combinator to make the serialized state is complete (contains null bytes, etc)