### PR TITLE
fix(query): fix subquery json pushdown without table name

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -2683,7 +2683,7 @@ impl<'a> TypeChecker<'a> {
     ) -> Option<Result<Box<(ScalarExpr, DataType)>>> {
         let table_index = self.metadata.read().get_table_index(
             column.database_name.as_deref(),
-            column.table_name.as_deref().unwrap(),
+            column.table_name.as_deref().unwrap_or_default(),
         )?;
 
         if !self

--- a/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
+++ b/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
@@ -211,7 +211,12 @@ select get_ignore_case(obj, 'A') from t2
 1
 
 query IT
-select id, obj:b from (select id, obj from t2) tt;
+select id, obj:b from (select id, obj from t2) tt
+----
+1 {"c":2}
+
+query IT
+select id, obj:b from (select id, obj from t2)
 ----
 1 {"c":2}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix subquery json pushdown without table name

related #12045
