### PR TITLE
feat: make the system.query_log distributed

### DIFF
--- a/src/query/service/src/interpreters/interpreter_query_log.rs
+++ b/src/query/service/src/interpreters/interpreter_query_log.rs
@@ -81,6 +81,7 @@ impl InterpreterQueryLog {
         let handler_type = ctx.get_current_session().get_type().to_string();
         let tenant_id = ctx.get_tenant();
         let cluster_id = GlobalConfig::instance().query.cluster_id.clone();
+        let node_id = ctx.get_cluster().local_id.clone();
         let user = ctx.get_current_user()?;
         let sql_user = user.name;
         let sql_user_quota = format!("{:?}", user.quota);
@@ -138,6 +139,7 @@ impl InterpreterQueryLog {
             handler_type,
             tenant_id,
             cluster_id,
+            node_id,
             sql_user,
             sql_user_quota,
             sql_user_privileges,
@@ -184,6 +186,7 @@ impl InterpreterQueryLog {
         let handler_type = ctx.get_current_session().get_type().to_string();
         let tenant_id = GlobalConfig::instance().query.tenant_id.clone();
         let cluster_id = GlobalConfig::instance().query.cluster_id.clone();
+        let node_id = ctx.get_cluster().local_id.clone();
         let user = ctx.get_current_user()?;
         let sql_user = user.name;
         let sql_user_quota = format!("{:?}", user.quota);
@@ -249,6 +252,7 @@ impl InterpreterQueryLog {
             handler_type,
             tenant_id,
             cluster_id,
+            node_id,
             sql_user,
             sql_user_quota,
             sql_user_privileges,

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -187,6 +187,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'node'                          | 'system'             | 'backtrace'           | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'node'                          | 'system'             | 'caches'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'node'                          | 'system'             | 'metrics'             | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'node_id'                       | 'system'             | 'query_log'           | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'non_unique'                    | 'information_schema' | 'statistics'          | 'NULL'                | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'nullable'                      | 'information_schema' | 'columns'             | 'Nullable(UInt8)'     | 'TINYINT UNSIGNED'  | ''       | ''       | 'YES'    | ''       |
 | 'nullable'                      | 'information_schema' | 'statistics'          | 'NULL'                | 'NULL'              | ''       | ''       | 'NO'     | ''       |

--- a/src/query/storages/system/src/query_log_table.rs
+++ b/src/query/storages/system/src/query_log_table.rs
@@ -65,6 +65,7 @@ pub struct QueryLogElement {
     // User.
     pub tenant_id: String,
     pub cluster_id: String,
+    pub node_id: String,
     pub sql_user: String,
 
     #[serde(skip_serializing)]
@@ -139,6 +140,7 @@ impl SystemLogElement for QueryLogElement {
             // User.
             TableField::new("tenant_id", TableDataType::String),
             TableField::new("cluster_id", TableDataType::String),
+            TableField::new("node_id", TableDataType::String),
             TableField::new("sql_user", TableDataType::String),
             TableField::new("sql_user_quota", TableDataType::String),
             TableField::new("sql_user_privileges", TableDataType::String),
@@ -238,11 +240,14 @@ impl SystemLogElement for QueryLogElement {
             .next()
             .unwrap()
             .push(Scalar::String(self.tenant_id.as_bytes().to_vec()).as_ref());
-
         columns
             .next()
             .unwrap()
             .push(Scalar::String(self.cluster_id.as_bytes().to_vec()).as_ref());
+        columns
+            .next()
+            .unwrap()
+            .push(Scalar::String(self.node_id.as_bytes().to_vec()).as_ref());
         columns
             .next()
             .unwrap()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* make system.query_log distributed, query any node will return the cluster query logs, it will be easier for users to collect the query logs
* add `node_id` new column to query_log

- Closes #issue
