### PR TITLE
fix: deletion with sub query

### DIFF
--- a/src/query/storages/fuse/src/operations/mutation/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutation_source.rs
@@ -227,10 +227,11 @@ impl Processor for MutationSource {
                     };
 
                     if affect_rows != 0 {
+                        // Pop the row_id column
                         if self.query_row_id_col {
-                            // remove the row_id_col
                             data_block = data_block.pop_columns(1)?;
                         }
+
                         let progress_values = ProgressValues {
                             rows: affect_rows,
                             bytes: 0,
@@ -265,10 +266,6 @@ impl Processor for MutationSource {
                                 }
                             }
                             MutationAction::Update => {
-                                // Pop the row_id column
-                                if self.query_row_id_col {
-                                    data_block = data_block.pop_columns(1)?;
-                                }
                                 if self.remain_reader.is_none() {
                                     data_block.add_column(BlockEntry::new(
                                         DataType::Boolean,

--- a/src/query/storages/fuse/src/operations/mutation/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutation_source.rs
@@ -227,6 +227,10 @@ impl Processor for MutationSource {
                     };
 
                     if affect_rows != 0 {
+                        if self.query_row_id_col {
+                            // remove the row_id_col
+                            data_block = data_block.pop_columns(1)?;
+                        }
                         let progress_values = ProgressValues {
                             rows: affect_rows,
                             bytes: 0,

--- a/tests/sqllogictests/suites/mode/cluster/distributed_delete.sql
+++ b/tests/sqllogictests/suites/mode/cluster/distributed_delete.sql
@@ -70,7 +70,7 @@ select * from v_after_deletion order by id except select * from t order by id;
 ----
 
 query III
-select *from t order by id except select * from v_after_deletion order by id;
+select * from t order by id except select * from v_after_deletion order by id;
 ----
 
 query I

--- a/tests/sqllogictests/suites/mode/cluster/distributed_delete.sql
+++ b/tests/sqllogictests/suites/mode/cluster/distributed_delete.sql
@@ -41,3 +41,52 @@ query I
 select (select sum(c2) from t_origin where id % 3 != 0 or id <= 500) = (select sum(c2) from t);
 ----
 1
+
+# for issue #11784 https://github.com/datafuselabs/databend/issues/11784
+
+statement ok
+drop table if exists t;
+
+statement ok
+drop table if exists del_id;
+
+statement ok
+create table t (id int, c1 int, c2 int) row_per_block=3;
+
+statement ok
+insert into t select number, number * 5, number * 7 from numbers(50);
+
+statement ok
+create table del_id (id int) as select cast(FLOOR(0 + RAND(number) * 50), int) from numbers(10);
+
+statement ok
+delete from t where id in (select id from del_id);
+
+statement ok
+create view v_after_deletion as select number as id, number * 5 as c1, number * 7 as c2 from numbers(50) where id not in (select * from del_id);
+
+query III
+select * from v_after_deletion order by id except select * from t order by id;
+----
+
+query III
+select *from t order by id except select * from v_after_deletion order by id;
+----
+
+query I
+select (select count() from v_rows_deleted) = (select count() from t);
+----
+1
+
+statement ok
+drop table t;
+
+statement ok
+drop view after_deletion;
+
+statement ok
+drop table if exists del_id;
+
+
+
+

--- a/tests/sqllogictests/suites/mode/cluster/distributed_delete.sql
+++ b/tests/sqllogictests/suites/mode/cluster/distributed_delete.sql
@@ -74,7 +74,7 @@ select * from t order by id except select * from v_after_deletion order by id;
 ----
 
 query I
-select (select count() from v_rows_deleted) = (select count() from t);
+select (select count() from v_after_deletion) = (select count() from t);
 ----
 1
 
@@ -82,7 +82,7 @@ statement ok
 drop table t;
 
 statement ok
-drop view after_deletion;
+drop view v_after_deletion;
 
 statement ok
 drop table if exists del_id;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix issue
- #11784 

Remove the internal column `row_id_col`  before performing row deletions, otherwise, the data block generated after deletion will be incorrect.



Closes #11784
