### PR TITLE
feat: new SQL command `SHOW CREATE CATALOG`.

### DIFF
--- a/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
@@ -71,7 +71,7 @@ impl Interpreter for ShowCreateCatalogInterpreter {
             vec![
                 BlockEntry::new(
                     DataType::String,
-                    Value::Scalar(Scalar::String(name.as_bytes().to_vec())),
+                    Value::Scalar(Scalar::String(name.into_bytes())),
                 ),
                 BlockEntry::new(
                     DataType::String,

--- a/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
@@ -1,0 +1,91 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_exception::Result;
+use common_expression::types::DataType;
+use common_expression::BlockEntry;
+use common_expression::DataBlock;
+use common_expression::DataSchemaRef;
+use common_expression::Scalar;
+use common_expression::Value;
+use common_meta_app::schema::CatalogOption;
+use common_sql::plans::ShowCreateCatalogPlan;
+use log::debug;
+
+use crate::interpreters::Interpreter;
+use crate::pipelines::PipelineBuildResult;
+use crate::sessions::QueryContext;
+use crate::sessions::TableContext;
+
+pub struct ShowCreateCatalogInterpreter {
+    ctx: Arc<QueryContext>,
+    plan: ShowCreateCatalogPlan,
+}
+
+impl ShowCreateCatalogInterpreter {
+    pub fn try_create(ctx: Arc<QueryContext>, plan: ShowCreateCatalogPlan) -> Result<Self> {
+        Ok(ShowCreateCatalogInterpreter { ctx, plan })
+    }
+}
+
+#[async_trait::async_trait]
+impl Interpreter for ShowCreateCatalogInterpreter {
+    fn name(&self) -> &str {
+        "ShowCreateTableInterpreter"
+    }
+
+    fn schema(&self) -> DataSchemaRef {
+        self.plan.schema()
+    }
+
+    #[async_backtrace::framed]
+    async fn execute2(&self) -> Result<PipelineBuildResult> {
+        let catalog = self.ctx.get_catalog(self.plan.catalog.as_str()).await?;
+
+        let name = catalog.name();
+        let info = catalog.info();
+
+        let (catalog_type, option) = match info.meta.catalog_option {
+            CatalogOption::Default => (String::from("default"), String::new()),
+            CatalogOption::Hive(op) => (String::from("hive"), format!("ADDRESS\n{}", op.address)),
+            CatalogOption::Iceberg(op) => (
+                String::from("iceberg"),
+                format!("STORAGE PARAMS\n{}", op.storage_params),
+            ),
+        };
+
+        let block = DataBlock::new(
+            vec![
+                BlockEntry::new(
+                    DataType::String,
+                    Value::Scalar(Scalar::String(name.as_bytes().to_vec())),
+                ),
+                BlockEntry::new(
+                    DataType::String,
+                    Value::Scalar(Scalar::String(catalog_type.into_bytes())),
+                ),
+                BlockEntry::new(
+                    DataType::String,
+                    Value::Scalar(Scalar::String(option.into_bytes())),
+                ),
+            ],
+            1,
+        );
+        debug!("Show create catalog executor result: {:?}", block);
+
+        PipelineBuildResult::from_blocks(vec![block])
+    }
+}

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -20,6 +20,7 @@ use common_expression::DataSchemaRef;
 use log::error;
 
 use super::interpreter_catalog_create::CreateCatalogInterpreter;
+use super::interpreter_catalog_show_create::ShowCreateCatalogInterpreter;
 use super::interpreter_index_create::CreateIndexInterpreter;
 use super::interpreter_index_drop::DropIndexInterpreter;
 use super::interpreter_share_desc::DescShareInterpreter;
@@ -121,7 +122,9 @@ impl InterpreterFactory {
                 *copy_plan.clone(),
             )?)),
             // catalogs
-            Plan::ShowCreateCatalog(_) => todo!(),
+            Plan::ShowCreateCatalog(plan) => Ok(Arc::new(
+                ShowCreateCatalogInterpreter::try_create(ctx, *plan.clone())?,
+            )),
             Plan::CreateCatalog(plan) => Ok(Arc::new(CreateCatalogInterpreter::try_create(
                 ctx,
                 *plan.clone(),

--- a/src/query/service/src/interpreters/mod.rs
+++ b/src/query/service/src/interpreters/mod.rs
@@ -18,6 +18,7 @@ mod interpreter;
 mod interpreter_call;
 mod interpreter_catalog_create;
 mod interpreter_catalog_drop;
+mod interpreter_catalog_show_create;
 mod interpreter_cluster_key_alter;
 mod interpreter_cluster_key_drop;
 mod interpreter_clustering_history;

--- a/src/query/sql/src/planner/binder/ddl/catalog.rs
+++ b/src/query/sql/src/planner/binder/ddl/catalog.rs
@@ -78,7 +78,8 @@ impl Binder {
         let catalog = normalize_identifier(catalog, &self.name_resolution_ctx).name;
         let schema = DataSchemaRefExt::create(vec![
             DataField::new("Catalog", DataType::String),
-            DataField::new("Create Catalog", DataType::String),
+            DataField::new("Type", DataType::String),
+            DataField::new("Option", DataType::String),
         ]);
         Ok(Plan::ShowCreateCatalog(Box::new(ShowCreateCatalogPlan {
             catalog,

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -480,6 +480,7 @@ impl Plan {
                 | Plan::Call(_)
                 | Plan::ShowCreateDatabase(_)
                 | Plan::ShowCreateTable(_)
+                | Plan::ShowCreateCatalog(_)
                 | Plan::ShowFileFormats(_)
                 | Plan::ShowRoles(_)
                 | Plan::DescShare(_)

--- a/tests/suites/1_stateful/10_iceberg/10_0000_create_and_show.result
+++ b/tests/suites/1_stateful/10_iceberg/10_0000_create_and_show.result
@@ -1,3 +1,3 @@
 iceberg_db
 iceberg_tbl
-iceberg_ctl iceberg 
+iceberg_ctl	iceberg	STORAGE PARAMS\ns3 | bucket=testbucket,root=/iceberg_ctl/,endpoint=http://127.0.0.1:9900

--- a/tests/suites/1_stateful/10_iceberg/10_0000_create_and_show.result
+++ b/tests/suites/1_stateful/10_iceberg/10_0000_create_and_show.result
@@ -1,2 +1,3 @@
 iceberg_db
 iceberg_tbl
+iceberg_ctl iceberg 

--- a/tests/suites/1_stateful/10_iceberg/10_0000_create_and_show.sh
+++ b/tests/suites/1_stateful/10_iceberg/10_0000_create_and_show.sh
@@ -20,3 +20,5 @@ EOF
 echo "SHOW DATABASES IN iceberg_ctl;" | $MYSQL_CLIENT_CONNECT
 
 echo "SHOW TABLES IN iceberg_ctl.iceberg_db;" | $MYSQL_CLIENT_CONNECT
+
+echo "SHOW CREATE CATALOG iceberg_ctl;" | $MYSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add a new SQL command `SHOW CREATE CATALOG`.

Usage:

```
> CREATE CATALOG iceberg_test
TYPE=ICEBERG
CONNECTION=(
    URL='s3://testbucket/iceberg_test/'
    AWS_KEY_ID='minioadmin'
    AWS_SECRET_KEY='minioadmin'
    ENDPOINT_URL='http://127.0.0.1:9000'
);

> SHOW CREATE catalog iceberg_test;

┌──────────────────────────────────────────────────────────────────────────────────────────────┐
│    Catalog   │   Type  │                                Option                               │
│    String    │  String │                                String                               │
├──────────────┼─────────┼─────────────────────────────────────────────────────────────────────┤
│ iceberg_test │ iceberg │ STORAGE PARAMS                                                      │
│              │         │ s3 | bucket=iceberg_test,root=/,endpoint=http://127.0.0.1:9000      │
└──────────────────────────────────────────────────────────────────────────────────────────────┘
```

For Iceberg catalog, the `Option` field is from formatted `StorageParams` directly, and the secrets will be hidden.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12373)
<!-- Reviewable:end -->
