### PR TITLE
chore: prune columns for `CteScan`

### DIFF
--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -595,6 +595,7 @@ impl PipelineBuilder {
                     output,
                     cte_scan.cte_idx,
                     self.cte_state.clone(),
+                    cte_scan.offsets.clone(),
                 )
             },
             max_threads as usize,

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -105,6 +105,7 @@ pub struct CteScan {
     pub plan_id: u32,
     pub cte_idx: (IndexType, IndexType),
     pub output_schema: DataSchemaRef,
+    pub offsets: Vec<IndexType>,
 }
 
 impl CteScan {

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -1108,6 +1108,7 @@ impl PhysicalPlanBuilder {
                 plan_id: self.next_plan_id(),
                 cte_idx: cte_scan.cte_idx,
                 output_schema: DataSchemaRefExt::create(cte_scan.fields.clone()),
+                offsets: cte_scan.offsets.clone(),
             })),
 
             RelOperator::MaterializedCte(op) => {

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -736,17 +736,20 @@ impl Binder {
             .set_materialized_cte((cte_info.cte_idx, cte_info.used_count), blocks)?;
         // Get the fields in the cte
         let mut fields = vec![];
-        for column in cte_info.columns.iter() {
+        let mut offsets = vec![];
+        for (idx, column) in cte_info.columns.iter().enumerate() {
             fields.push(DataField::new(
                 column.index.to_string().as_str(),
                 *column.data_type.clone(),
-            ))
+            ));
+            offsets.push(idx);
         }
         let cte_scan = SExpr::create_leaf(Arc::new(
             CteScan {
                 cte_idx: (cte_info.cte_idx, cte_info.used_count),
                 fields,
                 // It is safe to unwrap here because we have checked that the cte is materialized.
+                offsets,
                 stat: cte_info.stat_info.clone().unwrap(),
             }
             .into(),

--- a/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/prune_unused_columns.rs
@@ -22,6 +22,7 @@ use crate::optimizer::ColumnSet;
 use crate::optimizer::RelExpr;
 use crate::optimizer::SExpr;
 use crate::plans::Aggregate;
+use crate::plans::CteScan;
 use crate::plans::DummyTableScan;
 use crate::plans::EvalScalar;
 use crate::plans::ProjectSet;
@@ -279,6 +280,38 @@ impl UnusedColumnPruner {
                 ))
             }
 
+            RelOperator::CteScan(scan) => {
+                // Pruner column will be executed twice, the second shouldn't change cte scan
+                if self.apply_lazy {
+                    return Ok(SExpr::create_leaf(Arc::new(RelOperator::CteScan(
+                        CteScan {
+                            cte_idx: scan.cte_idx,
+                            fields: scan.fields.clone(),
+                            offsets: scan.offsets.clone(),
+                            stat: scan.stat.clone(),
+                        },
+                    ))));
+                }
+                let mut used_columns = scan.used_columns()?;
+                used_columns = required.intersection(&used_columns).cloned().collect();
+                let mut pruned_fields = vec![];
+                let mut pruned_offsets = vec![];
+                for (idx, field) in scan.fields.iter().enumerate() {
+                    if used_columns.contains(&field.name().parse()?) {
+                        pruned_fields.push(field.clone());
+                        pruned_offsets.push(idx);
+                    }
+                }
+                Ok(SExpr::create_leaf(Arc::new(RelOperator::CteScan(
+                    CteScan {
+                        cte_idx: scan.cte_idx,
+                        fields: pruned_fields,
+                        offsets: pruned_offsets,
+                        stat: scan.stat.clone(),
+                    },
+                ))))
+            }
+
             RelOperator::MaterializedCte(cte) => {
                 let left_output_column = RelExpr::with_s_expr(expr)
                     .derive_relational_prop_child(0)?
@@ -300,7 +333,7 @@ impl UnusedColumnPruner {
                 ))
             }
 
-            RelOperator::DummyTableScan(_) | RelOperator::CteScan(_) => Ok(expr.clone()),
+            RelOperator::DummyTableScan(_) => Ok(expr.clone()),
 
             _ => Err(ErrorCode::Internal(
                 "Attempting to prune columns of a physical plan is not allowed",

--- a/src/query/sql/src/planner/plans/cte_scan.rs
+++ b/src/query/sql/src/planner/plans/cte_scan.rs
@@ -28,11 +28,13 @@ use crate::optimizer::RequiredProperty;
 use crate::optimizer::StatInfo;
 use crate::plans::Operator;
 use crate::plans::RelOp;
+use crate::IndexType;
 
 #[derive(Clone, Debug)]
 pub struct CteScan {
     pub cte_idx: (usize, usize),
     pub fields: Vec<DataField>,
+    pub offsets: Vec<IndexType>,
     pub stat: Arc<StatInfo>,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Follow up https://github.com/datafuselabs/databend/pull/12090

Prune unused columns for CteScan to reduce data block transfer which can bring potential performance improvement.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12227)
<!-- Reviewable:end -->
