### PR TITLE
fix(query): parse string ignores unescape `\"`

### DIFF
--- a/src/common/io/src/cursor_ext/cursor_read_string_ext.rs
+++ b/src/common/io/src/cursor_ext/cursor_read_string_ext.rs
@@ -60,7 +60,6 @@ where T: AsRef<[u8]>
                     b'0' => buf.push(b'\0'),
                     b'\'' => buf.push(b'\''),
                     b'\\' => buf.push(b'\\'),
-                    b'\"' => buf.push(b'\"'),
                     _ => {
                         buf.push(b'\\');
                         buf.push(c);
@@ -165,7 +164,6 @@ where T: AsRef<[u8]>
                         check_pos(pos + 1, positions)?;
                         buf.push(b'\\');
                     }
-                    b'\"' => buf.push(b'\"'),
                     _ => {
                         buf.push(b'\\');
                         buf.push(c);

--- a/src/query/ast/src/parser/unescape.rs
+++ b/src/query/ast/src/parser/unescape.rs
@@ -28,7 +28,6 @@ pub fn unescape_string(s: &str, quote: char) -> Option<String> {
                 Some('r') => s.push('\r'),
                 Some('t') => s.push('\t'),
                 Some('\'') => s.push('\''),
-                Some('\"') => s.push('\"'),
                 Some('\\') => s.push('\\'),
                 Some('u') => s.push(unescape_unicode(&mut chars)?),
                 Some('x') => s.push(unescape_byte(&mut chars)?),

--- a/src/query/functions/tests/it/scalars/testdata/string.txt
+++ b/src/query/functions/tests/it/scalars/testdata/string.txt
@@ -357,12 +357,12 @@ output         : 'a\'b'
 
 
 ast            : quote('a\"b')
-raw expr       : quote('a"b')
-checked expr   : quote<String>("a\"b")
-optimized expr : "a\\\"b"
+raw expr       : quote('a\"b')
+checked expr   : quote<String>("a\\\"b")
+optimized expr : "a\\\\\\\"b"
 output type    : String
-output domain  : {"a\\\"b"..="a\\\"b"}
-output         : 'a\"b'
+output domain  : {"a\\\\\\\"b"..="a\\\\\\\"b"}
+output         : 'a\\\"b'
 
 
 ast            : quote('a\bb')

--- a/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values
+++ b/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values
@@ -46,8 +46,8 @@ onlyif mysql
 query T
 select * from t_str order by a
 ----
-a"b"c'd
-a"b"c\'d
+a"b\"c'd
+a"b\"c\'d
 
 statement ok
 create table if not exists st1(a string)

--- a/tests/sqllogictests/suites/base/03_common/03_0018_insert_into_variant
+++ b/tests/sqllogictests/suites/base/03_common/03_0018_insert_into_variant
@@ -22,6 +22,7 @@ INSERT INTO t1 (id, var) VALUES(1, '{"a":')
 statement error 1046
 INSERT INTO t1 (id, var) VALUES(1, [1,2,3])
 
+skipif clickhouse
 query IT
 select * from t1 order by id asc
 ----

--- a/tests/sqllogictests/suites/base/03_common/03_0018_insert_into_variant
+++ b/tests/sqllogictests/suites/base/03_common/03_0018_insert_into_variant
@@ -11,7 +11,7 @@ statement ok
 CREATE TABLE IF NOT EXISTS t1(id Int null, var Variant null) Engine = Fuse
 
 statement ok
-INSERT INTO t1 (id, var) VALUES(1, null), (2, true),(3, false),(4, 1),(5, -1),(6, 1000),(7, -1000),(8, 9223372036854775807),(9, -9223372036854775808),(10, 18446744073709551615),(11, 0.12345679),(12, 0.12345678912121212),(13, '"abcd"'),(14, '[1,2,3]'),(15, '{"k":"v"}')
+INSERT INTO t1 (id, var) VALUES(1, null), (2, true),(3, false),(4, 1),(5, -1),(6, 1000),(7, -1000),(8, 9223372036854775807),(9, -9223372036854775808),(10, 18446744073709551615),(11, 0.12345679),(12, 0.12345678912121212),(13, '"abcd"'),(14, '[1,2,3]'),(15, '{"k":"v"}'),(16, '"a\"b\\"c"')
 
 statement error 1001
 INSERT INTO t1 (id, var) VALUES(1, 'abc')
@@ -40,6 +40,7 @@ select * from t1 order by id asc
 13 "abcd"
 14 [1,2,3]
 15 {"k":"v"}
+16 "a\"b\"c"
 
 statement ok
 CREATE TABLE IF NOT EXISTS t2(id Int null, arr Json null) Engine = Fuse
@@ -194,3 +195,4 @@ select * from t4 where id >= 1 and 'vv' = m:b:k
 
 statement ok
 DROP DATABASE db1
+

--- a/tests/sqllogictests/suites/query/02_function/02_0023_function_strings_quote
+++ b/tests/sqllogictests/suites/query/02_function/02_0023_function_strings_quote
@@ -14,7 +14,7 @@ onlyif mysql
 query T
 select quote('a\"b')
 ----
-a\"b
+a\\\"b
 
 onlyif mysql
 query T

--- a/tests/sqllogictests/suites/query/02_function/02_0048_function_semi_structureds_parse_json
+++ b/tests/sqllogictests/suites/query/02_function/02_0048_function_semi_structureds_parse_json
@@ -60,7 +60,7 @@ select parse_json('{ "x" : "abc", "y" : false, "z": 10} ')
 
 skipif clickhouse
 query T
-select parse_json('{ "test" : "\\"abc\\"测试⚠️✅❌မြန်မာဘာသာ" } ')
+select parse_json('{ "test" : "\\"abc\"测试⚠️✅❌မြန်မာဘာသာ" } ')
 ----
 {"test":"\"abc\"测试⚠️✅❌မြန်မာဘာသာ"}
 

--- a/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
+++ b/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
@@ -432,7 +432,7 @@ select get_path(obj, '["car_no"]') from t5
 20
 
 query T
-select get(obj, '测试\"💎') from t5
+select get(obj, '测试"💎') from t5
 ----
 "a"
 NULL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

parse string ignores unescape `\"`, so that we can parse json string with `\"`.
for example 
```sql
mysql> select parse_json('"a\"b"');
+-----------------------+
| parse_json('"a\\"b"') |
+-----------------------+
| "a\"b"                |
+-----------------------+
1 row in set (0.04 sec)
```

Closes #issue
