### PR TITLE
fix: sanitize the headers in request log

### DIFF
--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -224,15 +224,16 @@ impl<E: Endpoint> Endpoint for HTTPSessionEndpoint<E> {
     }
 }
 
-fn sanitize_request_headers(headers: &HeaderMap) -> HashMap<&str, String> {
+fn sanitize_request_headers(headers: &HeaderMap) -> HashMap<String, String> {
     let sensitive_headers = vec!["authorization", "x-clickhouse-key", "cookie"];
     headers
         .iter()
         .map(|(k, v)| {
+            let k = k.as_str().to_lowercase();
             if sensitive_headers.contains(&k.as_str()) {
-                (k.as_str(), "******".to_string())
+                (k, "******".to_string())
             } else {
-                (k.as_str(), v.to_str().unwrap_or_default().to_string())
+                (k, v.to_str().unwrap_or_default().to_string())
             }
         })
         .collect()

--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -21,6 +21,7 @@ use headers::authorization::Basic;
 use headers::authorization::Bearer;
 use headers::authorization::Credentials;
 use http::header::AUTHORIZATION;
+use http::HeaderMap;
 use http::HeaderValue;
 use poem::error::Error as PoemError;
 use poem::error::Result as PoemResult;
@@ -158,6 +159,7 @@ pub struct HTTPSessionEndpoint<E> {
     pub kind: HttpHandlerKind,
     pub auth_manager: Arc<AuthMgr>,
 }
+
 impl<E> HTTPSessionEndpoint<E> {
     #[async_backtrace::framed]
     async fn auth(&self, req: &Request) -> Result<HttpQueryContext> {
@@ -189,7 +191,12 @@ impl<E: Endpoint> Endpoint for HTTPSessionEndpoint<E> {
     #[async_backtrace::framed]
     async fn call(&self, mut req: Request) -> PoemResult<Self::Output> {
         // method, url, version, header
-        info!("receive http handler request: {req:?},");
+        info!(
+            "http session endpoint: got new request: {} {} {:?}",
+            req.method(),
+            req.uri(),
+            sanitize_request_headers(req.headers()),
+        );
         let res = match self.auth(&req).await {
             Ok(ctx) => {
                 req.extensions_mut().insert(ctx);
@@ -215,4 +222,18 @@ impl<E: Endpoint> Endpoint for HTTPSessionEndpoint<E> {
             Ok(res) => Ok(res.into_response()),
         }
     }
+}
+
+fn sanitize_request_headers(headers: &HeaderMap) -> HashMap<&str, String> {
+    let sensitive_headers = vec!["authorization", "x-clickhouse-key", "cookie"];
+    headers
+        .iter()
+        .map(|(k, v)| {
+            if sensitive_headers.contains(&k.as_str()) {
+                (k.as_str(), "******".to_string())
+            } else {
+                (k.as_str(), v.to_str().unwrap_or_default().to_string())
+            }
+        })
+        .collect()
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently the request log may print the headers into logs, this may introduce some security risks.

This PR sanitize the headers in the request log.