### PR TITLE
fix: metrics_inc_replace_block_number_after_pruning

### DIFF
--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -225,11 +225,12 @@ impl MergeIntoOperationAggregator {
                         }
                     }
 
-                    let num_blocks_mutated = self
-                        .deletion_accumulator
-                        .deletions
-                        .values()
-                        .fold(0, |acc, block_deletion| acc + block_deletion.len());
+                    let num_blocks_mutated = self.deletion_accumulator.deletions.values().fold(
+                        0,
+                        |acc, blocks_may_have_row_deletion| {
+                            acc + blocks_may_have_row_deletion.len()
+                        },
+                    );
 
                     metrics_inc_replace_block_number_after_pruning(num_blocks_mutated as u64);
                 }

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -225,9 +225,13 @@ impl MergeIntoOperationAggregator {
                         }
                     }
 
-                    metrics_inc_replace_block_number_after_pruning(
-                        self.deletion_accumulator.deletions.len() as u64,
-                    );
+                    let num_blocks_mutated = self
+                        .deletion_accumulator
+                        .deletions
+                        .values()
+                        .fold(0, |acc, block_deletion| acc + block_deletion.len());
+
+                    metrics_inc_replace_block_number_after_pruning(num_blocks_mutated as u64);
                 }
             }
             MergeIntoOperation::None => {}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

during execution of `replace-into` statement, value feed to  `metrics_inc_replace_block_number_after_pruning` should be the number of blocks left after pruning, not the number of segments left.

 

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12229)
<!-- Reviewable:end -->
