### PR TITLE
feat: allow read one row_group to multi Datablock.

### DIFF
--- a/src/query/storages/parquet/src/parquet_reader.rs
+++ b/src/query/storages/parquet/src/parquet_reader.rs
@@ -32,6 +32,26 @@ use opendal::Operator;
 use crate::parquet_part::ParquetRowGroupPart;
 use crate::ParquetPart;
 
+pub trait BlockIterator: Iterator<Item = Result<DataBlock>> + Send {
+    fn has_next(&self) -> bool;
+}
+
+pub struct OneBlock(pub Option<DataBlock>);
+
+impl Iterator for OneBlock {
+    type Item = Result<DataBlock>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Ok(self.0.take()).transpose()
+    }
+}
+
+impl BlockIterator for OneBlock {
+    fn has_next(&self) -> bool {
+        self.0.is_some()
+    }
+}
+
 pub trait SeekRead: std::io::Read + std::io::Seek {}
 
 impl<T> SeekRead for T where T: std::io::Read + std::io::Seek {}
@@ -84,6 +104,16 @@ pub trait ParquetReader: Sync + Send {
         chunks: Vec<(FieldIndex, Vec<u8>)>,
         filter: Option<Bitmap>,
     ) -> Result<DataBlock>;
+
+    fn get_deserializer(
+        &self,
+        part: &ParquetRowGroupPart,
+        chunks: Vec<(FieldIndex, Vec<u8>)>,
+        filter: Option<Bitmap>,
+    ) -> Result<Box<dyn BlockIterator>> {
+        let block = self.deserialize(part, chunks, filter)?;
+        Ok(Box::new(OneBlock(Some(block))))
+    }
 
     fn read_from_readers(&self, readers: &mut IndexedReaders) -> Result<Vec<IndexedChunk>> {
         let mut chunks = Vec::with_capacity(self.columns_to_read().len());

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/reader.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/reader.rs
@@ -27,11 +27,14 @@ use common_expression::DataSchema;
 use common_expression::DataSchemaRef;
 use common_expression::FieldIndex;
 use opendal::Operator;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 use parquet::file::metadata::RowGroupMetaData;
 use parquet::schema::types::ColumnDescPtr;
 use parquet::schema::types::SchemaDescPtr;
 
 use crate::parquet_part::ParquetRowGroupPart;
+use crate::parquet_reader::BlockIterator;
+use crate::parquet_reader::OneBlock;
 use crate::parquet_rs::column_nodes::ColumnNodesRS;
 use crate::parquet_rs::convert::convert_column_meta;
 use crate::parquet_rs::parquet_reader::row_group_reader::bitmap_to_selection;
@@ -129,8 +132,24 @@ impl crate::parquet_reader::ParquetReader for ParquetReader {
         chunks: Vec<(FieldIndex, Vec<u8>)>,
         filter: Option<Bitmap>,
     ) -> Result<DataBlock> {
+        let blocks = self
+            .get_deserializer(part, chunks, filter)?
+            .collect::<Vec<_>>();
+        let blocks: Result<Vec<DataBlock>> = blocks.into_iter().collect();
+        DataBlock::concat(&blocks?)
+    }
+
+    fn get_deserializer(
+        &self,
+        part: &ParquetRowGroupPart,
+        chunks: Vec<(FieldIndex, Vec<u8>)>,
+        filter: Option<Bitmap>,
+    ) -> Result<Box<dyn BlockIterator>> {
         if chunks.is_empty() {
-            return Ok(DataBlock::new(vec![], part.num_rows));
+            return Ok(Box::new(OneBlock(Some(DataBlock::new(
+                vec![],
+                part.num_rows,
+            )))));
         }
 
         let selection = filter.map(bitmap_to_selection);
@@ -165,22 +184,95 @@ impl crate::parquet_reader::ParquetReader for ParquetReader {
             metadata,
             column_chunks,
         };
-        let mut reader = row_group
-            .get_record_batch_reader(part.num_rows, selection)
+        let rows_to_read = match &selection {
+            None => part.num_rows,
+            Some(s) => s.row_count(),
+        };
+        let reader = row_group
+            .get_record_batch_reader(rows_to_read, selection)
             .unwrap();
-        let batch = reader.next().unwrap().map_err(|e| {
-            ErrorCode::BadBytes(format!(
-                "Cannot read parquet file, error: {:?}",
-                e.to_string()
-            ))
-        })?;
-        DataBlock::from_record_batch(&batch)
-            .map_err(|e| {
-                ErrorCode::BadBytes(format!(
-                    "Cannot convert record batch to data block, error: {:?}",
-                    e
-                ))
-            })
-            .map(|v| v.0)
+        Ok(Box::new(RowGroupDeserializer::new(
+            reader,
+            part.location.clone(),
+            part.num_rows,
+            part.num_rows,
+        )))
+    }
+}
+
+struct RowGroupDeserializer {
+    batch_size: usize,
+    num_rows_to_read: usize,
+    num_rows_readn: usize,
+    seq: usize,
+    location: String,
+    reader: ParquetRecordBatchReader,
+}
+
+impl RowGroupDeserializer {
+    fn new(
+        reader: ParquetRecordBatchReader,
+        location: String,
+        num_rows_to_read: usize,
+        batch_size: usize,
+    ) -> Self {
+        Self {
+            batch_size,
+            num_rows_to_read,
+            num_rows_readn: 0,
+            seq: 0,
+            location,
+            reader,
+        }
+    }
+
+    fn error(&self, op: &str, err: &str) -> ErrorCode {
+        ErrorCode::BadBytes(format!(
+            "deserialize parquet fail to {}, path = {}, num_rows_to_read = {}, batch_size = {}, failed for the {} batch, num_rows_readn = {}, error: {}",
+            op,
+            self.location,
+            self.num_rows_to_read,
+            self.batch_size,
+            self.seq,
+            self.num_rows_readn,
+            err
+        ))
+    }
+}
+
+impl Iterator for RowGroupDeserializer {
+    type Item = Result<DataBlock>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.reader.next() {
+            None => {
+                if self.num_rows_readn < self.num_rows_to_read {
+                    let err = format!(
+                        "expect num of rows: {}, actual num of rows: {}",
+                        self.num_rows_to_read, self.num_rows_readn
+                    );
+                    Some(Err(self.error("read expect num of rows", &err)))
+                } else {
+                    None
+                }
+            }
+            Some(Err(e)) => Some(Err(self.error("read arrow batch", &e.to_string()))),
+            Some(Ok(batch)) => match DataBlock::from_record_batch(&batch) {
+                Ok(v) => {
+                    self.num_rows_readn += v.0.num_rows();
+                    self.seq += 1;
+                    Some(Ok(v.0))
+                }
+                Err(e) => Some(Err(
+                    self.error("convert arrow batch to data block", &e.to_string())
+                )),
+            },
+        }
+    }
+}
+
+impl BlockIterator for RowGroupDeserializer {
+    fn has_next(&self) -> bool {
+        self.num_rows_readn < self.num_rows_to_read
     }
 }

