### PR TITLE
feat: support explain query result cache reading.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,7 +2765,6 @@ dependencies = [
  "dashmap",
  "futures",
  "icelake",
- "itertools",
  "opendal",
  "parquet",
  "serde",

--- a/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache
+++ b/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache
@@ -68,6 +68,25 @@ SELECT * FROM t1, t2 ORDER BY a, b;
 3 b
 3 c
 
+# The explain results of cache reading are the same in both standalone and cluster modes.
+query T
+EXPLAIN SELECT * FROM t1 ORDER BY a;
+----
+ReadQueryResultCache
+├── SQL: SELECT * FROM t1 ORDER BY a
+├── Number of rows: 3
+└── Result size: 12
+
+query T
+EXPLAIN SELECT * FROM t1, t2 ORDER BY a, b;
+----
+ReadQueryResultCache
+├── SQL: SELECT * FROM t1, t2 ORDER BY a, b
+├── Number of rows: 9
+└── Result size: 125
+
+
+
 # Not cached
 query I
 SELECT count(*) FROM t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- If the query will read result cache, we can get this information by `explain`.
- We can `explain pipeline` for all plans now, as we can get the pipeline by `interpreter.execute2`.