### PR TITLE
ci: only create release if tag not exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,3 +540,27 @@ jobs:
     secrets: inherit
     with:
       tag: ${{ needs.create_release.outputs.version }}
+
+  notify:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - create_release
+      - linux
+      - docker_combined
+      - docker_separate
+      - distribution
+      - deb
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          status="${{ (contains(needs.*.result, 'failure') && 'failure') || (contains(needs.*.result, 'cancelled') && 'cancelled') || 'success' }}"
+          jq -n -f .github/release-report.jq \
+            --arg title "[Release] ${{ needs.create_release.outputs.version }}" \
+            --arg content "Build result: ${status}" \
+            --arg link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            > /tmp/release-report.json
+          curl -X POST "${{ secrets.RELEASE_REPORT_WEBHOOK }}" \
+            -H 'Content-Type: application/json' \
+            -H 'cache-control: no-cache' \
+            -d @/tmp/release-report.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
             console.log(`This event is triggered, return generated ${next_tag}.`)
             core.setOutput('tag', next_tag)
       - name: Create github release if not exist
+        # Only create release when the tag is not exist
+        if: 'steps.generated-tag.outputs.tag != steps.get-latest-tag.outputs.tag'
         # Allow this action failure
         # continue-on-error: true
         # Reference: https://cli.github.com/manual/gh_release_create


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

We assume that when tag exists, the corresponding release is already created manually.

- Closes #issue
