### PR TITLE
refactor: Remove thrift from dev_setup

### DIFF
--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -228,38 +228,6 @@ function install_protobuf {
 	protoc --version
 }
 
-function install_thrift {
-	PACKAGE_MANAGER=$1
-
-	echo "==> installing thrift compiler..."
-
-	case "$PACKAGE_MANAGER" in
-	apt-get)
-		install_pkg thrift-compiler "$PACKAGE_MANAGER"
-		;;
-	pacman)
-		install_pkg thrift "$PACKAGE_MANAGER"
-		;;
-
-	apk)
-		install_pkg thrift "$PACKAGE_MANAGER"
-		;;
-	yum)
-		install_pkg thrift "$PACKAGE_MANAGER"
-		;;
-	dnf)
-		install_pkg thrift "$PACKAGE_MANAGER"
-		;;
-	brew)
-		install_pkg thrift "$PACKAGE_MANAGER"
-		;;
-	*)
-		echo "Unable to install thrif with package manager: $PACKAGE_MANAGER"
-		exit 1
-		;;
-	esac
-}
-
 function install_jdk {
 	PACKAGE_MANAGER=$1
 
@@ -431,7 +399,6 @@ Build tools (since -b or no option was provided):
   * pkg-config
   * libssl-dev
   * protobuf-compiler
-  * thrift-compiler
   * openjdk
   * python3-dev
 EOF
@@ -606,7 +573,6 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
 	install_pkg_config "$PACKAGE_MANAGER"
 	install_openssl "$PACKAGE_MANAGER"
 	install_protobuf "$PACKAGE_MANAGER"
-	install_thrift "$PACKAGE_MANAGER"
 	install_jdk "$PACKAGE_MANAGER"
 	install_lapack "$PACKAGE_MANAGER"
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: Remove thrift from dev_setup

We don't need to install thrift anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12436)
<!-- Reviewable:end -->
