### PR TITLE
refactor: upgrade minitrace to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7029,11 +7029,10 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minitrace"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdc5c5a697f93f25a109f36988a60ce534c05b944afb8ef3c1498e131638133"
+checksum = "823c2c0be9db5d4a0497700a405a231c9db19e67a24f5fe1ef4e3fdaca6a9b7e"
 dependencies = [
- "defer",
  "futures",
  "minitrace-macro",
  "minstant",
@@ -7045,9 +7044,9 @@ dependencies = [
 
 [[package]]
 name = "minitrace-macro"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2277f13e7d585f02062590b3496cc0ca862aefadd24888efa01d50843605b79"
+checksum = "db3a906b1d9cacfe2174ad7c4139fccb441af566940559822103b79e5ea25f31"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -7293,7 +7292,7 @@ checksum = "57349d5a326b437989b6ee4dc8f2f34b0cc131202748414712a8e7d98952fc8c"
 dependencies = [
  "base64 0.21.0",
  "bigdecimal",
- "bindgen 0.59.2",
+ "bindgen 0.66.1",
  "bitflags 2.3.1",
  "bitvec",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ async-backtrace = "0.2.2"
 # observability
 logcall = "0.1.4"
 log = { version = "0.4.19", features = ["serde", "kv_unstable_std"] }
-minitrace = "0.5"
+minitrace = "0.5.1"
 
 [profile.release]
 debug = 1


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### dep: upgrade minitrace to 0.5.1

- Fix: #12513

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12520)
<!-- Reviewable:end -->
