### PR TITLE
feat: seperate running_queries_count and active_sessions_count in /v1/status

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt::Display;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -52,7 +53,7 @@ pub type MaterializedCtesBlocks = Arc<RwLock<HashMap<(usize, usize), Arc<RwLock<
 pub struct ProcessInfo {
     pub id: String,
     pub typ: String,
-    pub state: String,
+    pub state: ProcessInfoState,
     pub database: String,
     pub user: Option<UserInfo>,
     pub settings: Arc<Settings>,
@@ -65,6 +66,23 @@ pub struct ProcessInfo {
     pub mysql_connection_id: Option<u32>,
     pub created_time: SystemTime,
     pub status_info: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ProcessInfoState {
+    Query,
+    Aborting,
+    Idle,
+}
+
+impl Display for ProcessInfoState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProcessInfoState::Query => write!(f, "Query"),
+            ProcessInfoState::Aborting => write!(f, "Aborting"),
+            ProcessInfoState::Idle => write!(f, "Idle"),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/query/service/src/api/http/v1/instance_status.rs
+++ b/src/query/service/src/api/http/v1/instance_status.rs
@@ -23,8 +23,10 @@ use crate::sessions::SessionManager;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct InstanceStatus {
-    // the active sessions count
+    // the running sessions count
     pub running_queries_count: u64,
+    // the active sessions count
+    pub active_sessions_count: u64,
     // the timestamp on last query started
     pub last_query_started_at: Option<u64>,
     // the timestamp on last query finished
@@ -44,6 +46,7 @@ pub async fn instance_status_handler() -> poem::Result<impl IntoResponse> {
     let status = session_manager.get_current_session_status();
     let status = InstanceStatus {
         running_queries_count: status.running_queries_count,
+        active_sessions_count: status.active_sessions_count,
         last_query_started_at: status.last_query_started_at.map(unix_timestamp_secs),
         last_query_finished_at: status.last_query_finished_at.map(unix_timestamp_secs),
         instance_started_at: unix_timestamp_secs(status.instance_started_at),

--- a/src/query/service/src/api/http/v1/instance_status.rs
+++ b/src/query/service/src/api/http/v1/instance_status.rs
@@ -23,9 +23,9 @@ use crate::sessions::SessionManager;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct InstanceStatus {
-    // the running sessions count
+    // the active sessions count with running queries
     pub running_queries_count: u64,
-    // the active sessions count
+    // the active sessions count, have active connections, but may not have any query running
     pub active_sessions_count: u64,
     // the timestamp on last query started
     pub last_query_started_at: Option<u64>,

--- a/src/query/service/src/api/http/v1/processes.rs
+++ b/src/query/service/src/api/http/v1/processes.rs
@@ -46,7 +46,7 @@ pub async fn processlist_handler() -> poem::Result<impl IntoResponse> {
         .map(|process| ProcessInfo {
             id: process.id.clone(),
             typ: process.typ.clone(),
-            state: process.state.clone(),
+            state: process.state.to_string(),
             database: process.database.clone(),
             user: process
                 .user

--- a/src/query/service/src/sessions/session_info.rs
+++ b/src/query/service/src/sessions/session_info.rs
@@ -17,6 +17,7 @@ use std::time::SystemTime;
 
 use common_base::base::ProgressValues;
 pub use common_catalog::table_context::ProcessInfo;
+use common_catalog::table_context::ProcessInfoState;
 use common_storage::StorageMetrics;
 
 use crate::sessions::Session;
@@ -60,11 +61,11 @@ impl Session {
         }
     }
 
-    fn process_state(self: &Arc<Self>, status: &SessionContext) -> String {
+    fn process_state(self: &Arc<Self>, status: &SessionContext) -> ProcessInfoState {
         match status.get_query_context_shared() {
-            _ if status.get_abort() => String::from("Aborting"),
-            None => String::from("Idle"),
-            Some(_) => String::from("Query"),
+            _ if status.get_abort() => ProcessInfoState::Aborting,
+            None => ProcessInfoState::Idle,
+            Some(_) => ProcessInfoState::Query,
         }
     }
 

--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use common_base::base::tokio;
 use common_base::base::GlobalInstance;
 use common_base::base::SignalStream;
+use common_catalog::table_context::ProcessInfoState;
 use common_config::GlobalConfig;
 use common_config::InnerConfig;
 use common_exception::ErrorCode;
@@ -305,7 +306,7 @@ impl SessionManager {
                     continue;
                 }
                 active_sessions_count += 1;
-                if session_ref.process_info().state == "Query" {
+                if session_ref.process_info().state == ProcessInfoState::Query {
                     running_queries_count += 1;
                 }
             }

--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -292,18 +292,27 @@ impl SessionManager {
         Ok(())
     }
 
-    fn get_active_user_session_num(&self) -> usize {
-        let active_sessions = self.active_sessions.read();
-        active_sessions
-            .iter()
-            .filter(|(_, y)| y.upgrade().is_some_and(|a| a.get_type().is_user_session()))
-            .count()
-    }
-
     pub fn get_current_session_status(&self) -> SessionManagerStatus {
         let mut status_t = self.status.read().clone();
-        let active_session = self.get_active_user_session_num();
-        status_t.running_queries_count = active_session as u64;
+
+        let mut running_queries_count = 0;
+        let mut active_sessions_count = 0;
+
+        let active_sessions = self.active_sessions.read();
+        for session in active_sessions.values() {
+            if let Some(session_ref) = session.upgrade() {
+                if !session_ref.get_type().is_user_session() {
+                    continue;
+                }
+                active_sessions_count += 1;
+                if session_ref.process_info().state == "Query" {
+                    running_queries_count += 1;
+                }
+            }
+        }
+
+        status_t.running_queries_count = running_queries_count;
+        status_t.active_sessions_count = active_sessions_count;
         status_t
     }
 }

--- a/src/query/service/src/sessions/session_mgr_status.rs
+++ b/src/query/service/src/sessions/session_mgr_status.rs
@@ -17,6 +17,7 @@ use std::time::SystemTime;
 #[derive(Clone)]
 pub struct SessionManagerStatus {
     pub running_queries_count: u64,
+    pub active_sessions_count: u64,
     pub last_query_started_at: Option<SystemTime>,
     pub last_query_finished_at: Option<SystemTime>,
     pub instance_started_at: SystemTime,
@@ -40,6 +41,7 @@ impl Default for SessionManagerStatus {
     fn default() -> Self {
         SessionManagerStatus {
             running_queries_count: 0,
+            active_sessions_count: 0,
             last_query_started_at: None,
             last_query_finished_at: None,
             instance_started_at: SystemTime::now(),

--- a/src/query/storages/system/src/processes_table.rs
+++ b/src/query/storages/system/src/processes_table.rs
@@ -79,7 +79,7 @@ impl SyncSystemTable for ProcessesTable {
 
             processes_id.push(process_info.id.clone().into_bytes());
             processes_type.push(process_info.typ.clone().into_bytes());
-            processes_state.push(process_info.state.clone().into_bytes());
+            processes_state.push(process_info.state.to_string().into_bytes());
             processes_database.push(process_info.database.clone().into_bytes());
             processes_host.push(ProcessesTable::process_host(&process_info.client_address));
             processes_user.push(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

I'm using /v1/status in to detect inactive query instances. There're few cases about the `running_queries_count > 0` but they are actually in "Idle" state. If a query instance is full of Idle sessions, it's actually safe to shutdown it to reduce cost.

This PR filtered out the `Idle` sessions in the `running_queries_count` field, and added another `active_sessions_count` field to represent the active connections count.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12384)
<!-- Reviewable:end -->
