### PR TITLE
chore: remove block from panic message

### DIFF
--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -78,9 +78,8 @@ impl<'a> Evaluator<'a> {
             assert_eq!(
                 &column.data_type,
                 datatype,
-                "column datatype mismatch at index: {index}, expr: {} blocks: \n\n{}",
+                "column datatype mismatch at index: {index}, expr: {}",
                 expr.sql_display(),
-                self.input_columns,
             );
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

When the block is large, the panic message will occupy the whole screen and be useless. I think the main usage is to check data type, so remove block from the panic message.

- Closes #issue
