### PR TITLE
fix(query): dataframe sort api need bind projection

### DIFF
--- a/src/query/sql/src/planner/dataframe.rs
+++ b/src/query/sql/src/planner/dataframe.rs
@@ -358,6 +358,16 @@ impl Dataframe {
             )
             .await?;
 
+        self.s_expr = self.binder.bind_projection(
+            &mut self.bind_context,
+            &projections,
+            &scalar_items,
+            self.s_expr,
+        )?;
+        self.s_expr = self
+            .bind_context
+            .add_internal_column_into_expr(self.s_expr.clone());
+
         Ok(self)
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

dataframe sort api need bind projection

Closes #issue
