### PR TITLE
feat: add metrics for spill

### DIFF
--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod counter;
 mod dump;
 mod recorder;
+mod reset;
 
 pub use dump::dump_metric_samples;
 pub use dump::HistogramCount;
@@ -39,3 +40,4 @@ pub use recorder::label_increment_gauge_with_val_and_labels;
 pub use recorder::try_handle;
 pub use recorder::LABEL_KEY_CLUSTER;
 pub use recorder::LABEL_KEY_TENANT;
+pub use reset::reset_metrics;

--- a/src/common/metrics/src/reset.rs
+++ b/src/common/metrics/src/reset.rs
@@ -1,0 +1,31 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::Result;
+use metrics::gauge;
+use metrics_exporter_prometheus::PrometheusHandle;
+
+use crate::dump_metric_samples;
+use crate::MetricValue;
+
+/// Reset gauge metrics to 0.
+pub fn reset_metrics(handle: PrometheusHandle) -> Result<()> {
+    let samples = dump_metric_samples(handle)?;
+    for sample in samples {
+        if let MetricValue::Gauge(_) = sample.value {
+            gauge!(sample.name, 0_f64);
+        }
+    }
+    Ok(())
+}

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
@@ -38,6 +38,9 @@ use crate::pipelines::processors::transforms::aggregator::aggregate_meta::Aggreg
 use crate::pipelines::processors::transforms::group_by::HashMethodBounds;
 use crate::pipelines::processors::transforms::group_by::PartitionedHashMethod;
 use crate::pipelines::processors::transforms::group_by::PolymorphicKeysHelper;
+use crate::pipelines::processors::transforms::metrics::metrics_inc_aggregate_partial_hashtable_allocated_bytes;
+use crate::pipelines::processors::transforms::metrics::metrics_inc_aggregate_partial_spill_cell_count;
+use crate::pipelines::processors::transforms::metrics::metrics_inc_aggregate_partial_spill_count;
 use crate::pipelines::processors::transforms::HashTableCell;
 use crate::pipelines::processors::transforms::PartitionedHashTableDropper;
 use crate::pipelines::processors::AggregatorParams;
