### PR TITLE
refactor: optimize key digesting of replace into

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,7 @@ dependencies = [
 name = "common-storages-fuse"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.8.3",
  "async-backtrace",
  "async-trait-fn",
  "backoff",

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -42,6 +42,7 @@ storages-common-index = { path = "../common/index" }
 storages-common-pruner = { path = "../common/pruner" }
 storages-common-table-meta = { path = "../common/table-meta" }
 
+ahash = "0.8.3"
 async-backtrace = { workspace = true }
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }

--- a/src/query/storages/fuse/src/operations/replace_into/meta/merge_into_operation_meta.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/meta/merge_into_operation_meta.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::collections::HashSet;
 
+use ahash::HashSet;
 use common_exception::ErrorCode;
 use common_expression::BlockMetaInfo;
 use common_expression::BlockMetaInfoDowncast;

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/column_hash.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/column_hash.rs
@@ -1,0 +1,72 @@
+// Copyright 2023 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hash::Hasher;
+
+use common_expression::types::NumberScalar;
+use common_expression::Column;
+use common_expression::ScalarRef;
+use siphasher::sip128;
+use siphasher::sip128::Hasher128;
+
+pub fn row_hash_of_columns(columns: &[&Column], row_idx: usize) -> u128 {
+    let mut sip = sip128::SipHasher24::new();
+    for column in columns {
+        let value = column
+            .index(row_idx)
+            .expect("column index out of range (calculate columns hash)");
+        match value {
+            ScalarRef::Number(v) => match v {
+                NumberScalar::UInt8(v) => {
+                    sip.write_u8(v);
+                }
+                NumberScalar::UInt16(v) => {
+                    sip.write_u16(v);
+                }
+                NumberScalar::UInt32(v) => {
+                    sip.write_u32(v);
+                }
+                NumberScalar::UInt64(v) => {
+                    sip.write_u64(v);
+                }
+                NumberScalar::Int8(v) => {
+                    sip.write_i8(v);
+                }
+                NumberScalar::Int16(v) => {
+                    sip.write_i16(v);
+                }
+                NumberScalar::Int32(v) => {
+                    sip.write_i32(v);
+                }
+                NumberScalar::Int64(v) => {
+                    sip.write_i64(v);
+                }
+                NumberScalar::Float32(v) => {
+                    sip.write_u32(v.to_bits());
+                }
+                NumberScalar::Float64(v) => {
+                    sip.write_u64(v.to_bits());
+                }
+            },
+            ScalarRef::Timestamp(v) => {
+                sip.write_i64(v);
+            }
+            _ => {
+                let string = value.to_string();
+                sip.write(string.as_bytes());
+            }
+        }
+    }
+    sip.finish128().as_u128()
+}

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/deletion_accumulator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/deletion_accumulator.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::collections::HashSet;
+
+use ahash::HashMap;
+use ahash::HashSet;
 
 use crate::operations::mutation::BlockIndex;
 use crate::operations::mutation::SegmentIndex;

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::collections::HashSet;
-use std::hash::Hasher;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use common_arrow::arrow::bitmap::MutableBitmap;
 use common_base::base::tokio::sync::OwnedSemaphorePermit;
 use common_base::base::tokio::sync::Semaphore;
@@ -35,8 +34,6 @@ use common_expression::Scalar;
 use common_expression::TableSchema;
 use common_sql::evaluator::BlockOperator;
 use opendal::Operator;
-use siphasher::sip128;
-use siphasher::sip128::Hasher128;
 use storages_common_cache::LoadParams;
 use storages_common_table_meta::meta::BlockMeta;
 use storages_common_table_meta::meta::ColumnStatistics;
@@ -61,10 +58,11 @@ use crate::operations::mutation::SegmentIndex;
 use crate::operations::replace_into::meta::merge_into_operation_meta::DeletionByColumn;
 use crate::operations::replace_into::meta::merge_into_operation_meta::MergeIntoOperation;
 use crate::operations::replace_into::meta::merge_into_operation_meta::UniqueKeyDigest;
