### PR TITLE
fix(rbac): do not require GRANT privilege on SHOW ROLES statement

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -515,7 +515,6 @@ impl AccessChecker for PrivilegeAccess {
             | Plan::ShowObjectGrantPrivileges(_)
             | Plan::ShowGrantTenantsOfShare(_)
             | Plan::ShowGrants(_)
-            | Plan::ShowRoles(_)
             | Plan::GrantRole(_)
             | Plan::GrantPriv(_)
             | Plan::RevokePriv(_)
@@ -591,8 +590,9 @@ impl AccessChecker for PrivilegeAccess {
                     .await?;
             }
             // Note: No need to check privileges
-            // SET ROLE is a session-local statement (have same semantic with the SET ROLE in postgres), no need to check privileges
+            // SET ROLE & SHOW ROLES is a session-local statement (have same semantic with the SET ROLE in postgres), no need to check privileges
             Plan::SetRole(_) => {}
+            Plan::ShowRoles(_) => {}
             Plan::Presign(_) => {}
             Plan::ExplainAst { .. } => {}
             Plan::ExplainSyntax { .. } => {}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The SHOW ROLES statement displays the available roles for the current session. It's available for every one, do not require the GRANT privilege.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12478)
<!-- Reviewable:end -->
