### PR TITLE
feat(query): unnest function support variant data type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6336,7 +6336,7 @@ dependencies = [
 [[package]]
 name = "jsonb"
 version = "0.2.2"
-source = "git+https://github.com/datafuselabs/jsonb?rev=d1a401f#d1a401f2b8ccd040e18212c1aeca2575450bbead"
+source = "git+https://github.com/b41sh/jsonb?rev=191f2618ffcaa79b16cc367bf7a91ea4aa7cc5d8#191f2618ffcaa79b16cc367bf7a91ea4aa7cc5d8"
 dependencies = [
  "byteorder",
  "fast-float",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ opendal = { version = "0.37", features = [
 ] }
 ethnum = { version = "1.3.2" }
 ordered-float = { version = "3.6.0", default-features = false }
-jsonb = { git = "https://github.com/datafuselabs/jsonb", rev = "d1a401f" }
+jsonb = { git = "https://github.com/b41sh/jsonb", rev = "191f2618ffcaa79b16cc367bf7a91ea4aa7cc5d8" }
 
 # openraft = { version = "0.8.2", features = ["compat-07"] }
 # For debugging

--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -64,7 +64,6 @@ use jsonb::build_array;
 use jsonb::build_object;
 use jsonb::get_by_index;
 use jsonb::get_by_name;
-use jsonb::get_by_name_ignore_case;
 use jsonb::get_by_path;
 use jsonb::get_by_path_array;
 use jsonb::get_by_path_first;
@@ -237,7 +236,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     }
                 }
                 match std::str::from_utf8(name) {
-                    Ok(name) => match get_by_name(val, name) {
+                    Ok(name) => match get_by_name(val, name, false) {
                         Some(v) => {
                             output.push(&v);
                         }
@@ -275,7 +274,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 if idx < 0 || idx > i32::MAX.into() {
                     output.push_null();
                 } else {
-                    match get_by_index(val, idx as i32) {
+                    match get_by_index(val, idx as usize) {
                         Some(v) => {
                             output.push(&v);
                         }
@@ -300,7 +299,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     }
                 }
                 match std::str::from_utf8(name) {
-                    Ok(name) => match get_by_name_ignore_case(val, name) {
+                    Ok(name) => match get_by_name(val, name, true) {
                         Some(v) => output.push(&v),
                         None => output.push_null(),
                     },

--- a/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
+++ b/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
@@ -174,6 +174,12 @@ CREATE TABLE IF NOT EXISTS t4(id Int null, arr Array(Int64)) Engine = Fuse
 statement ok
 insert into t4 values(1, [10,20,30,40]), (2, [50,60,70,80])
 
+statement ok
+CREATE TABLE IF NOT EXISTS t5(id Int null, obj Variant null) Engine = Fuse
+
+statement ok
+insert into t5 values(1, '{"car_no":10,"测试\\"\\uD83D\\uDC8E":"a"}'), (2, '{"car_no":20}')
+
 query T
 select get(arr, 0) from t1
 ----
@@ -412,6 +418,46 @@ select id, json_path_query_first(obj, '$.b?(@.c > 2)') from t2
 
 statement error 1001
 select id, json_path_query_first(obj, '--') from t2
+
+query T
+select get(obj, 'car_no') from t5
+----
+10
+20
+
+query T
+select get_path(obj, '["car_no"]') from t5
+10
+20
+
+query T
+select get(obj, '测试\"💎') from t5
+----
+"a"
+NULL
+
+query T
+select get_path(obj, '["测试\\"\\uD83D\\uDC8E"]') from t5
+----
+"a"
+NULL
+
+query T
+select json_path_query(obj, '$.测试\\"\\uD83D\\uDC8E') from t5
+----
+"a"
+
+query T
+select json_path_query_array(obj, '$.测试\\"\\uD83D\\uDC8E') from t5
+----
+["a"]
+[]
+
+query T
+select json_path_query_first(obj, '$.测试\\"\\uD83D\\uDC8E') from t5
+----
+"a"
+NULL
 
 statement ok
 DROP DATABASE IF EXISTS db1

--- a/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
+++ b/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest
@@ -437,3 +437,15 @@ select * from unnest([[[1,2], [3,4]], [[5,6], [7,8,9]]]);
 7
 8
 9
+
+query T
+select unnest(parse_json('[1,2,"a",[3,4]]'))
+----
+1
+2
+"a"
+[3,4]
+
+query T
+select unnest(parse_json('"a"'))
+----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- unnest function support variant data type
- fix json path wrong key name 

Closes #issue
