### PR TITLE
chore(query): read all node backtrace table info for cluster mode

### DIFF
--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -73,6 +73,8 @@ pub enum PartitionsShuffleKind {
     Mod,
     // Bind the Partition to executor by partition.rand() order.
     Rand,
+    // Bind the Partition to executor by broadcast
+    Broadcast,
 }
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
 pub struct Partitions {
@@ -132,6 +134,21 @@ impl Partitions {
                 let mut parts = self.partitions.clone();
                 parts.shuffle(&mut rng);
                 parts
+            }
+            PartitionsShuffleKind::Broadcast => {
+                let mut executor_part = HashMap::default();
+                for executor in executors_sorted.iter() {
+                    executor_part.insert(
+                        executor.clone(),
+                        Partitions::create(
+                            PartitionsShuffleKind::Seq,
+                            self.partitions.clone(),
+                            self.is_lazy,
+                        ),
+                    );
+                }
+
+                return Ok(executor_part);
             }
         };
 

--- a/src/query/storages/system/src/backtrace_table.rs
+++ b/src/query/storages/system/src/backtrace_table.rs
@@ -40,6 +40,8 @@ pub struct BacktraceTable {
 impl SyncSystemTable for BacktraceTable {
     const NAME: &'static str = "system.backtrace";
 
+    const IS_LOCAL: bool = false;
+
     fn get_table_info(&self) -> &TableInfo {
         &self.table_info
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore(query): read all node backtrace table info for cluster mode

- Closes #issue
