### PR TITLE
chore: rename RETURN to RETURNS in masking policy rule; check masking policy rule input type and return type

### DIFF
--- a/docs/doc/14-sql-commands/00-ddl/102-mask-policy/create-mask-policy.md
+++ b/docs/doc/14-sql-commands/00-ddl/102-mask-policy/create-mask-policy.md
@@ -38,5 +38,5 @@ Ensure that *arg_type_to_mask* matches the data type of the column where the mas
 This example creates a masking policy named *email_mask* that, based on the user's role, either reveals an email address or masks it with asterisks.
 
 ```sql
-CREATE MASKING POLICY email_mask AS (val STRING) RETURN STRING -> CASE WHEN current_role() IN ('MANAGERS') THEN VAL ELSE '*********'END comment = 'hide_email';
+CREATE MASKING POLICY email_mask AS (val STRING) RETURNS STRING -> CASE WHEN current_role() IN ('MANAGERS') THEN VAL ELSE '*********'END comment = 'hide_email';
 ```

--- a/docs/doc/14-sql-commands/00-ddl/102-mask-policy/desc-mask-policy.md
+++ b/docs/doc/14-sql-commands/00-ddl/102-mask-policy/desc-mask-policy.md
@@ -21,7 +21,7 @@ DESC MASKING POLICY <policy_name>
 ## Examples
 
 ```sql
-CREATE MASKING POLICY email_mask AS (val STRING) RETURN STRING -> CASE WHEN current_role() IN ('MANAGERS') THEN VAL ELSE '*********'END comment = 'hide_email';
+CREATE MASKING POLICY email_mask AS (val STRING) RETURNS STRING -> CASE WHEN current_role() IN ('MANAGERS') THEN VAL ELSE '*********'END comment = 'hide_email';
 
 DESC MASKING POLICY email_mask;
 

--- a/docs/doc/14-sql-commands/00-ddl/102-mask-policy/drop-mask-policy.md
+++ b/docs/doc/14-sql-commands/00-ddl/102-mask-policy/drop-mask-policy.md
@@ -21,7 +21,7 @@ DROP MASKING POLICY [IF EXISTS] <policy_name>
 ## Examples
 
 ```sql
