### PR TITLE
feat: CSV allow at most 1000 extra fields.

### DIFF
--- a/src/query/pipeline/sources/src/input_formats/impls/input_format_csv.rs
+++ b/src/query/pipeline/sources/src/input_formats/impls/input_format_csv.rs
@@ -44,7 +44,7 @@ use crate::input_formats::InputFormatTextBase;
 use crate::input_formats::RowBatch;
 use crate::input_formats::SplitInfo;
 
-const MAX_CSV_COLUMNS: usize = 1024;
+const MAX_CSV_COLUMNS: usize = 1000;
 
 pub struct InputFormatCSV {}
 
@@ -154,9 +154,9 @@ impl InputFormatTextBase for InputFormatCSV {
             .build();
         let projection = ctx.projection.clone();
         let max_fields = match &projection {
-            Some(p) => std::cmp::max(p.iter().copied().max().unwrap_or(1) + 1, MAX_CSV_COLUMNS),
-            None => ctx.schema.num_fields() + 6,
-        };
+            Some(p) => p.iter().copied().max().unwrap_or(1),
+            None => ctx.schema.num_fields(),
+        } + MAX_CSV_COLUMNS;
         Ok(CsvReaderState {
             common: AligningStateCommon::create(split_info, false, csv_params.headers as usize),
             ctx: ctx.clone(),


### PR DESCRIPTION
used in :

1. select $<column_position>
2. copy with on_error=continue

both need to tolerant more fields than expected, but too many fields maybe indicate something wrong in format options or the files. 
for CSV, this limitation also allows a more efficient implementation.

doc: https://github.com/datafuselabs/databend/pull/11813

reason



I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

Closes #issue
