### PR TITLE
chore: doc bloom pruning in `replace into`

### DIFF
--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -637,23 +637,35 @@ impl AggregationContext {
                 Ok(filters) => {
                     // the caller ensures that the input_hashes is not empty
                     let row_count = input_hashes[0].len();
+
+                    // let assume that the target block is prunable
                     let mut block_pruned = true;
                     for row in 0..row_count {
-                        let mut contains_row = true;
+                        // for each row, by default, assume that columns of this row do have conflict with the target block.
+                        let mut row_not_prunable = true;
                         for (col_idx, col_hash) in input_hashes.iter().enumerate() {
-                            // if bloom filter presents, check if the row is contained
-                            // if bloom filter absents, do nothing(since by default, we assume that the row is contained)
+                            // For each column of current row, check if the corresponding bloom
+                            // filter contains the digest of the column.
+                            //
+                            // Any one of the columns NOT contains by the corresponding bloom filter,
+                            // indicates that the row is prunable(thus, we do not stop on the first column that
+                            // the bloom filter contains).
+
+                            // - if bloom filter presents, check if the column is contained
+                            // - if bloom filter absents, do nothing(since by default, we assume that the row is not-prunable)
                             if let Some(col_filter) = &filters[col_idx] {
                                 let hash = col_hash[row];
                                 if hash == 0 || !col_filter.contains_digest(hash) {
-                                    // hash == 0 indicates that the column value is null, which equals nothing.
-                                    // one column does not match, indicates that the row does not match
-                                    contains_row = false;
+                                    // - hash == 0 indicates that the column value is null, which equals nothing.
+                                    // - NOT `contains_digest`, indicates that this column of row does not match
+                                    row_not_prunable = false;
+                                    // if one column not match, we do not need to check other columns
                                     break;
                                 }
                             }
                         }
-                        if contains_row {
+                        if row_not_prunable {
+                            // any row not prunable indicates that the target block is not prunable
                             block_pruned = false;
                             break;
                         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

doc bloom pruning in `replace into`.

just comments and renaming vars.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12431)
<!-- Reviewable:end -->
