### PR TITLE
refactor: copy use BlockMetaInfo to pass RowBatch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,7 +2446,6 @@ dependencies = [
  "common-pipeline-core",
  "common-settings",
  "common-storage",
- "crossbeam-channel",
  "csv-core",
  "dashmap",
  "futures",

--- a/src/query/pipeline/core/src/pipeline.rs
+++ b/src/query/pipeline/core/src/pipeline.rs
@@ -188,13 +188,17 @@ impl Pipeline {
     }
 
     /// Add a ResizePipe to pipes
-    pub fn resize(&mut self, new_size: usize) -> Result<()> {
+    pub fn try_resize(&mut self, new_size: usize) -> Result<()> {
+        self.resize(new_size, false)
+    }
+
+    pub fn resize(&mut self, new_size: usize, force: bool) -> Result<()> {
         match self.pipes.last() {
             None => Err(ErrorCode::Internal("Cannot resize empty pipe.")),
             Some(pipe) if pipe.output_length == 0 => {
                 Err(ErrorCode::Internal("Cannot resize empty pipe."))
             }
-            Some(pipe) if pipe.output_length == new_size => Ok(()),
+            Some(pipe) if !force && pipe.output_length == new_size => Ok(()),
             Some(pipe) => {
                 let processor = ResizeProcessor::create(pipe.output_length, new_size);
                 let inputs_port = processor.get_inputs().to_vec();

--- a/src/query/pipeline/sources/Cargo.toml
+++ b/src/query/pipeline/sources/Cargo.toml
@@ -29,7 +29,6 @@ common-storage = { path = "../../../common/storage" }
 
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
 bstr = "1.0.1"
-crossbeam-channel = "0.5.6"
 csv-core = "0.1.10"
 dashmap = "5.4.0"
 futures = "0.3.24"

--- a/src/query/pipeline/sources/src/input_formats/impls/input_format_parquet.rs
+++ b/src/query/pipeline/sources/src/input_formats/impls/input_format_parquet.rs
@@ -36,6 +36,7 @@ use common_arrow::parquet::metadata::RowGroupMetaData;
 use common_arrow::parquet::read::read_metadata;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_expression::BlockMetaInfo;
 use common_expression::DataBlock;
 use common_expression::DataField;
 use common_expression::DataSchema;
@@ -236,6 +237,7 @@ impl DynData for SplitMeta {
     }
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct RowGroupInMemory {
     pub split_info: String,
     pub meta: RowGroupMetaData,
@@ -254,6 +256,21 @@ impl RowBatchTrait for RowGroupInMemory {
 
     fn rows(&self) -> usize {
         self.meta.num_rows()
+    }
+}
+
+#[typetag::serde(name = "row_batch_parquet")]
+impl BlockMetaInfo for RowGroupInMemory {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
+        unreachable!("RowGroupInMemory as BlockMetaInfo is not expected to be compared.")
+    }
+
+    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
+        unreachable!("RowGroupInMemory as BlockMetaInfo is not expected to be cloned.")
     }
 }
 

--- a/src/query/pipeline/sources/src/input_formats/input_format_text.rs
+++ b/src/query/pipeline/sources/src/input_formats/input_format_text.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::mem;
@@ -22,6 +23,7 @@ use common_compress::DecompressState;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::types::string::StringColumnBuilder;
+use common_expression::BlockMetaInfo;
 use common_expression::Column;
 use common_expression::ColumnBuilder;
 use common_expression::DataBlock;
@@ -352,6 +354,7 @@ impl<T: InputFormatTextBase> InputFormat for T {
     }
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct RowBatch {
     pub data: Vec<u8>,
     pub row_ends: Vec<usize>,
@@ -385,6 +388,21 @@ impl RowBatchTrait for RowBatch {
 
     fn rows(&self) -> usize {
         self.row_ends.len()
+    }
+}
+
+#[typetag::serde(name = "row_batch")]
+impl BlockMetaInfo for RowBatch {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
+        unreachable!("RowBatch as BlockMetaInfo is not expected to be compared.")
+    }
+
+    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
+        unreachable!("RowBatch as BlockMetaInfo is not expected to be cloned.")
     }
 }
 

--- a/src/query/pipeline/sources/src/input_formats/transform_deserializer.rs
+++ b/src/query/pipeline/sources/src/input_formats/transform_deserializer.rs
@@ -17,13 +17,13 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use common_exception::Result;
+use common_expression::BlockMetaInfoDowncast;
 use common_expression::DataBlock;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::port::OutputPort;
 use common_pipeline_core::processors::processor::Event;
 use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
-use crossbeam_channel::TryRecvError;
 
 use crate::input_formats::input_pipeline::BlockBuilderTrait;
 use crate::input_formats::input_pipeline::InputFormatPipe;
@@ -59,7 +59,6 @@ pub struct DeserializeTransformer<I: InputFormatPipe> {
     processor: DeserializeProcessor<I>,
     input: Arc<InputPort>,
     output: Arc<OutputPort>,
-    rx: crossbeam_channel::Receiver<I::RowBatch>,
     flushing: bool,
 }
 
@@ -68,14 +67,12 @@ impl<I: InputFormatPipe> DeserializeTransformer<I> {
         ctx: Arc<InputContext>,
         input: Arc<InputPort>,
         output: Arc<OutputPort>,
-        rx: crossbeam_channel::Receiver<I::RowBatch>,
     ) -> Result<ProcessorPtr> {
         let processor = DeserializeProcessor::create(ctx)?;
         Ok(ProcessorPtr::create(Box::new(Self {
             processor,
             input,
             output,
-            rx,
             flushing: false,
         })))
     }
@@ -108,38 +105,22 @@ impl<I: InputFormatPipe> Processor for DeserializeTransformer<I> {
                 None => {
                     if self.processor.input_buffer.is_some() {
                         Ok(Event::Sync)
-                    } else {
-                        if self.input.has_data() {
-                            self.input.pull_data();
-                            match self.rx.try_recv() {
-                                Ok(read_batch) => {
-                                    self.processor.input_buffer = Some(read_batch);
-                                    return Ok(Event::Sync);
-                                }
-                                Err(TryRecvError::Disconnected) => {
-                                    tracing::warn!("DeserializeTransformer rx disconnected");
-                                    self.input.finish();
-                                    self.flushing = true;
-                                    return Ok(Event::Finished);
-                                }
-                                Err(TryRecvError::Empty) => {
-                                    // do nothing
-                                }
-                            }
-                        }
-                        //  !has_data() or try_recv return Empty
-                        if self.input.is_finished() {
-                            if self.flushing {
-                                self.output.finish();
-                                Ok(Event::Finished)
-                            } else {
-                                self.flushing = true;
-                                Ok(Event::Sync)
-                            }
+                    } else if self.input.has_data() {
+                        let block = self.input.pull_data().unwrap()?;
+                        let block_meta = block.get_owned_meta().unwrap();
+                        self.processor.input_buffer = I::RowBatch::downcast_from(block_meta);
+                        Ok(Event::Sync)
+                    } else if self.input.is_finished() {
+                        if self.flushing {
+                            self.output.finish();
+                            Ok(Event::Finished)
                         } else {
-                            self.input.set_need_data();
-                            Ok(Event::NeedData)
+                            self.flushing = true;
+                            Ok(Event::Sync)
                         }
+                    } else {
+                        self.input.set_need_data();
+                        Ok(Event::NeedData)
                     }
                 }
             }

--- a/src/query/service/src/api/rpc/exchange/exchange_sink.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_sink.rs
@@ -73,7 +73,7 @@ impl ExchangeSink {
                     )]));
                 }
 
