### PR TITLE
refactor: refine polices to prevent OOM when copy parquet with large  row groups.

### DIFF
--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -57,7 +57,6 @@ impl FuseTable {
                 })?;
             }
             AppendMode::Copy => {
-                let size = pipeline.output_len();
                 pipeline.try_resize(1)?;
                 pipeline.add_transform(|transform_input_port, transform_output_port| {
                     Ok(ProcessorPtr::create(TransformCompact::try_create(
@@ -66,7 +65,7 @@ impl FuseTable {
                         BlockCompactorForCopy::new(block_thresholds),
                     )?))
                 })?;
-                pipeline.try_resize(size)?;
+                pipeline.try_resize(ctx.get_settings().get_max_threads()? as usize)?;
             }
         }
 

--- a/src/query/storages/parquet/src/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_table/read.rs
@@ -185,7 +185,8 @@ fn limit_parallelism_by_memory(max_memory: usize, sizes: &mut [usize]) -> usize 
     sizes.sort_by(|a, b| b.cmp(a));
     let mut mem = 0;
     for (i, s) in sizes.iter().enumerate() {
-        mem += s;
+        // there may be 2 blocks in a pipe.
+        mem += s * 2;
         if mem > max_memory {
             return i;
         }

--- a/src/query/storages/parquet/src/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_table/read.rs
@@ -201,6 +201,8 @@ fn calc_parallelism(
     if plan.parts.partitions.is_empty() {
         return Ok((1, 1));
     }
+    let num_partitions = plan.parts.partitions.len();
+    let max_threads = ctx.get_settings().get_max_threads()? as usize;
     let mut sizes = vec![];
     for p in plan.parts.partitions.iter() {
         sizes.push(ParquetPart::from_part(p)?.uncompressed_size() as usize);
@@ -220,12 +222,10 @@ fn calc_parallelism(
     .min(max_by_memory)
     .max(1);
 
-    let num_deserializer = (ctx.get_settings().get_max_threads()? as usize)
-        .min(max_by_memory)
-        .max(1);
+    let num_deserializer = max_threads.min(max_by_memory).max(1);
 
     tracing::info!(
-        "loading row groups with {num_readers} readers and {num_deserializer} deserializers, blocking = {is_blocking}, according to max_memory={max_memory}, num_chunks={num_chunks}, max_storage_io_requests={max_storage_io_requests}, max_split_size={}",
+        "loading {num_partitions} partitions with {num_readers} readers and {num_deserializer} deserializers, blocking = {is_blocking}, according to max_memory={max_memory}, num_chunks={num_chunks}, max_storage_io_requests={max_storage_io_requests}, max_split_size={}, max_threads={max_threads}",
         sizes[0]
     );
     Ok((num_readers, num_deserializer))

--- a/src/query/storages/parquet/src/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_table/read.rs
@@ -202,8 +202,9 @@ fn calc_parallelism(
     if plan.parts.partitions.is_empty() {
         return Ok((1, 1));
     }
+    let settings = ctx.get_settings();
     let num_partitions = plan.parts.partitions.len();
-    let max_threads = ctx.get_settings().get_max_threads()? as usize;
+    let max_threads = settings.get_max_threads()? as usize;
     let mut sizes = vec![];
     for p in plan.parts.partitions.iter() {
         sizes.push(ParquetPart::from_part(p)?.uncompressed_size() as usize);
@@ -211,10 +212,10 @@ fn calc_parallelism(
     let num_chunks = ParquetPart::from_part(&plan.parts.partitions[0])?
         .num_io()
         .max(1);
-    let max_memory = ctx.get_settings().get_max_memory_usage()? as usize;
+    let max_memory = settings.get_max_memory_usage()? as usize;
     let max_by_memory = limit_parallelism_by_memory(max_memory, &mut sizes).max(1);
 
-    let max_storage_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+    let max_storage_io_requests = settings.get_max_storage_io_requests()? as usize;
     let num_readers = if is_blocking {
         max_storage_io_requests
     } else {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1.  more sinks too  release memory faster
2.  assume more memory overhead per row group（x2）

cc @wubx 

- Closes #issue
