### PR TITLE
fix: fix refresh index sink bug

### DIFF
--- a/src/query/storages/fuse/src/operations/agg_index_sink.rs
+++ b/src/query/storages/fuse/src/operations/agg_index_sink.rs
@@ -136,6 +136,6 @@ impl AsyncSink for AggIndexSink {
         let mut block = data_block;
         self.process_block(&mut block);
 
-        Ok(true)
+        Ok(false)
     }
 }

--- a/tests/sqllogictests/suites/ee/02_ee_aggregating_index/02_0000_agg_index_base
+++ b/tests/sqllogictests/suites/ee/02_ee_aggregating_index/02_0000_agg_index_base
@@ -217,6 +217,39 @@ DROP AGGREGATING INDEX testi
 statement ok
 DROP TABLE t
 
+# force using spill
+
+statement ok
+SET spilling_bytes_threshold_per_proc=1;
+
+statement ok
+CREATE TABLE t (a int, b int, c int)
+
+statement ok
+INSERT INTO t VALUES (1,1,4), (1,2,1), (1,2,4), (2,2,5), (1,3,3)
+
+# query: eval-agg-eval-scan, index: eval-agg-eval-scan
+
+statement ok
+CREATE AGGREGATING INDEX testi AS select b, sum(a) from t where c > 1 group by b
+
+# partial refresh
+statement ok
+REFRESH AGGREGATING INDEX testi
+
+query II
+SELECT b, SUM(a) from t2 WHERE c > 1 GROUP BY b ORDER BY b
+----
+1 1
+2 3
+3 1
+
+statement ok
+DROP AGGREGATING INDEX testi
+
+statement ok
+DROP TABLE t
+
 statement ok
 use default
 

--- a/tests/sqllogictests/suites/ee/02_ee_aggregating_index/02_0000_agg_index_base
+++ b/tests/sqllogictests/suites/ee/02_ee_aggregating_index/02_0000_agg_index_base
@@ -238,7 +238,7 @@ statement ok
 REFRESH AGGREGATING INDEX testi
 
 query II
-SELECT b, SUM(a) from t2 WHERE c > 1 GROUP BY b ORDER BY b
+SELECT b, SUM(a) from t WHERE c > 1 GROUP BY b ORDER BY b
 ----
 1 1
 2 3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`consume` should return false to prevent early finish.

Big thanks @zhang2014 for the co-debug.

