### PR TITLE
chore: fix left single join

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -251,7 +251,7 @@ impl JoinHashTable {
         let mut data_block = data_block;
         if matches!(
             self.hash_join_desc.join_type,
-            JoinType::Left | JoinType::Full
+            JoinType::Left | JoinType::LeftSingle | JoinType::Full
         ) {
             let mut validity = MutableBitmap::new();
             validity.extend_constant(data_block.num_rows(), true);

--- a/src/query/sql/src/executor/physical_join/hash_join.rs
+++ b/src/query/sql/src/executor/physical_join/hash_join.rs
@@ -85,7 +85,7 @@ impl PhysicalPlanBuilder {
         }
 
         let build_schema = match join.join_type {
-            JoinType::Left | JoinType::Full => {
+            JoinType::Left | JoinType::LeftSingle | JoinType::Full => {
                 let build_schema = build_side.output_schema()?;
                 // Wrap nullable type for columns in build side.
                 let build_schema = DataSchemaRefExt::create(

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain
@@ -170,7 +170,7 @@ EvalScalar
     └── HashJoin
         ├── join type: LEFT SINGLE
         ├── build keys: [b (#13)]
-        ├── probe keys: [b (#5)]
+        ├── probe keys: [CAST(b (#5) AS Int32 NULL)]
         ├── filters: []
         ├── estimated rows: 0.00
         ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -234,7 +234,7 @@ alter table bloom_test_alter_t2 set options(bloom_index_columns='c1, c2')
 statement ok
 insert into  bloom_test_alter_t2 values(1,1), (3,4), (10,10)
 
-# note that the bloom index of column c1 is NOT created for the first 2 blocks (but created for the last block), 
+# note that the bloom index of column c1 is NOT created for the first 2 blocks (but created for the last block),
 # thus, while point querying on column c1, only 1 block might be filtered out.
 query T
 explain select 1 from bloom_test_alter_t2 where c1 = 5

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1167,3 +1167,67 @@ EvalScalar
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [numbers.number (#0) > 5], limit: NONE]
                     └── estimated rows: 10.00
+
+
+statement ok
+drop table if exists a
+
+statement ok
+drop table if exists b
+
+statement ok
+create table a(id int, c1 INT NULL)
+
+statement ok
+create table b(id int, c1 INT NULL)
+
+statement ok
+insert into a values (1, 2), (2, 4), (3, 6)
+
+statement ok
+insert into b values (1, 5), (4, 8)
+
+# LEFT SINGLE JOIN
+query T
+explain select * from a where a.id = (select id from b where a.id = b.id);
+----
+EvalScalar
+├── expressions: [a.id (#0), a.c1 (#1)]
+├── estimated rows: 0.60
+└── Filter
+    ├── filters: [is_true(CAST(a.id (#0) AS Int32 NULL) = scalar_subquery_2 (#2))]
+    ├── estimated rows: 0.60
+    └── HashJoin
+        ├── join type: LEFT SINGLE
+        ├── build keys: [id (#2)]
+        ├── probe keys: [CAST(id (#0) AS Int32 NULL)]
+        ├── filters: []
+        ├── estimated rows: 3.00
+        ├── EvalScalar(Build)
+        │   ├── expressions: [b.id (#2), id (#2)]
+        │   ├── estimated rows: 2.00
+        │   └── TableScan
+        │       ├── table: default.default.b
+        │       ├── read rows: 2
+        │       ├── read bytes: 39
+        │       ├── partitions total: 1
+        │       ├── partitions scanned: 1
+        │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+        │       ├── push downs: [filters: [], limit: NONE]
+        │       ├── output columns: [id]
+        │       └── estimated rows: 2.00
+        └── TableScan(Probe)
+            ├── table: default.default.a
+            ├── read rows: 3
+            ├── read bytes: 88
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 3.00
+
+statement ok
+drop table a;
+
+statement ok
+drop table b;

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -107,7 +107,7 @@ EvalScalar
                         └── HashJoin
                             ├── join type: LEFT SINGLE
                             ├── build keys: [number (#2)]
-                            ├── probe keys: [number (#0)]
+                            ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
                             ├── filters: []
                             ├── estimated rows: 1.00
                             ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -10,7 +10,7 @@ EvalScalar
     └── HashJoin
         ├── join type: LEFT SINGLE
         ├── build keys: [number (#2)]
-        ├── probe keys: [number (#0)]
+        ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
         ├── filters: []
         ├── estimated rows: 1.00
         ├── EvalScalar(Build)
@@ -412,7 +412,7 @@ EvalScalar
     └── HashJoin
         ├── join type: LEFT SINGLE
         ├── build keys: [number (#2)]
-        ├── probe keys: [number (#0)]
+        ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
         ├── filters: []
         ├── estimated rows: 1.00
         ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
@@ -107,7 +107,7 @@ EvalScalar
                         └── HashJoin
                             ├── join type: LEFT SINGLE
                             ├── build keys: [number (#2)]
-                            ├── probe keys: [number (#0)]
+                            ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
                             ├── filters: []
                             ├── estimated rows: 1.00
                             ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
@@ -10,7 +10,7 @@ EvalScalar
     └── HashJoin
         ├── join type: LEFT SINGLE
         ├── build keys: [number (#2)]
-        ├── probe keys: [number (#0)]
+        ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
         ├── filters: []
         ├── estimated rows: 1.00
         ├── EvalScalar(Build)
@@ -412,7 +412,7 @@ EvalScalar
     └── HashJoin
         ├── join type: LEFT SINGLE
         ├── build keys: [number (#2)]
-        ├── probe keys: [number (#0)]
+        ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
         ├── filters: []
         ├── estimated rows: 1.00
         ├── EvalScalar(Build)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR
If the join type is left single, the `Datablock` on the build side of the hash join need to be Nullable.

- Closes #issue
