### PR TITLE
chore: more metrics of `replace-into`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "storages-common-table-meta",
  "typetag",
 ]
 
@@ -2816,6 +2817,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "serde",
+ "storages-common-table-meta",
  "typetag",
 ]
 

--- a/src/query/service/src/interpreters/common/metrics.rs
+++ b/src/query/service/src/interpreters/common/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs
+// Copyright 2023 Datafuse Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod grant;
-mod metrics;
-mod table;
-mod util;
+// interpreter metrics
 
-pub use grant::validate_grant_object_exists;
-pub use table::check_referenced_computed_columns;
-pub use util::check_deduplicate_label;
+use metrics::increment_gauge;
 
-pub use self::metrics::*;
+pub fn metrics_inc_replace_execution_time_ms(c: u64) {
+    increment_gauge!("replace_into_time_execution_ms", c as f64);
+}
+
+pub fn metrics_inc_replace_mutation_time_ms(c: u64) {
+    increment_gauge!("replace_into_time_mutation_ms", c as f64);
+}

--- a/src/query/service/src/interpreters/common/metrics.rs
+++ b/src/query/service/src/interpreters/common/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Datafuse Labs
+// Copyright 2021 Datafuse Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-// interpreter metrics
 
 use metrics::increment_gauge;
 

--- a/src/query/service/src/interpreters/common/metrics.rs
+++ b/src/query/service/src/interpreters/common/metrics.rs
@@ -16,10 +16,12 @@
 
 use metrics::increment_gauge;
 
+// the time used in executing the whole replace-into statement
 pub fn metrics_inc_replace_execution_time_ms(c: u64) {
     increment_gauge!("replace_into_time_execution_ms", c as f64);
 }
 
+// the time used in executing the mutation (upsert) part of the replace-into statement
 pub fn metrics_inc_replace_mutation_time_ms(c: u64) {
     increment_gauge!("replace_into_time_mutation_ms", c as f64);
 }

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use common_base::runtime::GlobalIORuntime;
 use common_catalog::table_context::TableContext;
@@ -30,6 +31,8 @@ use common_sql::NameResolutionContext;
 use tracing::info;
 
 use crate::interpreters::common::check_deduplicate_label;
+use crate::interpreters::common::metrics_inc_replace_execution_time_ms;
+use crate::interpreters::common::metrics_inc_replace_mutation_time_ms;
 use crate::interpreters::interpreter_copy::CopyInterpreter;
 use crate::interpreters::interpreter_insert::ValueSource;
 use crate::interpreters::Interpreter;
@@ -93,6 +96,9 @@ impl Interpreter for ReplaceInterpreter {
         )?;
 
         let on_conflict_fields = plan.on_conflict_fields.clone();
