### PR TITLE
feat: support specify bloom index columns

### DIFF
--- a/src/query/ast/src/parser/mod.rs
+++ b/src/query/ast/src/parser/mod.rs
@@ -25,6 +25,7 @@ pub mod token;
 pub mod unescape;
 
 pub use parser::parse_comma_separated_exprs;
+pub use parser::parse_comma_separated_idents;
 pub use parser::parse_expr;
 pub use parser::parse_sql;
 pub use parser::parser_values_with_placeholder;

--- a/src/query/service/src/interpreters/interpreter_table_drop_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop_column.rs
@@ -20,8 +20,10 @@ use common_meta_app::schema::DatabaseType;
 use common_meta_app::schema::UpdateTableMetaReq;
 use common_meta_types::MatchSeq;
 use common_sql::plans::DropTableColumnPlan;
+use common_sql::BloomIndexColumns;
 use common_storages_share::save_share_table_info;
 use common_storages_view::view_table::VIEW_ENGINE;
+use storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 
 use crate::interpreters::common::check_referenced_computed_columns;
 use crate::interpreters::Interpreter;
@@ -85,6 +87,19 @@ impl Interpreter for DropTableColumnInterpreter {
         let catalog = self.ctx.get_catalog(catalog_name)?;
         let mut new_table_meta = table.get_table_info().meta.clone();
         new_table_meta.drop_column(&self.plan.column)?;
+
+        // update table options
+        let opts = &mut new_table_meta.options;
+        if let Some(value) = opts.get_mut(OPT_KEY_BLOOM_INDEX_COLUMNS) {
+            let bloom_index_cols = value.parse::<BloomIndexColumns>()?;
+            if let BloomIndexColumns::Specify(mut cols) = bloom_index_cols {
+                if let Some(pos) = cols.iter().position(|x| *x == self.plan.column) {
+                    // remove from the bloom index columns.
+                    cols.remove(pos);
+                    *value = cols.join(",");
+                }
+            }
+        }
 
         let table_id = table_info.ident.table_id;
         let table_version = table_info.ident.seq;

--- a/src/query/service/src/interpreters/interpreter_table_rename_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_rename_column.rs
@@ -20,8 +20,10 @@ use common_meta_app::schema::DatabaseType;
 use common_meta_app::schema::UpdateTableMetaReq;
 use common_meta_types::MatchSeq;
 use common_sql::plans::RenameTableColumnPlan;
+use common_sql::BloomIndexColumns;
 use common_storages_share::save_share_table_info;
 use common_storages_view::view_table::VIEW_ENGINE;
+use storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 
 use crate::interpreters::common::check_referenced_computed_columns;
 use crate::interpreters::interpreter_table_create::is_valid_column;
@@ -92,6 +94,19 @@ impl Interpreter for RenameTableColumnInterpreter {
             }
 
             new_table_meta.schema = Arc::new(self.plan.schema.clone());
+
+            // update table options
+            let opts = &mut new_table_meta.options;
+            if let Some(value) = opts.get_mut(OPT_KEY_BLOOM_INDEX_COLUMNS) {
+                let bloom_index_cols = value.parse::<BloomIndexColumns>()?;
+                if let BloomIndexColumns::Specify(mut cols) = bloom_index_cols {
+                    if let Some(pos) = cols.iter().position(|x| *x == self.plan.old_column) {
+                        // replace the bloom index columns with new column name.
+                        cols[pos] = self.plan.new_column.clone();
+                        *value = cols.join(",");
+                    }
+                }
+            }
 
             let table_id = table_info.ident.table_id;
             let table_version = table_info.ident.seq;

--- a/src/query/service/src/interpreters/interpreter_table_set_options.rs
+++ b/src/query/service/src/interpreters/interpreter_table_set_options.rs
@@ -26,6 +26,7 @@ use storages_common_table_meta::table::OPT_KEY_STORAGE_FORMAT;
 use tracing::error;
 
 use super::interpreter_table_create::is_valid_block_per_segment;
+use super::interpreter_table_create::is_valid_bloom_index_columns;
 use super::interpreter_table_create::is_valid_create_opt;
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -93,6 +94,9 @@ impl Interpreter for SetOptionsInterpreter {
         } else {
             return Err(ErrorCode::UnknownTable(self.plan.table.as_str()));
         };
+
+        // check bloom_index_columns.
+        is_valid_bloom_index_columns(&self.plan.set_options, table.schema())?;
 
         let req = UpsertTableOptionReq {
             table_id: table.get_id(),

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -272,13 +272,13 @@ impl PipelineBuilder {
         let cluster_stats_gen =
             table.get_cluster_stats_gen(self.ctx.clone(), 0, table.get_block_thresholds())?;
         self.main_pipeline.add_transform(|input, output| {
-            let proc = TransformSerializeBlock::new(
+            let proc = TransformSerializeBlock::try_create(
                 self.ctx.clone(),
                 input,
                 output,
                 table,
                 cluster_stats_gen.clone(),
-            );
+            )?;
             proc.into_processor()
         })?;
         Ok(())

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -25,6 +25,7 @@ use common_expression::DataBlock;
 use common_expression::Scalar;
 use common_expression::TableSchema;
 use common_expression::TableSchemaRef;
+use common_sql::BloomIndexColumns;
 use common_storages_fuse::operations::BlockMetaIndex;
 use common_storages_fuse::pruning::create_segment_location_vector;
 use common_storages_fuse::pruning::FusePruner;
@@ -127,9 +128,15 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
     let ctx: Arc<dyn TableContext> = ctx.clone();
     let segment_locations = base_snapshot.segments.clone();
     let segment_locations = create_segment_location_vector(segment_locations, None);
-    let block_metas = FusePruner::create(&ctx, data_accessor.clone(), schema, &None)?
-        .read_pruning(segment_locations)
-        .await?;
+    let block_metas = FusePruner::create(
+        &ctx,
+        data_accessor.clone(),
+        schema,
+        &None,
+        BloomIndexColumns::All,
+    )?
+    .read_pruning(segment_locations)
+    .await?;
     let mut blocks_map: BTreeMap<i32, Vec<(BlockMetaIndex, Arc<BlockMeta>)>> = BTreeMap::new();
     block_metas.iter().for_each(|(idx, b)| {
         if let Some(stats) = &b.cluster_stats {

--- a/src/query/service/tests/it/storages/fuse/pruning.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning.rs
@@ -31,6 +31,7 @@ use common_expression::TableSchemaRef;
 use common_expression::TableSchemaRefExt;
 use common_sql::parse_to_remote_string_expr;
 use common_sql::plans::CreateTablePlan;
+use common_sql::BloomIndexColumns;
 use common_storages_fuse::pruning::create_segment_location_vector;
 use common_storages_fuse::pruning::FusePruner;
 use common_storages_fuse::FuseTable;
@@ -56,11 +57,12 @@ async fn apply_block_pruning(
     push_down: &Option<PushDownInfo>,
     ctx: Arc<QueryContext>,
     op: Operator,
+    bloom_index_cols: BloomIndexColumns,
 ) -> Result<Vec<Arc<BlockMeta>>> {
     let ctx: Arc<dyn TableContext> = ctx;
     let segment_locs = table_snapshot.segments.clone();
     let segment_locs = create_segment_location_vector(segment_locs, None);
-    FusePruner::create(&ctx, op, schema, push_down)?
+    FusePruner::create(&ctx, op, schema, push_down, bloom_index_cols)?
         .read_pruning(segment_locs)
         .await
         .map(|v| v.into_iter().map(|(_, v)| v).collect())
@@ -244,6 +246,7 @@ async fn test_block_pruner() -> Result<()> {
             &extra,
             ctx.clone(),
             fuse_table.get_operator(),
+            fuse_table.bloom_index_cols(),
         )
         .await?;
 

--- a/src/query/sql/src/planner/bloom_index.rs
+++ b/src/query/sql/src/planner/bloom_index.rs
@@ -1,0 +1,146 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::str::FromStr;
+
+use common_ast::parser::parse_comma_separated_idents;
+use common_ast::parser::tokenize_sql;
+use common_ast::Dialect;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_expression::ComputedExpr;
+use common_expression::FieldIndex;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchemaRef;
+use common_settings::Settings;
+
+use crate::normalize_identifier;
+use crate::planner::semantic::NameResolutionContext;
+
+#[derive(Clone)]
+pub enum BloomIndexColumns {
+    /// Default, all columns that support bloom index.
+    All,
+    /// Specify with column names.
+    Specify(Vec<String>),
+    /// The column of bloom index is empty.
+    None,
+}
+
+impl FromStr for BloomIndexColumns {
+    type Err = ErrorCode;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.trim().is_empty() {
+            return Ok(BloomIndexColumns::None);
+        }
+
+        let sql_dialect = Dialect::MySQL;
+        let tokens = tokenize_sql(s)?;
+        let idents = parse_comma_separated_idents(&tokens, sql_dialect)?;
+
+        let settings = Settings::create("".to_string());
+        let name_resolution_ctx = NameResolutionContext::try_from(settings.as_ref())?;
+
+        let mut cols = Vec::with_capacity(idents.len());
+        idents
+            .into_iter()
+            .for_each(|ident| cols.push(normalize_identifier(&ident, &name_resolution_ctx).name));
+
+        Ok(BloomIndexColumns::Specify(cols))
+    }
+}
+
+impl BloomIndexColumns {
+    /// Verify the definition based on schema.
+    pub fn verify_definition<F>(
+        definition: &str,
+        schema: TableSchemaRef,
+        verify_type: F,
+    ) -> Result<()>
+    where
+        F: Fn(&TableDataType) -> bool,
+    {
+        if definition.trim().is_empty() {
+            return Ok(());
+        }
+
+        let settings = Settings::create("".to_string());
+        let name_resolution_ctx = NameResolutionContext::try_from(settings.as_ref())?;
+
+        let sql_dialect = Dialect::MySQL;
+        let tokens = tokenize_sql(definition)?;
+        let idents = parse_comma_separated_idents(&tokens, sql_dialect)?;
+        for ident in idents.iter() {
+            let name = &normalize_identifier(ident, &name_resolution_ctx).name;
+            let field = schema.field_with_name(name)?;
+
+            if matches!(field.computed_expr(), Some(ComputedExpr::Virtual(_))) {
+                return Err(ErrorCode::TableOptionInvalid(format!(
+                    "The value specified for computed column '{}' is not allowed for bloom index",
+                    name
+                )));
+            }
+
+            let data_type = field.data_type();
+            if !verify_type(data_type) {
+                return Err(ErrorCode::TableOptionInvalid(format!(
+                    "Unsupported data type '{}' for bloom index",
+                    data_type
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Get table field based on the BloomIndexColumns and schema.
+    pub fn bloom_index_fields<F>(
+        &self,
+        schema: TableSchemaRef,
+        verify_type: F,
+    ) -> Result<BTreeMap<FieldIndex, TableField>>
+    where
+        F: Fn(&TableDataType) -> bool,
+    {
+        let source_schema = schema.remove_virtual_computed_fields();
+        let mut fields_map = BTreeMap::new();
+        match self {
+            BloomIndexColumns::All => {
+                for (i, field) in source_schema.fields.into_iter().enumerate() {
+                    if verify_type(field.data_type()) {
+                        fields_map.insert(i, field);
+                    }
+                }
+            }
+            BloomIndexColumns::Specify(cols) => {
+                for col in cols {
+                    let field_index = source_schema.index_of(col)?;
+                    let field = source_schema.fields[field_index].clone();
+                    let data_type = field.data_type();
+                    if !verify_type(data_type) {
+                        return Err(ErrorCode::BadArguments(format!(
+                            "Unsupported data type for bloom index: {:?}",
+                            data_type
+                        )));
+                    }
+                    fields_map.insert(field_index, field);
+                }
+            }
+            BloomIndexColumns::None => (),
+        }
+        Ok(fields_map)
+    }
+}

--- a/src/query/sql/src/planner/mod.rs
+++ b/src/query/sql/src/planner/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod bloom_index;
 mod format;
 mod metadata;
 #[allow(clippy::module_inception)]
@@ -33,6 +34,7 @@ pub use binder::ScalarBinder;
 pub use binder::ScalarVisitor;
 pub use binder::SelectBuilder;
 pub use binder::Visibility;
+pub use bloom_index::BloomIndexColumns;
 pub use expression_parser::*;
 pub use format::format_scalar;
 pub use metadata::*;

--- a/src/query/storages/common/index/tests/it/main.rs
+++ b/src/query/storages/common/index/tests/it/main.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(box_patterns)]
 #![allow(clippy::uninlined_format_args)]
 
 mod filters;

--- a/src/query/storages/common/table-meta/src/table/table_keys.rs
+++ b/src/query/storages/common/table-meta/src/table/table_keys.rs
@@ -23,6 +23,7 @@ pub const OPT_KEY_TABLE_COMPRESSION: &str = "compression";
 pub const OPT_KEY_COMMENT: &str = "comment";
 pub const OPT_KEY_EXTERNAL_LOCATION: &str = "external_location";
 pub const OPT_KEY_ENGINE: &str = "engine";
+pub const OPT_KEY_BLOOM_INDEX_COLUMNS: &str = "bloom_index_columns";
 
 /// Legacy table snapshot location key
 ///

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -44,6 +44,7 @@ use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::UpsertTableCopiedFileReq;
 use common_sharing::create_share_table_operator;
 use common_sql::parse_exprs;
+use common_sql::BloomIndexColumns;
 use common_storage::init_operator;
 use common_storage::DataOperator;
 use common_storage::ShareTableConfig;
@@ -59,6 +60,7 @@ use storages_common_table_meta::meta::TableSnapshotStatistics;
 use storages_common_table_meta::meta::Versioned;
 use storages_common_table_meta::table::table_storage_prefix;
 use storages_common_table_meta::table::TableCompression;
+use storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 use storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use storages_common_table_meta::table::OPT_KEY_LEGACY_SNAPSHOT_LOC;
 use storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
@@ -94,6 +96,7 @@ pub struct FuseTable {
     pub(crate) cluster_key_meta: Option<ClusterKey>,
     pub(crate) storage_format: FuseStorageFormat,
     pub(crate) table_compression: TableCompression,
+    pub(crate) bloom_index_cols: BloomIndexColumns,
 
     pub(crate) operator: Operator,
     pub(crate) data_metrics: Arc<StorageMetrics>,
@@ -140,6 +143,12 @@ impl FuseTable {
             .cloned()
             .unwrap_or_default();
 
+        let bloom_index_cols = table_info
+            .options()
+            .get(OPT_KEY_BLOOM_INDEX_COLUMNS)
+            .and_then(|s| s.parse::<BloomIndexColumns>().ok())
+            .unwrap_or(BloomIndexColumns::All);
+
         let part_prefix = table_info.meta.part_prefix.clone();
 
         let meta_location_generator =
@@ -149,6 +158,7 @@ impl FuseTable {
             table_info,
             meta_location_generator,
             cluster_key_meta,
+            bloom_index_cols,
             operator,
             data_metrics,
             storage_format: FuseStorageFormat::from_str(storage_format.as_str())?,
@@ -337,6 +347,10 @@ impl FuseTable {
 
     pub fn cluster_key_str(&self) -> Option<&String> {
         self.cluster_key_meta.as_ref().map(|(_, key)| key)
+    }
+
+    pub fn bloom_index_cols(&self) -> BloomIndexColumns {
+        self.bloom_index_cols.clone()
     }
 }
 

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -73,13 +73,13 @@ impl FuseTable {
         let cluster_stats_gen =
             self.cluster_gen_for_append(ctx.clone(), pipeline, block_thresholds)?;
         pipeline.add_transform(|input, output| {
-            let proc = TransformSerializeBlock::new(
+            let proc = TransformSerializeBlock::try_create(
                 ctx.clone(),
                 input,
                 output,
                 self,
                 cluster_stats_gen.clone(),
-            );
+            )?;
             proc.into_processor()
         })?;
 

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -165,13 +165,13 @@ impl FuseTable {
 
         pipeline.add_transform(
             |input: Arc<common_pipeline_core::processors::port::InputPort>, output| {
-                let proc = TransformSerializeBlock::new(
+                let proc = TransformSerializeBlock::try_create(
                     ctx.clone(),
                     input,
                     output,
                     self,
                     cluster_stats_gen.clone(),
-                );
+                )?;
                 proc.into_processor()
             },
         )?;

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -304,6 +304,7 @@ impl FuseTable {
             self.operator.clone(),
             self.table_info.schema(),
             &push_down,
+            self.bloom_index_cols(),
         )?;
 
         let segment_locations = create_segment_location_vector(segment_locations, None);

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -166,7 +166,13 @@ impl FuseTable {
         }
 
         let mut pruner = if !self.is_native() || self.cluster_key_meta.is_none() {
-            FusePruner::create(&ctx, dal.clone(), table_info.schema(), &push_downs)?
+            FusePruner::create(
+                &ctx,
+                dal.clone(),
+                table_info.schema(),
+                &push_downs,
+                self.bloom_index_cols(),
+            )?
         } else {
             let cluster_keys = self.cluster_keys(ctx.clone());
 
@@ -177,6 +183,7 @@ impl FuseTable {
                 &push_downs,
                 self.cluster_key_meta.clone(),
                 cluster_keys,
+                self.bloom_index_cols(),
             )?
         };
 

--- a/src/query/storages/fuse/src/operations/replace.rs
+++ b/src/query/storages/fuse/src/operations/replace.rs
@@ -167,13 +167,13 @@ impl FuseTable {
         let segment_partition_num =
             std::cmp::min(base_snapshot.segments.len(), max_threads as usize);
 
-        let serialize_block_transform = TransformSerializeBlock::new(
+        let serialize_block_transform = TransformSerializeBlock::try_create(
             ctx.clone(),
             InputPort::create(),
             OutputPort::create(),
             self,
             cluster_stats_gen,
-        );
+        )?;
         let block_builder = serialize_block_transform.get_block_builder();
 
         let serialize_segment_transform = TransformSerializeSegment::new(

--- a/src/query/storages/fuse/src/operations/update.rs
+++ b/src/query/storages/fuse/src/operations/update.rs
@@ -100,13 +100,13 @@ impl FuseTable {
             self.cluster_gen_for_append(ctx.clone(), pipeline, block_thresholds)?;
 
         pipeline.add_transform(|input, output| {
-            let proc = TransformSerializeBlock::new(
+            let proc = TransformSerializeBlock::try_create(
                 ctx.clone(),
                 input,
                 output,
                 self,
                 cluster_stats_gen.clone(),
-            );
+            )?;
             proc.into_processor()
         })?;
 

--- a/src/query/storages/fuse/src/pruning/bloom_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/bloom_pruner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -23,6 +24,7 @@ use common_expression::FunctionContext;
 use common_expression::Scalar;
 use common_expression::TableField;
 use common_expression::TableSchemaRef;
+use common_sql::BloomIndexColumns;
 use opendal::Operator;
 use storages_common_index::BloomIndex;
 use storages_common_index::FilterEvalResult;
@@ -66,22 +68,23 @@ impl BloomPrunerCreator {
         schema: &TableSchemaRef,
         dal: Operator,
         filter_expr: Option<&Expr<String>>,
+        bloom_index_cols: BloomIndexColumns,
     ) -> Result<Option<Arc<dyn BloomPruner + Send + Sync>>> {
         if let Some(expr) = filter_expr {
-            let point_query_cols = BloomIndex::find_eq_columns(expr)?;
+            let bloom_columns_map =
+                bloom_index_cols.bloom_index_fields(schema.clone(), BloomIndex::supported_type)?;
+            let bloom_column_fields = bloom_columns_map.values().cloned().collect::<Vec<_>>();
+            let point_query_cols = BloomIndex::find_eq_columns(expr, bloom_column_fields)?;
 
             if !point_query_cols.is_empty() {
                 // convert to filter column names
                 let mut filter_fields = Vec::with_capacity(point_query_cols.len());
                 let mut scalar_map = HashMap::<Scalar, u64>::new();
-                for (col_name, scalar, ty) in point_query_cols.iter() {
-                    if let Ok(field) = schema.field_with_name(col_name) {
-                        filter_fields.push(field.clone());
-                        if !scalar_map.contains_key(scalar) {
-                            let digest =
-                                BloomIndex::calculate_scalar_digest(&func_ctx, scalar, ty)?;
-                            scalar_map.insert(scalar.clone(), digest);
-                        }
+                for (field, scalar, ty) in point_query_cols.into_iter() {
+                    filter_fields.push(field);
+                    if let Entry::Vacant(e) = scalar_map.entry(scalar.clone()) {
+                        let digest = BloomIndex::calculate_scalar_digest(&func_ctx, &scalar, &ty)?;
+                        e.insert(digest);
                     }
                 }
 
@@ -127,13 +130,15 @@ impl BloomPrunerCreator {
         match maybe_filter {
             Ok(filter) => Ok(BloomIndex::from_filter_block(
                 self.func_ctx.clone(),
-                self.data_schema.clone(),
                 filter.filter_schema,
                 filter.filters,
                 version,
             )?
-            .apply(self.filter_expression.clone(), &self.scalar_map)?
-                != FilterEvalResult::MustFalse),
+            .apply(
+                self.filter_expression.clone(),
+                &self.scalar_map,
+                self.data_schema.clone(),
+            )? != FilterEvalResult::MustFalse),
             Err(e) if e.code() == ErrorCode::DEPRECATED_INDEX_FORMAT => {
                 // In case that the index is no longer supported, just return true to indicate
                 // that the block being pruned should be kept. (Although the caller of this method

--- a/src/query/storages/fuse/src/pruning/fuse_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/fuse_pruner.rs
@@ -29,6 +29,7 @@ use common_expression::TableSchemaRef;
 use common_expression::SEGMENT_NAME_COL_NAME;
 use common_functions::BUILTIN_FUNCTIONS;
 use common_sql::field_default_value;
+use common_sql::BloomIndexColumns;
 use opendal::Operator;
 use storages_common_index::RangeIndex;
 use storages_common_pruner::BlockMetaIndex;
@@ -102,8 +103,17 @@ impl FusePruner {
         dal: Operator,
         table_schema: TableSchemaRef,
         push_down: &Option<PushDownInfo>,
+        bloom_index_cols: BloomIndexColumns,
     ) -> Result<Self> {
-        Self::create_with_pages(ctx, dal, table_schema, push_down, None, vec![])
+        Self::create_with_pages(
+            ctx,
+            dal,
+            table_schema,
+            push_down,
+            None,
+            vec![],
+            bloom_index_cols,
+        )
     }
 
     // Create fuse pruner with pages.
@@ -114,6 +124,7 @@ impl FusePruner {
         push_down: &Option<PushDownInfo>,
         cluster_key_meta: Option<ClusterKey>,
         cluster_keys: Vec<RemoteExpr<String>>,
+        bloom_index_cols: BloomIndexColumns,
     ) -> Result<Self> {
         let func_ctx = ctx.get_function_context()?;
 
@@ -166,6 +177,7 @@ impl FusePruner {
             &table_schema,
             dal.clone(),
             filter_expr.as_ref(),
+            bloom_index_cols,
         )?;
 
         // Page pruner, used in native format

--- a/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables
@@ -275,11 +275,20 @@ create table t(a int) snapshot_location='xxx'
 statement error 1301
 create table t(a int) database_id='xxx'
 
+statement error 1006
+create table t(a int) bloom_index_columns='b'
+
+statement error 1301
+create table t(a decimal(4,2)) bloom_index_columns='a'
+
 statement ok
 create table t(a int)
 
 statement error 1301
 alter table t set options(database_id = "22");
+
+statement ok
+drop table if exists t;
 
 statement ok
 drop table if exists t_without_engine_desc;
@@ -313,3 +322,12 @@ drop table if exists t_with_engine_desc;
 
 statement ok
 drop table if exists t_with_wrong_engine_desc;
+
+statement ok
+drop table if exists t_with_bloom_index;
+
+statement ok
+create table t_with_bloom_index(a int, b int) bloom_index_columns='b'
+
+statement ok
+drop table if exists t_with_bloom_index;

--- a/tests/sqllogictests/suites/base/05_ddl/05_0003_ddl_alter_table
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0003_ddl_alter_table
@@ -8,6 +8,12 @@ statement ok
 DROP TABLE IF EXISTS `05_0003_at_t1`
 
 statement ok
+DROP TABLE IF EXISTS `05_0003_at_t2`
+
+statement ok
+DROP TABLE IF EXISTS `05_0003_at_t3`
+
+statement ok
 CREATE TABLE `05_0003_at_t0`(a int)
 
 statement ok
@@ -72,3 +78,33 @@ SELECT b FROM `05_0003_at_t2`
 
 statement ok
 DROP TABLE IF EXISTS `05_0003_at_t2`
+
+statement ok
+set hide_options_in_show_create_table=0
+
+statement ok
+CREATE TABLE `05_0003_at_t3`(a int, b int, c int) bloom_index_columns='a,b,c' COMPRESSION='zstd' STORAGE_FORMAT='native'
+
+query TT
+SHOW CREATE TABLE `05_0003_at_t3`
+----
+05_0003_at_t3 CREATE TABLE `05_0003_at_t3` (   `a` INT,   `b` INT,   `c` INT ) ENGINE=FUSE BLOOM_INDEX_COLUMNS='a,b,c' COMPRESSION='zstd' STORAGE_FORMAT='native'
+
+statement ok
+ALTER TABLE `05_0003_at_t3` drop column c
+
+query TT
+SHOW CREATE TABLE `05_0003_at_t3`
+----
+05_0003_at_t3 CREATE TABLE `05_0003_at_t3` (   `a` INT,   `b` INT ) ENGINE=FUSE BLOOM_INDEX_COLUMNS='a,b' COMPRESSION='zstd' STORAGE_FORMAT='native'
+
+statement ok
+ALTER TABLE `05_0003_at_t3` rename column b to c
+
+query TT
+SHOW CREATE TABLE `05_0003_at_t3`
+----
+05_0003_at_t3 CREATE TABLE `05_0003_at_t3` (   `a` INT,   `c` INT ) ENGINE=FUSE BLOOM_INDEX_COLUMNS='a,c' COMPRESSION='zstd' STORAGE_FORMAT='native'
+
+statement ok
+DROP TABLE IF EXISTS `05_0003_at_t3`

--- a/tests/sqllogictests/suites/base/06_show/06_0001_show_create_table
+++ b/tests/sqllogictests/suites/base/06_show/06_0001_show_create_table
@@ -37,15 +37,12 @@ show create table test.v_b
 v_b CREATE VIEW `test`.`v_b` AS SELECT * FROM `test`.`b`
 
 statement ok
-CREATE TABLE test.c (a int) CLUSTER BY (a, a % 3)
+CREATE TABLE test.c (a int) CLUSTER BY (a, a % 3) COMPRESSION='lz4' STORAGE_FORMAT='parquet'
 
-## SQL LOGIC has bugs to compare these stmt
-## query TT
-## SHOW CREATE TABLE `test`.`c`
-## ----
-## c CREATE TABLE `c` (
-##   `a` INT
-## ) ENGINE=FUSE CLUSTER BY (a, (a % 3)) COMPRESSION='zstd' STORAGE_FORMAT='parquet'
+query TT
+SHOW CREATE TABLE `test`.`c`
+----
+c CREATE TABLE `c` (   `a` INT ) ENGINE=FUSE CLUSTER BY (a, (a % 3)) COMPRESSION='lz4' STORAGE_FORMAT='parquet'
 
 statement ok
 DROP TABLE `test`.`a`

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_01_bloom_in_pruning
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_01_bloom_in_pruning
@@ -55,7 +55,41 @@ select * from t1 where a = 6 order by b;
 5 6
 
 statement ok
+CREATE TABLE t2(a int, b int, c int) bloom_index_columns='a,b,c'
+
+statement ok
+INSERT INTO TABLE t2 values(1,2,3),(4,5,6)
+
+statement ok
+ALTER TABLE t2 drop column c
+
+statement ok
+INSERT INTO TABLE t2 values(7,8)
+
+statement ok
+ALTER TABLE t2 rename column b to c
+
+statement ok
+INSERT INTO TABLE t2 values(9,10)
+
+query II
+SELECT * FROM t2 ORDER BY a
+----
+1 2
+4 5
+7 8
+9 10
+
+query I
+SELECT a FROM t2 where a = 3
+----
+
+
+statement ok
 DROP TABLE t1
+
+statement ok
+DROP TABLE t2
 
 statement ok
 DROP DATABASE db_09_0009_01

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0001_computed_column
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0001_computed_column
@@ -98,6 +98,18 @@ select * from t_stored2
 {"id":3,"name":"jack"} 3 jack
 
 statement ok
+drop table if exists t_stored3
+
+statement ok
+create table t_stored3(a json null, b uint32 null as (a['id']::uint32) stored, c string null as (a['name']::string) stored) bloom_index_columns = 'b, c'
+
+statement error 1301
+alter table t_stored3 set options(bloom_index_columns = 'a, b')
+
+statement ok
+alter table t_stored3 set options(bloom_index_columns = 'b')
+
+statement ok
 drop table if exists t_virtual
 
 statement ok
@@ -144,6 +156,9 @@ a2 a2-c2 c2
 a3 a3-c c
 aa aa-cc cc
 
+statement error 1301
+alter table t_virtual set options(bloom_index_columns = 'b, c');
+
 statement ok
 drop table if exists t_virtual2
 
@@ -172,6 +187,9 @@ select * from t_virtual2
 {"id":1,"name":"tom"} 1 tom
 {"id":2,"name":"jim"} 2 jim
 {"id":3,"name":"jack"} 3 jack
+
+statement error 1301
+create table t_virtual3(a json null, b uint32 null as (a['id']::uint32) virtual, c string null as (a['name']::string) virtual) bloom_index_columns = 'b, c'
 
 statement ok
 DROP DATABASE test_computed_column

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -172,6 +172,9 @@ statement ok
 alter table bloom_test_alter_t1 set options(bloom_index_columns='c2')
 
 # the bloom index column 'c1' is invalid
+#
+# note that although the bloom index of column c1 has been created for the previous 2 blocks,
+# the index (of column c1) will NOT be used in the following case
 query T
 explain select 1 from bloom_test_alter_t1 where c1 = 5
 ----

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -234,6 +234,8 @@ alter table bloom_test_alter_t2 set options(bloom_index_columns='c1, c2')
 statement ok
 insert into  bloom_test_alter_t2 values(1,1), (3,4), (10,10)
 
+# note that the bloom index of column c1 is NOT created for the first 2 blocks (but created for the last block), 
+# thus, while point querying on column c1, only 1 block might be filtered out.
 query T
 explain select 1 from bloom_test_alter_t2 where c1 = 5
 ----

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -159,6 +159,126 @@ statement ok
 drop table bloom_test_t
 
 statement ok
+create table bloom_test_alter_t1(c1 int, c2 int) bloom_index_columns='c1, c2'
+
+statement ok
+insert into  bloom_test_alter_t1 values(1,1), (5,6), (10,10)
+
+statement ok
+insert into  bloom_test_alter_t1 values(1,1), (7,8), (10,10)
+
+# alter bloom_index_columns
+statement ok
+alter table bloom_test_alter_t1 set options(bloom_index_columns='c2')
+
+# the bloom index column 'c1' is invalid
+query T
+explain select 1 from bloom_test_alter_t1 where c1 = 5
+----
+EvalScalar
+├── expressions: [1]
+├── estimated rows: 1.00
+└── Filter
+    ├── filters: [bloom_test_alter_t1.c1 (#0) = 5]
+    ├── estimated rows: 1.00
+    └── TableScan
+        ├── table: default.default.bloom_test_alter_t1
+        ├── read rows: 6
+        ├── read bytes: 86
+        ├── partitions total: 2
+        ├── partitions scanned: 2
+        ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [bloom_test_alter_t1.c1 (#0) = 5], limit: NONE]
+        ├── output columns: [c1]
+        └── estimated rows: 6.00
+
+statement ok
+drop table bloom_test_alter_t1
+
+statement ok
+create table bloom_test_alter_t2(c1 int, c2 int) bloom_index_columns='c2'
+
+statement ok
+insert into  bloom_test_alter_t2 values(1,1), (5,6), (10,10)
+
+statement ok
+insert into  bloom_test_alter_t2 values(1,1), (7,8), (10,10)
+
+query T
+explain select 1 from bloom_test_alter_t2 where c1 = 5
+----
+EvalScalar
+├── expressions: [1]
+├── estimated rows: 1.00
+└── Filter
+    ├── filters: [bloom_test_alter_t2.c1 (#0) = 5]
+    ├── estimated rows: 1.00
+    └── TableScan
+        ├── table: default.default.bloom_test_alter_t2
+        ├── read rows: 6
+        ├── read bytes: 86
+        ├── partitions total: 2
+        ├── partitions scanned: 2
+        ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [bloom_test_alter_t2.c1 (#0) = 5], limit: NONE]
+        ├── output columns: [c1]
+        └── estimated rows: 6.00
+
+# alter bloom_index_columns
+statement ok
+alter table bloom_test_alter_t2 set options(bloom_index_columns='c1, c2')
+
+statement ok
+insert into  bloom_test_alter_t2 values(1,1), (3,4), (10,10)
+
+query T
+explain select 1 from bloom_test_alter_t2 where c1 = 5
+----
+EvalScalar
+├── expressions: [1]
+├── estimated rows: 1.00
+└── Filter
+    ├── filters: [bloom_test_alter_t2.c1 (#0) = 5]
+    ├── estimated rows: 1.00
+    └── TableScan
+        ├── table: default.default.bloom_test_alter_t2
+        ├── read rows: 6
+        ├── read bytes: 86
+        ├── partitions total: 3
+        ├── partitions scanned: 2
+        ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 3, bloom pruning: 3 to 2>]
+        ├── push downs: [filters: [bloom_test_alter_t2.c1 (#0) = 5], limit: NONE]
+        ├── output columns: [c1]
+        └── estimated rows: 9.00
+
+# drop bloom_index_columns
+statement ok
+alter table bloom_test_alter_t2 set options(bloom_index_columns='')
+
+query T
+explain select 1 from bloom_test_alter_t2 where c1 = 7
+----
+EvalScalar
+├── expressions: [1]
+├── estimated rows: 1.00
+└── Filter
+    ├── filters: [bloom_test_alter_t2.c1 (#0) = 7]
+    ├── estimated rows: 1.00
+    └── TableScan
+        ├── table: default.default.bloom_test_alter_t2
+        ├── read rows: 9
+        ├── read bytes: 129
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 3, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [bloom_test_alter_t2.c1 (#0) = 7], limit: NONE]
+        ├── output columns: [c1]
+        └── estimated rows: 9.00
+
+statement ok
+drop table bloom_test_alter_t2
+
+statement ok
 create table bloom_test_nullable_t(c1 int null, c2 int16 null);
 
 statement ok

--- a/tests/suites/0_stateless/17_altertable/17_0004_alter_table_set_options.result
+++ b/tests/suites/0_stateless/17_altertable/17_0004_alter_table_set_options.result
@@ -4,3 +4,5 @@ ERROR 1105 (HY000) at line 1: TableOptionInvalid. Code: 1301, Text = table optio
 ERROR 1105 (HY000) at line 1: TableOptionInvalid. Code: 1301, Text = table option abc is invalid for alter table statement.
 ERROR 1105 (HY000) at line 1: TableOptionInvalid. Code: 1301, Text = invalid block_per_segment option, can't be over 1000.
 ERROR 1105 (HY000) at line 1: TableOptionInvalid. Code: 1301, Text = can't change storage_format for alter table statement.
+ERROR 1105 (HY000) at line 1: BadArguments. Code: 1006, Text = Unable to get field named "b". Valid fields: ["a"].
+ERROR 1105 (HY000) at line 1: TableOptionInvalid. Code: 1301, Text = Unsupported data type 'Decimal(4, 2)' for bloom index.

--- a/tests/suites/0_stateless/17_altertable/17_0004_alter_table_set_options.sh
+++ b/tests/suites/0_stateless/17_altertable/17_0004_alter_table_set_options.sh
@@ -19,7 +19,13 @@ echo "select * from t2;" | $MYSQL_CLIENT_CONNECT
 echo "alter table t2 set options(abc = '1')" | $MYSQL_CLIENT_CONNECT
 echo "alter table t2 set options(block_per_segment = 2000)" | $MYSQL_CLIENT_CONNECT
 echo "alter table t2 set options(storage_format = 'memory')" | $MYSQL_CLIENT_CONNECT
+echo "alter table t2 set options(bloom_index_columns = 'b')" | $MYSQL_CLIENT_CONNECT
+
+# valid bloom index column data type.
+echo "create table t3(a decimal(4,2))" | $MYSQL_CLIENT_CONNECT
+echo "alter table t3 set options(bloom_index_columns = 'a')" | $MYSQL_CLIENT_CONNECT
 
 #drop table
 echo "drop table if exists t" | $MYSQL_CLIENT_CONNECT
 echo "drop table if exists t2" | $MYSQL_CLIENT_CONNECT
+echo "drop table if exists t3" | $MYSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add `bloom_index_columns` option for fuse engine.  Support for specifying bloom index columns. 

To create table with bloom index:
```sql
CREATE TABLE table_name (
  column_name1 column_type1,
  column_name2 column_type2,
  ...
) ... bloom_index_columns='columnName1[, ...]'
```

To create or modify bloom index for a existing table:
*The existing Bloom index options will be replaced by the new options, it does not create Bloom filters for existing data.*
```sql
ALTER TABLE <db.table_name> SET OPTIONS(bloom_index_columns='columnName1[, ...]');
```

To disable the bloom index:
```sql
ALTER TABLE <db.table_name> SET OPTIONS(bloom_index_columns='');
```

- Closes #issue
