### PR TITLE
chore:  bench  unpacking `CompactSegmentInfo`

### DIFF
--- a/src/query/storages/common/table-meta/benches/bench.rs
+++ b/src/query/storages/common/table-meta/benches/bench.rs
@@ -30,6 +30,7 @@ use storages_common_table_meta::meta::testing::MetaEncoding;
 use storages_common_table_meta::meta::BlockMeta;
 use storages_common_table_meta::meta::ColumnMeta;
 use storages_common_table_meta::meta::ColumnStatistics;
+use storages_common_table_meta::meta::CompactSegmentInfo;
 use storages_common_table_meta::meta::Compression;
 use storages_common_table_meta::meta::SegmentInfo;
 use storages_common_table_meta::meta::SingleColumnMeta;
@@ -120,13 +121,21 @@ fn bench_decode(c: &mut Criterion) {
 
     grp.bench_function("bincode-segment-deserialization", |b| {
         b.iter(|| {
-            let _ = SegmentInfo::from_slice(&segment_bincode_bytes).unwrap();
+            let _ = SegmentInfo::from_slice(black_box(&segment_bincode_bytes)).unwrap();
         })
     });
 
     grp.bench_function("msg-pack-segment-deserialization", |b| {
         b.iter(|| {
-            let _ = SegmentInfo::from_slice(&segment_msgpack_bytes).unwrap();
+            let _ = SegmentInfo::from_slice(black_box(&segment_msgpack_bytes)).unwrap();
+        })
+    });
+
+    let compact_segment = CompactSegmentInfo::from_slice(&segment_msgpack_bytes).unwrap();
+
+    grp.bench_function("msg-pack-segment-from-compact", |b| {
+        b.iter(|| {
+            let _ = SegmentInfo::try_from(black_box(&compact_segment)).unwrap();
         })
     });
 

--- a/src/query/storages/common/table-meta/src/meta/v4/segment.rs
+++ b/src/query/storages/common/table-meta/src/meta/v4/segment.rs
@@ -259,6 +259,18 @@ impl TryFrom<Arc<CompactSegmentInfo>> for SegmentInfo {
     }
 }
 
+impl TryFrom<&CompactSegmentInfo> for SegmentInfo {
+    type Error = ErrorCode;
+    fn try_from(value: &CompactSegmentInfo) -> Result<Self, Self::Error> {
+        let blocks = value.block_metas()?;
+        Ok(SegmentInfo {
+            format_version: value.format_version,
+            blocks,
+            summary: value.summary.clone(),
+        })
+    }
+}
+
 impl TryFrom<&SegmentInfo> for CompactSegmentInfo {
     type Error = ErrorCode;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

benchmark of unpacking `CompactSegmentInfo`

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12457)
<!-- Reviewable:end -->
