### PR TITLE
refactor(query): support different modes backtrace 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,6 +1889,7 @@ name = "common-exception"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "backtrace",
  "bincode 2.0.0-rc.2",
  "codespan-reporting 0.11.1 (git+https://github.com/brendanzab/codespan?rev=c84116f5)",
  "common-arrow",

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -30,3 +30,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tonic = { workspace = true }
+backtrace = "0.3.67"

--- a/src/common/exception/src/exception_backtrace.rs
+++ b/src/common/exception/src/exception_backtrace.rs
@@ -12,21 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(clippy::uninlined_format_args)]
-pub mod exception;
-mod exception_backtrace;
-mod exception_code;
-mod exception_flight;
-mod exception_into;
-mod span;
-mod with_context;
+// use std::backtrace::Backtrace;
+use std::sync::Arc;
 
-pub use exception::ErrorCode;
-pub use exception::Result;
-pub use exception::ToErrorCode;
-pub use exception_into::SerializedError;
-pub use span::pretty_print_error;
-pub use span::Range;
-pub use span::Span;
-pub use with_context::ErrorWithContext;
-pub use with_context::WithContext;
+use crate::exception::ErrorCodeBacktrace;
+
+pub fn capture() -> Option<ErrorCodeBacktrace> {
+    Some(ErrorCodeBacktrace::Origin(Arc::new(
+        backtrace::Backtrace::new_unresolved(),
+    )))
+}

--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -14,10 +14,7 @@
 
 #![allow(non_snake_case)]
 
-use std::backtrace::Backtrace;
-use std::sync::Arc;
-
-use crate::exception::ErrorCodeBacktrace;
+use crate::exception_backtrace::capture;
 use crate::ErrorCode;
 
 macro_rules! build_exceptions {
@@ -35,7 +32,7 @@ macro_rules! build_exceptions {
                     #[$meta]
                 )*
                 pub fn $body(display_text: impl Into<String>) -> ErrorCode {
-                    let bt = Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::capture())));
+                    let bt = capture();
                     ErrorCode::create(
                         $code,
                         display_text.into(),

--- a/src/common/exception/src/exception_into.rs
+++ b/src/common/exception/src/exception_into.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::backtrace::Backtrace;
 use std::error::Error;
 use std::fmt::Debug;
 use std::fmt::Display;
@@ -24,6 +23,7 @@ use common_meta_types::MetaAPIError;
 use common_meta_types::MetaError;
 
 use crate::exception::ErrorCodeBacktrace;
+use crate::exception_backtrace::capture;
 use crate::ErrorCode;
 use crate::Span;
 
@@ -66,7 +66,7 @@ impl From<anyhow::Error> for ErrorCode {
             1002,
             format!("{}, source: {:?}", error, error.source()),
             Some(Box::new(OtherErrors::AnyHow { error })),
-            Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::capture()))),
+            capture(),
         )
     }
 }
@@ -131,23 +131,13 @@ impl From<bincode::error::DecodeError> for ErrorCode {
 
 impl From<bincode::serde::EncodeError> for ErrorCode {
     fn from(error: bincode::serde::EncodeError) -> Self {
-        ErrorCode::create(
-            1002,
-            format!("{error:?}"),
-            None,
-            Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::capture()))),
-        )
+        ErrorCode::create(1002, format!("{error:?}"), None, capture())
     }
 }
 
 impl From<bincode::serde::DecodeError> for ErrorCode {
     fn from(error: bincode::serde::DecodeError) -> Self {
-        ErrorCode::create(
-            1002,
-            format!("{error:?}"),
-            None,
-            Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::capture()))),
-        )
+        ErrorCode::create(1002, format!("{error:?}"), None, capture())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(query): support different modes backtrace 

- Closes #issue
