### PR TITLE
fix(rbac): do not check the privilege about SET ROLE

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -514,7 +514,6 @@ impl AccessChecker for PrivilegeAccess {
             | Plan::AlterShareTenants(_)
             | Plan::ShowObjectGrantPrivileges(_)
             | Plan::ShowGrantTenantsOfShare(_)
-            | Plan::SetRole(_)
             | Plan::ShowGrants(_)
             | Plan::ShowRoles(_)
             | Plan::GrantRole(_)
@@ -593,6 +592,7 @@ impl AccessChecker for PrivilegeAccess {
                     .await?;
             }
             // Note: No need to check privileges
+            Plan::SetRole(_) => {}
             Plan::Presign(_) => {}
             Plan::ExplainAst { .. } => {}
             Plan::ExplainSyntax { .. } => {}

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -592,6 +592,7 @@ impl AccessChecker for PrivilegeAccess {
                     .await?;
             }
             // Note: No need to check privileges
+            // SET ROLE is a session-local statement (have same semantic with the SET ROLE in postgres), no need to check privileges
             Plan::SetRole(_) => {}
             Plan::Presign(_) => {}
             Plan::ExplainAst { .. } => {}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`SET ROLE` is a session-local statement (have same semantic with the `SET ROLE` in postgres: https://www.postgresql.org/docs/current/sql-set-role.html), it's not considered to be protected via the `GRANT` privilege.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12330)
<!-- Reviewable:end -->
