### PR TITLE
refactor: Remove values from TableReference

### DIFF
--- a/src/query/ast/src/ast/format/ast_format.rs
+++ b/src/query/ast/src/ast/format/ast_format.rs
@@ -2746,36 +2746,6 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
                 let node = FormatTreeNode::with_children(format_ctx, children);
                 self.children.push(node)
             }
-            TableReference::Values {
-                span: _,
-                values,
-                alias,
-            } => {
-                let mut children = Vec::with_capacity(values.len());
-                for (i, row_values) in values.iter().enumerate() {
-                    let mut row_children = Vec::with_capacity(row_values.len());
-                    for value in row_values {
-                        self.visit_expr(value);
-                        row_children.push(self.children.pop().unwrap());
-                    }
-                    let row_name = format!("Row {}", i);
-                    let row_format_ctx =
-                        AstFormatContext::with_children(row_name, row_children.len());
-                    let row_node = FormatTreeNode::with_children(row_format_ctx, row_children);
-                    children.push(row_node);
-                }
-                let format_ctx = if let Some(alias) = alias {
-                    AstFormatContext::with_children_alias(
-                        "Values".to_string(),
-                        children.len(),
-                        Some(format!("{}", alias)),
-                    )
-                } else {
-                    AstFormatContext::with_children("Values".to_string(), children.len())
-                };
-                let node = FormatTreeNode::with_children(format_ctx, children);
-                self.children.push(node);
-            }
         }
     }
 

--- a/src/query/ast/src/ast/format/syntax/query.rs
+++ b/src/query/ast/src/ast/format/syntax/query.rs
@@ -428,22 +428,6 @@ pub(crate) fn pretty_table(table: TableReference) -> RcDoc<'static> {
             } else {
                 RcDoc::nil()
             }),
-        TableReference::Values {
-            span: _,
-            values,
-            alias,
-        } => RcDoc::text("(VALUES")
-            .append(inline_comma(values.into_iter().map(|row_values| {
-                RcDoc::text("(")
-                    .append(inline_comma(row_values.into_iter().map(pretty_expr)))
-                    .append(RcDoc::text(")"))
-            })))
-            .append(RcDoc::text(")"))
-            .append(if let Some(alias) = alias {
-                RcDoc::text(format!(" {alias}"))
-            } else {
-                RcDoc::nil()
-            }),
     }
 }
 

--- a/src/query/ast/src/ast/query.rs
+++ b/src/query/ast/src/ast/query.rs
@@ -269,12 +269,6 @@ pub enum TableReference {
         options: SelectStageOptions,
         alias: Option<TableAlias>,
     },
-    // A set of values generates a temporary constant table that can be used for queries
-    Values {
-        span: Span,
-        values: Vec<Vec<Expr>>,
-        alias: Option<TableAlias>,
-    },
 }
 
 impl TableReference {
@@ -538,25 +532,6 @@ impl Display for TableReference {
                 write!(f, "{options}")?;
                 if let Some(alias) = alias {
                     write!(f, " AS {alias}")?;
-                }
-            }
-            TableReference::Values {
-                span: _,
-                values,
-                alias,
-            } => {
-                write!(f, "(VALUES")?;
-                for (i, value) in values.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "(")?;
-                    write_comma_separated_list(f, value)?;
-                    write!(f, ")")?;
-                }
-                write!(f, ")")?;
-                if let Some(alias) = alias {
-                    write!(f, " {alias}")?;
                 }
             }
         }

--- a/src/query/ast/src/parser/query.rs
+++ b/src/query/ast/src/parser/query.rs
@@ -545,10 +545,6 @@ pub enum TableReferenceElement {
         options: Vec<SelectStageOption>,
         alias: Option<TableAlias>,
     },
-    Values {
-        values: Vec<Vec<Expr>>,
-        alias: Option<TableAlias>,
-    },
 }
 
 pub fn table_reference_element(i: Input) -> IResult<WithSpan<TableReferenceElement>> {
@@ -656,18 +652,10 @@ pub fn table_reference_element(i: Input) -> IResult<WithSpan<TableReferenceEleme
         },
     );
 
