### PR TITLE
chore(planner): fix filter derive cardinality

### DIFF
--- a/src/query/sql/src/planner/optimizer/property/selectivity.rs
+++ b/src/query/sql/src/planner/optimizer/property/selectivity.rs
@@ -290,13 +290,12 @@ impl<'a> SelectivityEstimator<'a> {
                 let new_ndv = (column_stat.ndv * selectivity).ceil();
                 column_stat.ndv = new_ndv;
                 if let Some(histogram) = &mut column_stat.histogram {
-                    let new_ndv = new_ndv as u64;
-                    if new_ndv <= 2 {
+                    if new_ndv as u64 <= 2 {
                         column_stat.histogram = None;
-                        return;
-                    }
-                    for bucket in histogram.buckets.iter_mut() {
-                        bucket.update(selectivity);
+                    } else {
+                        for bucket in histogram.buckets.iter_mut() {
+                            bucket.update(selectivity);
+                        }
                     }
                 }
             }

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -109,17 +109,10 @@ impl Operator for Filter {
         // Update other columns's statistic according to selectivity.
         sb.update_other_statistic_by_selectivity(selectivity);
         let cardinality = input_cardinality * selectivity;
-
         // Derive column statistics
         let column_stats = if cardinality == 0.0 {
             HashMap::new()
         } else {
-            for (_, column_stat) in statistics.column_stats.iter_mut() {
-                if cardinality < input_cardinality {
-                    column_stat.histogram = None;
-                    column_stat.ndv = (column_stat.ndv * selectivity).ceil();
-                }
-            }
             statistics.column_stats
         };
         Ok(Arc::new(StatInfo {

--- a/src/query/sql/src/planner/plans/scan.rs
+++ b/src/query/sql/src/planner/plans/scan.rs
@@ -231,7 +231,6 @@ impl Operator for Scan {
                     precise_cardinality: Some(precise_cardinality),
                     column_stats,
                 };
-
                 // Derive cardinality
                 let mut sb = SelectivityEstimator::new(&mut statistics, HashSet::new());
                 let mut selectivity = MAX_SELECTIVITY;
@@ -241,8 +240,7 @@ impl Operator for Scan {
                 }
                 // Update other columns's statistic according to selectivity.
                 sb.update_other_statistic_by_selectivity(selectivity);
-
-                column_stats = sb.input_stat.column_stats.clone();
+                column_stats = statistics.column_stats;
                 (precise_cardinality as f64) * selectivity
             }
             (Some(precise_cardinality), None) => precise_cardinality as f64,

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -108,13 +108,13 @@ explain select * from t left join t t1 on t.a = t1.a where t1.a is not null
 ----
 EvalScalar
 ├── expressions: [t.a (#0), t1.a (#1)]
-├── estimated rows: 4.00
+├── estimated rows: 2.00
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
     ├── filters: []
-    ├── estimated rows: 4.00
+    ├── estimated rows: 2.00
     ├── Filter(Build)
     │   ├── filters: [is_not_null(t1.a (#1))]
     │   ├── estimated rows: 2.00
@@ -145,13 +145,13 @@ explain select * from t right join t t1 on t.a = t1.a where t.a is not null
 ----
 EvalScalar
 ├── expressions: [t.a (#0), t1.a (#1)]
-├── estimated rows: 4.00
+├── estimated rows: 2.00
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
     ├── filters: []
-    ├── estimated rows: 4.00
+    ├── estimated rows: 2.00
     ├── Filter(Build)
     │   ├── filters: [is_not_null(t1.a (#1))]
     │   ├── estimated rows: 2.00
@@ -250,13 +250,13 @@ explain select * from t left join t t1 on t.a = t1.a where t1.a is not null and 
 ----
 EvalScalar
 ├── expressions: [t.a (#0), t1.a (#1)]
-├── estimated rows: 4.00
+├── estimated rows: 2.00
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
     ├── filters: []
-    ├── estimated rows: 4.00
+    ├── estimated rows: 2.00
     ├── Filter(Build)
     │   ├── filters: [is_not_null(t1.a (#1))]
     │   ├── estimated rows: 2.00
@@ -324,13 +324,13 @@ explain select * from t left join t t1 on t.a = t1.a where t1.a > 1
 ----
 EvalScalar
 ├── expressions: [t.a (#0), t1.a (#1)]
-├── estimated rows: 8.37
+├── estimated rows: 9.00
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
     ├── filters: []
-    ├── estimated rows: 8.37
+    ├── estimated rows: 9.00
     ├── Filter(Build)
     │   ├── filters: [is_true(t1.a (#1) > 1)]
     │   ├── estimated rows: 8.18
@@ -435,13 +435,13 @@ explain select * from t left join t t1 on t.a = t1.a where t1.a >= 1
 ----
 EvalScalar
 ├── expressions: [t.a (#0), t1.a (#1)]
-├── estimated rows: 8.26
+├── estimated rows: 10.00
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
     ├── filters: []
-    ├── estimated rows: 8.26
+    ├── estimated rows: 10.00
     ├── Filter(Build)
     │   ├── filters: [is_true(t1.a (#1) >= 1)]
     │   ├── estimated rows: 9.09
@@ -472,13 +472,13 @@ explain select * from t left join t t1 on t.a = t1.a where t1.a <= 1
 ----
 EvalScalar
 ├── expressions: [t.a (#0), t1.a (#1)]
-├── estimated rows: 3.31
+├── estimated rows: 1.65
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
     ├── filters: []
-    ├── estimated rows: 3.31
+    ├── estimated rows: 1.65
     ├── Filter(Build)
     │   ├── filters: [is_true(t1.a (#1) <= 1)]
     │   ├── estimated rows: 1.82
@@ -544,16 +544,16 @@ explain select * from t left join t t1 on t.a = t1.a where t1.a <= 1 or (t.a > 1
 ----
 EvalScalar
 ├── expressions: [t.a (#0), t1.a (#1)]
-├── estimated rows: 3.26
+├── estimated rows: 7.15
 └── Filter
     ├── filters: [is_true(t1.a (#1) <= 1 OR t.a (#0) > 1 AND t1.a (#1) > 1)]
-    ├── estimated rows: 3.26
+    ├── estimated rows: 7.15
     └── HashJoin
         ├── join type: INNER
         ├── build keys: [t1.a (#1)]
         ├── probe keys: [t.a (#0)]
         ├── filters: []
-        ├── estimated rows: 9.06
+        ├── estimated rows: 8.51
         ├── Filter(Build)
         │   ├── filters: [is_true(t1.a (#1) <= 1 OR t1.a (#1) > 1)]
         │   ├── estimated rows: 8.51

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -788,17 +788,17 @@ explain select * from t1,t2 where ((t1.a > 1 or t1.b < 2) and t2.a > 2) or (t1.b
 ----
 EvalScalar
 ├── expressions: [t1.a (#0), t1.b (#1), t2.a (#2), t2.b (#3)]
-├── estimated rows: 0.73
+├── estimated rows: 0.99
 └── Limit
     ├── limit: 3
     ├── offset: 0
-    ├── estimated rows: 0.73
+    ├── estimated rows: 0.99
     └── Sort
         ├── sort keys: [a DESC NULLS LAST]
-        ├── estimated rows: 0.73
+        ├── estimated rows: 0.99
         └── Filter
             ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2) AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4]
-            ├── estimated rows: 0.73
+            ├── estimated rows: 0.99
             └── HashJoin
                 ├── join type: CROSS
                 ├── build keys: []

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -224,13 +224,13 @@ explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where
 ----
 EvalScalar
 ├── expressions: [a.x (#0), b.x (#1), b.y (#2)]
-├── estimated rows: 2.40
+├── estimated rows: 2.67
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [a.x (#0)]
     ├── probe keys: [b.x (#1)]
     ├── filters: []
-    ├── estimated rows: 2.40
+    ├── estimated rows: 2.67
     ├── Filter(Build)
     │   ├── filters: [is_true(a.x (#0) > 42)]
     │   ├── estimated rows: 3.00
@@ -261,13 +261,13 @@ explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where
 ----
 EvalScalar
 ├── expressions: [a.x (#0), b.x (#1), b.y (#2)]
-├── estimated rows: 1.82
+├── estimated rows: 1.21
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [a.x (#0)]
     ├── probe keys: [b.x (#1)]
     ├── filters: []
-    ├── estimated rows: 1.82
+    ├── estimated rows: 1.21
     ├── Filter(Build)
     │   ├── filters: [is_true(a.x (#0) > 44 OR a.x (#0) < 43)]
     │   ├── estimated rows: 1.75
@@ -298,13 +298,13 @@ explain select * from onecolumn as a left join twocolumn as b on a.x = b.x where
 ----
 EvalScalar
 ├── expressions: [a.x (#0), b.x (#1), b.y (#2)]
-├── estimated rows: 2.40
+├── estimated rows: 3.00
 └── HashJoin
     ├── join type: INNER
     ├── build keys: [a.x (#0)]
     ├── probe keys: [b.x (#1)]
     ├── filters: []
-    ├── estimated rows: 2.40
+    ├── estimated rows: 3.00
     ├── Filter(Build)
     │   ├── filters: [is_true(a.x (#0) > 42), is_true(a.x (#0) < 45)]
     │   ├── estimated rows: 3.00

--- a/tests/sqllogictests/suites/tpch/queries.test
+++ b/tests/sqllogictests/suites/tpch/queries.test
@@ -2082,15 +2082,15 @@ HashJoin: RIGHT SEMI
 │       └── Probe
 │           └── Scan: default.tpch.supplier, rows: 1000
 └── Probe
-    └── HashJoin: LEFT SINGLE
+    └── HashJoin: RIGHT SINGLE
         ├── Build
-        │   └── Scan: default.tpch.lineitem, rows: 600572
+        │   └── HashJoin: LEFT SEMI
+        │       ├── Build
+        │       │   └── Scan: default.tpch.part, rows: 20000
+        │       └── Probe
+        │           └── Scan: default.tpch.partsupp, rows: 80000
         └── Probe
-            └── HashJoin: LEFT SEMI
-                ├── Build
-                │   └── Scan: default.tpch.part, rows: 20000
-                └── Probe
-                    └── Scan: default.tpch.partsupp, rows: 80000
+            └── Scan: default.tpch.lineitem, rows: 600572
 
 # Q21
 query I


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

We update ndv in `update_other_statistic_by_selectivity`, currently ndv is multiplied by selectivity twice, but once is correct.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12387)
<!-- Reviewable:end -->
