### PR TITLE
docs: remove cross-reference links

### DIFF
--- a/docs/doc/14-sql-commands/10-dml/dml-insert.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-insert.md
@@ -126,7 +126,7 @@ SELECT * FROM t_insert_default;
 
 ## Insert with Staged Files
 
-Databend allows you to insert data from a staged file into a table by utilizing the INSERT INTO statement with its [HTTP Handler](../../03-develop/00-api/00-rest.md).
+Databend allows you to insert data from a staged file into a table by utilizing the INSERT INTO statement with its HTTP handler.
 
 ### Syntax
 
@@ -136,7 +136,7 @@ INSERT INTO [db.]table [(c1, c2, c3)] VALUES ...
 
 ### Examples
 
-This example showcases the usage of Databend's [HTTP handler](../../03-develop/00-api/00-rest.md) to insert data from a staged CSV file into a table. 
+This example showcases the usage of Databend's HTTP handler to insert data from a staged CSV file into a table. 
 
 ```sql
 CREATE TABLE t_insert_stage(a int null, b int default 2, c float, d varchar default 'd');

--- a/docs/doc/14-sql-commands/10-dml/dml-replace.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-replace.md
@@ -82,7 +82,7 @@ SELECT  * FROM Employees;
 
 ### Replace with Staged Files
 
-Below is an example that demonstrates how to use staged files for updating data with a REPLACE INTO statement. It's important to note that the REPLACE INTO functionality with staged files is only available when using Databend's [HTTP Handler](../../03-develop/00-api/00-rest.md).
+Below is an example that demonstrates how to use staged files for updating data with a REPLACE INTO statement. It's important to note that the REPLACE INTO functionality with staged files is only available when using Databend's HTTP handler.
 
 First, create a table called "sample":
 

--- a/docs/doc/14-sql-commands/20-query-syntax/01-query-select.md
+++ b/docs/doc/14-sql-commands/20-query-syntax/01-query-select.md
@@ -179,7 +179,7 @@ SELECT number FROM numbers(3);
 +--------+
 ```
 
-Databend supports direct querying of data from various locations without the need to load it into a table. These locations include user stages, internal stages, external stages, object storage buckets/containers (e.g., Amazon S3, Google Cloud Storage, Microsoft Azure), and remote servers accessible via HTTPS and IPFS. You can leverage this feature within the FROM clause to efficiently query data directly from these sources. See [Querying Staged Files](../../12-load-data/00-transform/05-querying-stage.md) for details.
+Databend supports direct querying of data from various locations without the need to load it into a table. These locations include user stages, internal stages, external stages, object storage buckets/containers (e.g., Amazon S3, Google Cloud Storage, Microsoft Azure), and remote servers accessible via HTTPS and IPFS. You can leverage this feature within the FROM clause to efficiently query data directly from these sources.
 
 ## AT Clause
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Removed cross-reference links that block the sync to Databend Cloud documentation. @flaneur2020 

- Closes #issue
