### PR TITLE
refactor: eliminate ambiguous cache API

### DIFF
--- a/src/common/cache/src/cache.rs
+++ b/src/common/cache/src/cache.rs
@@ -38,25 +38,10 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 
-    /// Returns a mutable reference to the value corresponding to the given key in the cache, if
-    /// any.
-    fn get_mut<'a, Q>(&'a mut self, k: &Q) -> Option<&'a mut V>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
-
     /// Returns a reference to the value corresponding to the key in the cache or `None` if it is
     /// not present in the cache. Unlike `get`, `peek` does not update the Cache state so the key's
     /// position will be unchanged.
     fn peek<'a, Q>(&'a self, k: &Q) -> Option<&'a V>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
-
-    /// Returns a mutable reference to the value corresponding to the key in the cache or `None`
-    /// if it is not present in the cache. Unlike `get_mut`, `peek_mut` does not update the Cache
-    /// state so the key's position will be unchanged.
-    fn peek_mut<'a, Q>(&'a mut self, k: &Q) -> Option<&'a mut V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;

--- a/src/common/cache/src/cache/lru.rs
+++ b/src/common/cache/src/cache/lru.rs
@@ -27,18 +27,18 @@
 //! cache.put(1, 10);
 //! cache.put(2, 20);
 //! cache.put(3, 30);
-//! assert!(cache.get_mut(&1).is_none());
-//! assert_eq!(*cache.get_mut(&2).unwrap(), 20);
-//! assert_eq!(*cache.get_mut(&3).unwrap(), 30);
+//! assert!(cache.get(&1).is_none());
+//! assert_eq!(*cache.get(&2).unwrap(), 20);
+//! assert_eq!(*cache.get(&3).unwrap(), 30);
 //!
 //! cache.put(2, 22);
-//! assert_eq!(*cache.get_mut(&2).unwrap(), 22);
+//! assert_eq!(*cache.get(&2).unwrap(), 22);
 //!
 //! cache.put(6, 60);
-//! assert!(cache.get_mut(&3).is_none());
+//! assert!(cache.get(&3).is_none());
 //!
 //! cache.set_capacity(1);
-//! assert!(cache.get_mut(&2).is_none());
+//! assert!(cache.get(&2).is_none());
 //! ```
 //!
 //! The cache can also be limited by an arbitrary metric calculated from its key-value pairs, see
@@ -195,35 +195,6 @@ impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> Cache<K, V, S, M>
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.get_mut(k).map(|v| &*v)
-    }
-
-    /// Returns a mutable reference to the value corresponding to the given key in the cache, if
-    /// any.
-    ///
-    /// Note that this method is not available for cache objects using `Meter` implementations
-    /// other than `Count`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use common_cache::{Cache, LruCache};
-    ///
-    /// let mut cache = LruCache::new(2);
-    ///
-    /// cache.put(1, "a");
-    /// cache.put(2, "b");
-    /// cache.put(2, "c");
-    /// cache.put(3, "d");
-    ///
-    /// assert_eq!(cache.get_mut(&1), None);
-    /// assert_eq!(cache.get_mut(&2), Some(&mut "c"));
-    /// ```
-    fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
         match self.map.raw_entry_mut().from_key(k) {
             linked_hash_map::RawEntryMut::Occupied(mut occupied) => {
                 occupied.to_back();
@@ -255,30 +226,6 @@ impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> Cache<K, V, S, M>
         Q: Hash + Eq + ?Sized,
     {
         self.map.get(k)
-    }
-
-    /// Returns a mutable reference to the value corresponding to the key in the cache or `None`
-    /// if it is not present in the cache. Unlike `get_mut`, `peek_mut` does not update the LRU
-    /// list so the key's position will be unchanged.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// use common_cache::{Cache, LruCache};
-    /// let mut cache = LruCache::new(2);
-    ///
-    /// cache.put(1, "a");
-    /// cache.put(2, "b");
-    ///
-    /// assert_eq!(cache.peek_mut(&1), Some(&mut "a"));
-    /// assert_eq!(cache.peek_mut(&2), Some(&mut "b"));
-    /// ```
-    fn peek_mut<'a, Q>(&'a mut self, k: &Q) -> Option<&'a mut V>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        self.map.get_mut(k)
     }
 
     /// Returns the value corresponding to the least recently used item or `None` if the
