### PR TITLE
fix(rbac): let visibility check take current_available_roles as parameter

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -117,6 +117,7 @@ pub trait TableContext: Send + Sync {
     fn get_current_database(&self) -> String;
     fn get_current_user(&self) -> Result<UserInfo>;
     fn get_current_role(&self) -> Option<RoleInfo>;
+    async fn get_current_available_roles(&self) -> Result<Arc<RoleInfo>>;
     fn get_fuse_version(&self) -> String;
     fn get_format_settings(&self) -> Result<FormatSettings>;
     fn get_tenant(&self) -> String;

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -117,7 +117,7 @@ pub trait TableContext: Send + Sync {
     fn get_current_database(&self) -> String;
     fn get_current_user(&self) -> Result<UserInfo>;
     fn get_current_role(&self) -> Option<RoleInfo>;
-    async fn get_current_available_roles(&self) -> Result<Arc<RoleInfo>>;
+    async fn get_current_available_roles(&self) -> Result<Vec<RoleInfo>>;
     fn get_fuse_version(&self) -> String;
     fn get_format_settings(&self) -> Result<FormatSettings>;
     fn get_tenant(&self) -> String;

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -436,6 +436,10 @@ impl TableContext for QueryContext {
         self.shared.get_current_role()
     }
 
+    async fn get_current_available_roles(&self) -> Result<Vec<RoleInfo>> {
+        self.shared.session.get_all_available_roles().await
+    }
+
     fn get_fuse_version(&self) -> String {
         let session = self.get_current_session();
         match session.get_type() {

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -462,6 +462,10 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
+    async fn get_current_available_roles(&self) -> Result<Vec<RoleInfo>> {
+        todo!()
+    }
+
     fn get_fuse_version(&self) -> String {
         todo!()
     }

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -36,6 +36,7 @@ use common_meta_app::principal::RoleInfo;
 use common_meta_app::principal::UserGrantSet;
 use common_meta_app::principal::UserInfo;
 use common_meta_app::principal::UserPrivilegeType::Grant;
+use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
 use common_sql::Planner;
@@ -287,14 +288,14 @@ pub(crate) async fn generate_unique_object(
     Ok((unique_object, global_object_priv))
 }
 
-struct GrantObjectVisibilityChecker<'a> {
+pub struct GrantObjectVisibilityChecker {
     visible_global: bool,
     visible_databases: HashSet<(String, String)>,
     visible_tables: HashSet<(String, String, String)>,
 }
 
-impl<'a> GrantObjectVisibilityChecker<'a> {
-    pub fn new(user: &'a UserInfo, available_roles: &'a Vec<RoleInfo>) -> Self {
+impl GrantObjectVisibilityChecker {
+    pub fn new(user: &UserInfo, available_roles: &Vec<RoleInfo>) -> Self {
         let mut visible_global = false;
         let mut visible_databases = HashSet::new();
         let mut visible_tables = HashSet::new();

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -216,7 +216,11 @@ impl ColumnsTable {
             };
 
             for table in tables {
-                if visibility_checker.check_table_visibility(&database, table.name()) {
+                if visibility_checker.check_table_visibility(
+                    CATALOG_DEFAULT,
+                    &database,
+                    table.name(),
+                ) {
                     let fields = generate_fields(&ctx, &table).await?;
                     for field in fields {
                         rows.push((database.clone(), table.name().into(), field.clone()))
@@ -343,20 +347,20 @@ impl GrantObjectVisibilityChecker {
             .contains(&(catalog.to_string(), db.to_string()))
     }
 
-    pub fn check_table_visibility(&self, database: &str, table: &str) -> bool {
+    pub fn check_table_visibility(&self, catalog: &str, database: &str, table: &str) -> bool {
         if self.visible_global {
             return true;
         }
 
         if self
             .visible_databases
-            .contains(&(CATALOG_DEFAULT.to_string(), database.to_string()))
+            .contains(&(catalog.to_string(), database.to_string()))
         {
             return true;
         }
 
         if self.visible_tables.contains(&(
-            CATALOG_DEFAULT.to_string(),
+            catalog.to_string(),
             database.to_string(),
             table.to_string(),
         )) {

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -32,8 +32,10 @@ use common_expression::TableField;
 use common_expression::TableSchemaRefExt;
 use common_functions::BUILTIN_FUNCTIONS;
 use common_meta_app::principal::GrantObject;
+use common_meta_app::principal::RoleInfo;
 use common_meta_app::principal::UserGrantSet;
-use common_meta_app::schema::TableIdent;
+use common_meta_app::principal::UserInfo;
+use common_meta_app::principal::UserPrivilegeType::Grant;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
 use common_sql::Planner;
@@ -154,6 +156,7 @@ impl ColumnsTable {
 
         let mut tables = Vec::new();
         let mut databases = Vec::new();
+
         if let Some(push_downs) = push_downs {
             if let Some(filter) = push_downs.filter {
                 let expr = filter.as_expr(&BUILTIN_FUNCTIONS);
@@ -184,41 +187,14 @@ impl ColumnsTable {
 
         let tenant = ctx.get_tenant();
         let user = ctx.get_current_user()?;
-        let grant_set = user.grants;
+        let roles = ctx.get_current_available_roles().await?;
+        let visibility_checker = GrantObjectVisibilityChecker::new(&user, &roles);
 
-        let (unique_object, global_object_priv) =
-            generate_unique_object(&tenant, grant_set).await?;
-
-        let mut access_dbs = HashMap::new();
-        let mut final_dbs = vec![];
-        let mut access_tables: HashSet<(String, String)> = HashSet::new();
-        if !global_object_priv {
-            for object in unique_object {
-                match object {
-                    GrantObject::Database(catalog, db) => {
-                        if catalog == CATALOG_DEFAULT && databases.contains(&db) {
-                            access_dbs.insert(db.clone(), false);
-                        }
-                    }
-                    GrantObject::Table(catalog, db, table) => {
-                        if catalog == CATALOG_DEFAULT && databases.contains(&db) {
-                            access_tables.insert((db.clone(), table));
-                            if !access_dbs.contains_key(&db) {
-                                access_dbs.insert(db.clone(), true);
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            for db in &databases {
-                if access_dbs.contains_key(db) {
-                    final_dbs.push(db.to_string());
-                }
-            }
-        } else {
-            final_dbs = databases;
-        }
+        let final_dbs: Vec<String> = databases
+            .iter()
+            .filter(|db| visibility_checker.check_database_visibility(CATALOG_DEFAULT, db))
+            .cloned()
+            .collect();
 
         let mut rows: Vec<(String, String, TableField)> = vec![];
         for database in final_dbs {
@@ -239,25 +215,10 @@ impl ColumnsTable {
             };
 
             for table in tables {
-                if global_object_priv {
+                if visibility_checker.check_table_visibility(&database, table.name()) {
                     let fields = generate_fields(&ctx, &table).await?;
                     for field in fields {
                         rows.push((database.clone(), table.name().into(), field.clone()))
-                    }
-                } else if let Some(contain_table_priv) = access_dbs.get(&database) {
-                    if *contain_table_priv {
-                        if access_tables.contains(&(database.to_string(), table.name().to_string()))
-                        {
-                            let fields = generate_fields(&ctx, &table).await?;
-                            for field in fields {
-                                rows.push((database.clone(), table.name().into(), field.clone()))
-                            }
-                        }
-                    } else {
-                        let fields = generate_fields(&ctx, &table).await?;
-                        for field in fields {
-                            rows.push((database.clone(), table.name().into(), field.clone()))
-                        }
                     }
                 }
             }
@@ -324,4 +285,83 @@ pub(crate) async fn generate_unique_object(
         .collect::<Vec<_>>();
 
     Ok((unique_object, global_object_priv))
+}
+
+struct GrantObjectVisibilityChecker<'a> {
+    visible_global: bool,
+    visible_databases: HashSet<(String, String)>,
+    visible_tables: HashSet<(String, String, String)>,
+}
+
+impl<'a> GrantObjectVisibilityChecker<'a> {
+    pub fn new(user: &'a UserInfo, available_roles: &'a Vec<RoleInfo>) -> Self {
+        let mut visible_global = false;
+        let mut visible_databases = HashSet::new();
+        let mut visible_tables = HashSet::new();
+
+        let mut grant_sets: Vec<&UserGrantSet> = vec![&user.grants];
+        for role in available_roles {
+            grant_sets.push(&role.grants);
+        }
+
+        for grant_set in grant_sets {
+            for ent in grant_set.entries() {
+                match ent.object() {
+                    GrantObject::Global => {
+                        visible_global = true;
+                    }
+                    GrantObject::Database(catalog, db) => {
+                        visible_databases.insert((catalog.to_string(), db.to_string()));
+                    }
+                    GrantObject::Table(catalog, db, table) => {
+                        visible_tables.insert((
+                            catalog.to_string(),
+                            db.to_string(),
+                            table.to_string(),
+                        ));
+                        // if table is visible, the table's database is also treated as visible
+                        visible_databases.insert((catalog.to_string(), db.to_string()));
+                    }
+                }
+            }
+        }
+
+        Self {
+            visible_global,
+            visible_databases,
+            visible_tables,
+        }
+    }
+
+    pub fn check_database_visibility(&self, catalog: &str, db: &str) -> bool {
+        if self.visible_global {
+            return true;
+        }
+
+        self.visible_databases
+            .contains(&(catalog.to_string(), db.to_string()))
+    }
+
+    pub fn check_table_visibility(&self, database: &str, table: &str) -> bool {
+        if self.visible_global {
+            return true;
+        }
+
+        if self
+            .visible_databases
+            .contains(&(CATALOG_DEFAULT.to_string(), database.to_string()))
+        {
+            return true;
+        }
+
+        if self.visible_tables.contains(&(
+            CATALOG_DEFAULT.to_string(),
+            database.to_string(),
+            table.to_string(),
+        )) {
+            return true;
+        }
+
+        false
+    }
 }

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -251,6 +251,9 @@ async fn generate_fields(
     Ok(fields)
 }
 
+/// GrantObjectVisibilityChecker is used to check whether a user has the privilege to access a
+/// database or table.
+/// It is used in `SHOW DATABASES` and `SHOW TABLES` statements.
 pub struct GrantObjectVisibilityChecker {
     visible_global: bool,
     visible_databases: HashSet<(String, String)>,

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -74,6 +74,7 @@ impl AsyncSystemTable for DatabasesTable {
 
         let (unique_object, global_object_priv) =
             generate_unique_object(&tenant, grant_set).await?;
+
         for (ctl_name, catalog) in catalogs.into_iter() {
             let mut access_dbs = HashSet::new();
             let mut final_dbs = vec![];

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -71,6 +71,7 @@ impl AsyncSystemTable for DatabasesTable {
 
         let user = ctx.get_current_user()?;
         let grant_set = user.grants;
+
         let (unique_object, global_object_priv) =
             generate_unique_object(&tenant, grant_set).await?;
         for (ctl_name, catalog) in catalogs.into_iter() {

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -35,6 +35,7 @@ use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
 
 use crate::columns_table::generate_unique_object;
+use crate::columns_table::GrantObjectVisibilityChecker;
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;
 
@@ -70,36 +71,15 @@ impl AsyncSystemTable for DatabasesTable {
         let mut db_id = vec![];
 
         let user = ctx.get_current_user()?;
-        let grant_set = user.grants;
-
-        let (unique_object, global_object_priv) =
-            generate_unique_object(&tenant, grant_set).await?;
+        let roles = ctx.get_current_available_roles().await?;
+        let visibility_checker = GrantObjectVisibilityChecker::new(&user, &roles);
 
         for (ctl_name, catalog) in catalogs.into_iter() {
-            let mut access_dbs = HashSet::new();
-            let mut final_dbs = vec![];
-            if global_object_priv {
-                final_dbs = catalog.list_databases(tenant.as_str()).await?;
-            } else {
-                for object in &unique_object {
-                    match object {
-                        GrantObject::Database(priv_catalog, db) => {
-                            if priv_catalog == &ctl_name {
-                                access_dbs.insert(db);
-                            }
-                        }
-                        GrantObject::Table(catalog, db, _) => {
-                            if catalog == &ctl_name && !access_dbs.contains(db) {
-                                access_dbs.insert(db);
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                for access_db in access_dbs {
-                    final_dbs.push(catalog.get_database(tenant.as_str(), access_db).await?);
-                }
-            }
+            let databases = catalog.list_databases(tenant.as_str()).await?;
+            let final_dbs = databases
+                .into_iter()
+                .filter(|db| visibility_checker.check_database_visibility(&ctl_name, &db.name()))
+                .collect::<Vec<_>>();
 
             for db in final_dbs {
                 catalog_names.push(ctl_name.clone().into_bytes());

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -75,7 +75,7 @@ impl AsyncSystemTable for DatabasesTable {
             let databases = catalog.list_databases(tenant.as_str()).await?;
             let final_dbs = databases
                 .into_iter()
-                .filter(|db| visibility_checker.check_database_visibility(&ctl_name, &db.name()))
+                .filter(|db| visibility_checker.check_database_visibility(&ctl_name, db.name()))
                 .collect::<Vec<_>>();
 
             for db in final_dbs {

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use common_catalog::catalog::Catalog;
@@ -29,12 +28,10 @@ use common_expression::DataBlock;
 use common_expression::TableDataType;
 use common_expression::TableField;
 use common_expression::TableSchemaRefExt;
-use common_meta_app::principal::GrantObject;
 use common_meta_app::schema::TableIdent;
 use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
 
-use crate::columns_table::generate_unique_object;
 use crate::columns_table::GrantObjectVisibilityChecker;
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -150,7 +150,7 @@ where TablesTable<T>: HistoryAware
 
             let final_dbs = dbs
                 .into_iter()
-                .filter(|db| visibility_checker.check_database_visibility(&ctl_name, db.name()))
+                .filter(|db| visibility_checker.check_database_visibility(ctl_name, db.name()))
                 .collect::<Vec<_>>();
             for db in final_dbs {
                 let name = db.name().to_string().into_boxed_str();
@@ -172,7 +172,7 @@ where TablesTable<T>: HistoryAware
                 for table in tables {
                     // If db1 is visible, do not means db1.table1 is visible. An user may have a grant about db1.table2, so db1 is visible
                     // for her, but db1.table1 may be not visible. So we need an extra check about table here after db visibility check.
-                    if visibility_checker.check_table_visibility(&ctl_name, db.name(), table.name())
+                    if visibility_checker.check_table_visibility(ctl_name, db.name(), table.name())
                     {
                         catalogs.push(ctl_name.as_bytes().to_vec());
                         databases.push(name.as_bytes().to_vec());

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -173,6 +173,8 @@ where TablesTable<T>: HistoryAware
                 };
 
                 for table in tables {
+                    // If db1 is visible, do not means db1.table1 is visible. An user may have a grant about db1.table2, so db1 is visible
+                    // for her, but db1.table1 may be not visible. So we need an extra check about table here after db visibility check.
                     if visibility_checker.check_table_visibility(&ctl_name, db.name(), table.name())
                     {
                         catalogs.push(ctl_name.as_bytes().to_vec());

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use common_catalog::catalog::Catalog;
@@ -40,7 +38,6 @@ use common_meta_app::schema::TableInfo;
 use common_meta_app::schema::TableMeta;
 use log::warn;
 
-use crate::columns_table::generate_unique_object;
 use crate::columns_table::GrantObjectVisibilityChecker;
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently the visibility check takes one user's granted roles and related roles. There's a minor difference between taking the currnet_available_roles:

On the case of external user authentication, the `role` is authenticated from the JWT token, but not the user's grant set. `get_current_available_roles` handles this behaviour, and collected the related roles together.

This PR also introduced a `GrantObjectVisibilityChecker` struct which may help reduce some duplicated logic among `tables_table.rs` `columns_table.rs` and `databases_table.rs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12343)
<!-- Reviewable:end -->
