### PR TITLE
feat: add system.backtrace table

### DIFF
--- a/src/common/base/src/lib.rs
+++ b/src/common/base/src/lib.rs
@@ -32,5 +32,6 @@ pub mod mem_allocator;
 pub mod rangemap;
 pub mod runtime;
 
+pub use runtime::dump_backtrace;
 pub use runtime::match_join_handle;
 pub use runtime::set_alloc_error_hook;

--- a/src/common/base/src/runtime/backtrace.rs
+++ b/src/common/base/src/runtime/backtrace.rs
@@ -1,0 +1,79 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Write;
+
+#[derive(Debug)]
+struct AsyncTaskItem {
+    stack_frames: Vec<String>,
+}
+
+pub fn dump_backtrace(wait_for_running_tasks: bool) -> String {
+    let tree = async_backtrace::taskdump_tree(wait_for_running_tasks);
+
+    let mut tasks = vec![];
+    let mut polling_tasks = vec![];
+    let mut current_stack_frames = vec![];
+
+    let mut first = true;
+    let mut is_polling = false;
+    for line in tree.lines() {
+        if line.starts_with(|x: char| !x.is_ascii_whitespace()) {
+            if !first {
+                match is_polling {
+                    true => polling_tasks.push(AsyncTaskItem {
+                        stack_frames: std::mem::take(&mut current_stack_frames),
+                    }),
+                    false => tasks.push(AsyncTaskItem {
+                        stack_frames: std::mem::take(&mut current_stack_frames),
+                    }),
+                };
+
+                is_polling = false;
+            }
+
+            first = false;
+        }
+
+        if line.ends_with("[POLLING]") {
+            is_polling = true;
+        }
+
+        current_stack_frames.push(line.to_string());
+    }
+
+    match is_polling {
+        true => polling_tasks.push(AsyncTaskItem {
+            stack_frames: std::mem::take(&mut current_stack_frames),
+        }),
+        false => tasks.push(AsyncTaskItem {
+            stack_frames: std::mem::take(&mut current_stack_frames),
+        }),
+    };
+
+    let mut output = String::new();
+    for mut tasks in [tasks, polling_tasks] {
+        tasks.sort_by(|l, r| Ord::cmp(&l.stack_frames.len(), &r.stack_frames.len()));
+
+        for item in tasks.into_iter().rev() {
+            for frame in item.stack_frames {
+                writeln!(output, "{}", frame).unwrap();
+            }
+
+            writeln!(output).unwrap();
+        }
+    }
+
+    output
+}

--- a/src/common/base/src/runtime/mod.rs
+++ b/src/common/base/src/runtime/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod backtrace;
 mod catch_unwind;
 mod global_runtime;
 #[allow(clippy::module_inception)]
@@ -20,6 +21,7 @@ mod runtime_tracker;
 mod thread;
 mod thread_pool;
 
+pub use backtrace::dump_backtrace;
 pub use catch_unwind::catch_unwind;
 pub use catch_unwind::CatchUnwindFuture;
 pub use global_runtime::GlobalIORuntime;

--- a/src/common/http/src/debug/stack.rs
+++ b/src/common/http/src/debug/stack.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Write;
-
+use common_base::dump_backtrace;
 use poem::web::Query;
 use poem::IntoResponse;
 
@@ -22,68 +21,7 @@ pub struct DumpStackRequest {
     wait_for_running_tasks: bool,
 }
 
