### PR TITLE
chore: remove deprecated table method `Table::replace_into`

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -25,7 +25,6 @@ use common_expression::ColumnId;
 use common_expression::FieldIndex;
 use common_expression::RemoteExpr;
 use common_expression::Scalar;
-use common_expression::TableField;
 use common_expression::TableSchema;
 use common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
 use common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
@@ -200,23 +199,6 @@ pub trait Table: Sync + Send {
             self.get_table_info().meta.engine
         )))
     }
-
-    #[async_backtrace::framed]
-    async fn replace_into(
-        &self,
-        ctx: Arc<dyn TableContext>,
-        pipeline: &mut Pipeline,
-        on_conflict_fields: Vec<TableField>,
-    ) -> Result<()> {
-        let (_, _, _) = (ctx, pipeline, on_conflict_fields);
-
-        Err(ErrorCode::Unimplemented(format!(
-            "replace_into operation for table {} is not implemented. table engine : {}",
-            self.name(),
-            self.get_table_info().meta.engine
-        )))
-    }
-
     fn commit_insertion(
         &self,
         ctx: Arc<dyn TableContext>,

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -15,7 +15,6 @@
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::panic;
 use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -37,7 +36,6 @@ use common_expression::BlockThresholds;
 use common_expression::ColumnId;
 use common_expression::FieldIndex;
 use common_expression::RemoteExpr;
-use common_expression::TableField;
 use common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
 use common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
 use common_meta_app::schema::DatabaseType;
@@ -541,16 +539,6 @@ impl Table for FuseTable {
         append_mode: AppendMode,
     ) -> Result<()> {
         self.do_append_data(ctx, pipeline, append_mode)
-    }
-
-    #[async_backtrace::framed]
-    async fn replace_into(
-        &self,
-        _ctx: Arc<dyn TableContext>,
-        _pipeline: &mut Pipeline,
-        _on_conflict_fields: Vec<TableField>,
-    ) -> Result<()> {
-        panic!("deprecated")
     }
 
     fn commit_insertion(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

remove  deprecated table method  `Table::replace_into`

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12430)
<!-- Reviewable:end -->
