### PR TITLE
refactor(databend-meta): retry when change-membership error encountered upon startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,6 +3626,7 @@ dependencies = [
  "anyhow",
  "async-backtrace",
  "background-service",
+ "chrono",
  "clap 3.2.23",
  "comfy-table 6.1.4",
  "common-base",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -64,6 +64,7 @@ storages-common-table-meta = { path = "../query/storages/common/table-meta" }
 anyerror = { workspace = true }
 anyhow = { workspace = true }
 async-backtrace = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 comfy-table = "6.1.3"
 limits-rs = "0.2.0"

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -687,7 +687,7 @@ impl MetaNode {
         }
 
         Err(MetaManagementError::Join(AnyError::error(format!(
-            "fail to join {} cluster via {:?}, caused by errors: {}",
+            "fail to join node-{} to cluster via {:?}, errors: {}",
             self.sto.id,
             addrs,
             errors.into_iter().map(|e| e.to_string()).join(", ")

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
@@ -113,7 +113,7 @@ async fn test_retry_join() -> anyhow::Result<()> {
         tc1.config.raft_config.join = vec![bad_addr.clone()];
         let ret = start_metasrv_with_context(&mut tc1).await;
         let expect = format!(
-            "fail to join {} cluster via {:?}",
+            "fail to join node-{} to cluster via {:?}",
             1, tc1.config.raft_config.join
         );
 

--- a/src/meta/types/src/errors/meta_api_errors.rs
+++ b/src/meta/types/src/errors/meta_api_errors.rs
@@ -77,7 +77,11 @@ impl MetaAPIError {
                 // Network is always unstable, retry.
                 true
             }
-            MetaAPIError::DataError(_) => false,
+            MetaAPIError::DataError(data_err) => match data_err {
+                MetaDataError::WriteError(_) => false,
+                MetaDataError::ChangeMembershipError(_) => true,
+                MetaDataError::ReadError(_) => false,
+            },
         }
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(databend-meta): retry when change-membership error encountered upon startup

When starting up more than one uninitialized meta-nodes, there is
chance a node fails to start up because:
- concurrent node-registering to the cluster with `Raft::change_membership()`,
- and `databend-meta` does not deal with `ChangeMembershipError`.

In this patch `ChangeMembershipError` is caught and the registering-node
is retried, which make bringing up 3 empty meta node without problem.


##### feat(metabench): add benchmark for upsert table with copied files


##### feat(metabench): add benchmark for get-table

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12359)
<!-- Reviewable:end -->
