### PR TITLE
feat: add arg in get_table_history to get all the drop tables

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -63,6 +63,7 @@ use common_meta_app::schema::DatabaseId;
 use common_meta_app::schema::DatabaseIdToName;
 use common_meta_app::schema::DatabaseIdent;
 use common_meta_app::schema::DatabaseInfo;
+use common_meta_app::schema::DatabaseInfoFilter;
 use common_meta_app::schema::DatabaseMeta;
 use common_meta_app::schema::DatabaseNameIdent;
 use common_meta_app::schema::DatabaseType;
@@ -810,7 +811,9 @@ impl<KV: kvapi::KVApi<Error = MetaError>> SchemaApi for KV {
                             continue;
                         }
                         let db_meta = db_meta.unwrap();
-                        if is_drop_time_out_of_retention_time(&db_meta.drop_on, &now) {
+                        if req.filter.is_none()
+                            && is_drop_time_out_of_retention_time(&db_meta.drop_on, &now)
+                        {
                             continue;
                         }
 
@@ -1987,6 +1990,62 @@ impl<KV: kvapi::KVApi<Error = MetaError>> SchemaApi for KV {
     ) -> Result<Vec<Arc<TableInfo>>, KVAppError> {
         debug!(req = debug(&req), "SchemaApi: {}", func_name!());
 
+        if let Some(TableInfoFilter::AllDroppedTables(filter_drop_on)) = &req.filter {
+            let db_infos = self
+                .get_database_history(ListDatabaseReq {
+                    tenant: req.inner.tenant.clone(),
+                    filter: Some(DatabaseInfoFilter::IncludeDropped),
+                })
+                .await?;
+
+            let mut ret_table_infos = vec![];
+
+            for db_info in db_infos {
+                let table_infos = match db_info.meta.drop_on {
+                    Some(db_drop_on) => {
+                        if let Some(filter_drop_on) = filter_drop_on {
+                            let filter = if db_drop_on.timestamp() <= filter_drop_on.timestamp() {
+                                // if db drop on before filter time, then get all the db tables.
+                                TableInfoFilter::All
+                            } else {
+                                // else get all the db tables drop on before filter time.
+                                TableInfoFilter::Dropped(Some(*filter_drop_on))
+                            };
+
+                            let req = ListTableReq {
+                                inner: db_info.name_ident.clone(),
+                                filter: Some(filter),
+                            };
+                            do_get_table_history(&self, req, db_info.ident.db_id, &db_info.meta)
+                                .await?
+                        } else {
+                            // while filter_drop_on is None, then get all the drop db tables
+                            let req = ListTableReq {
+                                inner: db_info.name_ident.clone(),
+                                filter: Some(TableInfoFilter::All),
+                            };
+                            do_get_table_history(&self, req, db_info.ident.db_id, &db_info.meta)
+                                .await?
+                        }
+                    }
+                    None => {
+                        // not drop db, only filter drop tables
+                        do_get_table_history(
+                            &self,
+                            ListTableReq {
+                                inner: db_info.name_ident.clone(),
+                                filter: Some(TableInfoFilter::Dropped(*filter_drop_on)),
+                            },
+                            db_info.ident.db_id,
+                            &db_info.meta,
+                        )
+                        .await?
+                    }
+                };
+                ret_table_infos.extend(table_infos);
+            }
+            return Ok(ret_table_infos);
+        }
         let tenant_dbname = &req.inner;
 
         // Get db by name to ensure presence
@@ -2004,123 +2063,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> SchemaApi for KV {
             }
         };
 
-        // List tables by tenant, db_id, table_name.
-        let dbid_tbname_idlist = TableIdListKey {
-            db_id,
-            table_name: "".to_string(),
-        };
-
-        let table_id_list_keys = list_keys(self, &dbid_tbname_idlist).await?;
-
-        let mut tb_info_list = vec![];
-        let now = Utc::now();
-        let keys: Vec<String> = table_id_list_keys
-            .iter()
-            .map(|table_id_list_key| {
-                TableIdListKey {
-                    db_id,
-                    table_name: table_id_list_key.table_name.clone(),
-                }
-                .to_string_key()
-            })
-            .collect();
-        let mut table_id_list_keys_iter = table_id_list_keys.into_iter();
-        for c in keys.chunks(DEFAULT_MGET_SIZE) {
-            let tb_id_list_seq_vec: Vec<(u64, Option<TableIdList>)> =
-                mget_pb_values(self, c).await?;
-            for (tb_id_list_seq, tb_id_list_opt) in tb_id_list_seq_vec {
-                let table_id_list_key = table_id_list_keys_iter.next().unwrap();
-                let tb_id_list = if tb_id_list_seq == 0 {
-                    continue;
-                } else {
-                    match tb_id_list_opt {
-                        Some(list) => list,
-                        None => {
-                            continue;
-                        }
-                    }
-                };
-
-                debug!(name = display(&table_id_list_key), "get_table_history");
-
-                let inner_keys: Vec<String> = tb_id_list
-                    .id_list
-                    .iter()
-                    .map(|table_id| {
-                        TableId {
-                            table_id: *table_id,
-                        }
-                        .to_string_key()
-                    })
-                    .collect();
-                let mut table_id_iter = tb_id_list.id_list.into_iter();
-                for c in inner_keys.chunks(DEFAULT_MGET_SIZE) {
-                    let tb_meta_vec: Vec<(u64, Option<TableMeta>)> =
-                        mget_pb_values(self, c).await?;
-                    for (tb_meta_seq, tb_meta) in tb_meta_vec {
-                        let table_id = table_id_iter.next().unwrap();
-                        if tb_meta_seq == 0 || tb_meta.is_none() {
-                            error!("get_table_history cannot find {:?} table_meta", table_id);
-                            continue;
-                        }
-
-                        // Safe unwrap() because: tb_meta_seq > 0
-                        let tb_meta = tb_meta.unwrap();
-                        if is_drop_time_out_of_retention_time(&tb_meta.drop_on, &now) {
-                            continue;
-                        }
-
-                        let tenant_dbname_tbname: TableNameIdent = TableNameIdent {
-                            tenant: tenant_dbname.tenant.clone(),
-                            db_name: tenant_dbname.db_name.clone(),
-                            table_name: table_id_list_key.table_name.clone(),
-                        };
-
-                        let db_type = match db_meta.from_share.clone() {
-                            Some(share_ident) => DatabaseType::ShareDB(share_ident),
-                            None => DatabaseType::NormalDB,
-                        };
-
-                        let tb_info = TableInfo {
-                            ident: TableIdent {
-                                table_id,
-                                seq: tb_meta_seq,
-                            },
-                            desc: tenant_dbname_tbname.to_string(),
-                            name: table_id_list_key.table_name.clone(),
-                            meta: tb_meta,
-                            tenant: tenant_dbname.tenant.clone(),
-                            db_type,
-                        };
-
-                        tb_info_list.push(Arc::new(tb_info));
-                    }
-                }
-            }
-        }
-
-        if let Some(filter) = req.filter {
-            let filter_tb_infos = tb_info_list
-                .clone()
-                .into_iter()
-                .filter(|tb_info| match filter {
-                    TableInfoFilter::Dropped(drop_on) => match tb_info.meta.drop_on {
-                        Some(tb_drop_on) => {
-                            if let Some(drop_on) = &drop_on {
-                                tb_drop_on.timestamp() <= drop_on.timestamp()
-                            } else {
-                                true
-                            }
-                        }
-                        None => false,
-                    },
-                })
-                .collect::<Vec<_>>();
-
-            return Ok(filter_tb_infos);
-        }
-
-        return Ok(tb_info_list);
+        do_get_table_history(&self, req, db_id, &db_meta).await
     }
 
     #[tracing::instrument(level = "debug", ret, err, skip_all)]
