### PR TITLE
feat(cluster): allow specify a client timeout on creating flight client

### DIFF
--- a/src/binaries/query/entry.rs
+++ b/src/binaries/query/entry.rs
@@ -134,6 +134,7 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
     precheck_services(conf).await?;
 
     let mut shutdown_handle = ShutdownHandle::create()?;
+    let start_time = std::time::Instant::now();
 
     info!("Databend Query start with config: {:?}", conf);
 
@@ -346,7 +347,11 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
         println!("    {}={}", k, v);
     }
 
-    info!("Ready for connections.");
+    info!(
+        "Ready for connections after {}s.",
+        start_time.elapsed().as_secs_f32()
+    );
+
     if conf.background.enable {
         println!("Start background service");
         get_background_service_handler().start().await?;

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1364,6 +1364,9 @@ pub struct QueryConfig {
     #[clap(long, default_value = "localhost")]
     pub rpc_tls_query_service_domain_name: String,
 
+    #[clap(long, default_value = "0")]
+    pub rpc_client_timeout_secs: u64,
+
     /// Table engine memory enabled
     #[clap(long, parse(try_from_str), default_value = "true")]
     pub table_engine_memory_enabled: bool,
@@ -1548,6 +1551,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             rpc_tls_server_key: self.rpc_tls_server_key,
             rpc_tls_query_server_root_ca_cert: self.rpc_tls_query_server_root_ca_cert,
             rpc_tls_query_service_domain_name: self.rpc_tls_query_service_domain_name,
+            rpc_client_timeout_secs: self.rpc_client_timeout_secs,
             table_engine_memory_enabled: self.table_engine_memory_enabled,
             wait_timeout_mills: self.wait_timeout_mills,
             max_query_log_size: self.max_query_log_size,
@@ -1621,6 +1625,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             rpc_tls_server_key: inner.rpc_tls_server_key,
             rpc_tls_query_server_root_ca_cert: inner.rpc_tls_query_server_root_ca_cert,
             rpc_tls_query_service_domain_name: inner.rpc_tls_query_service_domain_name,
+            rpc_client_timeout_secs: inner.rpc_client_timeout_secs,
             table_engine_memory_enabled: inner.table_engine_memory_enabled,
             wait_timeout_mills: inner.wait_timeout_mills,
             max_query_log_size: inner.max_query_log_size,

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -179,6 +179,7 @@ pub struct QueryConfig {
     /// Certificate for client to identify query rpc server
     pub rpc_tls_query_server_root_ca_cert: String,
     pub rpc_tls_query_service_domain_name: String,
+    pub rpc_client_timeout_secs: u64,
     /// Table engine memory enabled
     pub table_engine_memory_enabled: bool,
     pub wait_timeout_mills: u64,
@@ -247,6 +248,7 @@ impl Default for QueryConfig {
             rpc_tls_server_key: "".to_string(),
             rpc_tls_query_server_root_ca_cert: "".to_string(),
             rpc_tls_query_service_domain_name: "localhost".to_string(),
+            rpc_client_timeout_secs: 0,
             table_engine_memory_enabled: true,
             wait_timeout_mills: 5000,
             max_query_log_size: 10_000,

--- a/src/query/service/src/clusters/cluster.rs
+++ b/src/query/service/src/clusters/cluster.rs
@@ -528,17 +528,14 @@ pub async fn create_client(config: &InnerConfig, address: &str) -> Result<Flight
     } else {
         None
     };
-    match config.tls_query_cli_enabled() {
-        true => Ok(FlightClient::new(FlightServiceClient::new(
-            ConnectionFactory::create_rpc_channel(
-                address.to_owned(),
-                timeout,
-                Some(config.query.to_rpc_client_tls_config()),
-            )
-            .await?,
-        ))),
-        false => Ok(FlightClient::new(FlightServiceClient::new(
-            ConnectionFactory::create_rpc_channel(address.to_owned(), timeout, None).await?,
-        ))),
-    }
+
+    let rpc_tls_config = if config.tls_query_cli_enabled() {
+        Some(config.query.to_rpc_client_tls_config())
+    } else {
+        None
+    };
+
+    Ok(FlightClient::new(FlightServiceClient::new(
+        ConnectionFactory::create_rpc_channel(address.to_owned(), timeout, rpc_tls_config).await?,
+    )))
 }

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -94,6 +94,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | 'query'   | 'openai_api_version'                       | ''                                                             | ''       |
 | 'query'   | 'parquet_fast_read_bytes'                  | 'null'                                                         | ''       |
 | 'query'   | 'quota'                                    | 'null'                                                         | ''       |
+| 'query'   | 'rpc_client_timeout_secs'                  | '0'                                                            | ''       |
 | 'query'   | 'rpc_tls_query_server_root_ca_cert'        | ''                                                             | ''       |
 | 'query'   | 'rpc_tls_query_service_domain_name'        | 'localhost'                                                    | ''       |
 | 'query'   | 'rpc_tls_server_cert'                      | ''                                                             | ''       |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

today I met an issue that it takes a long period for a new databend-query instance to get ready for new connections:

![Screenshot 2023-08-21 at 20 18 17](https://github.com/datafuselabs/databend/assets/129800/f16201e4-8887-463a-a6ea-700815613503)

as the logs shows, it toke 2 minutes to finally get a timeout on create a new rpc client.

this pr try to fix this hanging issue by adding a timeout config

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12529)
<!-- Reviewable:end -->