-                pipeline.resize(1)?;
+                pipeline.try_resize(1)?;
                 assert_eq!(flight_senders.len(), 1);
                 let item = create_writer_item(flight_senders.remove(0));
                 pipeline.add_pipe(Pipe::create(1, 0, vec![item]));

--- a/src/query/service/src/api/rpc/exchange/exchange_source.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_source.rs
@@ -55,6 +55,6 @@ pub fn via_exchange_source(
     let last_output_len = pipeline.output_len();
     exchange_source_reader::via_reader(last_output_len, pipeline, flight_receivers);
 
-    pipeline.resize(last_output_len)?;
+    pipeline.try_resize(last_output_len)?;
     injector.apply_merge_deserializer(params, pipeline)
 }

--- a/src/query/service/src/api/rpc/exchange/exchange_transform.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_transform.rs
@@ -76,7 +76,7 @@ impl ExchangeTransform {
                 pipeline.add_pipe(Pipe::create(len, new_outputs, items));
 
                 if params.exchange_injector.exchange_sorting().is_none() {
-                    pipeline.resize(max_threads)?;
+                    pipeline.try_resize(max_threads)?;
                 }
 
                 injector.apply_shuffle_deserializer(params, pipeline)

--- a/src/query/service/src/interpreters/interpreter_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_index_refresh.rs
@@ -121,7 +121,7 @@ impl Interpreter for RefreshIndexInterpreter {
 
         let data_accessor = self.ctx.get_data_operator()?;
 
-        build_res.main_pipeline.resize(1)?;
+        build_res.main_pipeline.try_resize(1)?;
         build_res.main_pipeline.add_sink(|input| {
             AggIndexSink::try_create(
                 input,

--- a/src/query/service/src/pipelines/executor/pipeline_pushing_executor.rs
+++ b/src/query/service/src/pipelines/executor/pipeline_pushing_executor.rs
@@ -79,7 +79,7 @@ impl PipelinePushingExecutor {
         source_pipe_builder.add_source(output, pushing_source);
 
         new_pipeline.add_pipe(source_pipe_builder.finalize());
-        new_pipeline.resize(pipeline.input_len())?;
+        new_pipeline.try_resize(pipeline.input_len())?;
         for pipe in &pipeline.pipes {
             new_pipeline.add_pipe(pipe.clone())
         }

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -272,7 +272,7 @@ impl PipelineBuilder {
     ) -> Result<()> {
         self.build_pipeline(&range_join.left)?;
         let max_threads = self.ctx.get_settings().get_max_threads()? as usize;
-        self.main_pipeline.resize(max_threads)?;
+        self.main_pipeline.try_resize(max_threads)?;
         self.main_pipeline.add_transform(|input, output| {
             let transform = TransformRangeJoinLeft::create(input, output, state.clone());
             if self.enable_profiling {
@@ -812,7 +812,7 @@ impl PipelineBuilder {
 
         if params.group_columns.is_empty() {
             self.build_pipeline(&aggregate.input)?;
-            self.main_pipeline.resize(1)?;
+            self.main_pipeline.try_resize(1)?;
             return self.main_pipeline.add_transform(|input, output| {
                 let transform = FinalSingleStateAggregator::try_create(input, output, &params)?;
 
@@ -973,7 +973,7 @@ impl PipelineBuilder {
             self.build_sort_pipeline(input_schema.clone(), sort_desc, window.plan_id, None, false)?;
         }
         // `TransformWindow` is a pipeline breaker.
-        self.main_pipeline.resize(1)?;
+        self.main_pipeline.try_resize(1)?;
         let func = WindowFunctionInfo::try_create(&window.func, &input_schema)?;
         // Window
         self.main_pipeline.add_transform(|input, output| {
@@ -1034,7 +1034,7 @@ impl PipelineBuilder {
             Ok(ProcessorPtr::create(transform))
         })?;
 
-        self.main_pipeline.resize(old_output_len)
+        self.main_pipeline.try_resize(old_output_len)
     }
 
     fn build_sort(&mut self, sort: &Sort) -> Result<()> {
@@ -1078,7 +1078,7 @@ impl PipelineBuilder {
 
         // TODO(Winter): the query will hang in MultiSortMergeProcessor when max_threads == 1 and output_len != 1
         if self.main_pipeline.output_len() == 1 || max_threads == 1 {
-            self.main_pipeline.resize(max_threads)?;
+            self.main_pipeline.try_resize(max_threads)?;
         }
         let prof_info = if self.enable_profiling {
             Some((plan_id, self.prof_span_set.clone()))
@@ -1101,7 +1101,7 @@ impl PipelineBuilder {
     fn build_limit(&mut self, limit: &Limit) -> Result<()> {
         self.build_pipeline(&limit.input)?;
 
-        self.main_pipeline.resize(1)?;
+        self.main_pipeline.try_resize(1)?;
         self.main_pipeline.add_transform(|input, output| {
             let transform = TransformLimit::try_create(limit.limit, limit.offset, input, output)?;
 
@@ -1154,7 +1154,7 @@ impl PipelineBuilder {
         })?;
 
         if join.join_type == JoinType::LeftMark {
-            self.main_pipeline.resize(1)?;
+            self.main_pipeline.try_resize(1)?;
             self.main_pipeline.add_transform(|input, output| {
                 let transform = TransformMarkJoin::try_create(
                     input,

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
@@ -423,7 +423,7 @@ pub fn build_partition_bucket<Method: HashMethodBounds, V: Copy + Send + Sync + 
         vec![output],
     )]));
 
-    pipeline.resize(input_nums)?;
+    pipeline.try_resize(input_nums)?;
 
     let settings = ctx.get_settings();
     if !settings.get_spilling_bytes_threshold_per_proc()?.is_zero() {

--- a/src/query/service/tests/it/pipelines/executor/executor_graph.rs
+++ b/src/query/service/tests/it/pipelines/executor/executor_graph.rs
@@ -189,11 +189,11 @@ fn create_resize_pipeline(ctx: Arc<QueryContext>) -> Result<RunningGraph> {
 
     let mut pipeline = Pipeline::create();
     pipeline.add_pipe(source_pipe);
-    pipeline.resize(2)?;
+    pipeline.try_resize(2)?;
     pipeline.add_pipe(create_transform_pipe(2)?);
-    pipeline.resize(1)?;
+    pipeline.try_resize(1)?;
     pipeline.add_pipe(create_transform_pipe(1)?);
-    pipeline.resize(2)?;
+    pipeline.try_resize(2)?;
     pipeline.add_pipe(sink_pipe);
 
     RunningGraph::create(pipeline)

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -58,7 +58,7 @@ impl FuseTable {
             }
             AppendMode::Copy => {
                 let size = pipeline.output_len();
-                pipeline.resize(1)?;
+                pipeline.try_resize(1)?;
                 pipeline.add_transform(|transform_input_port, transform_output_port| {
                     Ok(ProcessorPtr::create(TransformCompact::try_create(
                         transform_input_port,
@@ -66,7 +66,7 @@ impl FuseTable {
                         BlockCompactorForCopy::new(block_thresholds),
                     )?))
                 })?;
-                pipeline.resize(size)?;
+                pipeline.try_resize(size)?;
             }
         }
 

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -75,7 +75,7 @@ impl FuseTable {
         copied_files: Option<UpsertTableCopiedFileReq>,
         overwrite: bool,
     ) -> Result<()> {
-        pipeline.resize(1)?;
+        pipeline.try_resize(1)?;
 
         pipeline.add_transform(|input, output| {
             let aggregator = TableMutationAggregator::create(

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -174,7 +174,7 @@ impl FuseTable {
             )
         })?;
 
-        pipeline.resize(1)?;
+        pipeline.try_resize(1)?;
 
         pipeline.add_transform(|input, output| {
             let compact_aggregator = CompactAggregator::new(

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -101,7 +101,7 @@ pub fn build_fuse_native_source_pipeline(
                 );
             }
             pipeline.add_pipe(source_builder.finalize());
-            pipeline.resize(max_threads)?;
+            pipeline.try_resize(max_threads)?;
         }
     };
 
@@ -116,7 +116,7 @@ pub fn build_fuse_native_source_pipeline(
         )
     })?;
 
-    pipeline.resize(max_threads)
+    pipeline.try_resize(max_threads)
 }
 
 pub fn build_fuse_parquet_source_pipeline(
@@ -172,7 +172,7 @@ pub fn build_fuse_parquet_source_pipeline(
                 );
             }
             pipeline.add_pipe(source_builder.finalize());
-            pipeline.resize(std::cmp::min(max_threads, max_io_requests))?;
+            pipeline.try_resize(std::cmp::min(max_threads, max_io_requests))?;
 
             info!(
                 "read block pipeline resize from:{} to:{}",

--- a/src/query/storages/fuse/src/operations/replace.rs
+++ b/src/query/storages/fuse/src/operations/replace.rs
@@ -129,7 +129,7 @@ impl FuseTable {
             self.cluster_gen_for_append(ctx.clone(), pipeline, self.get_block_thresholds())?;
 
         // 1. resize input to 1, since the UpsertTransform need to de-duplicate inputs "globally"
-        pipeline.resize(1)?;
+        pipeline.try_resize(1)?;
 
         // 2. connect with ReplaceIntoProcessor
 
@@ -329,7 +329,7 @@ impl FuseTable {
         base_snapshot: Arc<TableSnapshot>,
     ) -> Result<()> {
         // resize
-        pipeline.resize(1)?;
+        pipeline.try_resize(1)?;
 
         // a) append TableMutationAggregator
         pipeline.add_transform(|input, output| {

--- a/src/query/storages/memory/src/memory_table.rs
+++ b/src/query/storages/memory/src/memory_table.rs
@@ -250,7 +250,7 @@ impl Table for MemoryTable {
         _copied_files: Option<UpsertTableCopiedFileReq>,
         overwrite: bool,
     ) -> Result<()> {
-        pipeline.resize(1)?;
+        pipeline.try_resize(1)?;
 
         pipeline.add_sink(|input| {
             Ok(ProcessorPtr::create(MemoryTableSink::create(

--- a/src/query/storages/parquet/src/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_table/read.rs
@@ -155,7 +155,7 @@ impl ParquetTable {
             )?;
         };
 
-        pipeline.resize(num_deserializer)?;
+        pipeline.try_resize(num_deserializer)?;
 
         pipeline.add_transform(|input, output| {
             ParquetDeserializeTransform::create(

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -239,7 +239,7 @@ impl Table for StageTable {
         }
 
         // final compact unload
-        pipeline.resize(1)?;
+        pipeline.try_resize(1)?;
 
         // Add sink pipe.
         pipeline.add_sink(|input| {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

copy used to use a channel to pass  row batch when there was no BlockMetaInfo, which is complicate and buggy.


Closes https://github.com/datafuselabs/databend/issues/10647
