### PR TITLE
fix:  "Display" of "ReplaceStmt"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,6 +2676,7 @@ dependencies = [
  "log",
  "metrics",
  "opendal",
+ "ordered-float 3.7.0",
  "parquet",
  "regex",
  "reqwest",

--- a/src/query/ast/src/ast/statements/replace.rs
+++ b/src/query/ast/src/ast/statements/replace.rs
@@ -47,17 +47,17 @@ impl Display for ReplaceStmt {
                 .chain(Some(&self.table)),
         )?;
         if !self.columns.is_empty() {
-            write!(f, " (")?;
+            write!(f, "(")?;
             write_comma_separated_list(f, &self.columns)?;
             write!(f, ") ")?;
         }
-        write!(f, "ON CONFLICT ")?;
-        if !self.columns.is_empty() {
-            write!(f, " (")?;
-            write_comma_separated_list(f, &self.columns)?;
-            write!(f, ")")?;
+        write!(f, "ON CONFLICT")?;
+        if !self.on_conflict_columns.is_empty() {
+            write!(f, "(")?;
+            write_comma_separated_list(f, &self.on_conflict_columns)?;
+            write!(f, ") ")?;
         }
 
-        write!(f, " {}", self.source)
+        write!(f, "{}", self.source)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

correct the formatting of `ReplaceStmt`,  

- show the correct on-conflict fields
- tweak the formats (adding and removing spaces)

e.g.

sql `replace into t (c, c1, c2) on(c) values (1,2,3)`

logged as

~~~
 "query_text":"REPLACE INTO t(c, c1, c2) ON CONFLICT(c) VALUES (1,2,3)"
~~~


- Closes #12399

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12419)
<!-- Reviewable:end -->
