### PR TITLE
feat: introduce new config `table_bloom_index_filter_size`

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -2172,7 +2172,7 @@ pub struct CacheConfig {
     //
     // For example, a table of 1024 columns, with 800 data blocks, a query that triggers a full
     // table filter on 2 columns, might populate 2 * 800 bloom index filter cache items (at most)
-    #[clap(long = "cache-table-bloom-index-filter-count", default_value = "0")]
+    #[clap(long = "cache-table-bloom-index-filter-size", default_value = "0")]
     pub table_bloom_index_filter_count: u64,
 
     /// Max bytes of cached bloom index filters used. Set it to 0 to disable it.

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -2165,16 +2165,23 @@ pub struct CacheConfig {
     #[clap(long = "cache-table-bloom-index-meta-count", default_value = "3000")]
     pub table_bloom_index_meta_count: u64,
 
+    /// DEPRECATING, will be deprecated in the next prduction release.
+    ///
     /// Max number of cached bloom index filters. Set it to 0 to disable it.
     // One bloom index filter per column of data block being indexed will be generated if necessary.
     //
     // For example, a table of 1024 columns, with 800 data blocks, a query that triggers a full
     // table filter on 2 columns, might populate 2 * 800 bloom index filter cache items (at most)
-    #[clap(
-        long = "cache-table-bloom-index-filter-count",
-        default_value = "1048576"
-    )]
+    #[clap(long = "cache-table-bloom-index-filter-count", default_value = "0")]
     pub table_bloom_index_filter_count: u64,
+
+    /// Max bytes of cached bloom index filters used. Set it to 0 to disable it.
+    // One bloom index filter per column of data block being indexed will be generated if necessary.
+    #[clap(
+        long = "cache-table-bloom-index-filter-size",
+        default_value = "2147483648"
+    )]
+    pub table_bloom_index_filter_size: u64,
 
     #[clap(long = "cache-table-prune-partitions-count", default_value = "256")]
     pub table_prune_partitions_count: u64,
