### PR TITLE
fix: if there are derived columns in the select list, we cannot use lazy materialization.

### DIFF
--- a/tests/sqllogictests/suites/mode/standalone/explain/lazy_read.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lazy_read.test
@@ -182,4 +182,86 @@ EvalScalar
         └── estimated rows: 0.00
 
 statement ok
+set lazy_read_threshold=100
+
+# lazy materialization with CTE
+
+# Will not use lazy materialization
+query T
+explain with cte as (select a, a + 1 as X, b + 1 as Y from t_lazy) select X,Y,a from (select * from cte) order by X limit 1;
+----
+EvalScalar
+├── expressions: [cte.a (#0), cte.x (#7), cte.y (#8)]
+├── estimated rows: 0.00
+└── Limit
+    ├── limit: 1
+    ├── offset: 0
+    ├── estimated rows: 0.00
+    └── Sort
+        ├── sort keys: [x ASC NULLS LAST]
+        ├── estimated rows: 0.00
+        └── EvalScalar
+            ├── expressions: [cte.a (#0), cte.x (#7), cte.y (#8)]
+            ├── estimated rows: 0.00
+            └── EvalScalar
+                ├── expressions: [t_lazy.a (#0), t_lazy.a (#0) + 1, t_lazy.b (#1) + 1]
+                ├── estimated rows: 0.00
+                └── TableScan
+                    ├── table: default.default.t_lazy
+                    ├── read rows: 0
+                    ├── read bytes: 0
+                    ├── partitions total: 0
+                    ├── partitions scanned: 0
+                    ├── push downs: [filters: [], limit: NONE]
+                    ├── output columns: [a, b]
+                    └── estimated rows: 0.00
+
+# Will use lazy materialization
+query T
+explain with cte as (select a, a + 1 as X, b + 1 as Y from t_lazy order by a limit 3) select X,Y,a from (select * from cte order by Y limit 2) order by X limit 1;
+----
+EvalScalar
+├── expressions: [cte.a (#0), cte.x (#7), cte.y (#8)]
+├── estimated rows: 0.00
+└── Limit
+    ├── limit: 1
+    ├── offset: 0
+    ├── estimated rows: 0.00
+    └── Sort
+        ├── sort keys: [x ASC NULLS LAST]
+        ├── estimated rows: 0.00
+        └── EvalScalar
+            ├── expressions: [cte.a (#0), cte.x (#7), cte.y (#8)]
+            ├── estimated rows: 0.00
+            └── Limit
+                ├── limit: 2
+                ├── offset: 0
+                ├── estimated rows: 0.00
+                └── Sort
+                    ├── sort keys: [y ASC NULLS LAST]
+                    ├── estimated rows: 0.00
+                    └── EvalScalar
+                        ├── expressions: [t_lazy.a (#0), t_lazy.a (#0) + 1, t_lazy.b (#1) + 1]
+                        ├── estimated rows: 0.00
+                        └── RowFetch
+                            ├── columns to fetch: [b]
+                            ├── estimated rows: 0.00
+                            └── Limit
+                                ├── limit: 3
+                                ├── offset: 0
+                                ├── estimated rows: 0.00
+                                └── Sort
+                                    ├── sort keys: [a ASC NULLS LAST]
+                                    ├── estimated rows: 0.00
+                                    └── TableScan
+                                        ├── table: default.default.t_lazy
+                                        ├── read rows: 0
+                                        ├── read bytes: 0
+                                        ├── partitions total: 0
+                                        ├── partitions scanned: 0
+                                        ├── push downs: [filters: [], limit: 3]
+                                        ├── output columns: [a, _row_id]
+                                        └── estimated rows: 0.00
+
+statement ok
 drop table t_lazy

--- a/tests/sqllogictests/suites/query/cte.test
+++ b/tests/sqllogictests/suites/query/cte.test
@@ -370,4 +370,49 @@ query II
 with v as (select * from numbers(2)) select * from v t1, (select * from v where number = 0) t2 where t1.number = 1 and t2.number = 1
 ----
 
+# ISSUE 11974
+statement ok
+drop table if exists t_11974
 
+statement ok
+CREATE TABLE `t_11974` (`user_id` INT, `item_id` INT, `category_id` INT, `behavior_type` VARCHAR, `ts` TIMESTAMP, `day` DATE)
+
+query IIIIIIII
+with cte as(
+select user_id,
+       to_date('2017-12-04') - max(day) as R,
+       dense_rank() over(order by (to_date('2017-12-04') - max(day))) as R_rank,
+       count(1) as F,
+       dense_rank() over(order by count(1) desc) as F_rank
+from t_11974
+where behavior_type = 'buy'
+group by user_id)
+select user_id, R, R_rank, R_score, F, F_rank, F_score,  R_score + F_score AS score
+from(
+select *,
+       case ntile(5) over(order by R_rank) when 1 then 5
+                                           when 2 then 4
+                                           when 3 then 3
+                                           when 4 then 2
+                                           when 5 then 1
+       end as R_score,
+       case ntile(5) over(order by F_rank) when 1 then 5
+                                           when 2 then 4
+                                           when 3 then 3
+                                           when 4 then 2
+                                           when 5 then 1
+       end as F_score
+from cte
+) as a
+order by score desc
+limit 20
+----
+
+statement ok
+drop table t_11974
+
+# This query will use lazy materialization.
+query III
+with cte as (select a, a + 1 as X, b + 1 as Y from t1 order by a limit 3) select X,Y,a from (select * from cte order by Y limit 2) order by X limit 1;
+----
+105 101 104


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

If there are derived columns in the select list‘s `used_columns`, we cannot use lazy materialization.

The derived columns may come from CTE (or others), we cannot build rows fetcher on them.

Closes #11974
