### PR TITLE
fix: only cache query result from fuse table.

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -387,6 +387,10 @@ pub trait Table: Sync + Send {
     fn is_stage_table(&self) -> bool {
         false
     }
+
+    fn result_can_be_cached(&self) -> bool {
+        false
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -375,6 +375,11 @@ impl PhysicalPlanBuilder {
 
         let table_entry = metadata.table(scan.table_index);
         let table = table_entry.table();
+
+        if !table.result_can_be_cached() {
+            self.ctx.set_cacheable(false);
+        }
+
         let mut table_schema = table.schema();
         if !project_internal_columns.is_empty() {
             let mut schema = table_schema.as_ref().clone();
@@ -434,6 +439,11 @@ impl PhysicalPlanBuilder {
                     .get_catalog(CATALOG_DEFAULT)?
                     .get_table(self.ctx.get_tenant().as_str(), "system", "one")
                     .await?;
+
+                if !table.result_can_be_cached() {
+                    self.ctx.set_cacheable(false);
+                }
+
                 let source = table
                     .read_plan_with_catalog(
                         self.ctx.clone(),

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -184,10 +184,6 @@ impl Binder {
                         .await;
                 }
 
-                if database == "system" {
-                    self.ctx.set_cacheable(false);
-                }
-
                 let tenant = self.ctx.get_tenant();
 
                 let navigation_point = match travel_point {

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -723,6 +723,10 @@ impl Table for FuseTable {
     fn support_row_id_column(&self) -> bool {
         true
     }
+
+    fn result_can_be_cached(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/query/storages/result_cache/src/table_function/table.rs
+++ b/src/query/storages/result_cache/src/table_function/table.rs
@@ -146,4 +146,8 @@ impl Table for ResultScan {
         }
         Ok(())
     }
+
+    fn result_can_be_cached(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache
+++ b/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache
@@ -33,6 +33,16 @@ a
 b
 c
 
+query I
+SELECT count(*) FROM t1;
+----
+3
+
+query I
+select block_count as c from fuse_snapshot('db20_13','t1') order by c;
+----
+1
+
 statement ok
 SET enable_query_result_cache = 1;
 
@@ -58,6 +68,17 @@ SELECT * FROM t1, t2 ORDER BY a, b;
 3 b
 3 c
 
+# Not cached
+query I
+SELECT count(*) FROM t1;
+----
+3
+
+query I
+select block_count as c from fuse_snapshot('db20_13','t1') order by c;
+----
+1
+
 # Read cache
 
 query I
@@ -80,10 +101,34 @@ SELECT * FROM t1, t2 ORDER BY a, b;
 3 b
 3 c
 
+# Not cached
+query I
+SELECT count(*) FROM t1;
+----
+3
+
+query I
+select block_count as c from fuse_snapshot('db20_13','t1') order by c;
+----
+1
+
+
 # Insert new data
 
 statement ok
 INSERT INTO t1 VALUES (4), (5), (6);
+
+# Not cached
+query I
+SELECT count(*) FROM t1;
+----
+6
+
+query I
+select block_count as c from fuse_snapshot('db20_13','t1') order by c;
+----
+1
+2
 
 statement ok
 SET enable_query_result_cache = 0;
@@ -119,6 +164,18 @@ SELECT * FROM t1, t2 ORDER BY a, b;
 6 a
 6 b
 6 c
+
+# Not cached
+query I
+SELECT count(*) FROM t1;
+----
+6
+
+query I
+select block_count as c from fuse_snapshot('db20_13','t1') order by c;
+----
+1
+2
 
 # tolerate inconsistent result cache
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Make `result_can_be_cached` as a property of the `Table` trait. And only result from fuse table can be cached now.

Closes #11820