@@ -3392,6 +3335,7 @@ async fn count_tables(
     let databases = kv_api
         .list_databases(ListDatabaseReq {
             tenant: key.tenant.clone(),
+            filter: None,
         })
         .await?;
     let mut count = 0;
@@ -3565,6 +3509,142 @@ fn set_update_expire_operation(
         }
     }
     Ok(())
+}
+
+#[tracing::instrument(level = "debug", ret, err, skip_all)]
+async fn do_get_table_history(
+    kv_api: &impl kvapi::KVApi<Error = MetaError>,
+    req: ListTableReq,
+    db_id: u64,
+    db_meta: &DatabaseMeta,
+) -> Result<Vec<Arc<TableInfo>>, KVAppError> {
+    debug!(req = debug(&req), "SchemaApi: {}", func_name!());
+
+    let tenant_dbname = &req.inner;
+
+    // List tables by tenant, db_id, table_name.
+    let dbid_tbname_idlist = TableIdListKey {
+        db_id,
+        table_name: "".to_string(),
+    };
+
+    let table_id_list_keys = list_keys(kv_api, &dbid_tbname_idlist).await?;
+
+    let mut tb_info_list = vec![];
+    let now = Utc::now();
+    let keys: Vec<String> = table_id_list_keys
+        .iter()
+        .map(|table_id_list_key| {
+            TableIdListKey {
+                db_id,
+                table_name: table_id_list_key.table_name.clone(),
+            }
+            .to_string_key()
+        })
+        .collect();
+    let mut table_id_list_keys_iter = table_id_list_keys.into_iter();
+
+    for c in keys.chunks(DEFAULT_MGET_SIZE) {
+        let tb_id_list_seq_vec: Vec<(u64, Option<TableIdList>)> = mget_pb_values(kv_api, c).await?;
+        for (tb_id_list_seq, tb_id_list_opt) in tb_id_list_seq_vec {
+            let table_id_list_key = table_id_list_keys_iter.next().unwrap();
+            let tb_id_list = if tb_id_list_seq == 0 {
+                continue;
+            } else {
+                match tb_id_list_opt {
+                    Some(list) => list,
+                    None => {
+                        continue;
+                    }
+                }
+            };
+
+            debug!(name = display(&table_id_list_key), "get_table_history");
+
+            let inner_keys: Vec<String> = tb_id_list
+                .id_list
+                .iter()
+                .map(|table_id| {
+                    TableId {
+                        table_id: *table_id,
+                    }
+                    .to_string_key()
+                })
+                .collect();
+            let mut table_id_iter = tb_id_list.id_list.into_iter();
+            for c in inner_keys.chunks(DEFAULT_MGET_SIZE) {
+                let tb_meta_vec: Vec<(u64, Option<TableMeta>)> = mget_pb_values(kv_api, c).await?;
+                for (tb_meta_seq, tb_meta) in tb_meta_vec {
+                    let table_id = table_id_iter.next().unwrap();
+                    if tb_meta_seq == 0 || tb_meta.is_none() {
+                        error!("get_table_history cannot find {:?} table_meta", table_id);
+                        continue;
+                    }
+
+                    // Safe unwrap() because: tb_meta_seq > 0
+                    let tb_meta = tb_meta.unwrap();
+                    // if req.filter is some, filter tables with req.filter
+                    if req.filter.is_none()
+                        && is_drop_time_out_of_retention_time(&tb_meta.drop_on, &now)
+                    {
+                        continue;
+                    }
+
+                    let tenant_dbname_tbname: TableNameIdent = TableNameIdent {
+                        tenant: tenant_dbname.tenant.clone(),
+                        db_name: tenant_dbname.db_name.clone(),
+                        table_name: table_id_list_key.table_name.clone(),
+                    };
+
+                    let db_type = match db_meta.from_share.clone() {
+                        Some(share_ident) => DatabaseType::ShareDB(share_ident),
+                        None => DatabaseType::NormalDB,
+                    };
+
+                    let tb_info = TableInfo {
+                        ident: TableIdent {
+                            table_id,
+                            seq: tb_meta_seq,
+                        },
+                        desc: tenant_dbname_tbname.to_string(),
+                        name: table_id_list_key.table_name.clone(),
+                        meta: tb_meta,
+                        tenant: tenant_dbname.tenant.clone(),
+                        db_type,
+                    };
+
+                    tb_info_list.push(Arc::new(tb_info));
+                }
+            }
+        }
+    }
+
+    if let Some(filter) = req.filter {
+        let filter_tb_infos = tb_info_list
+            .clone()
+            .into_iter()
+            .filter(|tb_info| match filter {
+                TableInfoFilter::Dropped(drop_on) => match tb_info.meta.drop_on {
+                    Some(tb_drop_on) => {
+                        if let Some(drop_on) = &drop_on {
+                            tb_drop_on.timestamp() <= drop_on.timestamp()
+                        } else {
+                            true
+                        }
+                    }
+                    None => false,
+                },
+                TableInfoFilter::All => true,
+                _ => {
+                    unreachable!("unreachable");
+                }
+            })
+            .collect::<Vec<_>>();
+
+        return Ok(filter_tb_infos);
+    }
+
+    Ok(tb_info_list)
 }
 
 /// Returns (index_id_seq, index_id, index_meta_seq, index_meta)

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use chrono::DateTime;
@@ -268,6 +269,7 @@ impl SchemaApiTestSuite {
         suite
             .table_drop_out_of_retention_time_history(&b.build().await)
             .await?;
+        suite.table_history_filter(&b.build().await).await?;
         suite.get_table_by_id(&b.build().await).await?;
         suite.get_table_copied_file(&b.build().await).await?;
         suite.truncate_table(&b.build().await).await?;
@@ -280,6 +282,7 @@ impl SchemaApiTestSuite {
         suite
             .virtual_column_create_list_drop(&b.build().await)
             .await?;
+
         Ok(())
     }
 
@@ -889,6 +892,7 @@ impl SchemaApiTestSuite {
             let dbs = mt
                 .list_databases(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
 
@@ -933,6 +937,7 @@ impl SchemaApiTestSuite {
             let dbs = mt
                 .list_databases(ListDatabaseReq {
                     tenant: tenant1.to_string(),
+                    filter: None,
                 })
                 .await?;
             let got = dbs.iter().map(|x| x.ident.db_id).collect::<Vec<_>>();
@@ -944,6 +949,7 @@ impl SchemaApiTestSuite {
             let dbs = mt
                 .list_databases(ListDatabaseReq {
                     tenant: tenant2.to_string(),
+                    filter: None,
                 })
                 .await?;
             let want: Vec<u64> = vec![db_id_3];
@@ -1106,6 +1112,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
@@ -1124,6 +1131,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
@@ -1141,6 +1149,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
@@ -1162,6 +1171,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
@@ -1186,6 +1196,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
@@ -1213,6 +1224,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![
@@ -1239,6 +1251,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![
@@ -1269,6 +1282,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![
@@ -2263,6 +2277,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
 
@@ -2281,6 +2296,7 @@ impl SchemaApiTestSuite {
             let res = mt
                 .get_database_history(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await?;
 
@@ -2703,6 +2719,298 @@ impl SchemaApiTestSuite {
             assert_eq!(res.len(), 0);
         }
 
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn table_history_filter<MT: SchemaApi + kvapi::AsKVApi<Error = MetaError>>(
+        &self,
+        mt: &MT,
+    ) -> anyhow::Result<()> {
+        let tenant = "tenant1";
+        let schema = || {
+            Arc::new(TableSchema::new(vec![TableField::new(
+                "number",
+                TableDataType::Number(NumberDataType::UInt64),
+            )]))
+        };
+        let table_meta = |created_on| TableMeta {
+            schema: schema(),
+            engine: "JSON".to_string(),
+            options: BTreeMap::new(),
+            updated_on: created_on,
+            created_on,
+            ..TableMeta::default()
+        };
+        let created_on = Utc::now();
+
+        // first create a database drop within filter time
+        info!("--- create db1");
+        {
+            let req = CreateDatabaseReq {
+                if_not_exists: false,
+                name_ident: DatabaseNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "db1".to_string(),
+                },
+                meta: DatabaseMeta {
+                    engine: "".to_string(),
+                    ..DatabaseMeta::default()
+                },
+            };
+
+            let _res = mt.create_database(req).await;
+
+            let req = CreateTableReq {
+                if_not_exists: false,
+                name_ident: TableNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "db1".to_string(),
+                    table_name: "tb1".to_string(),
+                },
+
+                table_meta: table_meta(created_on),
+            };
+            let _resp = mt.create_table(req.clone()).await?;
+
+            mt.drop_database(DropDatabaseReq {
+                if_exists: false,
+                name_ident: DatabaseNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "db1".to_string(),
+                },
+            })
+            .await?;
+        }
+
+        // second create a database drop outof filter time, but has a table drop within filter time
+        info!("--- create db2");
+        {
+            let create_db_req = CreateDatabaseReq {
+                if_not_exists: false,
+                name_ident: DatabaseNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "db2".to_string(),
+                },
+                meta: DatabaseMeta {
+                    engine: "".to_string(),
+                    ..DatabaseMeta::default()
+                },
+            };
+
+            let res = mt.create_database(create_db_req.clone()).await?;
+            let db_id = res.db_id;
+
+            info!("--- create and drop db2.tb1");
+            {
+                let req = CreateTableReq {
+                    if_not_exists: false,
+                    name_ident: TableNameIdent {
+                        tenant: tenant.to_string(),
+                        db_name: "db2".to_string(),
+                        table_name: "tb1".to_string(),
+                    },
+
+                    table_meta: table_meta(created_on),
+                };
+                let resp = mt.create_table(req.clone()).await?;
+                mt.drop_table_by_id(DropTableByIdReq {
+                    if_exists: false,
+                    tb_id: resp.table_id,
+                })
+                .await?;
+            }
+
+            info!("--- create and drop db2.tb2, but make its drop time out of filter time");
+            {
+                let mut table_meta = table_meta(created_on);
+                let req = CreateTableReq {
+                    if_not_exists: false,
+                    name_ident: TableNameIdent {
+                        tenant: tenant.to_string(),
+                        db_name: "db2".to_string(),
+                        table_name: "tb2".to_string(),
+                    },
+
+                    table_meta: table_meta.clone(),
+                };
+                let resp = mt.create_table(req.clone()).await?;
+                mt.drop_table_by_id(DropTableByIdReq {
+                    if_exists: false,
+                    tb_id: resp.table_id,
+                })
+                .await?;
+                let table_id = resp.table_id;
+                let id_key = TableId { table_id };
+                table_meta.drop_on = Some(created_on + Duration::seconds(100));
+                let data = serialize_struct(&table_meta)?;
+                upsert_test_data(mt.as_kv_api(), &id_key, data).await?;
+            }
+
+            info!("--- create db2.tb3");
+            {
+                let req = CreateTableReq {
+                    if_not_exists: false,
+                    name_ident: TableNameIdent {
+                        tenant: tenant.to_string(),
+                        db_name: "db2".to_string(),
+                        table_name: "tb3".to_string(),
+                    },
+
+                    table_meta: table_meta(created_on),
+                };
+                let _resp = mt.create_table(req.clone()).await?;
+            }
+
+            mt.drop_database(DropDatabaseReq {
+                if_exists: false,
+                name_ident: DatabaseNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "db2".to_string(),
+                },
+            })
+            .await?;
+            // change db meta to make this db drop time outof filter time
+            let mut drop_db_meta = create_db_req.meta.clone();
+            drop_db_meta.drop_on = Some(created_on + Duration::seconds(100));
+            let id_key = DatabaseId { db_id };
+            let data = serialize_struct(&drop_db_meta)?;
+            upsert_test_data(mt.as_kv_api(), &id_key, data).await?;
+        }
+
+        // third create a database not dropped, but has a table drop within filter time
+        {
+            let create_db_req = CreateDatabaseReq {
+                if_not_exists: false,
+                name_ident: DatabaseNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "db3".to_string(),
+                },
+                meta: DatabaseMeta {
+                    engine: "".to_string(),
+                    ..DatabaseMeta::default()
+                },
+            };
+
+            let _res = mt.create_database(create_db_req.clone()).await?;
+
+            info!("--- create and drop db3.tb1");
+            {
+                let req = CreateTableReq {
+                    if_not_exists: false,
+                    name_ident: TableNameIdent {
+                        tenant: tenant.to_string(),
+                        db_name: "db3".to_string(),
+                        table_name: "tb1".to_string(),
+                    },
+
+                    table_meta: table_meta(created_on),
+                };
+                let resp = mt.create_table(req.clone()).await?;
+                mt.drop_table_by_id(DropTableByIdReq {
+                    if_exists: false,
+                    tb_id: resp.table_id,
+                })
+                .await?;
+            }
+
+            info!("--- create and drop db3.tb2, but make its drop time out of filter time");
+            {
+                let mut table_meta = table_meta(created_on);
+                let req = CreateTableReq {
+                    if_not_exists: false,
+                    name_ident: TableNameIdent {
+                        tenant: tenant.to_string(),
+                        db_name: "db3".to_string(),
+                        table_name: "tb2".to_string(),
+                    },
+
+                    table_meta: table_meta.clone(),
+                };
+                let resp = mt.create_table(req.clone()).await?;
+                mt.drop_table_by_id(DropTableByIdReq {
+                    if_exists: false,
+                    tb_id: resp.table_id,
+                })
+                .await?;
+                let table_id = resp.table_id;
+                let id_key = TableId { table_id };
+                table_meta.drop_on = Some(created_on + Duration::seconds(100));
+                let data = serialize_struct(&table_meta)?;
+                upsert_test_data(mt.as_kv_api(), &id_key, data).await?;
+            }
+
+            info!("--- create db3.tb3");
+            {
+                let req = CreateTableReq {
+                    if_not_exists: false,
+                    name_ident: TableNameIdent {
+                        tenant: tenant.to_string(),
+                        db_name: "db3".to_string(),
+                        table_name: "tb3".to_string(),
+                    },
+
+                    table_meta: table_meta(created_on),
+                };
+                let _resp = mt.create_table(req.clone()).await?;
+            }
+        }
+
+        // case 1: test AllDroppedTables with filter time
+        {
+            let now = Utc::now();
+            let plan = ListTableReq {
+                inner: DatabaseNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "".to_string(),
+                },
+                filter: Some(TableInfoFilter::AllDroppedTables(Some(now))),
+            };
+            let resp = mt.get_table_history(plan).await?;
+
+            let expected: BTreeSet<String> = vec![
+                "'tenant1'.'db1'.'tb1'".to_string(),
+                "'tenant1'.'db2'.'tb1'".to_string(),
+                "'tenant1'.'db3'.'tb1'".to_string(),
+            ]
+            .iter()
+            .cloned()
+            .collect();
+            let actual: BTreeSet<String> = resp
+                .iter()
+                .map(|table_info| table_info.desc.clone())
+                .collect();
+            assert_eq!(expected, actual);
+        }
+
+        // case 2: test AllDroppedTables without filter time
+        {
+            let plan = ListTableReq {
+                inner: DatabaseNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "".to_string(),
+                },
+                filter: Some(TableInfoFilter::AllDroppedTables(None)),
+            };
+            let resp = mt.get_table_history(plan).await?;
+
+            let expected: BTreeSet<String> = vec![
+                "'tenant1'.'db1'.'tb1'".to_string(),
+                "'tenant1'.'db2'.'tb1'".to_string(),
+                "'tenant1'.'db2'.'tb2'".to_string(),
+                "'tenant1'.'db2'.'tb3'".to_string(),
+                "'tenant1'.'db3'.'tb1'".to_string(),
+                "'tenant1'.'db3'.'tb2'".to_string(),
+            ]
+            .iter()
+            .cloned()
+            .collect();
+            let actual: BTreeSet<String> = resp
+                .iter()
+                .map(|table_info| table_info.desc.clone())
+                .collect();
+            assert_eq!(expected, actual);
+        }
         Ok(())
     }
 
@@ -4482,6 +4790,7 @@ impl SchemaApiTestSuite {
             let res = node_b
                 .list_databases(ListDatabaseReq {
                     tenant: tenant.to_string(),
+                    filter: None,
                 })
                 .await;
             debug!("get database list: {:?}", res);

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -289,8 +289,15 @@ impl GetDatabaseReq {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum DatabaseInfoFilter {
+    // include all dropped databases
+    IncludeDropped,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ListDatabaseReq {
     pub tenant: String,
+    pub filter: Option<DatabaseInfoFilter>,
 }
 
 mod kvapi_key_impl {

--- a/src/meta/app/src/schema/mod.rs
+++ b/src/meta/app/src/schema/mod.rs
@@ -33,6 +33,7 @@ pub use database::DatabaseId;
 pub use database::DatabaseIdToName;
 pub use database::DatabaseIdent;
 pub use database::DatabaseInfo;
+pub use database::DatabaseInfoFilter;
 pub use database::DatabaseMeta;
 pub use database::DatabaseNameIdent;
 pub use database::DbIdList;

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -649,6 +649,14 @@ pub enum TableInfoFilter {
     // if datatime is some, filter only dropped tables which drop time before that,
     // else filter all dropped tables
     Dropped(Option<DateTime<Utc>>),
+    // filter all dropped tables, including all tables in dropped database and dropped tables in exist dbs,
+    // in this case, `ListTableReq`.db_name will be ignored
+    // return Tables in two cases:
+    //  1) if database drop before date time, then all table in this db will be return;
+    //  2) else, return all the tables drop before data time.
+    AllDroppedTables(Option<DateTime<Utc>>),
+    // return all tables, ignore drop on time.
+    All,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -191,6 +191,7 @@ impl Catalog for MutableCatalog {
             .meta
             .list_databases(ListDatabaseReq {
                 tenant: tenant.to_string(),
+                filter: None,
             })
             .await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: add arg in get_table_history to get all the drop tables

add `AllDroppedTables` option to get tables in drop db, and test cases.

- Closes #issue