-CREATE MASKING POLICY email_mask AS (val STRING) RETURN STRING -> CASE WHEN current_role() IN ('MANAGERS') THEN VAL ELSE '*********'END comment = 'hide_email';
+CREATE MASKING POLICY email_mask AS (val STRING) RETURNS STRING -> CASE WHEN current_role() IN ('MANAGERS') THEN VAL ELSE '*********'END comment = 'hide_email';
 
 DROP MASKING POLICY email_mask;
 ```

--- a/docs/doc/14-sql-commands/00-ddl/20-table/90-alter-table-column.md
+++ b/docs/doc/14-sql-commands/00-ddl/20-table/90-alter-table-column.md
@@ -242,7 +242,7 @@ GRANT ROLE 'MANAGERS' TO 'manager_user';
 
 -- Create a masking policy
 CREATE MASKING POLICY email_mask AS (val STRING) 
-    RETURN STRING -> CASE WHEN current_role() IN ('MANAGERS') THEN VAL ELSE '*********' END 
+    RETURNS STRING -> CASE WHEN current_role() IN ('MANAGERS') THEN VAL ELSE '*********' END 
     COMMENT = 'hide_email';
 
 -- Associate the masking policy with the 'email' column

--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -145,8 +145,9 @@ build_exceptions! {
     ColumnReferencedByComputedColumn(1117),
     // The table is not a clustered table.
     UnclusteredTable(1118),
-    UnknownCatalog(11119),
-    UnknownCatalogType(11120),
+    UnknownCatalog(1119),
+    UnknownCatalogType(1120),
+    UnmatchMaskPolicyReturnType(1121),
 
     // Data Related Errors
 

--- a/src/meta/app/src/app_error.rs
+++ b/src/meta/app/src/app_error.rs
@@ -371,6 +371,33 @@ impl UnmatchColumnDataType {
 }
 
 #[derive(thiserror::Error, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[error(
+    "UnmatchMaskPolicyReturnType: `{arg_name}`:`{arg_type}` mismatch with return type `{return_type}` while `{context}`"
+)]
+pub struct UnmatchMaskPolicyReturnType {
+    arg_name: String,
+    arg_type: String,
+    return_type: String,
+    context: String,
+}
+
+impl UnmatchMaskPolicyReturnType {
+    pub fn new(
+        arg_name: impl Into<String>,
+        arg_type: impl Into<String>,
+        return_type: impl Into<String>,
+        context: impl Into<String>,
+    ) -> Self {
+        Self {
+            arg_name: arg_name.into(),
+            arg_type: arg_type.into(),
+            return_type: return_type.into(),
+            context: context.into(),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[error("UnknownTable: `{table_name}` while `{context}`")]
 pub struct UnknownTable {
     table_name: String,
@@ -899,6 +926,9 @@ pub enum AppError {
     UnmatchColumnDataType(#[from] UnmatchColumnDataType),
 
     #[error(transparent)]
+    UnmatchMaskPolicyReturnType(#[from] UnmatchMaskPolicyReturnType),
+
+    #[error(transparent)]
     VirtualColumnNotFound(#[from] VirtualColumnNotFound),
 
     #[error(transparent)]
@@ -1180,6 +1210,15 @@ impl AppErrorMessage for UnmatchColumnDataType {
     }
 }
 
+impl AppErrorMessage for UnmatchMaskPolicyReturnType {
+    fn message(&self) -> String {
+        format!(
+            "'{}':'{}' mismatch with return type '{}'",
+            self.arg_name, self.arg_type, self.return_type
+        )
+    }
+}
+
 impl AppErrorMessage for VirtualColumnNotFound {
     fn message(&self) -> String {
         format!("Virtual Column for table '{}' not found", self.table_id)
@@ -1273,6 +1312,9 @@ impl From<AppError> for ErrorCode {
             }
             AppError::UnknownBackgroundJob(err) => ErrorCode::UnknownBackgroundJob(err.message()),
             AppError::UnmatchColumnDataType(err) => ErrorCode::UnmatchColumnDataType(err.message()),
+            AppError::UnmatchMaskPolicyReturnType(err) => {
+                ErrorCode::UnmatchMaskPolicyReturnType(err.message())
+            }
             AppError::VirtualColumnNotFound(err) => ErrorCode::VirtualColumnNotFound(err.message()),
             AppError::VirtualColumnAlreadyExists(err) => {
                 ErrorCode::VirtualColumnAlreadyExists(err.message())

--- a/src/meta/app/src/data_mask/mod.rs
+++ b/src/meta/app/src/data_mask/mod.rs
@@ -48,6 +48,7 @@ impl Display for DatamaskId {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DatamaskMeta {
+    // Vec<(arg_name, arg_type)>
     pub args: Vec<(String, String)>,
     pub return_type: String,
     pub body: String,

--- a/src/query/ast/src/ast/statements/data_mask.rs
+++ b/src/query/ast/src/ast/statements/data_mask.rs
@@ -56,7 +56,7 @@ impl Display for CreateDatamaskPolicyStmt {
         }
         write!(
             f,
-            ") RETURN {} -> {}",
+            ") RETURNS {} -> {}",
             self.policy.return_type, self.policy.body
         )?;
         if let Some(comment) = &self.policy.comment {

--- a/src/query/ast/src/parser/data_mask.rs
+++ b/src/query/ast/src/parser/data_mask.rs
@@ -60,7 +60,7 @@ fn data_mask_body(i: Input) -> IResult<Expr> {
 }
 
 fn data_mask_return_type(i: Input) -> IResult<TypeName> {
-    map(rule! { RETURN ~ #type_name }, |(_, type_name)| type_name)(i)
+    map(rule! { RETURNS ~ #type_name }, |(_, type_name)| type_name)(i)
 }
 
 pub fn data_mask_policy(i: Input) -> IResult<DataMaskPolicy> {

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -772,6 +772,8 @@ pub enum TokenKind {
     RECURSIVE,
     #[token("RETURN", ignore(ascii_case))]
     RETURN,
+    #[token("RETURNS", ignore(ascii_case))]
+    RETURNS,
     #[token("RUN", ignore(ascii_case))]
     RUN,
     #[token("GRANTS", ignore(ascii_case))]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -439,7 +439,7 @@ fn test_statement() {
         r#"SELECT * FROM t GROUP BY GROUPING SETS ((a, b), (), (d, e))"#,
         r#"SELECT * FROM t GROUP BY CUBE (a, b, c)"#,
         r#"SELECT * FROM t GROUP BY ROLLUP (a, b, c)"#,
-        r#"CREATE MASKING POLICY email_mask AS (val STRING) RETURN STRING -> CASE WHEN current_role() IN ('ANALYST') THEN VAL ELSE '*********'END comment = 'this is a masking policy'"#,
+        r#"CREATE MASKING POLICY email_mask AS (val STRING) RETURNS STRING -> CASE WHEN current_role() IN ('ANALYST') THEN VAL ELSE '*********'END comment = 'this is a masking policy'"#,
         r#"DESC MASKING POLICY email_mask"#,
         r#"DROP MASKING POLICY IF EXISTS email_mask"#,
         r#"CREATE VIRTUAL COLUMNS (a['k1']['k2'], b[0][1]) FOR t"#,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -11892,9 +11892,9 @@ Query(
 
 
 ---------- Input ----------
-CREATE MASKING POLICY email_mask AS (val STRING) RETURN STRING -> CASE WHEN current_role() IN ('ANALYST') THEN VAL ELSE '*********'END comment = 'this is a masking policy'
+CREATE MASKING POLICY email_mask AS (val STRING) RETURNS STRING -> CASE WHEN current_role() IN ('ANALYST') THEN VAL ELSE '*********'END comment = 'this is a masking policy'
 ---------- Output ---------
-CREATE MASKING POLICY email_mask AS (val STRING) RETURN STRING -> CASE WHEN current_role() IN('ANALYST') THEN VAL ELSE '*********' END COMMENT = 'this is a masking policy'
+CREATE MASKING POLICY email_mask AS (val STRING) RETURNS STRING -> CASE WHEN current_role() IN('ANALYST') THEN VAL ELSE '*********' END COMMENT = 'this is a masking policy'
 ---------- AST ------------
 CreateDatamaskPolicy(
     CreateDatamaskPolicyStmt {
@@ -11910,24 +11910,24 @@ CreateDatamaskPolicy(
             return_type: String,
             body: Case {
                 span: Some(
-                    66..134,
+                    67..135,
                 ),
                 operand: None,
                 conditions: [
                     InList {
                         span: Some(
-                            91..105,
+                            92..106,
                         ),
                         expr: FunctionCall {
                             span: Some(
-                                76..90,
+                                77..91,
                             ),
                             distinct: false,
                             name: Identifier {
                                 name: "current_role",
                                 quote: None,
                                 span: Some(
-                                    76..88,
+                                    77..89,
                                 ),
                             },
                             args: [],
@@ -11938,7 +11938,7 @@ CreateDatamaskPolicy(
                         list: [
                             Literal {
                                 span: Some(
-                                    95..104,
+                                    96..105,
                                 ),
                                 lit: String(
                                     "ANALYST",
@@ -11951,7 +11951,7 @@ CreateDatamaskPolicy(
                 results: [
                     ColumnRef {
                         span: Some(
-                            111..114,
+                            112..115,
                         ),
                         database: None,
                         table: None,
@@ -11960,7 +11960,7 @@ CreateDatamaskPolicy(
                                 name: "VAL",
                                 quote: None,
                                 span: Some(
-                                    111..114,
+                                    112..115,
                                 ),
                             },
                         ),
@@ -11969,7 +11969,7 @@ CreateDatamaskPolicy(
                 else_result: Some(
                     Literal {
                         span: Some(
-                            120..131,
+                            121..132,
                         ),
                         lit: String(
                             "*********",

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -108,14 +108,6 @@ impl ModifyTableColumnInterpreter {
             )));
         }
 
-        // check if input type match to the return type
-        if policy.return_type != policy_data_type {
-            return Err(ErrorCode::UnmatchMaskPolicyReturnType(format!(
-                "arg '{}' data type {} does not match to the mask policy return type {}",
-                policy.args[0].0, policy_data_type, policy.return_type,
-            )));
-        }
-
         let table_id = table_info.ident.table_id;
         let table_version = table_info.ident.seq;
 

--- a/src/query/sql/src/planner/binder/ddl/data_mask.rs
+++ b/src/query/sql/src/planner/binder/ddl/data_mask.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_ast::ast::*;
+use common_exception::ErrorCode;
 use common_exception::Result;
 
 use crate::binder::Binder;
@@ -32,6 +33,16 @@ impl Binder {
             name,
             policy,
         } = stmt;
+
+        // check if input type match to the return type
+        let return_type = policy.return_type.to_string().to_lowercase();
+        let policy_data_type = policy.args[0].arg_type.to_string().to_lowercase();
+        if return_type != policy_data_type {
+            return Err(ErrorCode::UnmatchMaskPolicyReturnType(format!(
+                "arg '{}' data type {} does not match to the mask policy return type {}",
+                policy.args[0].arg_name, policy_data_type, return_type,
+            )));
+        }
 
         let tenant = self.ctx.get_tenant();
         let plan = CreateDatamaskPolicyPlan {

--- a/tests/sqllogictests/suites/base/05_ddl/05_0001_ddl_create_database
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0001_ddl_create_database
@@ -27,7 +27,7 @@ CREATE DATABASE system
 statement error 1002
 DROP DATABASE system
 
-statement error 11119
+statement error 1119
 CREATE DATABASE catalog_not_exist.t
 
 statement ok
@@ -59,6 +59,6 @@ CREATE SCHEMA system
 statement error 1002
 DROP SCHEMA system
 
-statement error 11119
+statement error 1119
 CREATE SCHEMA catalog_not_exist.t
 

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0001_ddl_data_mask
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0001_ddl_data_mask
@@ -15,8 +15,11 @@
 statement ok
 drop MASKING POLICY if exists mask
 
+statement error 1121
+CREATE MASKING POLICY mask AS (val STRING,num int) RETURNS INT -> CASE WHEN current_role() IN ('ANALYST') THEN 100 ELSE 200 END comment = 'this is a masking policy'
+
 statement ok
-CREATE MASKING POLICY mask AS (val STRING,num int) RETURN STRING -> CASE WHEN current_role() IN ('ANALYST') THEN VAL ELSE '*********'END comment = 'this is a masking policy'
+CREATE MASKING POLICY mask AS (val STRING,num int) RETURNS STRING -> CASE WHEN current_role() IN ('ANALYST') THEN VAL ELSE '*********'END comment = 'this is a masking policy'
 
 statement ok
 drop MASKING POLICY if exists mask

--- a/tests/suites/5_ee/02_data_mask/02_0000_data_mask.py
+++ b/tests/suites/5_ee/02_data_mask/02_0000_data_mask.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
         mycursor = mydb.cursor()
         mycursor.execute(
-            "CREATE MASKING POLICY mask AS (val STRING,num int) RETURN STRING -> CASE WHEN "
+            "CREATE MASKING POLICY mask AS (val STRING,num int) RETURNS STRING -> CASE WHEN "
             "current_role() IN ('ANALYST') THEN VAL ELSE '*********'END comment = 'this is a masking policy';"
         )
 
@@ -63,17 +63,17 @@ if __name__ == "__main__":
 
         mycursor = mydb.cursor()
         mycursor.execute(
-            "CREATE MASKING POLICY maska AS (val int) RETURN int -> CASE WHEN "
+            "CREATE MASKING POLICY maska AS (val int) RETURNS int -> CASE WHEN "
             "current_role() IN ('ANALYST') THEN VAL ELSE 200 END comment = 'this is a masking policy';"
         )
         mycursor = mydb.cursor()
         mycursor.execute(
-            "CREATE MASKING POLICY maskb AS (val STRING) RETURN STRING -> CASE WHEN "
+            "CREATE MASKING POLICY maskb AS (val STRING) RETURNS STRING -> CASE WHEN "
             "current_role() IN ('ANALYST') THEN VAL ELSE '*********'END comment = 'this is a masking policy';"
         )
         mycursor = mydb.cursor()
         mycursor.execute(
-            "CREATE MASKING POLICY maskc AS (val int) RETURN int -> CASE WHEN "
+            "CREATE MASKING POLICY maskc AS (val int) RETURNS int -> CASE WHEN "
             "current_role() IN ('ANALYST') THEN VAL ELSE 111 END comment = 'this is a masking policy';"
         )
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. rename RETURN to RETURNS in masking policy rule; 
2. check masking policy rule input type and return type, add test case.
3. refactor error code

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12406)
<!-- Reviewable:end -->
