### PR TITLE
fix(planner): check unicode to prevent invalid string index access

### DIFF
--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -303,7 +303,12 @@ impl<W: AsyncWrite + Send + Unpin> InteractiveWorkerBase<W> {
     // Here we fake some values for the command which Databend not supported.
     fn federated_server_command_check(&self, query: &str) -> Option<(DataSchemaRef, DataBlock)> {
         // INSERT don't need MySQL federated check
-        if query.len() > 6 && query[..6].eq_ignore_ascii_case("INSERT") {
+        // Ensure the query is start with ASCII chars so we won't
+        // panic when we slice the query string.
+        if query.len() > 6
+            && query.char_indices().take(6).all(|(_, c)| c.is_ascii())
+            && query[..6].eq_ignore_ascii_case("INSERT")
+        {
             return None;
         }
         let federated = MySQLFederated::create();

--- a/tests/sqllogictests/suites/query/issues/issue_11809.test
+++ b/tests/sqllogictests/suites/query/issues/issue_11809.test
@@ -1,0 +1,13 @@
+query I
+--总共
+select * from numbers(1);
+----
+0
+
+query I
+--总共总共总共总共
+--总共总共总共
+select * from numbers(1);
+----
+0
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

We will do some special checks for the queries from MySQL clients.

In case a query starts with some Unicode characters, e.g. comment like `--总共`, it may panic because of invalid index access of the string.

We may need a better way to skip the `INSERT` statement in the future.

Close #11809 