### PR TITLE
fix(storage): segment cluster statistics maybe enlarged

### DIFF
--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -262,6 +262,35 @@ fn test_reduce_cluster_statistics() -> common_exception::Result<()> {
 
     let res_2 = reducers::reduce_cluster_statistics(&[cluster_stats_0, cluster_stats_1], Some(1));
     assert_eq!(res_2, None);
+
+    // multi cluster keys.
+    let multi_cluster_stats_0 = Some(ClusterStatistics {
+        cluster_key_id: 0,
+        min: vec![Scalar::from(1i64), Scalar::from(4i64)],
+        max: vec![Scalar::from(1i64), Scalar::from(4i64)],
+        level: 0,
+        pages: None,
+    });
+    let multi_cluster_stats_2 = Some(ClusterStatistics {
+        cluster_key_id: 0,
+        min: vec![Scalar::from(3i64), Scalar::from(2i64)],
+        max: vec![Scalar::from(3i64), Scalar::from(2i64)],
+        level: 0,
+        pages: None,
+    });
+    let res_3 = reducers::reduce_cluster_statistics(
+        &[multi_cluster_stats_0, multi_cluster_stats_2],
+        default_cluster_key_id,
+    );
+    let expect = Some(ClusterStatistics {
+        cluster_key_id: 0,
+        min: vec![Scalar::from(1i64), Scalar::from(4i64)],
+        max: vec![Scalar::from(3i64), Scalar::from(2i64)],
+        level: 0,
+        pages: None,
+    });
+    assert_eq!(res_3, expect);
+
     Ok(())
 }
 

--- a/src/query/storages/fuse/src/table_functions/fuse_columns/fuse_column.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_columns/fuse_column.rs
@@ -124,7 +124,7 @@ impl<'a> FuseColumn<'a> {
 
         let mut row_num = 0;
         let chunk_size =
-            std::cmp::min(self.ctx.get_settings().get_max_threads()? as usize * 4, len);
+            std::cmp::min(self.ctx.get_settings().get_max_threads()? as usize * 4, len).max(1);
 
         let schema = self.table.schema();
         let leaf_fields = schema.leaf_fields();

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
@@ -112,20 +112,13 @@ impl<'a> FuseSegment<'a> {
         let mut row_num = 0;
         let mut end_flag = false;
         let chunk_size =
-            std::cmp::min(self.ctx.get_settings().get_max_threads()? as usize * 4, len);
+            std::cmp::min(self.ctx.get_settings().get_max_threads()? as usize * 4, len).max(1);
         for chunk in segment_locations.chunks(chunk_size) {
             let segments = segments_io
                 .read_segments::<Arc<SegmentInfo>>(chunk, true)
                 .await?;
 
-            let take_num = if row_num + chunk_size >= len {
-                end_flag = true;
-                len - row_num
-            } else {
-                row_num += chunk_size;
-                chunk_size
-            };
-            for (idx, segment) in segments.into_iter().take(take_num).enumerate() {
+            for (idx, segment) in segments.into_iter().enumerate() {
                 let segment = segment?;
                 format_versions.push(segment_locations[idx].1);
                 block_count.push(segment.summary.block_count);
@@ -133,6 +126,12 @@ impl<'a> FuseSegment<'a> {
                 compressed.push(segment.summary.compressed_byte_size);
                 uncompressed.push(segment.summary.uncompressed_byte_size);
                 file_location.push(segment_locations[idx].0.clone().into_bytes());
+
+                row_num += 1;
+                if row_num >= limit {
+                    end_flag = true;
+                    break;
+                }
             }
 
             if end_flag {

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0006_func_fuse_history
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0006_func_fuse_history
@@ -80,6 +80,21 @@ select count() from fuse_block('db_09_0006', 't1')
 ----
 5
 
+statement ok
+truncate table t1 purge
+
+query I
+select block_size from fuse_block('db_09_0006', 't1')
+----
+
+query I
+select block_count from fuse_segment('db_09_0006', 't1')
+----
+
+query I
+select row_count from fuse_column('db_09_0006', 't1')
+----
+
 statement error 1025
 select * from fuse_snapshot('db_09_0006', 'not_exist')
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. fix segment cluster statistics maybe enlarged when the table contain multi cluster keys
```
mysql> create table t(a int, b int) cluster by(a,b);
Query OK, 0 rows affected (0.07 sec)

mysql> insert into t values(1,4);
Query OK, 1 row affected (0.11 sec)

mysql> insert into t values(3,2);
Query OK, 1 row affected (0.11 sec)

mysql> optimize table t compact segment;
Query OK, 0 rows affected (0.10 sec)
```
The segment's cluster_statistics should be `{min: (1,4), max: (3,2)}`, but get `{min: (1,2), max: (3,4)}`

2. fix fuse_block/fuse_segment/fuse_column maybe panic bug.
```
mysql> create table t(a int);
Query OK, 0 rows affected (0.12 sec)

mysql> insert into t select number from numbers(12);
Query OK, 12 rows affected (0.09 sec)

mysql> truncate table t purge;
Query OK, 0 rows affected (0.17 sec)

mysql> select * from fuse_block('default', 't');
ERROR 1105 (HY000): PanicError. Code: 1104, Text = chunk size must be non-zero.
mysql> select * from fuse_column('default', 't');
ERROR 1105 (HY000): PanicError. Code: 1104, Text = chunk size must be non-zero.
mysql> select * from fuse_segment('default', 't');
ERROR 1105 (HY000): PanicError. Code: 1104, Text = chunk size must be non-zero.
```


- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12214)
<!-- Reviewable:end -->
