### PR TITLE
fix(storage): fix background_jobs panic

### DIFF
--- a/src/query/storages/system/src/background_jobs_table.rs
+++ b/src/query/storages/system/src/background_jobs_table.rs
@@ -111,7 +111,11 @@ impl AsyncSystemTable for BackgroundJobTable {
                                 .map(|tz| tz.to_string().as_bytes().to_vec()),
                         );
                     }
-                    _ => {}
+                    BackgroundJobType::ONESHOT => {
+                        scheduled_job_interval_secs.push(None);
+                        scheduled_job_cron_expression.push(None);
+                        scheduled_job_cron_timezone.push(None);
+                    }
                 }
             } else {
                 job_types.push(None);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix background_jobs panic

```sql
mysql> select * from system.background_jobs;
ERROR 1105 (HY000): PanicError. Code: 1104, Text = assertion failed: columns.iter().all(|c| c.len() == num_rows).
```

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12488)
<!-- Reviewable:end -->
