### PR TITLE
docs: support ON_ERROR=abort_N

### DIFF
--- a/docs/doc/14-sql-commands/10-dml/dml-copy-into-table.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-copy-into-table.md
@@ -216,7 +216,7 @@ copyOptions ::=
 | PURGE                 | If `True`, the command will purge the files in the stage after they are loaded successfully into the table. Default: `False`.                                                                                            | Optional |
 | FORCE                 | Defaults to `False` meaning the command will skip duplicate files in the stage when copying data. If `True`, duplicate files will not be skipped.                                                                        | Optional |
 | DISABLE_VARIANT_CHECK | If `True`, this will allow the variant field to insert invalid JSON strings. Default: `False`.                                                                                                                           | Optional |
-| ON_ERROR              | Provides options to handle a file containing errors. Select `continue` to skip the file and continue, or `abort_N` to abort the load operation when num of error >= N, the default values is abort, which means abort_1. | Optional |
+| ON_ERROR              | Provides options to handle a file containing errors. Select 'continue' to skip the file and proceed, or 'abort_N' to terminate the load operation when the number of errors is equal to or greater than N. The default value is 'abort', which is equivalent to 'abort_1'. | Optional |
 | MAX_FILES             | Sets the maximum number of files to load. Defaults to `0` meaning no limits.                                                                                                                                             | Optional |
 
 :::info

--- a/docs/doc/14-sql-commands/10-dml/dml-copy-into-table.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-copy-into-table.md
@@ -206,18 +206,18 @@ copyOptions ::=
   [ PURGE = <bool> ]
   [ FORCE = <bool> ]
   [ DISABLE_VARIANT_CHECK = <bool> ]
-  [ ON_ERROR = { continue | abort } ]
+  [ ON_ERROR = { continue | abort | abort_N } ]
   [ MAX_FILES = <num> ]
 ```
 
-| Parameter             | Description                                                                                                                                             | Required |
-|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| SIZE_LIMIT            | Specifies the maximum rows of data to be loaded for a given COPY statement. Defaults to `0` meaning no limits.                                          | Optional |
-| PURGE                 | If `True`, the command will purge the files in the stage after they are loaded successfully into the table. Default: `False`.                           | Optional |
-| FORCE                 | Defaults to `False` meaning the command will skip duplicate files in the stage when copying data. If `True`, duplicate files will not be skipped.       | Optional |
-| DISABLE_VARIANT_CHECK | If `True`, this will allow the variant field to insert invalid JSON strings. Default: `False`.                                                           | Optional |
-| ON_ERROR              | Provides options to handle a file containing errors. Select `continue` to skip the file and continue, or `abort` (default) to abort the load operation. | Optional |
-| MAX_FILES             | Sets the maximum number of files to load. Defaults to `0` meaning no limits.                                                                             | Optional |
+| Parameter             | Description                                                                                                                                                                                                              | Required |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| SIZE_LIMIT            | Specifies the maximum rows of data to be loaded for a given COPY statement. Defaults to `0` meaning no limits.                                                                                                           | Optional |
+| PURGE                 | If `True`, the command will purge the files in the stage after they are loaded successfully into the table. Default: `False`.                                                                                            | Optional |
+| FORCE                 | Defaults to `False` meaning the command will skip duplicate files in the stage when copying data. If `True`, duplicate files will not be skipped.                                                                        | Optional |
+| DISABLE_VARIANT_CHECK | If `True`, this will allow the variant field to insert invalid JSON strings. Default: `False`.                                                                                                                           | Optional |
+| ON_ERROR              | Provides options to handle a file containing errors. Select `continue` to skip the file and continue, or `abort_N` to abort the load operation when num of error >= N, the default values is abort, which means abort_1. | Optional |
+| MAX_FILES             | Sets the maximum number of files to load. Defaults to `0` meaning no limits.                                                                                                                                             | Optional |
 
 :::info
 The parameter ON_ERROR currently does not work for parquet files.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
cc @wubx 
Closes #issue