-#[derive(Debug)]
-struct AsyncTaskItem {
-    stack_frames: Vec<String>,
-}
-
 #[poem::handler]
 pub async fn debug_dump_stack(req: Option<Query<DumpStackRequest>>) -> impl IntoResponse {
-    let tree =
-        async_backtrace::taskdump_tree(req.map(|x| x.wait_for_running_tasks).unwrap_or(false));
-
-    let mut tasks = vec![];
-    let mut polling_tasks = vec![];
-    let mut current_stack_frames = vec![];
-
-    let mut first = true;
-    let mut is_polling = false;
-    for line in tree.lines() {
-        if line.starts_with(|x: char| !x.is_ascii_whitespace()) {
-            if !first {
-                match is_polling {
-                    true => polling_tasks.push(AsyncTaskItem {
-                        stack_frames: std::mem::take(&mut current_stack_frames),
-                    }),
-                    false => tasks.push(AsyncTaskItem {
-                        stack_frames: std::mem::take(&mut current_stack_frames),
-                    }),
-                };
-
-                is_polling = false;
-            }
-
-            first = false;
-        }
-
-        if line.ends_with("[POLLING]") {
-            is_polling = true;
-        }
-
-        current_stack_frames.push(line.to_string());
-    }
-
-    match is_polling {
-        true => polling_tasks.push(AsyncTaskItem {
-            stack_frames: std::mem::take(&mut current_stack_frames),
-        }),
-        false => tasks.push(AsyncTaskItem {
-            stack_frames: std::mem::take(&mut current_stack_frames),
-        }),
-    };
-
-    let mut output = String::new();
-    for mut tasks in [tasks, polling_tasks] {
-        tasks.sort_by(|l, r| Ord::cmp(&l.stack_frames.len(), &r.stack_frames.len()));
-
-        for item in tasks.into_iter().rev() {
-            for frame in item.stack_frames {
-                writeln!(output, "{}", frame).unwrap();
-            }
-
-            writeln!(output).unwrap();
-        }
-    }
-
-    output
+    dump_backtrace(req.map(|x| x.wait_for_running_tasks).unwrap_or(false))
 }

--- a/src/query/service/src/databases/system/system_database.rs
+++ b/src/query/service/src/databases/system/system_database.rs
@@ -22,6 +22,7 @@ use common_meta_app::schema::DatabaseMeta;
 use common_meta_app::schema::DatabaseNameIdent;
 use common_storages_system::BackgroundJobTable;
 use common_storages_system::BackgroundTaskTable;
+use common_storages_system::BacktraceTable;
 use common_storages_system::BuildOptionsTable;
 use common_storages_system::CachesTable;
 use common_storages_system::CatalogsTable;
@@ -109,6 +110,7 @@ impl SystemDatabase {
             QueryProfileTable::create(sys_db_meta.next_table_id()),
             BackgroundTaskTable::create(sys_db_meta.next_table_id()),
             BackgroundJobTable::create(sys_db_meta.next_table_id()),
+            BacktraceTable::create(sys_db_meta.next_table_id()),
         ];
 
         let disable_tables = Self::disable_system_tables();