--- a/src/query/storages/parquet/src/processors/deserialize_transform.rs
+++ b/src/query/storages/parquet/src/processors/deserialize_transform.rs
@@ -77,7 +77,7 @@ pub struct ParquetDeserializeTransform {
     scan_progress: Arc<Progress>,
     input: Arc<InputPort>,
     output: Arc<OutputPort>,
-    output_data: Option<DataBlock>,
+    output_data: Vec<DataBlock>,
 
     // data from input
     parts: VecDeque<(PartInfoPtr, ParquetPartData)>,
@@ -116,7 +116,7 @@ impl ParquetDeserializeTransform {
                 scan_progress,
                 input,
                 output,
-                output_data: None,
+                output_data: vec![],
 
                 parts: VecDeque::new(),
 
@@ -141,7 +141,7 @@ impl ParquetDeserializeTransform {
             bytes: data_block.memory_size(),
         };
         self.scan_progress.incr(&progress_values);
-        self.output_data = Some(data_block);
+        self.output_data.push(data_block);
         Ok(())
     }
 
@@ -331,7 +331,7 @@ impl Processor for ParquetDeserializeTransform {
             return Ok(Event::NeedConsume);
         }
 
-        if let Some(data_block) = self.output_data.take() {
+        if let Some(data_block) = self.output_data.pop() {
             self.output.push_data(Ok(data_block));
             return Ok(Event::NeedConsume);
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

part of https://github.com/datafuselabs/databend/issues/12245
this refactor only impl the mechanism, still read as one block.
need a police to choose a suitable batch_size in next pr.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12309)
<!-- Reviewable:end -->
