### PR TITLE
ci: upload nohup.out to failure artifacts

### DIFF
--- a/.github/actions/artifact_failure/action.yml
+++ b/.github/actions/artifact_failure/action.yml
@@ -19,7 +19,7 @@ runs:
             docker logs "$line" > .databend/docker/"$line".log
         done
 
-        find -type d -name .databend -print0 | xargs -0 tar -zcf target/failure-${{ inputs.name }}.tar.gz
+        { printf "nohup.out\0"; find -type d -name .databend -print0; } | xargs -0 tar -zcf target/failure-${{ inputs.name }}.tar.gz
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.name }}


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### ci: upload nohup.out to failure artifacts

## Changelog





- Build/Testing/CI

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12253)
<!-- Reviewable:end -->
