### PR TITLE
refactor: adjust calc of parallelism when load parquet.

### DIFF
--- a/src/common/storage/src/parquet.rs
+++ b/src/common/storage/src/parquet.rs
@@ -18,6 +18,7 @@ use common_arrow::arrow::datatypes::Schema as ArrowSchema;
 use common_arrow::arrow::io::parquet::read as pread;
 use common_arrow::parquet::metadata::FileMetaData;
 use common_base::runtime::execute_futures_in_parallel;
+use common_base::runtime::GLOBAL_MEM_STAT;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use opendal::Operator;
@@ -63,6 +64,7 @@ pub fn infer_schema_with_extension(meta: &FileMetaData) -> Result<ArrowSchema> {
 async fn read_parquet_metas_batch(
     file_infos: Vec<(String, u64)>,
     op: Operator,
+    max_memory_usage: u64,
 ) -> Result<Vec<FileMetaData>> {
     // todo(youngsofun): we should use size in StageFileInfo, but parquet2 do not have the interface for now
     let mut metas = vec![];
@@ -70,7 +72,15 @@ async fn read_parquet_metas_batch(
         let mut reader = op.reader(&path).await?;
         metas.push(pread::read_metadata_async(&mut reader).await?)
     }
-    Ok(metas)
+    let used = GLOBAL_MEM_STAT.get_memory_usage();
+    if max_memory_usage as i64 - used < 100 * 1024 * 1024 {
+        Err(ErrorCode::Internal(format!(
+            "not enough memory to load parquet file metas, max_memory_usage = {}, used = {}.",
+            max_memory_usage, used
+        )))
+    } else {
+        Ok(metas)
+    }
 }
 
 #[async_backtrace::framed]
@@ -79,17 +89,18 @@ pub async fn read_parquet_metas_in_parallel(
     file_infos: Vec<(String, u64)>,
     thread_nums: usize,
     permit_nums: usize,
+    max_memory_usage: u64,
 ) -> Result<Vec<FileMetaData>> {
-    let batch_size = 1000;
+    let batch_size = 100;
     if file_infos.len() <= batch_size {
-        read_parquet_metas_batch(file_infos, op.clone()).await
+        read_parquet_metas_batch(file_infos, op.clone(), max_memory_usage).await
     } else {
         let mut chunks = file_infos.chunks(batch_size);
 
         let tasks = std::iter::from_fn(move || {
-            chunks
-                .next()
-                .map(|location| read_parquet_metas_batch(location.to_vec(), op.clone()))
+            chunks.next().map(|location| {
+                read_parquet_metas_batch(location.to_vec(), op.clone(), max_memory_usage)
+            })
         });
 
         let result = execute_futures_in_parallel(

--- a/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
@@ -35,6 +35,7 @@ pub struct ParquetTableInfo {
     pub schema_descr: SchemaDescriptor,
     pub files_to_read: Option<Vec<StageFileInfo>>,
     pub schema_from: String,
+    pub compression_ratio: f64,
 }
 
 impl ParquetTableInfo {

--- a/src/query/pipeline/sources/src/input_formats/impls/input_format_parquet.rs
+++ b/src/query/pipeline/sources/src/input_formats/impls/input_format_parquet.rs
@@ -135,13 +135,15 @@ impl InputFormat for InputFormatParquet {
         file_infos: Vec<StageFileInfo>,
         _stage_info: &StageInfo,
         op: &Operator,
-        _settings: &Arc<Settings>,
+        settings: &Arc<Settings>,
     ) -> Result<Vec<Arc<SplitInfo>>> {
+        let max_memory_usage = settings.get_max_memory_usage()?;
         let files = file_infos
             .iter()
             .map(|f| (f.path.clone(), f.size))
             .collect::<Vec<_>>();
-        let metas = read_parquet_metas_in_parallel(op.clone(), files, 16, 64).await?;
+        let metas =
+            read_parquet_metas_in_parallel(op.clone(), files, 16, 64, max_memory_usage).await?;
         Self::make_splits(file_infos, metas)
     }
 

--- a/src/query/service/src/servers/http/v1/query/page_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/page_manager.rs
@@ -176,7 +176,7 @@ impl PageManager {
                             break;
                         }
                         Err(_) => {
-                            info!("http query {} long pulling timeout", &self.query_id);
+                            debug!("http query {} long pulling timeout", &self.query_id);
                             break;
                         }
                     }

--- a/src/query/storages/parquet/src/parquet_part.rs
+++ b/src/query/storages/parquet/src/parquet_part.rs
@@ -55,6 +55,13 @@ impl ParquetPart {
     pub fn uncompressed_size(&self) -> u64 {
         match self {
             ParquetPart::RowGroup(r) => r.uncompressed_size(),
+            ParquetPart::SmallFiles(p) => p.uncompressed_size(),
+        }
+    }
+
+    pub fn compressed_size(&self) -> u64 {
+        match self {
+            ParquetPart::RowGroup(r) => r.compressed_size(),
             ParquetPart::SmallFiles(p) => p.compressed_size(),
         }
     }
@@ -70,11 +77,15 @@ impl ParquetPart {
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct ParquetSmallFilesPart {
     pub files: Vec<(String, u64)>,
+    pub estimated_uncompressed_size: u64,
 }
 
 impl ParquetSmallFilesPart {
     pub fn compressed_size(&self) -> u64 {
         self.files.iter().map(|(_, s)| *s).sum()
+    }
+    pub fn uncompressed_size(&self) -> u64 {
+        self.estimated_uncompressed_size
     }
 }
 
@@ -94,6 +105,10 @@ impl ParquetRowGroupPart {
             .values()
             .map(|c| c.uncompressed_size)
             .sum()
+    }
+
+    pub fn compressed_size(&self) -> u64 {
+        self.column_metas.values().map(|c| c.length).sum()
     }
 }
 

--- a/src/query/storages/parquet/src/parquet_table/partition.rs
+++ b/src/query/storages/parquet/src/parquet_table/partition.rs
@@ -123,6 +123,7 @@ impl ParquetTable {
             skip_pruning,
             top_k,
             parquet_fast_read_bytes,
+            compression_ratio: self.compression_ratio,
         })
     }
 

--- a/src/query/storages/parquet/src/parquet_table/partition.rs
+++ b/src/query/storages/parquet/src/parquet_table/partition.rs
@@ -38,10 +38,11 @@ impl ParquetTable {
         push_down: Option<PushDownInfo>,
         is_small_file: bool,
     ) -> Result<PartitionPruner> {
+        let settings = ctx.get_settings();
         let parquet_fast_read_bytes = if is_small_file {
             0_usize
         } else {
-            ctx.get_settings().get_parquet_fast_read_bytes()? as usize
+            settings.get_parquet_fast_read_bytes()? as usize
         };
         // `plan.source_info.schema()` is the same as `TableSchema::from(&self.arrow_schema)`
         let projection = if let Some(PushDownInfo {
@@ -124,6 +125,7 @@ impl ParquetTable {
             top_k,
             parquet_fast_read_bytes,
             compression_ratio: self.compression_ratio,
+            max_memory_usage: settings.get_max_memory_usage()?,
         })
     }
 

--- a/src/query/storages/parquet/src/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_table/read.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_base::runtime::GLOBAL_MEM_STAT;
 use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::Projection;
 use common_catalog::plan::PushDownInfo;
@@ -181,12 +182,15 @@ impl ParquetTable {
     }
 }
 
-fn limit_parallelism_by_memory(max_memory: usize, sizes: &mut [usize]) -> usize {
-    sizes.sort_by(|a, b| b.cmp(a));
+fn limit_parallelism_by_memory(max_memory: usize, sizes: &mut [(usize, usize)]) -> usize {
+    // there may be 1 block  reading and 2 blocks in deserializer and sink.
+    // memory size of a can be as large as 2 * uncompressed_size.
+    // e.g. parquet may use 4 bytes for each string offset, but Block use 8 bytes i64.
+    // we can refine it later if this leads to too low parallelism.
     let mut mem = 0;
-    for (i, s) in sizes.iter().enumerate() {
-        // there may be 2 blocks in a pipe.
-        mem += s * 2;
+    for (i, (uncompressed, compressed)) in sizes.iter().enumerate() {
+        let s = uncompressed * 2 * 2 + compressed;
+        mem += s;
         if mem > max_memory {
             return i;
         }
@@ -205,30 +209,51 @@ pub fn calc_parallelism(
     let settings = ctx.get_settings();
     let num_partitions = plan.parts.partitions.len();
     let max_threads = settings.get_max_threads()? as usize;
+    let max_storage_io_requests = settings.get_max_storage_io_requests()? as usize;
+    let max_memory = settings.get_max_memory_usage()? as usize;
+
     let mut sizes = vec![];
     for p in plan.parts.partitions.iter() {
-        sizes.push(ParquetPart::from_part(p)?.uncompressed_size() as usize);
+        let p = ParquetPart::from_part(p)?;
+        sizes.push((p.uncompressed_size() as usize, p.compressed_size() as usize));
     }
+    sizes.sort_by(|a, b| b.cmp(a));
+    let max_split_size = sizes[0].0;
     let num_chunks = ParquetPart::from_part(&plan.parts.partitions[0])?
         .num_io()
         .max(1);
-    let max_memory = settings.get_max_memory_usage()? as usize;
-    let max_by_memory = limit_parallelism_by_memory(max_memory, &mut sizes).max(1);
+    // 1. used by other query
+    // 2. used for file metas, can be huge when there are many files.
+    let used_memory = GLOBAL_MEM_STAT.get_memory_usage();
+    let available_memory = max_memory.saturating_sub(used_memory as usize);
 
-    let max_storage_io_requests = settings.get_max_storage_io_requests()? as usize;
-    let num_readers = if is_blocking {
-        max_storage_io_requests
-    } else {
-        max_storage_io_requests / num_chunks
+    let max_by_memory = limit_parallelism_by_memory(available_memory, &mut sizes).max(1);
+    if max_by_memory == 0 {
+        return Err(ErrorCode::Overflow(format!(
+            "Memory limit exceeded before start copy pipeline: max_memory_usage: {}, used_memory: {}, max_split_size = {}",
+            max_memory, used_memory, max_split_size,
+        )));
     }
-    .min(max_by_memory)
-    .max(1);
-
     let num_deserializer = max_threads.min(max_by_memory).max(1);
+    // we somewhat considered the memory when calc num_deserializer: one reader for each num_deserializer.
+    let num_readers = if is_blocking {
+        num_deserializer
+    } else {
+        // chunks/files are read in parallel in each reader.
+        (max_storage_io_requests / num_chunks).max(num_deserializer)
+    };
 
     tracing::info!(
-        "loading {num_partitions} partitions with {num_readers} readers and {num_deserializer} deserializers, blocking = {is_blocking}, according to max_memory={max_memory}, num_chunks={num_chunks}, max_storage_io_requests={max_storage_io_requests}, max_split_size={}, max_threads={max_threads}",
-        sizes[0]
+        "loading {num_partitions} \
+        partitions with {num_readers} readers and {num_deserializer} deserializers, \
+        according to \
+        max_split_size={max_split_size}, \
+        max_threads={max_threads}, \
+        max_memory={max_memory}, \
+        available_memory={available_memory}, \
+        num_chunks={num_chunks}, \
+        max_storage_io_requests={max_storage_io_requests}, \
+        blocking = {is_blocking},",
     );
     Ok((num_readers, num_deserializer))
 }

--- a/src/query/storages/parquet/src/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_table/table.rs
@@ -55,6 +55,7 @@ pub struct ParquetTable {
     pub(super) schema_descr: SchemaDescriptor,
     pub(super) files_to_read: Option<Vec<StageFileInfo>>,
     pub(super) schema_from: String,
+    pub(super) compression_ratio: f64,
 }
 
 impl ParquetTable {
@@ -71,6 +72,7 @@ impl ParquetTable {
             files_to_read: info.files_to_read.clone(),
             schema_descr: info.schema_descr.clone(),
             schema_from: info.schema_from.clone(),
+            compression_ratio: info.compression_ratio,
         }))
     }
 }
@@ -111,6 +113,7 @@ impl Table for ParquetTable {
             files_info: self.files_info.clone(),
             files_to_read: self.files_to_read.clone(),
             schema_from: self.schema_from.clone(),
+            compression_ratio: self.compression_ratio,
         })
     }
 

--- a/src/query/storages/parquet/src/pruning.rs
+++ b/src/query/storages/parquet/src/pruning.rs
@@ -75,8 +75,8 @@ pub struct PartitionPruner {
     // /// Limit of this query. If there is order by and filter, it will not be used (assign to `usize::MAX`).
     // pub limit: usize,
     pub parquet_fast_read_bytes: usize,
-
     pub compression_ratio: f64,
+    pub max_memory_usage: u64,
 }
 
 fn check_parquet_schema(
@@ -249,7 +249,14 @@ impl PartitionPruner {
             }
             file_metas
         } else {
-            read_parquet_metas_in_parallel(operator.clone(), large_files.clone(), 16, 64).await?
+            read_parquet_metas_in_parallel(
+                operator.clone(),
+                large_files.clone(),
+                16,
+                64,
+                self.max_memory_usage,
+            )
+            .await?
         };
 
         // 2. Use file meta to prune row groups or pages.

--- a/src/query/storages/parquet/src/pruning.rs
+++ b/src/query/storages/parquet/src/pruning.rs
@@ -276,6 +276,8 @@ impl PartitionPruner {
             stats.read_rows += sub_stats.read_rows;
         }
 
+        let num_large_partitions = partitions.len();
+
         collect_small_file_parts(
             small_files,
             max_compression_ratio,
@@ -283,6 +285,11 @@ impl PartitionPruner {
             &mut partitions,
             &mut stats,
             self.columns_to_read.len(),
+        );
+
+        tracing::info!(
+            "copy {num_large_partitions} large partitions and {} small partitions.",
+            partitions.len() - num_large_partitions
         );
 
         let partition_kind = PartitionsShuffleKind::Mod;

--- a/src/query/storages/parquet/src/pruning.rs
+++ b/src/query/storages/parquet/src/pruning.rs
@@ -276,44 +276,14 @@ impl PartitionPruner {
             stats.read_rows += sub_stats.read_rows;
         }
 
-        if max_compression_ratio <= 0.0 || max_compression_ratio >= 1.0 {
-            max_compression_ratio = 1.0;
-        }
-        if max_compressed_size == 0 {
-            let max = 128usize >> 20;
-            max_compressed_size = (max as f64 / max_compression_ratio) as u64;
-        }
-
-        stats.read_rows += small_files.len();
-        let mut num_small_files = small_files.len();
-        let mut small_part = vec![];
-        let mut part_size = 0;
-        let mut make_small_files_part = |files, part_size| {
-            let estimated_uncompressed_size = (part_size as f64 / max_compression_ratio) as u64;
-            partitions.push(ParquetPart::SmallFiles(ParquetSmallFilesPart {
-                files,
-                estimated_uncompressed_size,
-            }));
-            stats.partitions_scanned += 1;
-            stats.partitions_total += 1;
-            num_small_files -= 1;
-        };
-        let max_files = self.columns_to_read.len() * 2;
-        for (path, size) in small_files.into_iter() {
-            stats.read_bytes += size as usize;
-            if !small_part.is_empty()
-                && (part_size + size > max_compressed_size || small_part.len() + 1 >= max_files)
-            {
-                make_small_files_part(mem::take(&mut small_part), part_size);
-                part_size = 0;
-            }
-            small_part.push((path, size));
-            part_size += size;
-        }
-        if !small_part.is_empty() {
-            make_small_files_part(mem::take(&mut small_part), part_size);
-        }
-        assert_eq!(num_small_files, 0);
+        collect_small_file_parts(
+            small_files,
+            max_compression_ratio,
+            max_compressed_size,
+            &mut partitions,
+            &mut stats,
+            self.columns_to_read.len(),
+        );
 
         let partition_kind = PartitionsShuffleKind::Mod;
         let partitions = partitions
@@ -323,6 +293,60 @@ impl PartitionPruner {
 
         Ok((stats, Partitions::create_nolazy(partition_kind, partitions)))
     }
+}
+
+/// files smaller than setting fast_read_part_bytes is small file,
+/// which is load in one read, without reading its meta in advance.
+/// some considerations:
+/// 1. to fully utilize the IO, multiple small files are loaded in one part.
+/// 2. to avoid OOM, the total size of small files in one part is limited,
+///    and we need compression_ratio to estimate the uncompressed size.
+fn collect_small_file_parts(
+    small_files: Vec<(String, u64)>,
+    mut max_compression_ratio: f64,
+    mut max_compressed_size: u64,
+    partitions: &mut Vec<ParquetPart>,
+    stats: &mut PartStatistics,
+    num_columns_to_read: usize,
+) {
+    if max_compression_ratio <= 0.0 || max_compression_ratio >= 1.0 {
+        // just incase
+        max_compression_ratio = 1.0;
+    }
+    if max_compressed_size == 0 {
+        // there are no large files, so we choose a default value.
+        max_compressed_size = ((128usize << 20) as f64 / max_compression_ratio) as u64;
+    }
+    let mut num_small_files = small_files.len();
+    stats.read_rows += num_small_files;
+    let mut small_part = vec![];
+    let mut part_size = 0;
+    let mut make_small_files_part = |files: Vec<(String, u64)>, part_size| {
+        let estimated_uncompressed_size = (part_size as f64 / max_compression_ratio) as u64;
+        num_small_files -= files.len();
+        partitions.push(ParquetPart::SmallFiles(ParquetSmallFilesPart {
+            files,
+            estimated_uncompressed_size,
+        }));
+        stats.partitions_scanned += 1;
+        stats.partitions_total += 1;
+    };
+    let max_files = num_columns_to_read * 2;
+    for (path, size) in small_files.into_iter() {
+        stats.read_bytes += size as usize;
+        if !small_part.is_empty()
+            && (part_size + size > max_compressed_size || small_part.len() + 1 >= max_files)
+        {
+            make_small_files_part(mem::take(&mut small_part), part_size);
+            part_size = 0;
+        }
+        small_part.push((path, size));
+        part_size += size;
+    }
+    if !small_part.is_empty() {
+        make_small_files_part(mem::take(&mut small_part), part_size);
+    }
+    assert_eq!(num_small_files, 0);
 }
 
 /// [`RangePruner`]s for each column


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

@wubx hope this pr can further reduce the chance of OOM when loading parquet.

1. consider the memory already used.
2. small file can be as large as 100MB,  each ParquetSmallFilesPart should not be too large, let it be at most the largest of the normal  ParquetPart::RowGroup 
3. use compression ratio to estimate the uncompressed size of ParquetSmallFilesPart
4. consider the compressed size when calc num by memory limit,  there are cases the compression ratio is low.
 