### PR TITLE
fix: consider lazy columns when pruning unused columns.

### DIFF
--- a/src/query/sql/src/planner/optimizer/heuristic/heuristic.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/heuristic.rs
@@ -84,13 +84,15 @@ impl HeuristicOptimizer {
         }
 
         // always pruner the unused columns before and after optimization
-        let pruner = UnusedColumnPruner::new(self.metadata.clone());
+        // Don't consider lazy columns pruning in pre optimize, because the order of each operator is not determined.
+        let pruner = UnusedColumnPruner::new(self.metadata.clone(), false);
         let require_columns: ColumnSet = self.bind_context.column_set();
         pruner.remove_unused_columns(&s_expr, require_columns)
     }
 
     fn post_optimize(&self, s_expr: SExpr) -> Result<SExpr> {
-        let pruner = UnusedColumnPruner::new(self.metadata.clone());
+        // Consider lazy columns pruning in post optimize
+        let pruner = UnusedColumnPruner::new(self.metadata.clone(), true);
         let require_columns: ColumnSet = self.bind_context.column_set();
         pruner.remove_unused_columns(&s_expr, require_columns)
     }

--- a/tests/sqllogictests/suites/mode/standalone/explain/lazy_read.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lazy_read.test
@@ -75,6 +75,46 @@ EvalScalar
         ├── push downs: [filters: [], limit: 2]
         └── estimated rows: 0.00
 
+# ISSUE #11831
+
+statement ok
+create table if not exists t_11831 (uid uint64, c1 string, c2 string, time uint64);
+
+query T
+explain SELECT * FROM (SELECT * FROM t_11831 WHERE time >= 1686672000000 AND time <= 1686758399000) AS t1 WHERE uid = 11 ORDER BY time DESC LIMIT 10;
+----
+EvalScalar
+├── expressions: [t1.uid (#0), t1.c1 (#1), t1.c2 (#2), t1.time (#3)]
+├── estimated rows: 0.00
+└── RowFetch
+    ├── columns to fetch: [c1, c2]
+    ├── estimated rows: 0.00
+    └── Limit
+        ├── limit: 10
+        ├── offset: 0
+        ├── estimated rows: 0.00
+        └── Sort
+            ├── sort keys: [time DESC NULLS LAST]
+            ├── estimated rows: 0.00
+            └── EvalScalar
+                ├── expressions: [t_11831.uid (#0), t_11831.time (#3)]
+                ├── estimated rows: 0.00
+                └── Filter
+                    ├── filters: [t1.uid (#0) = 11, t_11831.time (#3) >= 1686672000000, t_11831.time (#3) <= 1686758399000]
+                    ├── estimated rows: 0.00
+                    └── TableScan
+                        ├── table: default.default.t_11831
+                        ├── read rows: 0
+                        ├── read bytes: 0
+                        ├── partitions total: 0
+                        ├── partitions scanned: 0
+                        ├── push downs: [filters: [and_filters(CAST(and_filters(CAST(and_filters(CAST(and_filters(CAST(t_11831.time (#3) >= 1686672000000 AS Boolean NULL), CAST(t_11831.time (#3) <= 1686758399000 AS Boolean NULL)) AS Boolean NULL), CAST(t1.uid (#0) = 11 AS Boolean NULL)) AS Boolean NULL), CAST(t_11831.time (#3) >= 1686672000000 AS Boolean NULL)) AS Boolean NULL), CAST(t_11831.time (#3) <= 1686758399000 AS Boolean NULL))], limit: NONE]
+                        ├── output columns: [uid, time, _row_id]
+                        └── estimated rows: 0.00
+
+statement ok
+drop table t_11831
+
 statement ok
 set lazy_read_threshold=0
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`UnusedColumnPruner` should consider lazy columns and remove them from `require_columns`.

Closes #11831
