### PR TITLE
chore: add storage params to show create hive catalog

### DIFF
--- a/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
@@ -21,6 +21,7 @@ use common_expression::DataBlock;
 use common_expression::Scalar;
 use common_expression::Value;
 use common_meta_app::schema::CatalogOption;
+use common_meta_app::storage::StorageParams;
 use common_sql::plans::ShowCreateCatalogPlan;
 use log::debug;
 
@@ -55,7 +56,14 @@ impl Interpreter for ShowCreateCatalogInterpreter {
 
         let (catalog_type, option) = match info.meta.catalog_option {
             CatalogOption::Default => (String::from("default"), String::new()),
-            CatalogOption::Hive(op) => (String::from("hive"), format!("ADDRESS\n{}", op.address)),
+            CatalogOption::Hive(op) => (
+                String::from("hive"),
+                format!(
+                    "ADDRESS\n{}\nSTORAGE PARAMS\n{}",
+                    op.address,
+                    op.storage_params.unwrap_or(Box::new(StorageParams::None))
+                ),
+            ),
             CatalogOption::Iceberg(op) => (
                 String::from("iceberg"),
                 format!("STORAGE PARAMS\n{}", op.storage_params),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```SQL
--- without storage params
CREATE CATALOG ctl TYPE=HIVE CONNECTION=(ADDRESS='127.0.0.1:9083');
--- with storage params
CREATE CATALOG ctl2 TYPE = HIVE CONNECTION =(
  ADDRESS = '127.0.0.1:9083' URL = 's3://warehouse/' AWS_KEY_ID = 'admin' AWS_SECRET_KEY = 'password' ENDPOINT_URL = 'http://localhost:9000/'
)
```

![image](https://github.com/datafuselabs/databend/assets/36896360/7a2102d6-d58d-4700-ba61-6796a07658a8)

![image](https://github.com/datafuselabs/databend/assets/36896360/46e4ff1a-0113-46b8-8668-52ba8313bbcf)


- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12516)
<!-- Reviewable:end -->
