### PR TITLE
feat: make system.caches/backtrace/metrics distributed and with node column

### DIFF
--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -50,6 +50,7 @@ use common_users::UserApiProvider;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContext;
 use databend_query::stream::ReadDataBlockStream;
+use databend_query::test_kits::ClusterDescriptor;
 use futures::TryStreamExt;
 use goldenfile::Mint;
 use wiremock::matchers::method;
@@ -279,7 +280,7 @@ async fn test_metrics_table() -> Result<()> {
     let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
-    assert_eq!(block.num_columns(), 4);
+    assert_eq!(block.num_columns(), 5);
     assert!(block.num_rows() >= 1);
 
     let output = pretty_format_blocks(result.as_slice())?;
@@ -400,7 +401,9 @@ async fn test_caches_table() -> Result<()> {
     let mut mint = Mint::new("tests/it/storages/testdata");
     let file = &mut mint.new_goldenfile("caches_table.txt").unwrap();
 
-    let (_guard, ctx) = databend_query::test_kits::create_query_context().await?;
+    let cluster_desc = ClusterDescriptor::new().with_local_id("test-node");
+    let (_guard, ctx) =
+        databend_query::test_kits::create_query_context_with_cluster(cluster_desc).await?;
 
     let table = CachesTable::create(1);
 

--- a/src/query/service/tests/it/storages/testdata/caches_table.txt
+++ b/src/query/service/tests/it/storages/testdata/caches_table.txt
@@ -1,16 +1,16 @@
 ---------- TABLE INFO ------------
 DB.Table: 'system'.'caches', Table: caches-table_id:1, ver:0, Engine: SystemCache
 -------- TABLE CONTENTS ----------
-+----------------------------------+----------+----------+
-| Column 0                         | Column 1 | Column 2 |
-+----------------------------------+----------+----------+
-| 'bloom_index_filter_cache'       | 0        | 0        |
-| 'bloom_index_meta_cache'         | 0        | 0        |
-| 'file_meta_data_cache'           | 0        | 0        |
-| 'prune_partitions_cache'         | 0        | 0        |
-| 'segment_info_cache'             | 0        | 0        |
-| 'table_snapshot_cache'           | 0        | 0        |
-| 'table_snapshot_statistic_cache' | 0        | 0        |
-+----------------------------------+----------+----------+
++-------------+----------------------------------+----------+----------+
+| Column 0    | Column 1                         | Column 2 | Column 3 |
++-------------+----------------------------------+----------+----------+
+| 'test-node' | 'bloom_index_filter_cache'       | 0        | 0        |
+| 'test-node' | 'bloom_index_meta_cache'         | 0        | 0        |
+| 'test-node' | 'file_meta_data_cache'           | 0        | 0        |
+| 'test-node' | 'prune_partitions_cache'         | 0        | 0        |
+| 'test-node' | 'segment_info_cache'             | 0        | 0        |
+| 'test-node' | 'table_snapshot_cache'           | 0        | 0        |
+| 'test-node' | 'table_snapshot_statistic_cache' | 0        | 0        |
++-------------+----------------------------------+----------+----------+
 
 

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -184,6 +184,9 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'name'                          | 'system'             | 'tables_with_history' | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'name'                          | 'system'             | 'users'               | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'next_task_scheduled_time'      | 'system'             | 'background_jobs'     | 'Timestamp'        | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
+| 'node'                          | 'system'             | 'backtrace'           | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'node'                          | 'system'             | 'caches'              | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'node'                          | 'system'             | 'metrics'             | 'String'           | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'non_unique'                    | 'information_schema' | 'statistics'          | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'nullable'                      | 'information_schema' | 'columns'             | 'Nullable(UInt8)'  | 'TINYINT UNSIGNED'  | ''       | ''       | 'YES'    | ''       |
 | 'nullable'                      | 'information_schema' | 'statistics'          | 'NULL'             | 'NULL'              | ''       | ''       | 'NO'     | ''       |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Cluster system tables:
* system.backtrace
* system.metrics
* system.caches

```
SELECT
  *
FROM
  system.caches

┌──────────────────────────────────────────────────────────────────────────────┐
│          node          │              name              │ num_items │  size  │
│         String         │             String             │   UInt64  │ UInt64 │
├────────────────────────┼────────────────────────────────┼───────────┼────────┤
│ BKMQbxhCoZO5yaGLrPG822 │ table_snapshot_cache           │         1 │      1 │
│ BKMQbxhCoZO5yaGLrPG822 │ table_snapshot_statistic_cache │         0 │      0 │
│ BKMQbxhCoZO5yaGLrPG822 │ segment_info_cache             │         2 │ 934730 │
│ BKMQbxhCoZO5yaGLrPG822 │ bloom_index_filter_cache       │         0 │      0 │
│ BKMQbxhCoZO5yaGLrPG822 │ bloom_index_meta_cache         │         0 │      0 │
│ BKMQbxhCoZO5yaGLrPG822 │ prune_partitions_cache         │         1 │      1 │
│ BKMQbxhCoZO5yaGLrPG822 │ file_meta_data_cache           │         0 │      0 │
│ Oe6nAYPYgZRNyKNivntff6 │ table_snapshot_cache           │         0 │      0 │
│ Oe6nAYPYgZRNyKNivntff6 │ table_snapshot_statistic_cache │         0 │      0 │
│ Oe6nAYPYgZRNyKNivntff6 │ segment_info_cache             │         2 │ 933664 │
│ Oe6nAYPYgZRNyKNivntff6 │ bloom_index_filter_cache       │         0 │      0 │
│ Oe6nAYPYgZRNyKNivntff6 │ bloom_index_meta_cache         │         0 │      0 │
│ Oe6nAYPYgZRNyKNivntff6 │ prune_partitions_cache         │         1 │      1 │
│ Oe6nAYPYgZRNyKNivntff6 │ file_meta_data_cache           │         0 │      0 │
└──────────────────────────────────────────────────────────────────────────────┘
```

- Closes #issue
