### PR TITLE
fix: wrong memory_size of StringColumn.

### DIFF
--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -178,6 +178,12 @@ impl StringColumn {
         self.offsets.len() - 1
     }
 
+    pub fn memory_size(&self) -> usize {
+        let offsets = self.offsets.as_slice();
+        let len = offsets.len();
+        len * 8 + (offsets[len - 1] - offsets[0]) as usize
+    }
+
     pub fn index(&self, index: usize) -> Option<&[u8]> {
         if index + 1 < self.offsets.len() {
             Some(&self.data[(self.offsets[index] as usize)..(self.offsets[index + 1] as usize)])

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -1732,15 +1732,15 @@ impl Column {
             Column::Decimal(DecimalColumn::Decimal128(col, _)) => col.len() * 16,
             Column::Decimal(DecimalColumn::Decimal256(col, _)) => col.len() * 32,
             Column::Boolean(c) => c.as_slice().0.len(),
-            Column::String(col) => col.data.len() + col.offsets.len() * 8,
+            Column::String(col) => col.memory_size(),
             Column::Timestamp(col) => col.len() * 8,
             Column::Date(col) => col.len() * 4,
             Column::Array(col) => col.values.memory_size() + col.offsets.len() * 8,
             Column::Map(col) => col.values.memory_size() + col.offsets.len() * 8,
-            Column::Bitmap(col) => col.data.len() + col.offsets.len() * 8,
+            Column::Bitmap(col) => col.memory_size(),
             Column::Nullable(c) => c.column.memory_size() + c.validity.as_slice().0.len(),
             Column::Tuple(fields) => fields.iter().map(|f| f.memory_size()).sum(),
-            Column::Variant(col) => col.data.len() + col.offsets.len() * 8,
+            Column::Variant(col) => col.memory_size(),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

should not use `col.data.len()`, the `data` maybe shared(sliced). 