### PR TITLE
chore: Bump z3 to remove build time warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,35 +985,12 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.58.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr 0.4.0",
- "clang-sys",
- "clap 2.34.0",
- "env_logger 0.8.4",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "which 3.1.1",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags 1.3.2",
- "cexpr 0.6.0",
+ "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
@@ -1023,6 +1000,26 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.3.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1427,20 +1424,11 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
-dependencies = [
- "nom 5.1.2",
-]
-
-[[package]]
-name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1534,21 +1522,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -1559,9 +1532,9 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -1585,7 +1558,7 @@ dependencies = [
  "anstyle",
  "bitflags 1.3.2",
  "clap_lex 0.4.1",
- "strsim 0.10.0",
+ "strsim",
 ]
 
 [[package]]
@@ -1740,7 +1713,7 @@ dependencies = [
  "goldenfile",
  "itertools",
  "logos",
- "nom 7.1.3",
+ "nom",
  "nom-rule",
  "pratt 0.4.0",
  "pretty",
@@ -1847,7 +1820,7 @@ version = "0.1.0"
 dependencies = [
  "async-compression-issue-150-workaround",
  "bytes",
- "env_logger 0.10.0",
+ "env_logger",
  "futures",
  "log",
  "pin-project",
@@ -2080,7 +2053,7 @@ name = "common-hive-meta-store"
 version = "0.1.0"
 dependencies = [
  "databend-thrift",
- "which 4.4.0",
+ "which",
 ]
 
 [[package]]
@@ -3296,7 +3269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff76b51e4c068c52bfd2866e1567bee7c567ae8f24ada09fd4307019e25eab7"
 dependencies = [
  "chrono",
- "nom 7.1.3",
+ "nom",
  "once_cell",
 ]
 
@@ -3566,7 +3539,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 2.0.15",
 ]
 
@@ -3694,7 +3667,7 @@ dependencies = [
  "common-metrics",
  "common-tracing",
  "derive_more",
- "env_logger 0.10.0",
+ "env_logger",
  "futures",
  "itertools",
  "maplit",
@@ -3867,7 +3840,7 @@ dependencies = [
  "async-trait",
  "clap 4.2.7",
  "common-exception",
- "env_logger 0.10.0",
+ "env_logger",
  "futures-util",
  "lazy_static",
  "mysql_async",
@@ -4269,19 +4242,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -4926,7 +4886,7 @@ dependencies = [
  "btoi",
  "gix-date",
  "itoa",
- "nom 7.1.3",
+ "nom",
  "quick-error 2.0.1",
 ]
 
@@ -4940,7 +4900,7 @@ dependencies = [
  "btoi",
  "gix-date",
  "itoa",
- "nom 7.1.3",
+ "nom",
  "thiserror",
 ]
 
@@ -5016,7 +4976,7 @@ dependencies = [
  "gix-ref 0.24.1",
  "gix-sec",
  "memchr",
- "nom 7.1.3",
+ "nom",
  "once_cell",
  "smallvec",
  "thiserror",
@@ -5037,7 +4997,7 @@ dependencies = [
  "gix-ref 0.27.1",
  "gix-sec",
  "memchr",
- "nom 7.1.3",
+ "nom",
  "once_cell",
  "smallvec",
  "thiserror",
@@ -5326,7 +5286,7 @@ dependencies = [
  "gix-validate",
  "hex",
  "itoa",
- "nom 7.1.3",
+ "nom",
  "smallvec",
  "thiserror",
 ]
@@ -5345,7 +5305,7 @@ dependencies = [
  "gix-validate",
  "hex",
  "itoa",
- "nom 7.1.3",
+ "nom",
  "smallvec",
  "thiserror",
 ]
@@ -5482,7 +5442,7 @@ dependencies = [
  "gix-tempfile 3.0.2",
  "gix-validate",
  "memmap2",
- "nom 7.1.3",
+ "nom",
  "thiserror",
 ]
 
@@ -5501,7 +5461,7 @@ dependencies = [
  "gix-tempfile 5.0.1",
  "gix-validate",
  "memmap2",
- "nom 7.1.3",
+ "nom",
  "thiserror",
 ]
 
@@ -5866,7 +5826,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "flate2",
- "nom 7.1.3",
+ "nom",
  "num-traits",
 ]
 
@@ -6416,7 +6376,7 @@ source = "git+https://github.com/datafuselabs/jsonb?rev=fe6835a#fe6835a0a6813279
 dependencies = [
  "byteorder",
  "fast-float",
- "nom 7.1.3",
+ "nom",
  "ordered-float 3.7.0",
  "rand 0.8.5",
  "serde",
@@ -7223,16 +7183,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -7247,7 +7197,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8dd3c6d80d1e61031aecc5fdfaf4b7d2324dbd94d575ac12f94e5d6856c2d4"
 dependencies = [
- "nom 7.1.3",
+ "nom",
  "pratt 0.3.0",
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -7543,7 +7493,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "mysql_common",
- "nom 7.1.3",
+ "nom",
  "pin-project-lite",
  "tokio",
  "tokio-rustls 0.23.4",
@@ -8444,7 +8394,7 @@ dependencies = [
  "regex",
  "syn 1.0.109",
  "tempfile",
- "which 4.4.0",
+ "which",
 ]
 
 [[package]]
@@ -9836,7 +9786,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1649c86f6ff4bec1c5a96b834f1e0da09eff92d85e3963286a61f41afca65de5"
 dependencies = [
- "strsim 0.10.0",
+ "strsim",
  "triple_accel",
 ]
 
@@ -10184,12 +10134,6 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -10402,15 +10346,6 @@ name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "textwrap"
@@ -11244,12 +11179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "vergen"
 version = "8.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11438,15 +11367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -11754,22 +11674,21 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "z3"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25754b4bf4516a65d0e596ea9c1f0082224bdf20823a37fdd9111fa08d5bf48"
+checksum = "1fdd5cf0f7cd1fe2faaa4912e8939107e0306eb3f0acb9131fbeb8396c8479c8"
 dependencies = [
- "lazy_static",
  "log",
  "z3-sys",
 ]
 
 [[package]]
 name = "z3-sys"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c82dcbc58be4bf1994c520066cb2bd6c3d36aed0fdc57244f34d277421986a6"
+checksum = "e831b0f8b5a26b4676e36f8ccf4224e996f61fd750a18c1e621e71b89441cd80"
 dependencies = [
- "bindgen 0.58.1",
+ "bindgen 0.66.1",
  "cmake",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11674,9 +11674,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "z3"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd5cf0f7cd1fe2faaa4912e8939107e0306eb3f0acb9131fbeb8396c8479c8"
+checksum = "4a7ff5718c079e7b813378d67a5bed32ccc2086f151d6185074a7e24f4a565e8"
 dependencies = [
  "log",
  "z3-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11684,9 +11684,9 @@ dependencies = [
 
 [[package]]
 name = "z3-sys"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e831b0f8b5a26b4676e36f8ccf4224e996f61fd750a18c1e621e71b89441cd80"
+checksum = "d7cf70fdbc0de3f42b404f49b0d4686a82562254ea29ff0a155eef2f5430f4b0"
 dependencies = [
  "bindgen 0.66.1",
  "cmake",

--- a/src/query/constraint/Cargo.toml
+++ b/src/query/constraint/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 # Workspace dependencies
 
 # Crates.io dependencies
-z3 = { version = "0.12.0", features = ["static-link-z3"] }
+z3 = { version = "0.12.1", features = ["static-link-z3"] }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/query/constraint/Cargo.toml
+++ b/src/query/constraint/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 # Workspace dependencies
 
 # Crates.io dependencies
-z3 = { version = "0.11.2", features = ["static-link-z3"] }
+z3 = { version = "0.12.0", features = ["static-link-z3"] }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -75,4 +75,4 @@ simsearch = "0.2"
 time = "0.3.14"
 tracing = "0.1.36"
 url = { version = "2.3" }
-z3 = { version = "0.12.0", features = ["static-link-z3"], optional = true }
+z3 = { version = "0.12.1", features = ["static-link-z3"], optional = true }

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -75,4 +75,4 @@ simsearch = "0.2"
 time = "0.3.14"
 tracing = "0.1.36"
 url = { version = "2.3" }
-z3 = { version = "0.11.2", features = ["static-link-z3"], optional = true }
+z3 = { version = "0.12.0", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: Bump z3 to remove build time warning

This PR will remove the warning during build time like the following:

```shell
warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 2`
```