@@ -332,8 +279,8 @@ impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> Cache<K, V, S, M>
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "b");
-    /// assert_eq!(cache.get_mut(&1), Some(&mut "a"));
-    /// assert_eq!(cache.get_mut(&2), Some(&mut "b"));
+    /// assert_eq!(cache.get(&1), Some(&"a"));
+    /// assert_eq!(cache.get(&2), Some(&"b"));
     /// ```
     fn put(&mut self, k: K, v: V) -> Option<V> {
         let new_size = self.meter.measure(&k, &v);
@@ -420,23 +367,23 @@ impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> Cache<K, V, S, M>
     /// cache.put(2, "b");
     /// cache.put(3, "c");
     ///
-    /// assert_eq!(cache.get_mut(&1), None);
-    /// assert_eq!(cache.get_mut(&2), Some(&mut "b"));
-    /// assert_eq!(cache.get_mut(&3), Some(&mut "c"));
+    /// assert_eq!(cache.get(&1), None);
+    /// assert_eq!(cache.get(&2), Some(&"b"));
+    /// assert_eq!(cache.get(&3), Some(&"c"));
     ///
     /// cache.set_capacity(3);
     /// cache.put(1, "a");
     /// cache.put(2, "b");
     ///
-    /// assert_eq!(cache.get_mut(&1), Some(&mut "a"));
-    /// assert_eq!(cache.get_mut(&2), Some(&mut "b"));
-    /// assert_eq!(cache.get_mut(&3), Some(&mut "c"));
+    /// assert_eq!(cache.get(&1), Some(&"a"));
+    /// assert_eq!(cache.get(&2), Some(&"b"));
+    /// assert_eq!(cache.get(&3), Some(&"c"));
     ///
     /// cache.set_capacity(1);
     ///
-    /// assert_eq!(cache.get_mut(&1), None);
-    /// assert_eq!(cache.get_mut(&2), None);
-    /// assert_eq!(cache.get_mut(&3), Some(&mut "c"));
+    /// assert_eq!(cache.get(&1), None);
+    /// assert_eq!(cache.get(&2), None);
+    /// assert_eq!(cache.get(&3), Some(&"c"));
     /// ```
     fn set_capacity(&mut self, capacity: u64) {
         while self.size() > capacity {
@@ -535,8 +482,8 @@ impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> LruCache<K, V, S,
     /// }
     ///
     /// assert_eq!(n, 4);
-    /// assert_eq!(cache.get_mut(&2), Some(&mut 200));
-    /// assert_eq!(cache.get_mut(&3), Some(&mut 300));
+    /// assert_eq!(cache.gett(&2), Some(&200));
+    /// assert_eq!(cache.gett(&3), Some(&300));
     /// ```
     pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut(self.map.iter_mut())

--- a/src/common/cache/tests/it/cache/lru.rs
+++ b/src/common/cache/tests/it/cache/lru.rs
@@ -23,8 +23,8 @@ fn test_put_and_get() {
     let mut cache = LruCache::new(2);
     cache.put(1, 10);
     cache.put(2, 20);
-    assert_eq!(cache.get_mut(&1), Some(&mut 10));
-    assert_eq!(cache.get_mut(&2), Some(&mut 20));
+    assert_eq!(cache.get(&1), Some(&10));
+    assert_eq!(cache.get(&2), Some(&20));
     assert_eq!(cache.len(), 2);
     assert_eq!(cache.size(), 2);
 }
@@ -34,7 +34,7 @@ fn test_put_update() {
     let mut cache = LruCache::new(1);
     cache.put("1", 10);
     cache.put("1", 19);
-    assert_eq!(cache.get_mut("1"), Some(&mut 19));
+    assert_eq!(cache.get("1"), Some(&19));
     assert_eq!(cache.len(), 1);
 }
 
@@ -51,10 +51,10 @@ fn test_expire_lru() {
     cache.put("foo1", "bar1");
     cache.put("foo2", "bar2");
     cache.put("foo3", "bar3");
-    assert!(cache.get_mut("foo1").is_none());
+    assert!(cache.get("foo1").is_none());
     cache.put("foo2", "bar2update");
     cache.put("foo4", "bar4");
-    assert!(cache.get_mut("foo3").is_none());
+    assert!(cache.get("foo3").is_none());
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn test_pop() {
     let opt1 = cache.pop(&1);
     assert!(opt1.is_some());
     assert_eq!(opt1.unwrap(), 10);
-    assert!(cache.get_mut(&1).is_none());
+    assert!(cache.get(&1).is_none());
     assert_eq!(cache.len(), 1);
 }
 
@@ -77,7 +77,7 @@ fn test_change_capacity() {
     cache.put(1, 10);
     cache.put(2, 20);
     cache.set_capacity(1);
-    assert!(cache.get_mut(&1).is_none());
+    assert!(cache.get(&1).is_none());
     assert_eq!(cache.capacity(), 1);
 }
 
@@ -92,7 +92,7 @@ fn test_debug() {
     assert_eq!(format!("{:?}", cache), "{2: 22, 3: 30, 1: 10}");
     cache.put(6, 60);
     assert_eq!(format!("{:?}", cache), "{6: 60, 2: 22, 3: 30}");
-    cache.get_mut(&3);
+    cache.get(&3);
     assert_eq!(format!("{:?}", cache), "{3: 30, 6: 60, 2: 22}");
     cache.set_capacity(2);
     assert_eq!(format!("{:?}", cache), "{3: 30, 6: 60}");
@@ -108,15 +108,15 @@ fn test_remove() {
     cache.put(5, 50);
     cache.pop(&3);
     cache.pop(&4);
-    assert!(cache.get_mut(&3).is_none());
-    assert!(cache.get_mut(&4).is_none());
+    assert!(cache.get(&3).is_none());
+    assert!(cache.get(&4).is_none());
     cache.put(6, 60);
     cache.put(7, 70);
     cache.put(8, 80);
-    assert!(cache.get_mut(&5).is_none());
-    assert_eq!(cache.get_mut(&6), Some(&mut 60));
-    assert_eq!(cache.get_mut(&7), Some(&mut 70));
-    assert_eq!(cache.get_mut(&8), Some(&mut 80));
+    assert!(cache.get(&5).is_none());
+    assert_eq!(cache.get(&6), Some(&60));
+    assert_eq!(cache.get(&7), Some(&70));
+    assert_eq!(cache.get(&8), Some(&80));
 }
 
 #[test]
@@ -125,8 +125,8 @@ fn test_clear() {
     cache.put(1, 10);
     cache.put(2, 20);
     cache.clear();
-    assert!(cache.get_mut(&1).is_none());
-    assert!(cache.get_mut(&2).is_none());
+    assert!(cache.get(&1).is_none());
+    assert!(cache.get(&2).is_none());
     assert_eq!(format!("{:?}", cache), "{}");
 }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### Refactor: eliminate ambiguous cache API

In the `Cache` trait, the `get_mut()` and `peek_mut()` methods return
mutable references that permit users to modify the stored value.
However, when the updated value is given back into the cache, the
eviction policy determined by `Meter` is not validated against these
changes. This could potentially lead to risks, such as the cache
surpassing its maximum capacity.

Given that these two APIs are currently unused, my suggestion is to
remove them to prevent potential misuse in the future.

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12519)
<!-- Reviewable:end -->