@@ -304,8 +307,21 @@ impl<Method: HashMethodBounds> AccumulatingTransform for TransformPartialAggrega
             if matches!(&self.hash_table, HashTable::PartitionedHashTable(cell) if cell.allocated_bytes() > self.settings.spilling_bytes_threshold_per_proc)
             {
                 if let HashTable::PartitionedHashTable(v) = std::mem::take(&mut self.hash_table) {
+                    // perf
+                    {
+                        metrics_inc_aggregate_partial_spill_count();
+                        metrics_inc_aggregate_partial_hashtable_allocated_bytes(
+                            v.allocated_bytes() as u64,
+                        );
+                    }
+
                     let _dropper = v._dropper.clone();
                     let cells = PartitionedHashTableDropper::split_cell(v);
+                    // perf
+                    {
+                        metrics_inc_aggregate_partial_spill_cell_count(cells.len() as u64);
+                    }
+
                     let mut blocks = Vec::with_capacity(cells.len());
                     for (bucket, cell) in cells.into_iter().enumerate() {
                         if cell.hashtable.len() != 0 {

--- a/src/query/service/src/pipelines/processors/transforms/metrics/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/metrics/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod transform_metrics;
+
+pub use transform_metrics::*;

--- a/src/query/service/src/pipelines/processors/transforms/metrics/transform_metrics.rs
+++ b/src/query/service/src/pipelines/processors/transforms/metrics/transform_metrics.rs
@@ -1,0 +1,72 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use metrics::increment_gauge;
+
+macro_rules! key {
+    ($key: literal) => {
+        concat!("transform_", $key)
+    };
+}
+
+pub fn metrics_inc_aggregate_partial_spill_count() {
+    increment_gauge!(key!("aggregate_partial_spill_count"), 1_f64);
+}
+
+pub fn metrics_inc_aggregate_partial_spill_cell_count(c: u64) {
+    increment_gauge!(key!("aggregate_partial_spill_cell_count"), c as f64);
+}
+
+pub fn metrics_inc_aggregate_partial_hashtable_allocated_bytes(c: u64) {
+    increment_gauge!(
+        key!("aggregate_partial_hashtable_allocated_bytes"),
+        c as f64
+    );
+}
+
+pub fn metrics_inc_group_by_spill_write_count() {
+    increment_gauge!(key!("group_by_spill_write_count"), 1_f64);
+}
+
+pub fn metrics_inc_group_by_spill_write_bytes(c: u64) {
+    increment_gauge!(key!("group_by_spill_write_bytes"), c as f64);
+}
+
+pub fn metrics_inc_group_by_spill_write_milliseconds(c: u64) {
+    increment_gauge!(key!("group_by_spill_write_milliseconds"), c as f64);
+}
+
+pub fn metrics_inc_aggregate_spill_write_count() {
+    increment_gauge!(key!("aggregate_spill_write_count"), 1_f64);
+}
+
+pub fn metrics_inc_aggregate_spill_write_bytes(c: u64) {
+    increment_gauge!(key!("aggregate_spill_write_bytes"), c as f64);
+}
+
+pub fn metrics_inc_aggregate_spill_write_milliseconds(c: u64) {
+    increment_gauge!(key!("aggregate_spill_write_milliseconds"), c as f64);
+}
+
+pub fn metrics_inc_aggregate_spill_read_count() {
+    increment_gauge!(key!("aggregate_spill_read_count"), 1_f64);
+}
+
+pub fn metrics_inc_aggregate_spill_read_bytes(c: u64) {
+    increment_gauge!(key!("aggregate_spill_read_bytes"), c as f64);
+}
+
+pub fn metrics_inc_aggregate_spill_read_milliseconds(c: u64) {
+    increment_gauge!(key!("aggregate_spill_read_milliseconds"), c as f64);
+}

--- a/src/query/service/src/pipelines/processors/transforms/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/mod.rs
@@ -21,6 +21,7 @@ mod transform_hash_join;
 mod transform_limit;
 mod window;
 
+mod metrics;
 mod range_join;
 mod runtime_filter;
 mod transform_add_computed_columns;

--- a/src/query/storages/fuse/src/lib.rs
+++ b/src/query/storages/fuse/src/lib.rs
@@ -42,8 +42,6 @@ pub use fuse_table::FuseTable;
 pub use io::MergeIOReadResult;
 pub use pruning::SegmentLocation;
 
-pub use crate::metrics::metrics_reset;
-
 mod sessions {
     pub use common_catalog::table_context::TableContext;
 }

--- a/src/query/storages/fuse/src/metrics/fuse_metrics.rs
+++ b/src/query/storages/fuse/src/metrics/fuse_metrics.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use metrics::counter;
-use metrics::gauge;
 use metrics::increment_gauge;
 
 macro_rules! key {
@@ -185,55 +184,4 @@ pub fn metrics_inc_deletion_block_range_pruned_whole_block_nums(c: u64) {
         key!("deletion_block_range_pruned_whole_block_nums"),
         c as f64
     );
-}
-
-pub fn metrics_reset() {
-    let c = 0 as f64;
-
-    // IO metrics.
-    gauge!(key!("remote_io_seeks"), c);
-    gauge!(key!("remote_io_seeks_after_merged"), c);
-    gauge!(key!("remote_io_read_bytes"), c);
-    gauge!(key!("remote_io_read_bytes_after_merged"), c);
-    gauge!(key!("remote_io_read_parts"), c);
-    gauge!(key!("remote_io_read_milliseconds"), c);
-    gauge!(key!("remote_io_deserialize_milliseconds"), c);
-
-    // Block metrics.
-    gauge!(key!("block_write_nums"), c);
-    gauge!(key!("block_write_bytes"), c);
-    gauge!(key!("block_write_milliseconds"), c);
-    gauge!(key!("block_index_write_nums"), c);
-    gauge!(key!("block_index_write_bytes"), c);
-    gauge!(key!("block_index_write_milliseconds"), c);
-    gauge!(key!("block_index_read_nums"), c);
-    gauge!(key!("block_index_read_bytes"), c);
-    gauge!(key!("block_index_read_milliseconds"), c);
-
-    // Compact metrics.
-    gauge!(key!("compact_block_read_nums"), c);
-    gauge!(key!("compact_block_read_bytes"), c);
-    gauge!(key!("compact_block_read_milliseconds"), c);
-
-    // Pruning metrics.
-    gauge!(key!("pruning_prewhere_nums"), c);
-    gauge!(key!("pruning_milliseconds"), c);
-
-    gauge!(key!("segments_range_pruning_before"), c);
-    gauge!(key!("segments_range_pruning_after"), c);
-    gauge!(key!("blocks_range_pruning_before"), c);
-    gauge!(key!("blocks_range_pruning_after"), c);
-    gauge!(key!("blocks_bloom_pruning_before"), c);
-    gauge!(key!("blocks_bloom_pruning_after"), c);
-    gauge!(key!("bytes_segment_range_pruning_before"), c);
-    gauge!(key!("bytes_segment_range_pruning_after"), c);
-    gauge!(key!("bytes_block_bloom_pruning_before"), c);
-    gauge!(key!("bytes_block_bloom_pruning_after"), c);
-    gauge!(key!("bytes_block_range_pruning_before"), c);
-    gauge!(key!("bytes_block_range_pruning_after"), c);
-    gauge!(key!("deletion_block_range_pruned_nums"), c);
-    gauge!(key!("deletion_block_range_pruned_whole_block_nums"), c);
-
-    // segment metrics
-    gauge!(key!("deletion_segment_range_pruned_whole_segment_nums"), c);
 }

--- a/src/query/storages/system/src/metrics_table.rs
+++ b/src/query/storages/system/src/metrics_table.rs
@@ -28,8 +28,8 @@ use common_expression::TableSchemaRefExt;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
+use common_metrics::reset_metrics;
 use common_metrics::MetricValue;
-use common_storages_fuse::metrics_reset;
 
 use crate::SyncOneBlockSystemTable;
 use crate::SyncSystemTable;
@@ -71,7 +71,11 @@ impl SyncSystemTable for MetricsTable {
     }
 
     fn truncate(&self, _ctx: Arc<dyn TableContext>) -> Result<()> {
-        metrics_reset();
+        let prometheus_handle = common_metrics::try_handle().ok_or_else(|| {
+            ErrorCode::InitPrometheusFailure("Prometheus recorder is not initialized yet.")
+        })?;
+
+        reset_metrics(prometheus_handle)?;
         Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* **Metrics**: Added functions for incrementing various metrics related to transforms and spilling operations. Metrics are used to measure the time and size of write and read operations.
* **Fuse Metrics**: Removed unused `gauge` function and replaced `metrics_reset` with `reset_metrics` from `common_metrics` crate.
* **Metrics Table**: Added new module `metrics_table` to `system` crate, importing `reset_metrics` from `common_metrics` crate. Removed unused `metrics_reset` function and implemented `SyncSystemTable` trait for `MetricsTable` struct. Added `truncate` function to reset metrics using `reset_metrics`.

- Closes #issue
