### PR TITLE
poc: mount table

### DIFF
--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -48,6 +48,7 @@ use storages_common_table_meta::table::OPT_KEY_EXTERNAL_LOCATION;
 use storages_common_table_meta::table::OPT_KEY_LEGACY_SNAPSHOT_LOC;
 use storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use storages_common_table_meta::table::OPT_KEY_STORAGE_FORMAT;
+use storages_common_table_meta::table::OPT_KEY_STORAGE_PREFIX;
 use storages_common_table_meta::table::OPT_KEY_TABLE_COMPRESSION;
 use tracing::error;
 
@@ -295,6 +296,7 @@ pub static CREATE_TABLE_OPTIONS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     r.insert(OPT_KEY_COMMENT);
     r.insert(OPT_KEY_EXTERNAL_LOCATION);
     r.insert(OPT_KEY_ENGINE);
+    r.insert(OPT_KEY_STORAGE_PREFIX);
 
     r.insert("transient");
     r

--- a/src/query/storages/common/table-meta/src/table/table_keys.rs
+++ b/src/query/storages/common/table-meta/src/table/table_keys.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 
 use once_cell::sync::Lazy;
 pub const OPT_KEY_DATABASE_ID: &str = "database_id";
+pub const OPT_KEY_STORAGE_PREFIX: &str = "storage_prefix";
 pub const OPT_KEY_SNAPSHOT_LOCATION: &str = "snapshot_location";
 pub const OPT_KEY_STORAGE_FORMAT: &str = "storage_format";
 pub const OPT_KEY_TABLE_COMPRESSION: &str = "compression";

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -64,6 +64,7 @@ use storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use storages_common_table_meta::table::OPT_KEY_LEGACY_SNAPSHOT_LOC;
 use storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use storages_common_table_meta::table::OPT_KEY_STORAGE_FORMAT;
+use storages_common_table_meta::table::OPT_KEY_STORAGE_PREFIX;
 use storages_common_table_meta::table::OPT_KEY_TABLE_COMPRESSION;
 use tracing::error;
 use tracing::warn;
@@ -200,6 +201,13 @@ impl FuseTable {
     }
 
     pub fn parse_storage_prefix(table_info: &TableInfo) -> Result<String> {
+        // if OPT_KE_STORAGE_PREFIX is specified, use it as storage prefix
+        if let Some(prefix) = table_info.options().get(OPT_KEY_STORAGE_PREFIX) {
+            return Ok(prefix.clone());
+        }
+
+        // otherwise, use database id and table id as storage prefix
+
         let table_id = table_info.ident.table_id;
         let db_id = table_info
             .options()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

introduces a new table option key `OPT_KEY_STORAGE_PREFIX`, which override the default table storage prefix `{db_id}/{table_id}` if specified. 

so that a table could be created and "mount" to an existing table data directory.




e.g.

~~~
create table mounted(number bigint unsigned) 
SNAPSHOT_LOCATION='275/370/_ss/71acd6ca65344d4d8637a8d2860d23ff_v4.mpk'  
storage_prefix='275/370';
~~~

will "mount" a table data directory `275/370`, and use the  `275/370/_ss/71acd6ca65344d4d8637a8d2860d23ff_v4.mpk` as its first snapshot.

--------------

it is just a proof of concept:


 - the syntax is not that user friendly
 - user should take care of using the same schema while creating new table
 - not been tested on the external table yet, should work, guess.


--------------


a sample scenario:


~~~~

mysql > reate table t as select * from numbers(5);

mysql> set global hide_options_in_show_create_table=0;
Query OK, 0 rows affected (0.03 sec)

mysql> show create table t;
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                    |
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `number` BIGINT UNSIGNED
) ENGINE=FUSE COMPRESSION='zstd' SNAPSHOT_LOCATION='275/370/_ss/71acd6ca65344d4d8637a8d2860d23ff_v4.mpk' STORAGE_FORMAT='parquet' |
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.06 sec)
Read 0 rows, 0.00 B in 0.048 sec., 0 rows/sec., 0.00 B/sec.

mysql> create table mounted(number bigint unsigned) SNAPSHOT_LOCATION='275/370/_ss/71acd6ca65344d4d8637a8d2860d23ff_v4.mpk'  storage_prefix='275/370';
Query OK, 0 rows affected (0.09 sec)

mysql> show create table mounted;
+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table   | Create Table                                                                                                                                                                                                   |
+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| mounted | CREATE TABLE `mounted` (
  `number` BIGINT UNSIGNED
) ENGINE=FUSE COMPRESSION='zstd' SNAPSHOT_LOCATION='275/370/_ss/71acd6ca65344d4d8637a8d2860d23ff_v4.mpk' STORAGE_FORMAT='parquet' STORAGE_PREFIX='275/370' |
+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.03 sec)
Read 0 rows, 0.00 B in 0.018 sec., 0 rows/sec., 0.00 B/sec.

mysql> select * from mounted;
+--------+
| number |
+--------+
|      0 |
|      1 |
|      2 |
|      3 |
|      4 |
+--------+
5 rows in set (0.07 sec)
Read 5 rows, 40.00 B in 0.007 sec., 704.79 rows/sec., 5.51 KiB/sec.

mysql> insert into mounted values(5);
Query OK, 1 row affected (0.15 sec)

mysql> select * from mounted;
+--------+
| number |
+--------+
|      0 |
|      1 |
|      2 |
|      3 |
|      4 |
|      5 |
+--------+
6 rows in set (0.02 sec)
Read 6 rows, 48.00 B in 0.012 sec., 509.27 rows/sec., 3.98 KiB/sec.

mysql> delete from mounted where number < 5;
Query OK, 5 rows affected (0.08 sec)

mysql> select * from mounted;
+--------+
| number |
+--------+
|      5 |
+--------+
1 row in set (0.07 sec)
Read 1 rows, 8.00 B in 0.014 sec., 72.84 rows/sec., 582.71 B/sec.

~~~~



- Closes #issue
