### PR TITLE
fix: bloom pruning of `replace-into` may use incorrect bloom filter

### DIFF
--- a/src/query/storages/fuse/src/io/read/bloom/block_filter_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom/block_filter_reader.rs
@@ -50,6 +50,8 @@ pub trait BloomBlockFilterReader {
 
 #[async_trait::async_trait]
 impl BloomBlockFilterReader for Location {
+    // NOTE that the `columns` will be de-duplicated first,
+    // and the filters contained by the returned `BlockFilter` may not order by `columns`
     #[async_backtrace::framed]
     async fn read_block_filter(
         &self,

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -642,13 +642,16 @@ impl AggregationContext {
                     for row in 0..row_count {
                         let mut contains_row = true;
                         for (col_idx, col_hash) in input_hashes.iter().enumerate() {
-                            let col_filer = &filters[col_idx];
-                            let hash = col_hash[row];
-                            if hash == 0 || !col_filer.contains_digest(hash) {
-                                // hash == 0 indicates that the column value is null, which equals nothing.
-                                // one column does not match, indicates that the row does not match
-                                contains_row = false;
-                                break;
+                            // if bloom filter presents, check if the row is contained
+                            // if bloom filter absents, do nothing(since by default, we assume that the row is contained)
+                            if let Some(col_filter) = &filters[col_idx] {
+                                let hash = col_hash[row];
+                                if hash == 0 || !col_filter.contains_digest(hash) {
+                                    // hash == 0 indicates that the column value is null, which equals nothing.
+                                    // one column does not match, indicates that the row does not match
+                                    contains_row = false;
+                                    break;
+                                }
                             }
                         }
                         if contains_row {
@@ -676,9 +679,8 @@ impl AggregationContext {
         location: &Location,
         index_len: u64,
         bloom_on_conflict_field_index: &[FieldIndex],
-    ) -> Result<Vec<Arc<Xor8Filter>>> {
+    ) -> Result<Vec<Option<Arc<Xor8Filter>>>> {
         // different block may have different version of bloom filter index
-
         let mut col_names = Vec::with_capacity(bloom_on_conflict_field_index.len());
 
         for idx in bloom_on_conflict_field_index {
@@ -689,18 +691,30 @@ impl AggregationContext {
             col_names.push(bloom_column_name);
         }
 
-        // let bloom_column_name = BloomIndex::build_filter_column_name(
-        //     location.1,
-        //     &self.on_conflict_fields[bloom_on_conflict_field_index[0]].table_field,
-        // )?;
-
         // using load_bloom_filter_by_columns is attractive,
         // but it do not care about the version of the bloom filter index
         let block_filter = location
             .read_block_filter(self.data_accessor.clone(), &col_names, index_len)
             .await?;
-        // we know that there is exactly one filter
-        Ok(block_filter.filters)
+
+        // reorder the filter according to the order of bloom_on_conflict_field
+        let mut filters = Vec::with_capacity(bloom_on_conflict_field_index.len());
+        for filter_col_name in &col_names {
+            match block_filter.filter_schema.index_of(filter_col_name) {
+                Ok(idx) => {
+                    filters.push(Some(block_filter.filters[idx].clone()));
+                }
+                Err(_) => {
+                    info!(
+                        "bloom filter column {} not found for block {}",
+                        filter_col_name, location.0
+                    );
+                    filters.push(None);
+                }
+            }
+        }
+
+        Ok(filters)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

reorder the bloom filters according to the order of columns being pruned,  during execution of  bloom pruning in replace-into statement.

The order of bloom filters returned by `read_block_filter` may not be the same with columns passed into. (in fact, the number of filters returned may be less than the number of columns, if there were duplicated columns passed in).

thus, during bloom pruning of `replace-into`, if incorrect bloom filter is used, blocks may be pruned incorrectly,  and left duplicated rows in target table. (but no rows will be removed incorrectly).







- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12411)
<!-- Reviewable:end -->
