### PR TITLE
fix: add ignore_err in get_block_locations

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum.rs
@@ -122,7 +122,7 @@ pub async fn get_snapshot_referenced_files(
     };
 
     let locations_referenced = fuse_table
-        .get_block_locations(ctx.clone(), &segments_vec, false)
+        .get_block_locations(ctx.clone(), &segments_vec, false, false)
         .await?;
 
     let mut segments = HashSet::with_capacity(segments_vec.len());

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -347,6 +347,7 @@ impl FuseTable {
         let mut count = 0;
         let segment_locations = Vec::from_iter(segments_to_be_purged);
         for chunk in segment_locations.chunks(chunk_size) {
+            // since we are purging files, the ErrorCode::STORAGE_NOT_FOUND error can be safely ignored.
             let locations = self
                 .get_block_locations(ctx.clone(), chunk, false, true)
                 .await?;

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -306,6 +306,7 @@ impl FuseTable {
         // Purge segments&blocks by chunk size
         let segment_locations = Vec::from_iter(segments_to_be_purged);
         for chunk in segment_locations.chunks(chunk_size) {
+            // since we are purging files, the ErrorCode::STORAGE_NOT_FOUND error can be safely ignored.
             let locations = self
                 .get_block_locations(ctx.clone(), chunk, false, true)
                 .await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add ignore_err in get_block_locations to avoid missing blocks and bloom indexes

- Closes #issue
