### PR TITLE
refactor: replace ritelinked with hashlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,8 +1798,9 @@ dependencies = [
 name = "common-cache"
 version = "0.1.0"
 dependencies = [
+ "hashbrown 0.14.0",
+ "hashlink",
  "heapsize",
- "ritelinked",
 ]
 
 [[package]]
@@ -5713,16 +5720,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "griddle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb81d22191b89b117cd12d6549544bfcba0da741efdcec7c7d2fd06a0f56363"
-dependencies = [
- "ahash 0.7.6",
- "hashbrown 0.11.2",
-]
-
-[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5809,15 +5806,6 @@ checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -5839,6 +5827,19 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
+dependencies = [
+ "hashbrown 0.14.0",
+]
 
 [[package]]
 name = "hdfs-sys"
@@ -9129,17 +9130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e98c25665909853c07874301124482754434520ab572ac6a22e90366de6685b"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "ritelinked"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f2771d255fd99f0294f13249fecd0cae6e074f86b4197ec1f1689d537b44d3"
-dependencies = [
- "ahash 0.7.6",
- "griddle",
- "hashbrown 0.11.2",
 ]
 
 [[package]]

--- a/src/common/cache/Cargo.toml
+++ b/src/common/cache/Cargo.toml
@@ -12,12 +12,12 @@ test = false
 
 [features]
 heapsize = ["heapsize_"]
-amortized = ["ritelinked/ahash-amortized", "ritelinked/inline-more-amortized"]
 
 [dependencies]
 
 # Crates.io dependencies
-ritelinked = { version = "0.3.2", default-features = false, features = ["ahash", "inline-more"] }
+hashlink = "0.8"
+hashbrown = "0.14"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 heapsize_ = { package = "heapsize", version = "0.4.2", optional = true }

--- a/src/common/cache/Cargo.toml
+++ b/src/common/cache/Cargo.toml
@@ -16,8 +16,8 @@ heapsize = ["heapsize_"]
 [dependencies]
 
 # Crates.io dependencies
-hashlink = "0.8"
 hashbrown = "0.14"
+hashlink = "0.8"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 heapsize_ = { package = "heapsize", version = "0.4.2", optional = true }

--- a/src/common/cache/src/lib.rs
+++ b/src/common/cache/src/lib.rs
@@ -23,6 +23,7 @@ mod meter;
 
 pub use cache::lru::LruCache;
 pub use cache::Cache;
+pub use hashbrown::hash_map::DefaultHashBuilder;
 pub use meter::bytes_meter::BytesMeter;
 pub use meter::count_meter::Count;
 pub use meter::count_meter::CountableMeter;
@@ -32,4 +33,3 @@ pub use meter::file_meter::FileSize;
 #[cfg(not(target_os = "macos"))]
 pub use meter::heap_meter::HeapSize;
 pub use meter::Meter;
-pub use ritelinked::DefaultHashBuilder;

--- a/src/query/storages/common/cache/src/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache.rs
@@ -70,7 +70,7 @@ impl From<&DiskCacheKey> for PathBuf {
 impl<C> DiskCache<C>
 where C: Cache<String, u64, DefaultHashBuilder, FileSize>
 {
-    /// Create an `DiskCache` with `ritelinked::DefaultHashBuilder` that stores files in `path`,
+    /// Create an `DiskCache` with `hashbrown::hash_map::DefaultHashBuilder` that stores files in `path`,
     /// limited to `size` bytes.
     ///
     /// Existing files in `path` will be stored with their last-modified time from the filesystem

--- a/src/query/storages/common/cache/src/providers/memory_cache.rs
+++ b/src/query/storages/common/cache/src/providers/memory_cache.rs
@@ -40,7 +40,7 @@ impl InMemoryCacheBuilder {
     where
         M: CountableMeter<String, Arc<V>>,
     {
-        let cache = LruCache::with_meter_and_hasher(capacity, meter, DefaultHashBuilder::new());
+        let cache = LruCache::with_meter_and_hasher(capacity, meter, DefaultHashBuilder::default());
         Arc::new(RwLock::new(cache))
     }
 
@@ -53,7 +53,7 @@ impl InMemoryCacheBuilder {
     // new cache that cache `Vec<u8>`, and metered by byte size
     pub fn new_bytes_cache(capacity: u64) -> InMemoryBytesCacheHolder {
         let cache =
-            LruCache::with_meter_and_hasher(capacity, BytesMeter, DefaultHashBuilder::new());
+            LruCache::with_meter_and_hasher(capacity, BytesMeter, DefaultHashBuilder::default());
         Arc::new(RwLock::new(cache))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ritelinked and the upstream griddle have been abandoned. Let's migrate to hashlink.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12254)
<!-- Reviewable:end -->