-    let values = map(
-        rule! {
-            "(" ~ VALUES ~ ^#comma_separated_list1(row_values) ~ ")" ~ #table_alias?
-        },
-        |(_, _, values, _, alias)| TableReferenceElement::Values { values, alias },
-    );
-
     let (rest, (span, elem)) = consumed(rule! {
         #aliased_stage
         | #table_function
         | #aliased_table
-        | #values
         | #subquery
         | #group
         | #join
@@ -761,11 +749,6 @@ impl<'a, I: Iterator<Item = WithSpan<'a, TableReferenceElement>>> PrattParser<I>
                     alias,
                 }
             }
-            TableReferenceElement::Values { values, alias } => TableReference::Values {
-                span: transform_span(input.span.0),
-                values,
-                alias,
-            },
             _ => unreachable!(),
         };
         Ok(table_ref)

--- a/src/query/ast/src/visitors/walk.rs
+++ b/src/query/ast/src/visitors/walk.rs
@@ -270,16 +270,6 @@ pub fn walk_table_reference<'a, V: Visitor<'a>>(visitor: &mut V, table_ref: &'a 
             visitor.visit_join(join);
         }
         TableReference::Stage { .. } => {}
-        TableReference::Values { values, alias, .. } => {
-            for row_values in values {
-                for value in row_values {
-                    visitor.visit_expr(value);
-                }
-            }
-            if let Some(alias) = alias {
-                visitor.visit_identifier(&alias.name);
-            }
-        }
     }
 }
 

--- a/src/query/ast/src/visitors/walk_mut.rs
+++ b/src/query/ast/src/visitors/walk_mut.rs
@@ -274,16 +274,6 @@ pub fn walk_table_reference_mut<V: VisitorMut>(visitor: &mut V, table_ref: &mut 
             visitor.visit_join(join);
         }
         TableReference::Stage { .. } => {}
-        TableReference::Values { values, alias, .. } => {
-            for row_values in values {
-                for value in row_values {
-                    visitor.visit_expr(value);
-                }
-            }
-            if let Some(alias) = alias {
-                visitor.visit_identifier(&mut alias.name);
-            }
-        }
     }
 }
 

