### PR TITLE
chore(planner): improve table schema of `system.query_profile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,6 +2941,7 @@ dependencies = [
  "common-metrics",
  "common-pipeline-core",
  "common-pipeline-sources",
+ "common-profile",
  "common-sql",
  "common-storages-fuse",
  "common-storages-result-cache",

--- a/src/query/profile/src/prof.rs
+++ b/src/query/profile/src/prof.rs
@@ -12,49 +12,161 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::time::Duration;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct QueryProfile {
     /// Query ID of the query profile
     pub query_id: String,
 
     /// Flattened plan node profiles
-    pub plan_node_profs: Vec<PlanNodeProfile>,
+    pub operator_profiles: Vec<OperatorProfile>,
 }
 
 impl QueryProfile {
-    pub fn new(query_id: String, plan_node_profs: Vec<PlanNodeProfile>) -> Self {
+    pub fn new(query_id: String, operator_profiles: Vec<OperatorProfile>) -> Self {
         QueryProfile {
             query_id,
-            plan_node_profs,
+            operator_profiles,
         }
     }
 }
 
-#[derive(Clone)]
-pub struct PlanNodeProfile {
-    /// ID of the `PhysicalPlan`
+#[derive(Debug, Clone)]
+pub struct OperatorProfile {
+    /// ID of the plan node
     pub id: u32,
 
-    /// Name of the `PhysicalPlan`, e.g. `HashJoin`
-    pub plan_node_name: String,
+    /// Type of the plan operator, e.g. `HashJoin`
+    pub operator_type: OperatorType,
 
-    // TODO(leiysky): making this a typed enum
-    /// Description of the `PhysicalPlan`
-    pub description: String,
+    /// IDs of the children plan nodes
+    pub children: Vec<u32>,
 
-    /// The time spent to process in nanoseconds
+    /// The time spent to process data
     pub cpu_time: Duration,
+
+    /// Attribute of the plan operator
+    pub attribute: OperatorAttribute,
 }
 
-impl PlanNodeProfile {
-    pub fn new(id: u32, plan_node_name: String, description: String, cpu_time: Duration) -> Self {
-        PlanNodeProfile {
-            id,
-            plan_node_name,
-            description,
-            cpu_time,
+#[derive(Debug, Clone)]
+pub enum OperatorType {
+    Join,
+    Aggregate,
+    AggregateExpand,
+    Filter,
+    ProjectSet,
+    EvalScalar,
+    Limit,
+    TableScan,
+    Sort,
+    UnionAll,
+    Project,
+    Window,
+    RowFetch,
+    Exchange,
+    RuntimeFilter,
+    Insert,
+}
+
+impl Display for OperatorType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OperatorType::Join => write!(f, "Join"),
+            OperatorType::Aggregate => write!(f, "Aggregate"),
+            OperatorType::AggregateExpand => write!(f, "AggregateExpand"),
+            OperatorType::Filter => write!(f, "Filter"),
+            OperatorType::ProjectSet => write!(f, "ProjectSet"),
+            OperatorType::EvalScalar => write!(f, "EvalScalar"),
+            OperatorType::Limit => write!(f, "Limit"),
+            OperatorType::TableScan => write!(f, "TableScan"),
+            OperatorType::Sort => write!(f, "Sort"),
+            OperatorType::UnionAll => write!(f, "UnionAll"),
+            OperatorType::Project => write!(f, "Project"),
+            OperatorType::Window => write!(f, "Window"),
+            OperatorType::RowFetch => write!(f, "RowFetch"),
+            OperatorType::Exchange => write!(f, "Exchange"),
+            OperatorType::RuntimeFilter => write!(f, "RuntimeFilter"),
+            OperatorType::Insert => write!(f, "Insert"),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub enum OperatorAttribute {
+    Join(JoinAttribute),
+    Aggregate(AggregateAttribute),
+    AggregateExpand(AggregateExpandAttribute),
+    Filter(FilterAttribute),
+    EvalScalar(EvalScalarAttribute),
+    ProjectSet(ProjectSetAttribute),
+    Limit(LimitAttribute),
+    TableScan(TableScanAttribute),
+    Sort(SortAttribute),
+    Window(WindowAttribute),
+    Exchange(ExchangeAttribute),
+    Empty,
+}
+
+#[derive(Debug, Clone)]
+pub struct JoinAttribute {
+    pub join_type: String,
+    pub equi_conditions: String,
+    pub non_equi_conditions: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AggregateAttribute {
+    pub group_keys: String,
+    pub functions: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AggregateExpandAttribute {
+    pub group_keys: String,
+    pub aggr_exprs: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvalScalarAttribute {
+    pub scalars: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectSetAttribute {
+    pub functions: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilterAttribute {
+    pub predicate: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct LimitAttribute {
+    pub limit: usize,
+    pub offset: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct SortAttribute {
+    pub sort_keys: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TableScanAttribute {
+    pub qualified_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WindowAttribute {
+    pub functions: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExchangeAttribute {
+    pub exchange_mode: String,
 }

--- a/src/query/service/src/interpreters/interpreter_explain.rs
+++ b/src/query/service/src/interpreters/interpreter_explain.rs
@@ -25,6 +25,7 @@ use common_expression::DataField;
 use common_expression::DataSchemaRef;
 use common_expression::DataSchemaRefExt;
 use common_expression::FromData;
+use common_profile::QueryProfileManager;
 use common_profile::SharedProcessorProfiles;
 use common_sql::executor::ProfileHelper;
 use common_sql::MetadataRef;
@@ -284,11 +285,15 @@ impl ExplainInterpreter {
             while (pulling_executor.pull_data()?).is_some() {}
         }
 
-        let profile =
-            ProfileHelper::build_query_profile(&query_id, &plan, &prof_span_set.lock().unwrap())?;
+        let profile = ProfileHelper::build_query_profile(
+            &query_id,
+            metadata,
+            &plan,
+            &prof_span_set.lock().unwrap(),
+        )?;
 
         // Record the query profile
-        let prof_mgr = self.ctx.get_query_profile_manager();
+        let prof_mgr = QueryProfileManager::instance();
         prof_mgr.insert(Arc::new(profile));
 
         let result = plan

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -859,6 +859,9 @@ impl PipelineBuilder {
                         v,
                         &mut self.main_pipeline,
                         params.clone(),
+                        self.enable_profiling,
+                        aggregate.plan_id,
+                        self.prof_span_set.clone(),
                     )
                 }
             }),
@@ -880,6 +883,9 @@ impl PipelineBuilder {
                         v,
                         &mut self.main_pipeline,
                         params.clone(),
+                        self.enable_profiling,
+                        aggregate.plan_id,
+                        self.prof_span_set.clone(),
                     )
                 }
             }),

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -25,7 +25,7 @@ use common_hashtable::HashtableEntryRefLike;
 use common_hashtable::HashtableLike;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::port::OutputPort;
-use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 use common_pipeline_transforms::processors::transforms::BlockMetaTransform;
 use common_pipeline_transforms::processors::transforms::BlockMetaTransformer;
 
@@ -49,8 +49,8 @@ impl<Method: HashMethodBounds> TransformFinalAggregate<Method> {
         output: Arc<OutputPort>,
         method: Method,
         params: Arc<AggregatorParams>,
-    ) -> Result<ProcessorPtr> {
-        Ok(ProcessorPtr::create(BlockMetaTransformer::create(
+    ) -> Result<Box<dyn Processor>> {
+        Ok(Box::new(BlockMetaTransformer::create(
             input,
             output,
             TransformFinalAggregate::<Method> { method, params },

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_final.rs
@@ -21,7 +21,7 @@ use common_hashtable::HashtableEntryRefLike;
 use common_hashtable::HashtableLike;
 use common_pipeline_core::processors::port::InputPort;
 use common_pipeline_core::processors::port::OutputPort;
-use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_core::processors::Processor;
 use common_pipeline_transforms::processors::transforms::BlockMetaTransform;
 use common_pipeline_transforms::processors::transforms::BlockMetaTransformer;
 
@@ -43,8 +43,8 @@ impl<Method: HashMethodBounds> TransformFinalGroupBy<Method> {
         output: Arc<OutputPort>,
         method: Method,
         params: Arc<AggregatorParams>,
-    ) -> Result<ProcessorPtr> {
-        Ok(ProcessorPtr::create(BlockMetaTransformer::create(
+    ) -> Result<Box<dyn Processor>> {
+        Ok(Box::new(BlockMetaTransformer::create(
             input,
             output,
             TransformFinalGroupBy::<Method> { method, params },

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -49,7 +49,6 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'constraint_name'               | 'information_schema' | 'key_column_usage'    | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'constraint_schema'             | 'information_schema' | 'key_column_usage'    | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'copy_options'                  | 'system'             | 'stages'              | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
-| 'cpu_time'                      | 'system'             | 'query_profile'       | 'UInt64'           | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'cpu_usage'                     | 'system'             | 'query_log'           | 'UInt32'           | 'INT UNSIGNED'      | ''       | ''       | 'NO'     | ''       |
 | 'create_time'                   | 'information_schema' | 'tables'              | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'created_on'                    | 'system'             | 'background_jobs'     | 'Timestamp'        | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
@@ -93,7 +92,6 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'definition'                    | 'system'             | 'indexes'             | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'description'                   | 'system'             | 'configs'             | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'description'                   | 'system'             | 'functions'           | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
-| 'description'                   | 'system'             | 'query_profile'       | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'description'                   | 'system'             | 'settings'            | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'domain_catalog'                | 'information_schema' | 'columns'             | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'domain_name'                   | 'information_schema' | 'columns'             | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
@@ -197,15 +195,18 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'numeric_precision'             | 'information_schema' | 'columns'             | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'numeric_precision_radix'       | 'information_schema' | 'columns'             | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'numeric_scale'                 | 'information_schema' | 'columns'             | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
+| 'operator_attribute'            | 'system'             | 'query_profile'       | 'Variant'          | 'VARIANT'           | ''       | ''       | 'NO'     | ''       |
+| 'operator_children'             | 'system'             | 'query_profile'       | 'Array(UInt32)'    | 'ARRAY(UINT32)'     | ''       | ''       | 'NO'     | ''       |
+| 'operator_id'                   | 'system'             | 'query_profile'       | 'UInt32'           | 'INT UNSIGNED'      | ''       | ''       | 'NO'     | ''       |
+| 'operator_type'                 | 'system'             | 'query_profile'       | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'ordinal_position'              | 'information_schema' | 'columns'             | 'UInt8'            | 'TINYINT UNSIGNED'  | ''       | ''       | 'NO'     | ''       |
 | 'ordinal_position'              | 'information_schema' | 'key_column_usage'    | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'packed'                        | 'information_schema' | 'statistics'          | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'partitions_sha'                | 'system'             | 'query_cache'         | 'Array(String)'    | 'ARRAY(STRING)'     | ''       | ''       | 'NO'     | ''       |
-| 'plan_id'                       | 'system'             | 'query_profile'       | 'UInt32'           | 'INT UNSIGNED'      | ''       | ''       | 'NO'     | ''       |
-| 'plan_name'                     | 'system'             | 'query_profile'       | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'port'                          | 'system'             | 'clusters'            | 'UInt16'           | 'SMALLINT UNSIGNED' | ''       | ''       | 'NO'     | ''       |
 | 'position_in_unique_constraint' | 'information_schema' | 'key_column_usage'    | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'privileges'                    | 'information_schema' | 'columns'             | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
+| 'process_time'                  | 'system'             | 'query_profile'       | 'UInt64'           | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'projections'                   | 'system'             | 'query_log'           | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'query_duration_ms'             | 'system'             | 'query_log'           | 'Int64'            | 'BIGINT'            | ''       | ''       | 'NO'     | ''       |
 | 'query_id'                      | 'system'             | 'query_cache'         | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -427,11 +427,7 @@ fn aggregate_partial_to_format_tree(
     let group_by = plan
         .group_by
         .iter()
-        .map(|&index| {
-            let name = metadata.read().column(index).name();
-            Ok(name)
-        })
-        .collect::<Result<Vec<_>>>()?
+        .map(|&index| metadata.read().column(index).name())
         .join(", ");
     let agg_funcs = plan
         .agg_funcs

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -1287,7 +1287,7 @@ impl PhysicalPlanBuilder {
     fn build_eval_scalar(
         &mut self,
         input: PhysicalPlan,
-        eval_scalar: &crate::planner::plans::EvalScalar,
+        eval_scalar: &planner::plans::EvalScalar,
         stat_info: PlanStatsInfo,
     ) -> Result<PhysicalPlan> {
         let input_schema = input.output_schema()?;

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -26,6 +26,7 @@ common-meta-app = { path = "../../../meta/app" }
 common-metrics = { path = "../../../common/metrics" }
 common-pipeline-core = { path = "../../pipeline/core" }
 common-pipeline-sources = { path = "../../pipeline/sources" }
+common-profile = { path = "../../profile" }
 common-sql = { path = "../../sql" }
 common-storages-fuse = { path = "../fuse" }
 common-storages-result-cache = { path = "../result_cache" }

--- a/src/query/storages/system/src/query_profile_table.rs
+++ b/src/query/storages/system/src/query_profile_table.rs
@@ -16,10 +16,14 @@ use std::sync::Arc;
 
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
+use common_expression::types::array::ArrayColumnBuilder;
+use common_expression::types::ArrayType;
 use common_expression::types::NumberDataType;
 use common_expression::types::StringType;
 use common_expression::types::UInt32Type;
 use common_expression::types::UInt64Type;
+use common_expression::types::ValueType;
+use common_expression::types::VariantType;
 use common_expression::DataBlock;
 use common_expression::FromData;
 use common_expression::TableDataType;
@@ -28,9 +32,60 @@ use common_expression::TableSchemaRefExt;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
+use common_profile::OperatorAttribute;
+use common_profile::QueryProfileManager;
 
 use crate::SyncOneBlockSystemTable;
 use crate::SyncSystemTable;
+
+// Encode an `OperatorAttribute` into jsonb::Value.
+fn encode_operator_attribute(attr: &OperatorAttribute) -> jsonb::Value {
+    match attr {
+        OperatorAttribute::Join(join_attr) => (&serde_json::json! ({
+            "join_type": join_attr.join_type,
+            "equi_conditions": join_attr.equi_conditions,
+            "non_equi_conditions": join_attr.non_equi_conditions,
+        }))
+            .into(),
+        OperatorAttribute::Aggregate(agg_attr) => (&serde_json::json!({
+            "group_keys": agg_attr.group_keys,
+            "functions": agg_attr.functions,
+        }))
+            .into(),
+        OperatorAttribute::AggregateExpand(expand_attr) => (&serde_json::json!({
+            "group_keys": expand_attr.group_keys,
+            "aggr_exprs": expand_attr.aggr_exprs,
+        }))
+            .into(),
+        OperatorAttribute::Filter(filter_attr) => {
+            (&serde_json::json!({ "predicate": filter_attr.predicate })).into()
+        }
+        OperatorAttribute::EvalScalar(scalar_attr) => {
+            (&serde_json::json!({ "scalars": scalar_attr.scalars })).into()
+        }
+        OperatorAttribute::ProjectSet(project_attr) => {
+            (&serde_json::json!({ "functions": project_attr.functions })).into()
+        }
+        OperatorAttribute::Limit(limit_attr) => (&serde_json::json!({
+            "limit": limit_attr.limit,
+            "offset": limit_attr.offset,
+        }))
+            .into(),
+        OperatorAttribute::TableScan(scan_attr) => {
+            (&serde_json::json!({ "qualified_name": scan_attr.qualified_name })).into()
+        }
+        OperatorAttribute::Sort(sort_attr) => {
+            (&serde_json::json!({ "sort_keys": sort_attr.sort_keys })).into()
+        }
+        OperatorAttribute::Window(window_attr) => {
+            (&serde_json::json!({ "functions": window_attr.functions })).into()
+        }
+        OperatorAttribute::Exchange(exchange_attr) => {
+            (&serde_json::json!({ "exchange_mode": exchange_attr.exchange_mode })).into()
+        }
+        OperatorAttribute::Empty => jsonb::Value::Null,
+    }
+}
 
 pub struct QueryProfileTable {
     table_info: TableInfo,
@@ -40,10 +95,17 @@ impl QueryProfileTable {
     pub fn create(table_id: u64) -> Arc<dyn Table> {
         let schema = TableSchemaRefExt::create(vec![
             TableField::new("query_id", TableDataType::String),
-            TableField::new("plan_id", TableDataType::Number(NumberDataType::UInt32)),
-            TableField::new("plan_name", TableDataType::String),
-            TableField::new("description", TableDataType::String),
-            TableField::new("cpu_time", TableDataType::Number(NumberDataType::UInt64)),
+            TableField::new("operator_id", TableDataType::Number(NumberDataType::UInt32)),
+            TableField::new("operator_type", TableDataType::String),
+            TableField::new(
+                "operator_children",
+                TableDataType::Array(Box::new(TableDataType::Number(NumberDataType::UInt32))),
+            ),
+            TableField::new(
+                "process_time",
+                TableDataType::Number(NumberDataType::UInt64),
+            ),
+            TableField::new("operator_attribute", TableDataType::Variant),
         ]);
 
         let table_info = TableInfo {
@@ -69,32 +131,57 @@ impl SyncSystemTable for QueryProfileTable {
         &self.table_info
     }
 
-    fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> common_exception::Result<DataBlock> {
-        let profile_mgr = ctx.get_query_profile_manager();
+    fn get_full_data(&self, _ctx: Arc<dyn TableContext>) -> common_exception::Result<DataBlock> {
+        let profile_mgr = QueryProfileManager::instance();
         let query_profs = profile_mgr.list_all();
 
         let mut query_ids: Vec<Vec<u8>> = Vec::with_capacity(query_profs.len());
-        let mut plan_ids: Vec<u32> = Vec::with_capacity(query_profs.len());
-        let mut plan_names: Vec<Vec<u8>> = Vec::with_capacity(query_profs.len());
-        let mut descriptions: Vec<Vec<u8>> = Vec::with_capacity(query_profs.len());
-        let mut cpu_times: Vec<u64> = Vec::with_capacity(query_profs.len());
+        let mut operator_ids: Vec<u32> = Vec::with_capacity(query_profs.len());
+        let mut operator_types: Vec<Vec<u8>> = Vec::with_capacity(query_profs.len());
+        let mut operator_childrens: Vec<Vec<u32>> = Vec::with_capacity(query_profs.len());
+        let mut process_times: Vec<u64> = Vec::with_capacity(query_profs.len());
+        let mut operator_attributes: Vec<Vec<u8>> = Vec::with_capacity(query_profs.len());
 
         for prof in query_profs.iter() {
-            for plan_prof in prof.plan_node_profs.iter() {
+            for plan_prof in prof.operator_profiles.iter() {
                 query_ids.push(prof.query_id.clone().into_bytes());
-                plan_ids.push(plan_prof.id);
-                plan_names.push(plan_prof.plan_node_name.clone().into_bytes());
-                descriptions.push(plan_prof.description.clone().into_bytes());
-                cpu_times.push(plan_prof.cpu_time.as_nanos() as u64);
+                operator_ids.push(plan_prof.id);
+                operator_types.push(plan_prof.operator_type.to_string().into_bytes());
+                operator_childrens.push(plan_prof.children.clone());
+                process_times.push(plan_prof.cpu_time.as_nanos() as u64);
+
+                let attribute_value = encode_operator_attribute(&plan_prof.attribute);
+                operator_attributes.push(attribute_value.to_vec());
             }
         }
 
         let block = DataBlock::new_from_columns(vec![
+            // query_id
             StringType::from_data(query_ids),
-            UInt32Type::from_data(plan_ids),
-            StringType::from_data(plan_names),
-            StringType::from_data(descriptions),
-            UInt64Type::from_data(cpu_times),
+            // operator_id
+            UInt32Type::from_data(operator_ids),
+            // operator_type
+            StringType::from_data(operator_types),
+            // operator_children
+            {
+                let mut builder = ArrayColumnBuilder::<UInt32Type>::with_capacity(
+                    operator_childrens.len(),
+                    operator_childrens.iter().map(|v| v.len()).sum(),
+                    &[],
+                );
+                for children in operator_childrens.iter() {
+                    for v in children.iter() {
+                        builder.put_item(*v);
+                    }
+                    builder.commit_row();
+                }
+
+                <ArrayType<UInt32Type> as ValueType>::upcast_column(builder.build())
+            },
+            // process_time
+            UInt64Type::from_data(process_times),
+            // operator_attribute
+            VariantType::from_data(operator_attributes),
         ]);
 
         Ok(block)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Improve table schema of `system.query_profile`.

Add the `operator_children` field to represent the topology relationship between plan operators.

Add the `operator_attribute` field to represent the attribute information of plan operators.

```
mysql> explain analyze select sum(a) from t group by a;
+--------------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                              |
+--------------------------------------------------------------------------------------------------------------------------------------+
| EvalScalar                                                                                                                           |
| ├── expressions: [sum(a) (#1)]                                                                                                       |
| ├── estimated rows: 100000.00                                                                                                        |
| ├── total cpu time: 0.7755029999999999ms                                                                                             |
| └── AggregateFinal                                                                                                                   |
|     ├── group by: [a]                                                                                                                |
|     ├── aggregate functions: [sum(a)]                                                                                                |
|     ├── estimated rows: 100000.00                                                                                                    |
|     ├── total cpu time: 43.187252ms                                                                                                  |
|     └── AggregatePartial                                                                                                             |
|         ├── group by: [a]                                                                                                            |
|         ├── aggregate functions: [sum(a)]                                                                                            |
|         ├── estimated rows: 100000.00                                                                                                |
|         ├── total cpu time: 47.375667ms                                                                                              |
|         └── EvalScalar                                                                                                               |
|             ├── expressions: [t.a (#0), t.a (#0)]                                                                                    |
|             ├── estimated rows: 100000.00                                                                                            |
|             ├── total cpu time: 0.028543000000000002ms                                                                               |
|             └── TableScan                                                                                                            |
|                 ├── table: default.default.t                                                                                         |
|                 ├── read rows: 100000                                                                                                |
|                 ├── read bytes: 255263                                                                                               |
|                 ├── partitions total: 2                                                                                              |
|                 ├── partitions scanned: 2                                                                                            |
|                 ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 0 to 0>]       |
|                 ├── push downs: [filters: [], limit: NONE]                                                                           |
|                 └── estimated rows: 100000.00                                                                                        |
+--------------------------------------------------------------------------------------------------------------------------------------+
27 rows in set (1.79 sec)
Read 100000 rows, 390.62 KiB in 0.628 sec., 159.32 thousand rows/sec., 622.36 KiB/sec.

mysql> select * from system.query_profile;
+--------------------------------------+-------------+---------------+-------------------+--------------+-----------------------------------------+
| query_id                             | operator_id | operator_type | operator_children | process_time | operator_attribute                      |
+--------------------------------------+-------------+---------------+-------------------+--------------+-----------------------------------------+
| 43458a1e-1689-4aa5-a487-dd0a844ba014 |           0 | TableScan     | []                |            0 | {"qualified_name":"default.t"}          |
| 43458a1e-1689-4aa5-a487-dd0a844ba014 |           1 | EvalScalar    | [0]               |        28543 | {"scalars":"t.a (#0), t.a (#0)"}        |
| 43458a1e-1689-4aa5-a487-dd0a844ba014 |           2 | Aggregate     | [1]               |     47375667 | {"functions":"sum(a)","group_keys":"a"} |
| 43458a1e-1689-4aa5-a487-dd0a844ba014 |           3 | Aggregate     | [2]               |     43187252 | {"functions":"sum(a)","group_keys":"a"} |
| 43458a1e-1689-4aa5-a487-dd0a844ba014 |           4 | EvalScalar    | [3]               |       775503 | {"scalars":"sum(a) (#1)"}               |
+--------------------------------------+-------------+---------------+-------------------+--------------+-----------------------------------------+
5 rows in set (0.01 sec)
Read 5 rows, 689.00 B in 0.002 sec., 2.41 thousand rows/sec., 323.81 KiB/sec.
```
