### PR TITLE
docs(website): add translation upload and download cmd

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
+    "upload-translations": "crowdin upload --config=../.github/crowdin.yml --delete-obsolete",
+    "download-translations": "crowdin download --config=../.github/crowdin.yml --all",
     "typecheck": "tsc"
   },
   "dependencies": {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For the sake of document collaboration, we need to reintegrate Crowdin into our workflow.

Uploading translations needs to be integrated with Vercel builds to ensure that the latest content is always synchronized with Crowdin.

As we are not currently maintaining multilingual documents, downloading translations is for demonstration purposes only.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12379)
<!-- Reviewable:end -->
