### PR TITLE
chore: spilt `HashJoinStep` into `HashJoinBuildStep` and `HashJoinProbeStep`

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state.rs
@@ -90,7 +90,7 @@ pub trait HashJoinState: Send + Sync {
     /// Wait until the build phase is finished.
     async fn wait_build_finish(&self) -> Result<()>;
 
-    /// Wait until the finalize phase is finished.
+    /// Wait until the build finalize phase is finished.
     async fn wait_finalize_finish(&self) -> Result<()>;
 
     /// Wait until the probe phase is finished.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The PR spilt `HashJoinStep` into `HashJoinBuildStep` and `HashJoinProbeStep`, to make it clear.

Add some comments for thoes steps.

In the future, we'll add more spilling-related steps to them.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12501)
<!-- Reviewable:end -->