+
+        let start = Instant::now();
+
         table
             .replace_into(
                 self.ctx.clone(),
@@ -109,55 +115,57 @@ impl Interpreter for ReplaceInterpreter {
             let catalog = self.plan.catalog.clone();
             let database = self.plan.database.to_string();
             let table = self.plan.table.to_string();
-            pipeline.main_pipeline.set_on_finished(|err| {
-                    if err.is_none() {
-                        info!("execute replace into finished successfully. running table optimization job.");
-                         match  GlobalIORuntime::instance().block_on({
-                             async move {
-                                 ctx.evict_table_from_cache(&catalog, &database, &table)?;
-                                 let optimize_interpreter = OptimizeTableInterpreter::try_create(ctx.clone(),
-                                 OptimizeTablePlan {
-                                     catalog,
-                                     database,
-                                     table,
-                                     action: OptimizeTableAction::CompactBlocks,
-                                     limit: None,
-                                 }
-                                 )?;
-
-                                 let mut build_res = optimize_interpreter.execute2().await?;
-
-                                 if build_res.main_pipeline.is_empty() {
-                                     return Ok(());
-                                 }
-
-                                 let settings = ctx.get_settings();
-                                 let query_id = ctx.get_id();
-                                 build_res.set_max_threads(settings.get_max_threads()? as usize);
-                                 let settings = ExecutorSettings::try_create(&settings, query_id)?;
-
-                                 if build_res.main_pipeline.is_complete_pipeline()? {
-                                     let mut pipelines = build_res.sources_pipelines;
-                                     pipelines.push(build_res.main_pipeline);
-
-                                     let complete_executor = PipelineCompleteExecutor::from_pipelines(pipelines, settings)?;
-
-                                     ctx.set_executor(complete_executor.get_inner())?;
-                                     complete_executor.execute()?;
-                                 }
-                                 Ok(())
+            pipeline.main_pipeline.set_on_finished(move |err| {
+                metrics_inc_replace_mutation_time_ms(start.elapsed().as_millis() as u64);
+                if err.is_none() {
+                    info!("execute replace into finished successfully. running table optimization job.");
+                     match  GlobalIORuntime::instance().block_on({
+                         async move {
+                             ctx.evict_table_from_cache(&catalog, &database, &table)?;
+                             let optimize_interpreter = OptimizeTableInterpreter::try_create(ctx.clone(),
+                             OptimizeTablePlan {
+                                 catalog,
+                                 database,
+                                 table,
+                                 action: OptimizeTableAction::CompactBlocks,
+                                 limit: None,
                              }
-                         }) {
-                            Ok(_) => {
-                                info!("execute replace into finished successfully. table optimization job finished.");
-                            }
-                            Err(e) => { info!("execute replace into finished successfully. table optimization job failed. {:?}", e)}
-                        }
+                             )?;
 
-                        return Ok(());
+                             let mut build_res = optimize_interpreter.execute2().await?;
+
+                             if build_res.main_pipeline.is_empty() {
+                                 return Ok(());
+                             }
+
+                             let settings = ctx.get_settings();
+                             let query_id = ctx.get_id();
+                             build_res.set_max_threads(settings.get_max_threads()? as usize);
+                             let settings = ExecutorSettings::try_create(&settings, query_id)?;
+
+                             if build_res.main_pipeline.is_complete_pipeline()? {
+                                 let mut pipelines = build_res.sources_pipelines;
+                                 pipelines.push(build_res.main_pipeline);
+
+                                 let complete_executor = PipelineCompleteExecutor::from_pipelines(pipelines, settings)?;
+
+                                 ctx.set_executor(complete_executor.get_inner())?;
+                                 complete_executor.execute()?;
+                             }
+                             Ok(())
+                         }
+                     }) {
+                        Ok(_) => {
+                            info!("execute replace into finished successfully. table optimization job finished.");
+                        }
+                        Err(e) => { info!("execute replace into finished successfully. table optimization job failed. {:?}", e)}
                     }
-                    Ok(())
-                });
+
+                    return Ok(());
+                }
+                metrics_inc_replace_execution_time_ms(start.elapsed().as_millis() as u64);
+                Ok(())
+            });
         }
         Ok(pipeline)
     }

--- a/src/query/storages/fuse/src/metrics/fuse_metrics.rs
+++ b/src/query/storages/fuse/src/metrics/fuse_metrics.rs
@@ -244,18 +244,22 @@ pub fn metrics_inc_replace_partition_number(c: u64) {
     increment_gauge!(key!("replace_into_partition_number"), c as f64);
 }
 
+// time used in processing the input block
 pub fn metrics_inc_replace_process_input_block_time_ms(c: u64) {
     increment_gauge!(key!("replace_into_time_process_input_block_ms"), c as f64);
 }
 
+// the number of accumulate_merge_action operation invoked
 pub fn metrics_inc_replace_number_accumulated_merge_action() {
-    counter!(key!("replace_into_accumulated_merge_action"), 1);
+    counter!(key!("replace_into_number_accumulated_merge_action"), 1);
 }
 
+// the number of apply_deletion operation applied
 pub fn metrics_inc_replace_number_apply_deletion() {
-    counter!(key!("replace_into_apply_deletion"), 1);
+    counter!(key!("replace_into_number_apply_deletion"), 1);
 }
 
+// time used in executing the accumulated_merge_action operation
 pub fn metrics_inc_replace_accumulated_merge_action_time_ms(c: u64) {
     increment_gauge!(
         key!("replace_into_time_accumulated_merge_action_ms"),
@@ -263,6 +267,7 @@ pub fn metrics_inc_replace_accumulated_merge_action_time_ms(c: u64) {
     );
 }
 
+// time used in executing the apply_deletion operation
 pub fn metrics_inc_replace_apply_deletion_time_ms(c: u64) {
     increment_gauge!(key!("replace_into_time_apply_deletion_ms"), c as f64);
 }

--- a/src/query/storages/fuse/src/metrics/fuse_metrics.rs
+++ b/src/query/storages/fuse/src/metrics/fuse_metrics.rs
@@ -243,3 +243,26 @@ pub fn metrics_inc_replace_row_number_after_table_level_pruning(c: u64) {
 pub fn metrics_inc_replace_partition_number(c: u64) {
     increment_gauge!(key!("replace_into_partition_number"), c as f64);
 }
+
+pub fn metrics_inc_replace_process_input_block_time_ms(c: u64) {
+    increment_gauge!(key!("replace_into_time_process_input_block_ms"), c as f64);
+}
+
+pub fn metrics_inc_replace_number_accumulated_merge_action() {
+    counter!(key!("replace_into_accumulated_merge_action"), 1);
+}
+
+pub fn metrics_inc_replace_number_apply_deletion() {
+    counter!(key!("replace_into_apply_deletion"), 1);
+}
+
+pub fn metrics_inc_replace_accumulated_merge_action_time_ms(c: u64) {
+    increment_gauge!(
+        key!("replace_into_time_accumulated_merge_action_ms"),
+        c as f64
+    );
+}
+
+pub fn metrics_inc_replace_apply_deletion_time_ms(c: u64) {
+    increment_gauge!(key!("replace_into_time_apply_deletion_ms"), c as f64);
+}

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use ahash::AHashMap;
 use common_arrow::arrow::bitmap::MutableBitmap;
@@ -48,10 +49,14 @@ use crate::io::CompactSegmentInfoReader;
 use crate::io::MetaReaders;
 use crate::io::ReadSettings;
 use crate::io::WriteSettings;
+use crate::metrics::metrics_inc_replace_accumulated_merge_action_time_ms;
+use crate::metrics::metrics_inc_replace_apply_deletion_time_ms;
 use crate::metrics::metrics_inc_replace_block_number_after_pruning;
 use crate::metrics::metrics_inc_replace_block_number_totally_loaded;
 use crate::metrics::metrics_inc_replace_block_number_write;
 use crate::metrics::metrics_inc_replace_block_of_zero_row_deleted;
+use crate::metrics::metrics_inc_replace_number_accumulated_merge_action;
+use crate::metrics::metrics_inc_replace_number_apply_deletion;
 use crate::metrics::metrics_inc_replace_row_number_after_pruning;
 use crate::metrics::metrics_inc_replace_row_number_totally_loaded;
 use crate::metrics::metrics_inc_replace_row_number_write;
@@ -179,6 +184,9 @@ impl MergeIntoOperationAggregator {
     #[async_backtrace::framed]
     pub async fn accumulate(&mut self, merge_into_operation: MergeIntoOperation) -> Result<()> {
         let aggregation_ctx = &self.aggregation_ctx;
+        metrics_inc_replace_number_accumulated_merge_action();
+
+        let start = Instant::now();
         match merge_into_operation {
             MergeIntoOperation::Delete(partitions) => {
                 for (segment_index, (path, ver)) in &aggregation_ctx.segment_locations {
@@ -237,6 +245,7 @@ impl MergeIntoOperationAggregator {
             }
             MergeIntoOperation::None => {}
         }
+        metrics_inc_replace_accumulated_merge_action_time_ms(start.elapsed().as_millis() as u64);
         Ok(())
     }
 }
@@ -245,6 +254,8 @@ impl MergeIntoOperationAggregator {
 impl MergeIntoOperationAggregator {
     #[async_backtrace::framed]
     pub async fn apply(&mut self) -> Result<Option<MutationLogs>> {
+        metrics_inc_replace_number_apply_deletion();
+        let start = Instant::now();
         let mut mutation_logs = Vec::new();
         let aggregation_ctx = &self.aggregation_ctx;
         let io_runtime = GlobalIORuntime::instance();
@@ -310,6 +321,8 @@ impl MergeIntoOperationAggregator {
                 mutation_logs.push(segment_mutation_log);
             }
         }
+
+        metrics_inc_replace_apply_deletion_time_ms(start.elapsed().as_millis() as u64);
 
         Ok(Some(MutationLogs {
             entries: mutation_logs,

--- a/src/query/storages/fuse/src/operations/replace_into/processors/processor_replace_into.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/processors/processor_replace_into.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -31,6 +32,7 @@ use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 use storages_common_table_meta::meta::ColumnStatistics;
 
+use crate::metrics::metrics_inc_replace_process_input_block_time_ms;
 use crate::operations::replace_into::mutator::mutator_replace_into::ReplaceIntoMutator;
 use crate::operations::replace_into::OnConflictField;
 
@@ -159,7 +161,9 @@ impl Processor for ReplaceIntoProcessor {
 
     fn process(&mut self) -> Result<()> {
         if let Some(data_block) = self.input_data.take() {
+            let start = Instant::now();
             let merge_into_action = self.replace_into_mutator.process_input_block(&data_block)?;
+            metrics_inc_replace_process_input_block_time_ms(start.elapsed().as_millis() as u64);
             if !self.target_table_empty {
                 self.output_data_merge_into_action =
                     Some(DataBlock::empty_with_meta(Box::new(merge_into_action)));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

to better investigate the execution time of `replace into` performance, to following metrics added

- replace_into_time_execution_ms
   time used by executing the whole replace-into statement (including compact and re-cluster)

- replace_into_time_mutation_ms
   time used in executing the mutation (upsert) part of the replace-into statement

- replace_into_time_process_input_block_ms
  time used in processing the input block

- replace_into_time_accumulated_merge_action_ms
  time used in executing the accumulated_merge_action operation 
- replace_into_time_apply_deletion_ms
 time used in executing the accumulated_merge_action operation 
- replace_into_number_accumulated_merge_action
  the number of accumulaee_merge_action operations invoked
- replace_into_number_apply_deletion
   the number of apply_deletion operations applied



- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12242)
<!-- Reviewable:end -->
