### PR TITLE
chore: remove disk cache when query init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9945,7 +9945,6 @@ dependencies = [
  "siphasher",
  "tempfile",
  "tracing",
- "walkdir",
 ]
 
 [[package]]

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -27,7 +27,6 @@ metrics = "0.20.1"
 parking_lot = "0.12.1"
 siphasher = "0.3.10"
 tracing = "0.1.36"
-walkdir = "2.3.2"
 
 [dev-dependencies]
 tempfile = "3.4.0"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: remove disk cache when query init

Closes #issue