--- a/src/query/service/src/table_functions/list_stage/table_args.rs
+++ b/src/query/service/src/table_functions/list_stage/table_args.rs
@@ -26,7 +26,7 @@ pub(crate) struct ListStageArgsParsed {
 
 impl ListStageArgsParsed {
     pub fn parse(table_args: &TableArgs) -> Result<Self> {
-        let args = table_args.expect_all_named("infer_schema")?;
+        let args = table_args.expect_all_named("list_stage")?;
 
         let mut location = None;
         let mut files_info = StageFilesInfo {

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -247,6 +247,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'sql_user'                      | 'system'             | 'query_log'           | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'sql_user_privileges'           | 'system'             | 'query_log'           | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'sql_user_quota'                | 'system'             | 'query_log'           | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'stack'                         | 'system'             | 'backtrace'           | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'stack_trace'                   | 'system'             | 'query_log'           | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'stage_params'                  | 'system'             | 'stages'              | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'stage_type'                    | 'system'             | 'stages'              | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/storages/system/src/backtrace_table.rs
+++ b/src/query/storages/system/src/backtrace_table.rs
@@ -1,0 +1,77 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::dump_backtrace;
+use common_catalog::table::Table;
+use common_catalog::table_context::TableContext;
+use common_exception::Result;
+use common_expression::types::DataType;
+use common_expression::ColumnBuilder;
+use common_expression::DataBlock;
+use common_expression::Scalar;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchemaRefExt;
+use common_meta_app::schema::TableIdent;
+use common_meta_app::schema::TableInfo;
+use common_meta_app::schema::TableMeta;
+
+use crate::SyncOneBlockSystemTable;
+use crate::SyncSystemTable;
+
+pub struct BacktraceTable {
+    table_info: TableInfo,
+}
+
+#[async_trait::async_trait]
+impl SyncSystemTable for BacktraceTable {
+    const NAME: &'static str = "system.backtrace";
+
+    fn get_table_info(&self) -> &TableInfo {
+        &self.table_info
+    }
+
+    fn get_full_data(&self, _ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
+        let stack = dump_backtrace(false);
+
+        let mut stacks = ColumnBuilder::with_capacity(&DataType::String, 1);
+        stacks.push(Scalar::String(stack.as_bytes().to_vec()).as_ref());
+
+        Ok(DataBlock::new_from_columns(vec![stacks.build()]))
+    }
+}
+
+impl BacktraceTable {
+    pub fn create(table_id: u64) -> Arc<dyn Table> {
+        let schema =
+            TableSchemaRefExt::create(vec![TableField::new("stack", TableDataType::String)]);
+
+        let table_info = TableInfo {
+            desc: "'system'.'backtrace'".to_string(),
+            name: "backtrace".to_string(),
+            ident: TableIdent::new(table_id, 0),
+            meta: TableMeta {
+                schema,
+                engine: "SystemBacktrace".to_string(),
+
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        SyncOneBlockSystemTable::create(BacktraceTable { table_info })
+    }
+}

--- a/src/query/storages/system/src/lib.rs
+++ b/src/query/storages/system/src/lib.rs
@@ -20,6 +20,7 @@ extern crate core;
 
 mod background_jobs_table;
 mod background_tasks_table;
+mod backtrace_table;
 mod build_options_table;
 mod caches_table;
 mod catalogs_table;
@@ -54,6 +55,7 @@ mod util;
 
 pub use background_jobs_table::BackgroundJobTable;
 pub use background_tasks_table::BackgroundTaskTable;
+pub use backtrace_table::BacktraceTable;
 pub use build_options_table::BuildOptionsTable;
 pub use caches_table::CachesTable;
 pub use catalogs_table::CatalogsTable;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Standalone only:
```
select * from system.backtrace
```

```
╼ <databend_query::servers::http::middleware::HTTPSessionEndpoint<poem::route::router::Route> as poem::endpoint::endpoint::Endpoint>::call::{{closure}} at src/query/service/src/servers/http/middleware.rs:191:5   └╼ <databend_query::servers::http::v1::http_query_handlers::query_handler as poem::endpoint::endpoint::Endpoint>::call::{{closure}}::query_handler::{{closure}} at src/query/service/src/servers/http/v1/http_query_handlers.rs:278:1      └╼ databend_query::servers::http::v1::query::http_query::HttpQuery::get_response_page::{{closure}} at src/query/service/src/servers/http/v1/query/http_query.rs:367:5         └╼ databend_query::servers::http::v1::query::http_query::HttpQuery::get_page::{{closure}} at src/query/service/src/servers/http/v1/query/http_query.rs:409:5            └╼ databend_query::servers::http::v1::query::page_manager::PageManager::get_a_page::{{closure}} at src/query/service/src/servers/http/v1/query/page_manager.rs:94:5               └╼ databend_query::servers::http::v1::query::page_manager::PageManager::collect_new_page::{{closure}} at src/query/service/src/servers/http/v1/query/page_manager.rs:141:5                  └╼ databend_query::servers::http::v1::query::sized_spsc::SizedChannelReceiver<common_expression::block::DataBlock>::recv::{{closure}} at src/query/service/src/servers/http/v1/query/sized_spsc.rs:178:5                     └╼ databend_query::servers::http::v1::query::sized_spsc::SizedChannel<common_expression::block::DataBlock>::recv::{{closure}} at src/query/service/src/servers/http/v1/query/sized_spsc.rs:135:5  ╼ <databend_query::servers::http::middleware::HTTPSessionEndpoint<poem::route::router::Route> as poem::endpoint::endpoint::Endpoint>::call::{{closure}} at src/query/service/src/servers/http/middleware.rs:191:5   └╼ databend_query::servers::http::v1::query::http_query::HttpQuery::get_response_page::{{closure}} at src/query/service/src/servers/http/v1/query/http_query.rs:367:5      └╼ databend_query::servers::http::v1::query::http_query::HttpQuery::get_page::{{closure}} at src/query/service/src/servers/http/v1/query/http_query.rs:409:5         └╼ databend_query::servers::http::v1::query::page_manager::PageManager::get_a_page::{{closure}} at src/query/service/src/servers/http/v1/query/page_manager.rs:94:5            └╼ databend_query::servers::http::v1::query::page_manager::PageManager::collect_new_page::{{closure}} at src/query/service/src/servers/http/v1/query/page_manager.rs:141:5               └╼ databend_query::servers::http::v1::query::sized_spsc::SizedChannelReceiver<common_expression::block::DataBlock>::recv::{{closure}} at src/query/service/src/servers/http/v1/query/sized_spsc.rs:178:5                  └╼ databend_query::servers::http::v1::query::sized_spsc::SizedChannel<common_expression::block::DataBlock>::recv::{{closure}} at src/query/service/src/servers/http/v1/query/sized_spsc.rs:135:5  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<common_base::runtime::runtime_tracker::TrackedFuture<databend_query::pipelines::executor::processor_async_task::ProcessorAsyncTask>> at src/common/base/src/runtime/runtime.rs:293:30   └╼ <common_pipeline_sinks::async_sink::AsyncSinker<databend_query::api::rpc::exchange::exchange_sink_writer::ExchangeWriterSink> as common_pipeline_core::processors::processor::Processor>::async_process::{{closure}} at src/query/pipeline/sinks/src/async_sink.rs:137:5      └╼ <databend_query::api::rpc::exchange::exchange_sink_writer::ExchangeWriterSink as common_pipeline_sinks::async_sink::AsyncSink>::consume::{{closure}} at src/query/service/src/api/rpc/exchange/exchange_sink_writer.rs:52:5         └╼ databend_query::api::rpc::flight_client::FlightSender::send::{{closure}} at src/query/service/src/api/rpc/flight_client.rs:205:5  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<common_base::runtime::runtime_tracker::TrackedFuture<databend_query::pipelines::executor::processor_async_task::ProcessorAsyncTask>> at src/common/base/src/runtime/runtime.rs:293:30   └╼ <databend_query::api::rpc::exchange::exchange_source_reader::ExchangeSourceReader as common_pipeline_core::processors::processor::Processor>::async_process::{{closure}} at src/query/service/src/api/rpc/exchange/exchange_source_reader.rs:90:5      └╼ databend_query::api::rpc::flight_client::FlightReceiver::recv::{{closure}} at src/query/service/src/api/rpc/flight_client.rs:182:5  ╼ databend_query::main at src/binaries/query/ee_main.rs:40:45   └╼ databend_query::servers::server::ShutdownHandle::wait_for_termination_request::{{closure}} at src/query/service/src/servers/server.rs:75:5  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<databend_query::api::rpc::exchange::statistics_receiver::StatisticsReceiver::spawn_receiver::{{closure}}> at src/common/base/src/runtime/runtime.rs:293:30   └╼ databend_query::api::rpc::flight_client::FlightReceiver::recv::{{closure}} at src/query/service/src/api/rpc/flight_client.rs:182:5  ╼ <databend_query::servers::mysql::mysql_handler::MySQLHandler as databend_query::servers::server::Server>::start::{{closure}}::{{closure}} at src/query/service/src/servers/mysql/mysql_handler.rs:169:21  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<databend_query::api::rpc::flight_client::FlightClient::do_get::{{closure}}::{{closure}}::{{closure}}> at src/common/base/src/runtime/runtime.rs:293:30  ╼ databend_query::api::rpc_service::RpcService::start_with_incoming::{{closure}}::{{closure}} at src/query/service/src/api/rpc_service.rs:89:22  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<common_base::runtime::runtime_tracker::UnlimitedFuture<common_meta_client::grpc_client::MetaGrpcClient::worker_loop::{{closure}}>> at src/common/base/src/runtime/runtime.rs:293:30  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<databend_query::servers::http::v1::query::http_query_manager::HttpQueryManager::add_query::{{closure}}::{{closure}}::{{closure}}> at src/common/base/src/runtime/runtime.rs:293:30  ╼ common_http::http_shutdown_handlers::HttpShutdownHandler::start_service<poem::middleware::add_data::AddDataEndpoint<poem::route::router::Route, metrics_exporter_prometheus::recorder::PrometheusHandle>>::{{closure}} at src/common/http/src/http_shutdown_handlers.rs:83:13  ╼ common_http::http_shutdown_handlers::HttpShutdownHandler::start_service<poem::route::router::Route>::{{closure}} at src/common/http/src/http_shutdown_handlers.rs:83:13  ╼ common_http::http_shutdown_handlers::HttpShutdownHandler::start_service<alloc::boxed::Box<dyn poem::endpoint::endpoint::Endpoint<Output = poem::response::Response>>>::{{closure}} at src/common/http/src/http_shutdown_handlers.rs:83:13  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<databend_query::servers::http::v1::query::http_query_manager::HttpQueryManager::add_query::{{closure}}::{{closure}}::{{closure}}> at src/common/base/src/runtime/runtime.rs:293:30  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<common_base::runtime::runtime_tracker::UnlimitedFuture<common_meta_client::grpc_client::MetaGrpcClient::worker_loop::{{closure}}>> at src/common/base/src/runtime/runtime.rs:293:30  ╼ common_users::role_cache_mgr::RoleCacheManager::background_polling at src/query/users/src/role_cache_mgr.rs:72:54  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<databend_query::api::rpc::flight_client::FlightClient::do_get::{{closure}}::{{closure}}::{{closure}}> at src/common/base/src/runtime/runtime.rs:293:30  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<common_base::runtime::runtime_tracker::UnlimitedFuture<common_meta_client::grpc_client::MetaGrpcClient::worker_loop::{{closure}}>> at src/common/base/src/runtime/runtime.rs:293:30  ╼ common_http::http_shutdown_handlers::HttpShutdownHandler::start_service<alloc::boxed::Box<dyn poem::endpoint::endpoint::Endpoint<Output = poem::response::Response>>>::{{closure}} at src/common/http/src/http_shutdown_handlers.rs:83:13  ╼ databend_query::servers::flight_sql::flight_sql_server::FlightSQLServer::start_with_incoming::{{closure}}::{{closure}} at src/query/service/src/servers/flight_sql/flight_sql_server.rs:85:22  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<databend_query::api::rpc::flight_client::FlightClient::request_server_exchange::{{closure}}::{{closure}}::{{closure}}> at src/common/base/src/runtime/runtime.rs:293:30  ╼ databend_query::clusters::cluster::ClusterHeartbeat::start at src/query/service/src/clusters/cluster.rs:501:13  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<databend_query::servers::http::v1::query::http_query::HttpQuery::try_create::{{closure}}::{{closure}}::{{closure}}> at src/common/base/src/runtime/runtime.rs:293:30   └┈ [POLLING]  ╼ <common_base::runtime::runtime::Runtime as common_base::runtime::runtime::TrySpawn>::try_spawn<databend_query::servers::http::v1::query::http_query::HttpQuery::try_create::{{closure}}::{{closure}}::{{closure}}> at src/common/base/src/runtime/runtime.rs:293:30   └┈ [POLLING]  
```

- Closes #issue
