### PR TITLE
fix(logging): log messages are lost with heavy load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,7 +2311,7 @@ dependencies = [
  "common-tracing",
  "derive_more",
  "hostname",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "maplit",


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### fix(logging): log messages are lost with heavy load

`tracing_appender::non_blocking()` will drop log messages if the channel
is full. Replace it with a `BufWriter<_>`

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12385)
<!-- Reviewable:end -->
