### PR TITLE
chore: adjust MAX_COPIED_FILES_NUM (from 500) to 2000

### DIFF
--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -44,7 +44,7 @@ use crate::rule;
 use crate::util::*;
 use crate::ErrorKind;
 
-const MAX_COPIED_FILES_NUM: usize = 500;
+const MAX_COPIED_FILES_NUM: usize = 2000;
 
 pub enum ShowGrantOption {
     PrincipalIdentity(PrincipalIdentity),

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -271,7 +271,7 @@ fn test_statement() {
                     skip_header = 1
                 )
                 size_limit=10
-                max_files=1000;"#,
+                max_files=3000;"#,
         r#"COPY INTO mytable
                 FROM 's3://mybucket/data.csv'
                 CONNECTION = (

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -9078,10 +9078,10 @@ COPY INTO mytable
                     skip_header = 1
                 )
                 size_limit=10
-                max_files=1000;
+                max_files=3000;
 ---------- Output ---------
 COPY INTO mytable FROM 's3://mybucket/data.csv' FILE_FORMAT = ( field_delimiter = ',' record_delimiter = '
-' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 MAX_FILES = 500 SINGLE = false PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+' skip_header = '1' type = 'CSV' ) SIZE_LIMIT = 10 MAX_FILES = 2000 SINGLE = false PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 Copy(
     CopyStmt {
@@ -9120,7 +9120,7 @@ Copy(
         },
         validation_mode: "",
         size_limit: 10,
-        max_files: 500,
+        max_files: 2000,
         max_file_size: 0,
         split_size: 0,
         single: false,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

adjust  MAX_COPIED_FILES_NUM (from 500) to 2000

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12506)
<!-- Reviewable:end -->
