### PR TITLE
fix: allow SHOW ROLES in management mode

### DIFF
--- a/src/query/service/src/interpreters/access/management_mode_access.rs
+++ b/src/query/service/src/interpreters/access/management_mode_access.rs
@@ -85,6 +85,12 @@ impl AccessChecker for ManagementModeAccess {
                 | Plan::AlterUser(_)
                 | Plan::CreateUser(_)
                 | Plan::DropUser(_)
+
+                // Roles.
+                | Plan::ShowRoles(_)
+                | Plan::CreateRole(_)
+                | Plan::DropRole(_)
+
                 // Privilege.
                 | Plan::GrantPriv(_)
                 | Plan::RevokePriv(_)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

SHOW ROLES is expected to be allowed in the management mode. but currently we'd get this issue if we try SHOW ROLES on management mode:

```
uery error: code: 1062, message: Access denied for operation:Ok(\"ShowRolesPlan\") in management-mode
```