--- a/src/query/ast/tests/it/testdata/query.txt
+++ b/src/query/ast/tests/it/testdata/query.txt
@@ -5651,7 +5651,7 @@ Query {
 ---------- Input ----------
 SELECT * FROM (VALUES(1,1),(2,null),(null,5)) AS t(a,b)
 ---------- Output ---------
-SELECT * FROM (VALUES(1, 1), (2, NULL), (NULL, 5)) t(a, b)
+SELECT * FROM (VALUES(1, 1), (2, NULL), (NULL, 5)) AS t(a, b)
 ---------- AST ------------
 Query {
     span: Some(
@@ -5678,62 +5678,77 @@ Query {
                 },
             ],
             from: [
-                Values {
+                Subquery {
                     span: Some(
                         14..55,
                     ),
-                    values: [
-                        [
-                            Literal {
-                                span: Some(
-                                    22..23,
-                                ),
-                                lit: UInt64(
-                                    1,
-                                ),
-                            },
-                            Literal {
-                                span: Some(
-                                    24..25,
-                                ),
-                                lit: UInt64(
-                                    1,
-                                ),
-                            },
-                        ],
-                        [
-                            Literal {
-                                span: Some(
-                                    28..29,
-                                ),
-                                lit: UInt64(
-                                    2,
-                                ),
-                            },
-                            Literal {
-                                span: Some(
-                                    30..34,
-                                ),
-                                lit: Null,
-                            },
-                        ],
-                        [
-                            Literal {
-                                span: Some(
-                                    37..41,
-                                ),
-                                lit: Null,
-                            },
-                            Literal {
-                                span: Some(
-                                    42..43,
-                                ),
-                                lit: UInt64(
-                                    5,
-                                ),
-                            },
-                        ],
-                    ],
+                    subquery: Query {
+                        span: Some(
+                            15..44,
+                        ),
+                        with: None,
+                        body: Values {
+                            span: Some(
+                                15..44,
+                            ),
+                            values: [
+                                [
+                                    Literal {
+                                        span: Some(
+                                            22..23,
+                                        ),
+                                        lit: UInt64(
+                                            1,
+                                        ),
+                                    },
+                                    Literal {
+                                        span: Some(
+                                            24..25,
+                                        ),
+                                        lit: UInt64(
+                                            1,
+                                        ),
+                                    },
+                                ],
+                                [
+                                    Literal {
+                                        span: Some(
+                                            28..29,
+                                        ),
+                                        lit: UInt64(
+                                            2,
+                                        ),
+                                    },
+                                    Literal {
+                                        span: Some(
+                                            30..34,
+                                        ),
+                                        lit: Null,
+                                    },
+                                ],
+                                [
+                                    Literal {
+                                        span: Some(
+                                            37..41,
+                                        ),
+                                        lit: Null,
+                                    },
+                                    Literal {
+                                        span: Some(
+                                            42..43,
+                                        ),
+                                        lit: UInt64(
+                                            5,
+                                        ),
+                                    },
+                                ],
+                            ],
+                        },
+                        order_by: [],
+                        limit: [],
+                        offset: None,
+                        ignore_result: false,
+                    },
                     alias: Some(
                         TableAlias {
                             name: Identifier {

--- a/src/query/catalog/src/plan/projection.rs
+++ b/src/query/catalog/src/plan/projection.rs
@@ -32,6 +32,18 @@ pub enum Projection {
     /// inner column indices for tuple data type with inner columns.
     /// the key is the column_index of ColumnEntry.
     /// the value is the path indices of inner columns.
+    /// the following is an example of a tuple and the corresponding path indices:
+    /// a: Tuple (          path: [0]
+    ///   b1: Tuple (       path: [0, 0]
+    ///     c1: Int32,      path: [0, 0, 0]
+    ///     c2: String,     path: [0, 0, 1]
+    ///   ),
+    ///   b2: Tuple (       path: [0, 1]
+    ///     d1: Int32,      path: [0, 1, 0]
+    ///     d2: String,     path: [0, 1, 1]
+    ///     d3: String,     path: [0, 1, 2]
+    ///   )
+    /// )
     InnerColumns(BTreeMap<FieldIndex, Vec<FieldIndex>>),
 }
 

--- a/src/query/sql/src/planner/binder/mod.rs
+++ b/src/query/sql/src/planner/binder/mod.rs
@@ -47,6 +47,7 @@ mod stage;
 mod table;
 mod table_args;
 mod update;
+mod values;
 mod window;
 
 pub use aggregate::AggregateInfo;

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -24,7 +24,6 @@ use common_ast::ast::Expr;
 use common_ast::ast::Expr::Array;
 use common_ast::ast::GroupBy;
 use common_ast::ast::Identifier;
-use common_ast::ast::Indirection;
 use common_ast::ast::Join;
 use common_ast::ast::JoinCondition;
 use common_ast::ast::JoinOperator;
@@ -318,29 +317,7 @@ impl Binder {
                 )
                 .await
             }
-            SetExpr::Values { span, values } => {
-                // rewrite values clause as select stmt
-                let stmt = SelectStmt {
-                    span: *span,
-                    hints: None,
-                    distinct: false,
-                    select_list: vec![SelectTarget::QualifiedName {
-                        qualified: vec![Indirection::Star(None)],
-                        exclude: None,
-                    }],
-                    from: vec![TableReference::Values {
-                        span: None,
-                        values: values.clone(),
-                        alias: None,
-                    }],
-                    selection: None,
-                    group_by: None,
-                    having: None,
-                    window_list: None,
-                };
-                self.bind_select_stmt(bind_context, &stmt, order_by, limit)
-                    .await
-            }
+            SetExpr::Values { span, values } => self.bind_values(bind_context, *span, values).await,
         }
     }
 

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -363,7 +363,7 @@ impl Binder {
         };
 
         let (mut s_expr, bind_context) = match query.body {
-            SetExpr::Select(_) | SetExpr::Query(_) | SetExpr::Values { .. } => {
+            SetExpr::Select(_) | SetExpr::Query(_) => {
                 self.bind_set_expr(
                     bind_context,
                     &query.body,
@@ -372,7 +372,7 @@ impl Binder {
                 )
                 .await?
             }
-            SetExpr::SetOperation(_) => {
+            SetExpr::SetOperation(_) | SetExpr::Values { .. } => {
                 let (mut s_expr, mut bind_context) = self
                     .bind_set_expr(bind_context, &query.body, &[], limit.unwrap_or_default())
                     .await?;

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use async_recursion::async_recursion;
 use chrono::TimeZone;
 use chrono::Utc;
-use common_ast::ast::Expr as AExpr;
 use common_ast::ast::Indirection;
 use common_ast::ast::Join;
 use common_ast::ast::SelectStmt;
@@ -45,16 +44,10 @@ use common_catalog::table_function::TableFunction;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_exception::Span;
-use common_expression::type_check::common_super_type;
 use common_expression::types::DataType;
-use common_expression::ColumnBuilder;
 use common_expression::ColumnId;
 use common_expression::ConstantFolder;
-use common_expression::DataBlock;
 use common_expression::DataField;
-use common_expression::DataSchema;
-use common_expression::DataSchemaRefExt;
-use common_expression::Evaluator;
 use common_expression::FunctionKind;
 use common_expression::Scalar;
 use common_expression::TableDataType;
@@ -81,24 +74,20 @@ use common_storages_stage::StageTable;
 use common_storages_view::view_table::QUERY;
 use common_users::UserApiProvider;
 use dashmap::DashMap;
-use indexmap::IndexMap;
 use parking_lot::RwLock;
 
 use crate::binder::copy::parse_file_location;
 use crate::binder::scalar::ScalarBinder;
 use crate::binder::table_args::bind_table_args;
-use crate::binder::wrap_cast_scalar;
 use crate::binder::Binder;
 use crate::binder::ColumnBindingBuilder;
 use crate::binder::CteInfo;
 use crate::binder::ExprContext;
 use crate::binder::Visibility;
-use crate::optimizer::ColumnSet;
 use crate::optimizer::RelExpr;
 use crate::optimizer::SExpr;
 use crate::planner::semantic::normalize_identifier;
 use crate::planner::semantic::TypeChecker;
-use crate::plans::ConstantTableScan;
 use crate::plans::CteScan;
 use crate::plans::Scan;
 use crate::plans::Statistics;
@@ -573,188 +562,7 @@ impl Binder {
                     .await
             }
             TableReference::Join { .. } => unreachable!(),
-            TableReference::Values {
-                span,
-                values,
-                alias,
-            } => self.bind_values(bind_context, *span, values, alias).await,
         }
-    }
-
-    #[async_backtrace::framed]
-    pub(crate) async fn bind_values(
-        &mut self,
-        bind_context: &mut BindContext,
-        span: Span,
-        values: &Vec<Vec<AExpr>>,
-        alias: &Option<TableAlias>,
-    ) -> Result<(SExpr, BindContext)> {
-        if values.is_empty() {
-            return Err(ErrorCode::SemanticError(
-                "Values lists must have at least one row".to_string(),
-            )
-            .set_span(span));
-        }
-        let same_length = values.windows(2).all(|v| v[0].len() == v[1].len());
-        if !same_length {
-            return Err(ErrorCode::SemanticError(
-                "Values lists must all be the same length".to_string(),
-            )
-            .set_span(span));
-        }
-
-        let num_rows = values.len();
-        let num_cols = values[0].len();
-
-        let mut names = match alias {
-            Some(alias) => {
-                if alias.columns.len() > num_cols {
-                    return Err(ErrorCode::SemanticError(format!(
-                        "table {} has {} columns available but {} columns specified",
-                        alias.name,
-                        num_cols,
-                        alias.columns.len()
-                    ))
-                    .set_span(span));
-                }
-                alias
-                    .columns
-                    .iter()
-                    .map(|c| c.to_string())
-                    .collect::<Vec<_>>()
-            }
-            None => vec![],
-        };
-        // For columns whose names are not specified, assigns default column names col0, col2, etc.
-        for i in names.len()..num_cols {
-            names.push(format!("col{}", i));
-        }
-
-        let mut scalar_binder = ScalarBinder::new(
-            bind_context,
-            self.ctx.clone(),
-            &self.name_resolution_ctx,
-            self.metadata.clone(),
-            &[],
-            HashMap::new(),
-            Box::new(IndexMap::new()),
-        );
-
-        let mut col_scalars = vec![Vec::with_capacity(values.len()); num_cols];
-        let mut common_types: Vec<Option<DataType>> = vec![None; num_cols];
-
-        for row_values in values.iter() {
-            for (i, value) in row_values.iter().enumerate() {
-                let (scalar, data_type) = scalar_binder.bind(value).await?;
-                col_scalars[i].push((scalar, data_type.clone()));
-
-                // Get the common data type for each columns.
-                match &common_types[i] {
-                    Some(common_type) => {
-                        if common_type != &data_type {
-                            let new_common_type = common_super_type(
-                                common_type.clone(),
-                                data_type.clone(),
-                                &BUILTIN_FUNCTIONS.default_cast_rules,
-                            );
-                            if new_common_type.is_none() {
-                                return Err(ErrorCode::SemanticError(format!(
-                                    "{} and {} don't have common data type",
-                                    common_type, data_type
-                                ))
-                                .set_span(span));
-                            }
-                            common_types[i] = new_common_type;
-                        }
-                    }
-                    None => {
-                        common_types[i] = Some(data_type);
-                    }
-                }
-            }
-        }
-
-        let mut value_fields = Vec::with_capacity(names.len());
-        for (name, common_type) in names.into_iter().zip(common_types.into_iter()) {
-            let value_field = DataField::new(&name, common_type.unwrap());
-            value_fields.push(value_field);
-        }
-        let value_schema = DataSchema::new(value_fields);
-
-        let input = DataBlock::empty();
-        let func_ctx = self.ctx.get_function_context()?;
-        let evaluator = Evaluator::new(&input, &func_ctx, &BUILTIN_FUNCTIONS);
-
-        // use values to build columns
-        let mut value_columns = Vec::with_capacity(col_scalars.len());
-        for (scalars, value_field) in col_scalars.iter().zip(value_schema.fields().iter()) {
-            let mut builder =
-                ColumnBuilder::with_capacity(value_field.data_type(), col_scalars.len());
-            for (scalar, value_type) in scalars {
-                let scalar = if value_type != value_field.data_type() {
-                    wrap_cast_scalar(scalar, value_type, value_field.data_type())?
-                } else {
-                    scalar.clone()
-                };
-                let expr = scalar.as_expr()?.project_column_ref(|col| {
-                    value_schema.index_of(&col.index.to_string()).unwrap()
-                });
-                let result = evaluator.run(&expr)?;
-
-                match result.as_scalar() {
-                    Some(val) => {
-                        builder.push(val.as_ref());
-                    }
-                    None => {
-                        return Err(ErrorCode::SemanticError(format!(
-                            "Value must be a scalar, but get {}",
-                            result
-                        ))
-                        .set_span(span));
-                    }
-                }
-            }
-            value_columns.push(builder.build());
-        }
-
-        // add column bindings
-        let mut columns = ColumnSet::new();
-        let mut fields = Vec::with_capacity(values.len());
-        for value_field in value_schema.fields() {
-            let index = self
-                .metadata
-                .write()
-                .add_derived_column(value_field.name().clone(), value_field.data_type().clone());
-            columns.insert(index);
-
-            let column_binding = ColumnBindingBuilder::new(
-                value_field.name().clone(),
-                index,
-                Box::new(value_field.data_type().clone()),
-                Visibility::Visible,
-            )
-            .build();
-            bind_context.add_column_binding(column_binding);
-
-            let field = DataField::new(&index.to_string(), value_field.data_type().clone());
-            fields.push(field);
-        }
-        let schema = DataSchemaRefExt::create(fields);
-
-        let s_expr = SExpr::create_leaf(Arc::new(
-            ConstantTableScan {
-                values: value_columns,
-                num_rows,
-                schema,
-                columns,
-            }
-            .into(),
-        ));
-        if let Some(alias) = alias {
-            bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
-        }
-
-        Ok((s_expr, bind_context.clone()))
     }
 
     #[async_backtrace::framed]

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -535,6 +535,13 @@ impl Binder {
                     self.bind_query(&mut new_bind_context, subquery).await?;
                 if let Some(alias) = alias {
                     res_bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
+                    // reset column name as alias column name
+                    for i in 0..alias.columns.len() {
+                        let column = &res_bind_context.columns[i];
+                        self.metadata
+                            .write()
+                            .change_derived_column_alias(column.index, column.column_name.clone());
+                    }
                 }
                 Ok((s_expr, res_bind_context))
             }

--- a/src/query/sql/src/planner/binder/values.rs
+++ b/src/query/sql/src/planner/binder/values.rs
@@ -1,0 +1,196 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_ast::ast::Expr as AExpr;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_exception::Span;
+use common_expression::type_check::common_super_type;
+use common_expression::types::DataType;
+use common_expression::ColumnBuilder;
+use common_expression::DataBlock;
+use common_expression::DataField;
+use common_expression::DataSchema;
+use common_expression::DataSchemaRefExt;
+use common_expression::Evaluator;
+use common_functions::BUILTIN_FUNCTIONS;
+use indexmap::IndexMap;
+
+use crate::binder::wrap_cast_scalar;
+use crate::optimizer::ColumnSet;
+use crate::optimizer::SExpr;
+use crate::plans::ConstantTableScan;
+use crate::BindContext;
+use crate::Binder;
+use crate::ColumnBindingBuilder;
+use crate::ScalarBinder;
+use crate::Visibility;
+
+impl Binder {
+    #[async_backtrace::framed]
+    pub(crate) async fn bind_values(
+        &mut self,
+        bind_context: &mut BindContext,
+        span: Span,
+        values: &Vec<Vec<AExpr>>,
+    ) -> Result<(SExpr, BindContext)> {
+        if values.is_empty() {
+            return Err(ErrorCode::SemanticError(
+                "Values lists must have at least one row".to_string(),
+            )
+            .set_span(span));
+        }
+        let same_length = values.windows(2).all(|v| v[0].len() == v[1].len());
+        if !same_length {
+            return Err(ErrorCode::SemanticError(
+                "Values lists must all be the same length".to_string(),
+            )
+            .set_span(span));
+        }
+
+        let num_rows = values.len();
+        let num_cols = values[0].len();
+
+        // assigns default column names col0, col1, etc.
+        let names = (0..num_cols)
+            .map(|i| format!("col{}", i))
+            .collect::<Vec<_>>();
+
+        let mut scalar_binder = ScalarBinder::new(
+            bind_context,
+            self.ctx.clone(),
+            &self.name_resolution_ctx,
+            self.metadata.clone(),
+            &[],
+            HashMap::new(),
+            Box::new(IndexMap::new()),
+        );
+
+        let mut col_scalars = vec![Vec::with_capacity(values.len()); num_cols];
+        let mut common_types: Vec<Option<DataType>> = vec![None; num_cols];
+
+        for row_values in values.iter() {
+            for (i, value) in row_values.iter().enumerate() {
+                let (scalar, data_type) = scalar_binder.bind(value).await?;
+                col_scalars[i].push((scalar, data_type.clone()));
+
+                // Get the common data type for each columns.
+                match &common_types[i] {
+                    Some(common_type) => {
+                        if common_type != &data_type {
+                            let new_common_type = common_super_type(
+                                common_type.clone(),
+                                data_type.clone(),
+                                &BUILTIN_FUNCTIONS.default_cast_rules,
+                            );
+                            if new_common_type.is_none() {
+                                return Err(ErrorCode::SemanticError(format!(
+                                    "{} and {} don't have common data type",
+                                    common_type, data_type
+                                ))
+                                .set_span(span));
+                            }
+                            common_types[i] = new_common_type;
+                        }
+                    }
+                    None => {
+                        common_types[i] = Some(data_type);
+                    }
+                }
+            }
+        }
+
+        let mut value_fields = Vec::with_capacity(names.len());
+        for (name, common_type) in names.into_iter().zip(common_types.into_iter()) {
+            let value_field = DataField::new(&name, common_type.unwrap());
+            value_fields.push(value_field);
+        }
+        let value_schema = DataSchema::new(value_fields);
+
+        let input = DataBlock::empty();
+        let func_ctx = self.ctx.get_function_context()?;
+        let evaluator = Evaluator::new(&input, &func_ctx, &BUILTIN_FUNCTIONS);
+
+        // use values to build columns
+        let mut value_columns = Vec::with_capacity(col_scalars.len());
+        for (scalars, value_field) in col_scalars.iter().zip(value_schema.fields().iter()) {
+            let mut builder =
+                ColumnBuilder::with_capacity(value_field.data_type(), col_scalars.len());
+            for (scalar, value_type) in scalars {
+                let scalar = if value_type != value_field.data_type() {
+                    wrap_cast_scalar(scalar, value_type, value_field.data_type())?
+                } else {
+                    scalar.clone()
+                };
+                let expr = scalar.as_expr()?.project_column_ref(|col| {
+                    value_schema.index_of(&col.index.to_string()).unwrap()
+                });
+                let result = evaluator.run(&expr)?;
+
+                match result.as_scalar() {
+                    Some(val) => {
+                        builder.push(val.as_ref());
+                    }
+                    None => {
+                        return Err(ErrorCode::SemanticError(format!(
+                            "Value must be a scalar, but get {}",
+                            result
+                        ))
+                        .set_span(span));
+                    }
+                }
+            }
+            value_columns.push(builder.build());
+        }
+
+        // add column bindings
+        let mut columns = ColumnSet::new();
+        let mut fields = Vec::with_capacity(values.len());
+        for value_field in value_schema.fields() {
+            let index = self
+                .metadata
+                .write()
+                .add_derived_column(value_field.name().clone(), value_field.data_type().clone());
+            columns.insert(index);
+
+            let column_binding = ColumnBindingBuilder::new(
+                value_field.name().clone(),
+                index,
+                Box::new(value_field.data_type().clone()),
+                Visibility::Visible,
+            )
+            .build();
+            bind_context.add_column_binding(column_binding);
+
+            let field = DataField::new(&index.to_string(), value_field.data_type().clone());
+            fields.push(field);
+        }
+        let schema = DataSchemaRefExt::create(fields);
+
+        let s_expr = SExpr::create_leaf(Arc::new(
+            ConstantTableScan {
+                values: value_columns,
+                num_rows,
+                schema,
+                columns,
+            }
+            .into(),
+        ));
+
+        Ok((s_expr, bind_context.clone()))
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Remove values from `TableReference` to simplify repetitive code and turn the Values source into a Subquery
- Add example comments for `Projection::InnerColumns`

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12528)
<!-- Reviewable:end -->
