### PR TITLE
fix: rows fetcher should complete the block if the input is empty.

### DIFF
--- a/src/query/storages/fuse/src/operations/read/native_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/native_rows_fetcher.rs
@@ -26,6 +26,7 @@ use common_catalog::plan::Projection;
 use common_catalog::table::Table;
 use common_exception::Result;
 use common_expression::DataBlock;
+use common_expression::DataSchema;
 use common_expression::TableSchemaRef;
 use common_storage::ColumnNodes;
 use storages_common_cache::LoadParams;
@@ -100,6 +101,10 @@ impl<const BLOCKING_IO: bool> RowsFetcher for NativeRowsFetcher<BLOCKING_IO> {
 
         let blocks = blocks.iter().collect::<Vec<_>>();
         Ok(DataBlock::take_blocks(&blocks, &indices, num_rows))
+    }
+
+    fn schema(&self) -> DataSchema {
+        self.reader.data_schema()
     }
 }
 

--- a/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
@@ -24,6 +24,7 @@ use common_catalog::plan::Projection;
 use common_catalog::table::Table;
 use common_exception::Result;
 use common_expression::DataBlock;
+use common_expression::DataSchema;
 use common_expression::TableSchemaRef;
 use common_storage::ColumnNodes;
 use storages_common_cache::LoadParams;
@@ -84,6 +85,10 @@ impl<const BLOCKING_IO: bool> RowsFetcher for ParquetRowsFetcher<BLOCKING_IO> {
 
         let blocks = blocks.iter().collect::<Vec<_>>();
         Ok(DataBlock::take_blocks(&blocks, &indices, num_rows))
+    }
+
+    fn schema(&self) -> DataSchema {
+        self.reader.data_schema()
     }
 }
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0025_lazy_read
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0025_lazy_read
@@ -92,7 +92,7 @@ insert into t_11882 values(1,'asdsa')
 statement ok
 insert into t_11882 values(2,'aaaa'), (3,'bbb')
 
-# Construct the case that one of the blocks will be fitlered into a empty block (`num_rows` = 0)
+# Construct the case that one of the blocks will be filtered into a empty block (`num_rows` = 0)
 # P.S. The block will exist in the computing pipeline, but its `num_rows` = 0.
 query IT
 select * from t_11882 where substr(b,1,1)='b' limit 2

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0025_lazy_read
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0025_lazy_read
@@ -79,3 +79,25 @@ select d:b, d, e from t_lazy order by a desc limit 2
 statement ok
 drop table t_lazy
 
+# ISSUE 11882
+statement ok
+drop table if exists t_11882
+
+statement ok
+create table t_11882(a int, b string)
+
+statement ok
+insert into t_11882 values(1,'asdsa')
+
+statement ok
+insert into t_11882 values(2,'aaaa'), (3,'bbb')
+
+# Construct the case that one of the blocks will be fitlered into a empty block (`num_rows` = 0)
+# P.S. The block will exist in the computing pipeline, but its `num_rows` = 0.
+query IT
+select * from t_11882 where substr(b,1,1)='b' limit 2
+----
+3 bbb
+
+statement ok
+drop table t_11882


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The pipeline will panic because the number of columns is incorrect.

- Closes #11882