@@ -2331,6 +2338,7 @@ mod cache_config_converters {
                 enable_table_index_bloom: value.enable_table_bloom_index_cache,
                 table_bloom_index_meta_count: value.table_bloom_index_meta_count,
                 table_bloom_index_filter_count: value.table_bloom_index_filter_count,
+                table_bloom_index_filter_size: value.table_bloom_index_filter_size,
                 table_prune_partitions_count: value.table_prune_partitions_count,
                 data_cache_storage: value.data_cache_storage.try_into()?,
                 table_data_cache_population_queue_size: value
@@ -2351,6 +2359,7 @@ mod cache_config_converters {
                 enable_table_bloom_index_cache: value.enable_table_index_bloom,
                 table_bloom_index_meta_count: value.table_bloom_index_meta_count,
                 table_bloom_index_filter_count: value.table_bloom_index_filter_count,
+                table_bloom_index_filter_size: value.table_bloom_index_filter_size,
                 table_prune_partitions_count: value.table_prune_partitions_count,
                 data_cache_storage: value.data_cache_storage.into(),
                 table_data_cache_population_queue_size: value

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -2172,7 +2172,7 @@ pub struct CacheConfig {
     //
     // For example, a table of 1024 columns, with 800 data blocks, a query that triggers a full
     // table filter on 2 columns, might populate 2 * 800 bloom index filter cache items (at most)
-    #[clap(long = "cache-table-bloom-index-filter-size", default_value = "0")]
+    #[clap(long = "cache-table-bloom-index-filter-count", default_value = "0")]
     pub table_bloom_index_filter_count: u64,
 
     /// Max bytes of cached bloom index filters used. Set it to 0 to disable it.

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -506,6 +506,10 @@ pub struct CacheConfig {
     // table filter on 2 columns, might populate 2 * 800 bloom index filter cache items (at most)
     pub table_bloom_index_filter_count: u64,
 
+    /// Max bytes of cached bloom index filters used. Set it to 0 to disable it.
+    // One bloom index filter per column of data block being indexed will be generated if necessary.
+    pub table_bloom_index_filter_size: u64,
+
     pub data_cache_storage: CacheStorageTypeConfig,
 
     /// Max size of external cache population queue length
@@ -582,7 +586,8 @@ impl Default for CacheConfig {
             table_meta_statistic_count: 256,
             enable_table_index_bloom: true,
             table_bloom_index_meta_count: 3000,
-            table_bloom_index_filter_count: 1048576,
+            table_bloom_index_filter_count: 0,
+            table_bloom_index_filter_size: 2147483648,
             table_prune_partitions_count: 256,
             data_cache_storage: Default::default(),
             table_data_cache_population_queue_size: 65536,

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -58,6 +58,10 @@ fn test_env_config_s3() -> Result<()> {
                 "CACHE_TABLE_BLOOM_INDEX_FILTER_COUNT",
                 Some(format!("{}", 1024 * 1024 * 1024).as_str()),
             ),
+            (
+                "CACHE_TABLE_BLOOM_INDEX_FILTER_SIZE",
+                Some(format!("{}", 2u64 * 1024 * 1024 * 1024).as_str()),
+            ),
             ("STORAGE_TYPE", Some("s3")),
             ("STORAGE_NUM_CPUS", Some("16")),
             ("STORAGE_FS_DATA_PATH", Some("/tmp/test")),
@@ -141,6 +145,10 @@ fn test_env_config_s3() -> Result<()> {
                 1024 * 1024 * 1024,
                 configured.cache.table_bloom_index_filter_count
             );
+            assert_eq!(
+                2 * 1024 * 1024 * 1024,
+                configured.cache.table_bloom_index_filter_size
+            );
             assert_eq!(HashMap::new(), configured.catalogs);
         },
     );
@@ -178,6 +186,10 @@ fn test_env_config_fs() -> Result<()> {
             (
                 "CACHE_TABLE_BLOOM_INDEX_FILTER_COUNT",
                 Some(format!("{}", 1024 * 1024 * 1024).as_str()),
+            ),
+            (
+                "CACHE_TABLE_BLOOM_INDEX_FILTER_SIZE",
+                Some(format!("{}", 2u64 * 1024 * 1024 * 1024).as_str()),
             ),
             ("STORAGE_TYPE", Some("fs")),
             ("STORAGE_NUM_CPUS", Some("16")),
@@ -261,6 +273,10 @@ fn test_env_config_fs() -> Result<()> {
                 1024 * 1024 * 1024,
                 configured.cache.table_bloom_index_filter_count
             );
+            assert_eq!(
+                2 * 1024 * 1024 * 1024,
+                configured.cache.table_bloom_index_filter_size
+            );
         },
     );
 
@@ -296,6 +312,10 @@ fn test_env_config_gcs() -> Result<()> {
             (
                 "CACHE_TABLE_BLOOM_INDEX_FILTER_COUNT",
                 Some(format!("{}", 1024 * 1024 * 1024).as_str()),
+            ),
+            (
+                "CACHE_TABLE_BLOOM_INDEX_FILTER_SIZE",
+                Some(format!("{}", 3u64 * 1024 * 1024 * 1024).as_str()),
             ),
             ("STORAGE_TYPE", Some("gcs")),
             ("STORAGE_NUM_CPUS", Some("16")),
@@ -386,6 +406,10 @@ fn test_env_config_gcs() -> Result<()> {
                 1024 * 1024 * 1024,
                 configured.cache.table_bloom_index_filter_count
             );
+            assert_eq!(
+                3 * 1024 * 1024 * 1024,
+                configured.cache.table_bloom_index_filter_size
+            );
         },
     );
 
@@ -423,6 +447,10 @@ fn test_env_config_oss() -> Result<()> {
             (
                 "CACHE_TABLE_BLOOM_INDEX_FILTER_COUNT",
                 Some(format!("{}", 1024 * 1024 * 1024).as_str()),
+            ),
+            (
+                "CACHE_TABLE_BLOOM_INDEX_FILTER_SIZE",
+                Some(format!("{}", 4u64 * 1024 * 1024 * 1024).as_str()),
             ),
             ("STORAGE_TYPE", Some("oss")),
             ("STORAGE_NUM_CPUS", Some("16")),
@@ -521,6 +549,10 @@ fn test_env_config_oss() -> Result<()> {
             assert_eq!(
                 1024 * 1024 * 1024,
                 configured.cache.table_bloom_index_filter_count
+            );
+            assert_eq!(
+                4 * 1024 * 1024 * 1024,
+                configured.cache.table_bloom_index_filter_size
             );
         },
     );

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -9,7 +9,8 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | 'cache'   | 'disk.path'                                | './.databend/_cache'                                           | ''       |
 | 'cache'   | 'enable_table_bloom_index_cache'           | 'true'                                                         | ''       |
 | 'cache'   | 'enable_table_meta_cache'                  | 'true'                                                         | ''       |
-| 'cache'   | 'table_bloom_index_filter_count'           | '1048576'                                                      | ''       |
+| 'cache'   | 'table_bloom_index_filter_count'           | '0'                                                            | ''       |
+| 'cache'   | 'table_bloom_index_filter_size'            | '2147483648'                                                   | ''       |
 | 'cache'   | 'table_bloom_index_meta_count'             | '3000'                                                         | ''       |
 | 'cache'   | 'table_data_cache_population_queue_size'   | '65536'                                                        | ''       |
 | 'cache'   | 'table_data_deserialized_data_bytes'       | '0'                                                            | ''       |

--- a/src/query/storages/common/cache-manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache-manager/src/cache_manager.rs
@@ -106,7 +106,7 @@ impl CacheManager {
                 "segment_info",
             );
             let bloom_index_filter_cache = Self::new_in_memory_cache(
-                config.table_bloom_index_filter_count,
+                config.table_bloom_index_filter_size,
                 BloomIndexFilterMeter {},
                 "bloom_index_filter",
             );


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- introduce new config `table_bloom_index_filter_size`, which set the max bytes that the bloom filter cache used.

  by default, the size is set to 2G (in bytes).

  during the construction of the bloom filter cache, the new config will be used.


- config option `table_bloom_index_filter_size` is in the state of "deprecating", which will not be consulted during initialization of the bloom filter cache, but need not be removed from the config files (if it is explicitly specified in user's config files).

   this config option is planned to be deprecated in the next stable release, and users may need to remove this option from config files if specified, otherwise, the query node will refuse to start.



- Closes #12434

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12435)
<!-- Reviewable:end -->
