### PR TITLE
chore: refine `create_column_binding` method

### DIFF
--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -371,13 +371,7 @@ impl Binder {
                     column.column_name = item.alias.clone();
                     column
                 } else {
-                    self.create_column_binding(
-                        None,
-                        None,
-                        None,
-                        item.alias.clone(),
-                        item.scalar.data_type()?,
-                    )
+                    self.create_derived_column_binding(item.alias.clone(), item.scalar.data_type()?)
                 };
                 available_aliases.push((column, item.scalar.clone()));
             }
@@ -525,10 +519,7 @@ impl Binder {
         let grouping_sets = grouping_sets.into_iter().unique().collect();
         agg_info.grouping_sets = grouping_sets;
         // Add a virtual column `_grouping_id` to group items.
-        let grouping_id_column = self.create_column_binding(
-            None,
-            None,
-            None,
+        let grouping_id_column = self.create_derived_column_binding(
             "_grouping_id".to_string(),
             DataType::Number(NumberDataType::UInt32),
         );
@@ -603,7 +594,7 @@ impl Binder {
                     {
                         column_ref.column.clone()
                     } else {
-                        self.create_column_binding(None, None, None, alias, scalar.data_type()?)
+                        self.create_derived_column_binding(alias, scalar.data_type()?)
                     };
                     bind_context.aggregate_info.group_items.push(ScalarItem {
                         scalar: scalar.clone(),

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -58,7 +58,6 @@ use crate::plans::ShowRolesPlan;
 use crate::plans::UseDatabasePlan;
 use crate::BindContext;
 use crate::ColumnBinding;
-use crate::IndexType;
 use crate::MetadataRef;
 use crate::NameResolutionContext;
 use crate::TypeChecker;
@@ -560,12 +559,9 @@ impl<'a> Binder {
         Ok(plan)
     }
 
-    /// Create a new ColumnBinding with assigned index
-    pub(crate) fn create_column_binding(
+    /// Create a new ColumnBinding for derived column
+    pub(crate) fn create_derived_column_binding(
         &mut self,
-        database_name: Option<String>,
-        table_name: Option<String>,
-        table_index: Option<IndexType>,
         column_name: String,
         data_type: DataType,
     ) -> ColumnBinding {
@@ -574,10 +570,10 @@ impl<'a> Binder {
             .write()
             .add_derived_column(column_name.clone(), data_type.clone());
         ColumnBinding {
-            database_name,
-            table_name,
+            database_name: None,
+            table_name: None,
             column_position: None,
-            table_index,
+            table_index: None,
             column_name,
             index,
             data_type: Box::new(data_type),

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -68,13 +68,7 @@ impl Binder {
                 column_binding.column_name = item.alias.clone();
                 column_binding
             } else {
-                self.create_column_binding(
-                    None,
-                    None,
-                    None,
-                    item.alias.clone(),
-                    item.scalar.data_type()?,
-                )
+                self.create_derived_column_binding(item.alias.clone(), item.scalar.data_type()?)
             };
             if is_grouping_sets_item {
                 column_binding.data_type = Box::new(column_binding.data_type.wrap_nullable());

--- a/src/query/sql/src/planner/binder/sort.rs
+++ b/src/query/sql/src/planner/binder/sort.rs
@@ -155,10 +155,7 @@ impl Binder {
                             if let ScalarExpr::BoundColumnRef(col) = &rewrite_scalar {
                                 col.column.clone()
                             } else {
-                                self.create_column_binding(
-                                    None,
-                                    None,
-                                    None,
+                                self.create_derived_column_binding(
                                     format!("{:#}", order.expr),
                                     rewrite_scalar.data_type()?,
                                 )


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For derived column, it doesn't have `database_name`, `table_name`, `table_index`, so let's simplify the method

- Closes #issue