+use crate::operations::replace_into::mutator::column_hash::row_hash_of_columns;
 use crate::operations::replace_into::mutator::deletion_accumulator::DeletionAccumulator;
 use crate::operations::replace_into::OnConflictField;
 struct AggregationContext {
-    segment_locations: HashMap<SegmentIndex, Location>,
+    segment_locations: AHashMap<SegmentIndex, Location>,
     // the fields specified in ON CONFLICT clause
     on_conflict_fields: Vec<OnConflictField>,
     // table fields excludes `on_conflict_fields`
@@ -153,7 +151,7 @@ impl MergeIntoOperationAggregator {
         Ok(Self {
             deletion_accumulator,
             aggregation_ctx: Arc::new(AggregationContext {
-                segment_locations: HashMap::from_iter(segment_locations.into_iter()),
+                segment_locations: AHashMap::from_iter(segment_locations.into_iter()),
                 on_conflict_fields,
                 remain_column_field_ids,
                 key_column_reader,
@@ -174,7 +172,7 @@ impl MergeIntoOperationAggregator {
     #[async_backtrace::framed]
     pub async fn accumulate(&mut self, merge_action: MergeIntoOperation) -> Result<()> {
         let aggregation_ctx = &self.aggregation_ctx;
-        match &merge_action {
+        match merge_action {
             MergeIntoOperation::Delete(DeletionByColumn {
                 columns_min_max,
                 key_hashes,
@@ -191,15 +189,15 @@ impl MergeIntoOperationAggregator {
                     let segment_info: SegmentInfo = segment_info.as_ref().try_into()?;
 
                     // segment level
-                    if aggregation_ctx.overlapped(&segment_info.summary.col_stats, columns_min_max)
+                    if aggregation_ctx.overlapped(&segment_info.summary.col_stats, &columns_min_max)
                     {
                         // block level
                         for (block_index, block_meta) in segment_info.blocks.iter().enumerate() {
-                            if aggregation_ctx.overlapped(&block_meta.col_stats, columns_min_max) {
+                            if aggregation_ctx.overlapped(&block_meta.col_stats, &columns_min_max) {
                                 self.deletion_accumulator.add_block_deletion(
                                     *segment_index,
                                     block_index,
-                                    key_hashes,
+                                    &key_hashes,
                                 )
                             }
                         }
@@ -290,7 +288,7 @@ impl AggregationContext {
         segment_index: SegmentIndex,
         block_index: BlockIndex,
         block_meta: &BlockMeta,
-        deleted_key_hashes: &HashSet<UniqueKeyDigest>,
+        deleted_key_hashes: &ahash::HashSet<UniqueKeyDigest>,
     ) -> Result<Option<ReplacementLogEntry>> {
         info!(
             "apply delete to segment idx {}, block idx {}, num of deletion key hashes: {}",
@@ -333,13 +331,7 @@ impl AggregationContext {
 
         let mut bitmap = MutableBitmap::new();
         for row in 0..num_rows {
-            let mut sip = sip128::SipHasher24::new();
-            for column in &columns {
-                let value = column.index(row).unwrap();
-                let string = value.to_string();
-                sip.write(string.as_bytes());
-            }
-            let hash = sip.finish128().as_u128();
+            let hash = row_hash_of_columns(&columns, row);
             bitmap.push(!deleted_key_hashes.contains(&hash));
         }
 

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/mod.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod column_hash;
 pub mod deletion_accumulator;
 pub mod merge_into_mutator;
 pub mod mutator_replace_into;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

optimize impl of `replace into`

- optimize the row hashing of columns

  previously, the hash of the row of on-conflict columns is a digest of `column_value.to_string`, the to_string is rather a CPU-intensive operation.
  
  in this PR,  for commonly used Scalar types, the digest is performed directly on the underneath type of values(u8, u32, &[u8], etc..)  

- using ahash map/set for better performance 

TODO

performance evaluation data (coming soon)

Closes #issue
