### PR TITLE
refactor(storage): recluster with segment cluster stat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ dependencies = [
  "common-storage",
  "futures",
  "futures-util",
+ "indexmap 2.0.0",
  "itertools 0.10.5",
  "jsonb",
  "log",

--- a/src/query/service/src/test_kits/table_test_fixture.rs
+++ b/src/query/service/src/test_kits/table_test_fixture.rs
@@ -332,6 +332,7 @@ impl TestFixture {
         rows_per_block: usize,
         start: i32,
     ) -> (TableSchemaRef, Vec<Result<DataBlock>>) {
+        let repeat = rows_per_block % 3 == 0;
         let schema = TableSchemaRefExt::create(vec![
             TableField::new("id", TableDataType::Number(NumberDataType::Int32)),
             TableField::new("t", TableDataType::Tuple {
@@ -346,10 +347,17 @@ impl TestFixture {
             schema,
             (0..num_of_block)
                 .map(|idx| {
+                    let mut curr = idx as i32 + start;
                     let column0 = Int32Type::from_data(
-                        std::iter::repeat_with(|| idx as i32 + start)
-                            .take(rows_per_block)
-                            .collect::<Vec<i32>>(),
+                        std::iter::repeat_with(|| {
+                            let tmp = curr;
+                            if !repeat {
+                                curr *= 2;
+                            }
+                            tmp
+                        })
+                        .take(rows_per_block)
+                        .collect::<Vec<i32>>(),
                     );
                     let column1 = Int32Type::from_data(
                         std::iter::repeat_with(|| (idx as i32 + start) * 2)

--- a/src/query/service/tests/it/main.rs
+++ b/src/query/service/tests/it/main.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::uninlined_format_args)]
 #![feature(thread_local)]
 #![feature(io_error_other)]
+#![feature(int_roundings)]
 
 extern crate core;
 

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -224,7 +224,7 @@ async fn test_safety_for_recluster() -> Result<()> {
         let mut mutator =
             ReclusterMutator::try_create(ctx.clone(), 1.0, threshold, cluster_key_id)?;
         let selected_segs =
-            ReclusterMutator::select_segments(&compact_segments, block_per_seg, 8, cluster_key_id);
+            ReclusterMutator::select_segments(&compact_segments, block_per_seg, 8, cluster_key_id)?;
         if selected_segs.is_empty() {
             for compact_segment in compact_segments.into_iter() {
                 if !ReclusterMutator::segment_can_recluster(

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -13,10 +13,12 @@
 //  limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use chrono::Utc;
 use common_base::base::tokio;
+use common_base::runtime::execute_futures_in_parallel;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::BlockThresholds;
@@ -24,22 +26,30 @@ use common_expression::DataBlock;
 use common_expression::Scalar;
 use common_expression::TableSchema;
 use common_expression::TableSchemaRef;
+use common_storages_fuse::io::MetaWriter;
+use common_storages_fuse::io::SegmentWriter;
+use common_storages_fuse::io::TableMetaLocationGenerator;
+use common_storages_fuse::operations::ReclusterMutator;
 use common_storages_fuse::pruning::create_segment_location_vector;
+use common_storages_fuse::statistics::reducers::merge_statistics_mut;
 use common_storages_fuse::statistics::reducers::reduce_block_metas;
+use common_storages_fuse::statistics::sort_by_cluster_stats;
 use common_storages_fuse::FuseTable;
 use databend_query::sessions::TableContext;
-use databend_query::storages::fuse::io::SegmentWriter;
-use databend_query::storages::fuse::io::TableMetaLocationGenerator;
-use databend_query::storages::fuse::operations::ReclusterMutator;
 use databend_query::test_kits::table_test_fixture::TestFixture;
+use itertools::Itertools;
+use rand::thread_rng;
+use rand::Rng;
 use storages_common_table_meta::meta;
 use storages_common_table_meta::meta::BlockMeta;
 use storages_common_table_meta::meta::ClusterStatistics;
+use storages_common_table_meta::meta::Location;
 use storages_common_table_meta::meta::SegmentInfo;
 use storages_common_table_meta::meta::Statistics;
-use storages_common_table_meta::meta::TableSnapshot;
 use storages_common_table_meta::meta::Versioned;
 use uuid::Uuid;
+
+use crate::storages::fuse::operations::mutation::CompactSegmentTestFixture;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_recluster_mutator_block_select() -> Result<()> {
@@ -113,22 +123,9 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
     test_segment_locations.push(segment_location);
     test_block_locations.push(block_location);
 
-    let base_snapshot = TableSnapshot::new(
-        Uuid::new_v4(),
-        &None,
-        None,
-        TableSchema::empty(),
-        Statistics::default(),
-        test_segment_locations.clone(),
-        Some((0, "(id)".to_string())),
-        None,
-    );
-    let base_snapshot = Arc::new(base_snapshot);
-
     let schema = TableSchemaRef::new(TableSchema::empty());
     let ctx: Arc<dyn TableContext> = ctx.clone();
-    let segment_locations = base_snapshot.segments.clone();
-    let segment_locations = create_segment_location_vector(segment_locations, None);
+    let segment_locations = create_segment_location_vector(test_segment_locations, None);
     let compact_segments = FuseTable::segment_pruning(
         &ctx,
         schema,
@@ -145,4 +142,227 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
     assert_eq!(mutator.take_blocks().len(), 3);
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_safety_for_recluster() -> Result<()> {
+    let fixture = TestFixture::new().await;
+    let ctx = fixture.ctx();
+    let operator = ctx.get_data_operator()?.operator();
+
+    let cluster_key_id = 0;
+    let block_per_seg = 5;
+    let threshold = BlockThresholds {
+        max_rows_per_block: 5,
+        min_rows_per_block: 4,
+        max_bytes_per_block: 1024,
+    };
+
+    let data_accessor = operator.clone();
+    let schema = TestFixture::default_table_schema();
+    let mut rand = thread_rng();
+
+    // for r in 1..100 { // <- use this at home
+    for r in 1..10 {
+        eprintln!("round {}", r);
+        let number_of_segments: usize = rand.gen_range(1..10);
+
+        let mut block_number_of_segments = Vec::with_capacity(number_of_segments);
+        let mut rows_per_blocks = Vec::with_capacity(number_of_segments);
+
+        for _ in 0..number_of_segments {
+            block_number_of_segments.push(rand.gen_range(1..8));
+            rows_per_blocks.push(rand.gen_range(1..8));
+        }
+
+        let number_of_blocks: usize = block_number_of_segments.iter().sum();
+        if number_of_blocks < 2 {
+            eprintln!("number_of_blocks must large than 1");
+            continue;
+        }
+        eprintln!(
+            "generating segments number of segments {},  number of blocks {}",
+            number_of_segments, number_of_blocks,
+        );
+
+        let (locations, _, segment_infos) = CompactSegmentTestFixture::gen_segments(
+            ctx.clone(),
+            block_number_of_segments,
+            rows_per_blocks,
+            threshold,
+            Some(cluster_key_id),
+            block_per_seg,
+        )
+        .await?;
+
+        eprintln!("data ready");
+
+        let mut summary = Statistics::default();
+        for seg in &segment_infos {
+            merge_statistics_mut(&mut summary, &seg.summary, Some(cluster_key_id));
+        }
+
+        let mut block_ids = HashSet::new();
+        for seg in &segment_infos {
+            for b in &seg.blocks {
+                block_ids.insert(b.location.clone());
+            }
+        }
+
+        let ctx: Arc<dyn TableContext> = ctx.clone();
+        let segment_locations = create_segment_location_vector(locations, None);
+        let compact_segments = FuseTable::segment_pruning(
+            &ctx,
+            schema.clone(),
+            data_accessor.clone(),
+            &None,
+            segment_locations,
+        )
+        .await?;
+
+        let mut need_recluster = false;
+        let mut mutator =
+            ReclusterMutator::try_create(ctx.clone(), 1.0, threshold, cluster_key_id)?;
+        let selected_segs =
+            ReclusterMutator::select_segments(&compact_segments, block_per_seg, 8, cluster_key_id);
+        if selected_segs.is_empty() {
+            for compact_segment in compact_segments.into_iter() {
+                if !ReclusterMutator::segment_can_recluster(
+                    &compact_segment.1.summary,
+                    block_per_seg,
+                    cluster_key_id,
+                ) {
+                    continue;
+                }
+
+                if mutator.target_select(vec![compact_segment]).await? {
+                    need_recluster = true;
+                    break;
+                }
+            }
+        } else {
+            let mut selected_segments = Vec::with_capacity(selected_segs.len());
+            selected_segs.into_iter().for_each(|i| {
+                selected_segments.push(compact_segments[i].clone());
+            });
+            need_recluster = mutator.target_select(selected_segments).await?;
+        }
+
+        eprintln!("need_recluster: {}", need_recluster);
+        if need_recluster {
+            let mut blocks = mutator.take_blocks();
+            let remained_blocks = std::mem::take(&mut mutator.remained_blocks);
+            eprintln!(
+                "selected segments number {}, selected blocks number {}, remained blocks number {}",
+                mutator.removed_segment_indexes.len(),
+                blocks.len(),
+                remained_blocks.len()
+            );
+            blocks.extend(remained_blocks);
+
+            let mut block_ids_after_target = HashSet::new();
+            for b in &blocks {
+                block_ids_after_target.insert(b.location.clone());
+            }
+
+            let mut origin_blocks_ids = HashSet::new();
+            for idx in &mutator.removed_segment_indexes {
+                for b in &segment_infos[*idx].blocks {
+                    origin_blocks_ids.insert(b.location.clone());
+                }
+            }
+            assert_eq!(block_ids_after_target, origin_blocks_ids);
+
+            // test recluster aggregator.
+            let mut new_segments =
+                generage_segments(ctx, blocks, threshold, cluster_key_id, block_per_seg).await?;
+            let new_segments_len = new_segments.len();
+            let removed_segments_len = mutator.removed_segment_indexes.len();
+            let replaced_segments_len = new_segments_len.min(removed_segments_len);
+            let mut merged_statistics = Statistics::default();
+            let mut appended_segments = Vec::new();
+            let mut replaced_segments = HashMap::with_capacity(replaced_segments_len);
+
+            if new_segments_len > removed_segments_len {
+                let appended = new_segments.split_off(removed_segments_len);
+                for (location, stats) in appended.into_iter().rev() {
+                    appended_segments.push(location);
+                    merge_statistics_mut(&mut merged_statistics, &stats, Some(cluster_key_id));
+                }
+            }
+
+            let mut indices = Vec::with_capacity(removed_segments_len);
+            for (i, (location, stats)) in new_segments.into_iter().enumerate() {
+                let idx = mutator.removed_segment_indexes[i];
+                indices.push(idx);
+                replaced_segments.insert(idx, location);
+                merge_statistics_mut(&mut merged_statistics, &stats, Some(cluster_key_id));
+            }
+
+            let removed_segment_indexes =
+                mutator.removed_segment_indexes[replaced_segments_len..].to_vec();
+            eprintln!(
+                "append segments number {}, replaced segments number {}, removed segments number {}",
+                appended_segments.len(),
+                replaced_segments.len(),
+                removed_segment_indexes.len()
+            );
+            indices.extend(removed_segment_indexes);
+            assert_eq!(indices, mutator.removed_segment_indexes);
+            assert_eq!(merged_statistics, mutator.removed_segment_summary);
+            assert_eq!(
+                new_segments_len,
+                appended_segments.len() + replaced_segments.len()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn generage_segments(
+    ctx: Arc<dyn TableContext>,
+    blocks: Vec<Arc<BlockMeta>>,
+    block_thresholds: BlockThresholds,
+    default_cluster_key: u32,
+    block_per_seg: usize,
+) -> Result<Vec<(Location, Statistics)>> {
+    let location_gen = TableMetaLocationGenerator::with_prefix("test/".to_owned());
+    let data_accessor = ctx.get_data_operator()?.operator();
+
+    let mut merged_blocks = blocks;
+    // sort ascending.
+    merged_blocks.sort_by(|a, b| {
+        sort_by_cluster_stats(&a.cluster_stats, &b.cluster_stats, default_cluster_key)
+    });
+
+    let mut tasks = Vec::new();
+    let segments_num = (merged_blocks.len() / block_per_seg).max(1);
+    let chunk_size = merged_blocks.len().div_ceil(segments_num);
+    for chunk in &merged_blocks.into_iter().chunks(chunk_size) {
+        let new_blocks = chunk.collect::<Vec<_>>();
+        let location_gen = location_gen.clone();
+        let data_accessor = data_accessor.clone();
+        tasks.push(async move {
+            let new_summary =
+                reduce_block_metas(&new_blocks, block_thresholds, Some(default_cluster_key));
+            let segment_info = SegmentInfo::new(new_blocks, new_summary.clone());
+
+            let path = location_gen.gen_segment_info_location();
+            segment_info.write_meta(&data_accessor, &path).await?;
+            Ok::<_, ErrorCode>(((path, SegmentInfo::VERSION), new_summary))
+        });
+    }
+
+    let threads_nums = ctx.get_settings().get_max_threads()? as usize;
+    let permit_nums = ctx.get_settings().get_max_storage_io_requests()? as usize;
+    execute_futures_in_parallel(
+        tasks,
+        threads_nums,
+        permit_nums,
+        "fuse-write-segments-worker".to_owned(),
+    )
+    .await?
+    .into_iter()
+    .collect::<Result<Vec<_>>>()
 }

--- a/src/query/service/tests/it/storages/fuse/table.rs
+++ b/src/query/service/tests/it/storages/fuse/table.rs
@@ -71,9 +71,9 @@ async fn test_fuse_table_normal_case() -> Result<()> {
             "| Column 0 | Column 1 |",
             "+----------+----------+",
             "| 1        | (2, 3)   |",
-            "| 1        | (2, 3)   |",
+            "| 2        | (2, 3)   |",
             "| 2        | (4, 6)   |",
-            "| 2        | (4, 6)   |",
+            "| 4        | (4, 6)   |",
             "+----------+----------+",
         ];
         common_expression::block_debug::assert_blocks_sorted_eq(expected, blocks.as_slice());
@@ -115,9 +115,9 @@ async fn test_fuse_table_normal_case() -> Result<()> {
             "| Column 0 | Column 1 |",
             "+----------+----------+",
             "| 2        | (4, 6)   |",
-            "| 2        | (4, 6)   |",
             "| 3        | (6, 9)   |",
-            "| 3        | (6, 9)   |",
+            "| 4        | (4, 6)   |",
+            "| 6        | (6, 9)   |",
             "+----------+----------+",
         ];
         common_expression::block_debug::assert_blocks_sorted_eq(expected, blocks.as_slice());

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -49,7 +49,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 chrono = { workspace = true }
 futures = "0.3.24"
 futures-util = { workspace = true }
-
+indexmap = "2.0.0"
 itertools = "0.10.5"
 log = { workspace = true }
 metrics = "0.20.1"

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -265,7 +265,10 @@ impl TableMutationAggregator {
             }
         };
 
-        let meta = CommitMeta::new(conflict_resolve_context, self.abort_operation.clone());
+        let meta = CommitMeta::new(
+            conflict_resolve_context,
+            std::mem::take(&mut self.abort_operation),
+        );
         Ok(meta)
     }
 

--- a/src/query/storages/fuse/src/operations/mutation/mod.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mod.rs
@@ -16,6 +16,7 @@ mod compact;
 mod mutation_meta;
 mod mutation_part;
 mod mutation_source;
+mod recluster_aggregator;
 mod recluster_mutator;
 
 pub use compact::BlockCompactMutator;
@@ -32,6 +33,7 @@ pub use mutation_part::MutationDeletedSegment;
 pub use mutation_part::MutationPartInfo;
 pub use mutation_source::MutationAction;
 pub use mutation_source::MutationSource;
+pub use recluster_aggregator::ReclusterAggregator;
 pub use recluster_mutator::ReclusterMutator;
 
 pub static MAX_BLOCK_COUNT: usize = 1000_1000;

--- a/src/query/storages/fuse/src/operations/mutation/recluster_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/recluster_aggregator.rs
@@ -1,0 +1,207 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use common_base::runtime::execute_futures_in_parallel;
+use common_catalog::table_context::TableContext;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_expression::BlockMetaInfoDowncast;
+use common_expression::BlockMetaInfoPtr;
+use common_expression::BlockThresholds;
+use common_expression::DataBlock;
+use common_pipeline_transforms::processors::transforms::AsyncAccumulatingTransform;
+use itertools::Itertools;
+use opendal::Operator;
+use storages_common_table_meta::meta::BlockMeta;
+use storages_common_table_meta::meta::SegmentInfo;
+use storages_common_table_meta::meta::Statistics;
+use storages_common_table_meta::meta::Versioned;
+
+use crate::io::SegmentsIO;
+use crate::io::SerializedSegment;
+use crate::io::TableMetaLocationGenerator;
+use crate::operations::common::AbortOperation;
+use crate::operations::common::CommitMeta;
+use crate::operations::common::ConflictResolveContext;
+use crate::operations::common::SnapshotChanges;
+use crate::operations::ReclusterMutator;
+use crate::statistics::reduce_block_metas;
+use crate::statistics::reducers::merge_statistics_mut;
+use crate::statistics::sort_by_cluster_stats;
+
+pub struct ReclusterAggregator {
+    ctx: Arc<dyn TableContext>,
+    dal: Operator,
+    location_gen: TableMetaLocationGenerator,
+
+    default_cluster_key: u32,
+    block_thresholds: BlockThresholds,
+    block_per_seg: usize,
+    start_time: Instant,
+
+    abort_operation: AbortOperation,
+    merged_blocks: Vec<Arc<BlockMeta>>,
+
+    removed_segment_indexes: Vec<usize>,
+    removed_statistics: Statistics,
+}
+
+#[async_trait::async_trait]
+impl AsyncAccumulatingTransform for ReclusterAggregator {
+    const NAME: &'static str = "ReclusterAggregator";
+
+    #[async_backtrace::framed]
+    async fn transform(&mut self, data: DataBlock) -> Result<Option<DataBlock>> {
+        // gather the input data.
+        if let Some(meta) = data.get_owned_meta().and_then(BlockMeta::downcast_from) {
+            self.abort_operation.add_block(&meta);
+            self.merged_blocks.push(Arc::new(meta));
+            // Refresh status
+            {
+                let status = format!(
+                    "recluster: generate new blocks:{}, cost:{} sec",
+                    self.abort_operation.blocks.len(),
+                    self.start_time.elapsed().as_secs()
+                );
+                self.ctx.set_status_info(&status);
+            }
+        }
+        // no partial output
+        Ok(None)
+    }
+
+    #[async_backtrace::framed]
+    async fn on_finish(&mut self, _output: bool) -> Result<Option<DataBlock>> {
+        let mut new_segments = self.apply().await?;
+
+        let default_cluster_key = Some(self.default_cluster_key);
+        let new_segments_len = new_segments.len();
+        let removed_segments_len = self.removed_segment_indexes.len();
+        let replaced_segments_len = new_segments_len.min(removed_segments_len);
+        let mut merged_statistics = Statistics::default();
+        let mut appended_segments = Vec::new();
+        let mut replaced_segments = HashMap::with_capacity(replaced_segments_len);
+
+        if new_segments_len > removed_segments_len {
+            // The remain new segments will be append.
+            let appended = new_segments.split_off(removed_segments_len);
+            for (location, stats) in appended.into_iter().rev() {
+                self.abort_operation.add_segment(location.clone());
+                appended_segments.push((location, SegmentInfo::VERSION));
+                merge_statistics_mut(&mut merged_statistics, &stats, default_cluster_key);
+            }
+        }
+
+        for (i, (location, stats)) in new_segments.into_iter().enumerate() {
+            // The old segments will be replaced with the news.
+            self.abort_operation.add_segment(location.clone());
+            replaced_segments.insert(
+                self.removed_segment_indexes[i],
+                (location, SegmentInfo::VERSION),
+            );
+            merge_statistics_mut(&mut merged_statistics, &stats, default_cluster_key);
+        }
+
+        let conflict_resolve_context =
+            ConflictResolveContext::ModifiedSegmentExistsInLatest(SnapshotChanges {
+                appended_segments,
+                removed_segment_indexes: self.removed_segment_indexes[replaced_segments_len..]
+                    .to_vec(),
+                replaced_segments,
+                removed_statistics: self.removed_statistics.clone(),
+                merged_statistics,
+            });
+
+        let meta = CommitMeta::new(
+            conflict_resolve_context,
+            std::mem::take(&mut self.abort_operation),
+        );
+        let block_meta: BlockMetaInfoPtr = Box::new(meta);
+        Ok(Some(DataBlock::empty_with_meta(block_meta)))
+    }
+}
+
+impl ReclusterAggregator {
+    pub fn new(
+        mutator: &ReclusterMutator,
+        dal: Operator,
+        location_gen: TableMetaLocationGenerator,
+        block_per_seg: usize,
+    ) -> Self {
+        ReclusterAggregator {
+            ctx: mutator.ctx.clone(),
+            dal,
+            location_gen,
+            default_cluster_key: mutator.cluster_key_id,
+            block_thresholds: mutator.block_thresholds,
+            block_per_seg,
+            merged_blocks: mutator.remained_blocks.clone(),
+            removed_segment_indexes: mutator.removed_segment_indexes.clone(),
+            removed_statistics: mutator.removed_segment_summary.clone(),
+            start_time: Instant::now(),
+            abort_operation: AbortOperation::default(),
+        }
+    }
+
+    async fn apply(&mut self) -> Result<Vec<(String, Statistics)>> {
+        // sort ascending.
+        self.merged_blocks.sort_by(|a, b| {
+            sort_by_cluster_stats(&a.cluster_stats, &b.cluster_stats, self.default_cluster_key)
+        });
+
+        let mut tasks = Vec::new();
+        let merged_blocks = std::mem::take(&mut self.merged_blocks);
+        let segments_num = (merged_blocks.len() / self.block_per_seg).max(1);
+        let chunk_size = merged_blocks.len().div_ceil(segments_num);
+        let default_cluster_key = Some(self.default_cluster_key);
+        let block_thresholds = self.block_thresholds;
+        for chunk in &merged_blocks.into_iter().chunks(chunk_size) {
+            let new_blocks = chunk.collect::<Vec<_>>();
+
+            let location_gen = self.location_gen.clone();
+            let op = self.dal.clone();
+            tasks.push(async move {
+                let new_summary =
+                    reduce_block_metas(&new_blocks, block_thresholds, default_cluster_key);
+                // create new segment info
+                let new_segment = SegmentInfo::new(new_blocks, new_summary.clone());
+
+                // write the segment info.
+                let location = location_gen.gen_segment_info_location();
+                let serialized_segment = SerializedSegment {
+                    path: location.clone(),
+                    segment: Arc::new(new_segment),
+                };
+                SegmentsIO::write_segment(op, serialized_segment).await?;
+                Ok::<_, ErrorCode>((location, new_summary))
+            });
+        }
+
+        let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
+        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+        execute_futures_in_parallel(
+            tasks,
+            threads_nums,
+            permit_nums,
+            "fuse-write-segments-worker".to_owned(),
+        )
+        .await?
+        .into_iter()
+        .collect::<Result<Vec<_>>>()
+    }
+}

--- a/src/query/storages/fuse/src/operations/mutation/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/recluster_mutator.rs
@@ -19,28 +19,36 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use common_base::runtime::execute_futures_in_parallel;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::BlockThresholds;
 use common_expression::Scalar;
+use indexmap::IndexSet;
 use itertools::Itertools;
-use log::debug;
+use minitrace::future::FutureExt;
+use minitrace::Span;
 use storages_common_table_meta::meta::BlockMeta;
+use storages_common_table_meta::meta::CompactSegmentInfo;
+use storages_common_table_meta::meta::SegmentInfo;
+use storages_common_table_meta::meta::Statistics;
 
-use crate::operations::common::BlockMetaIndex;
-use crate::operations::common::MutationLogEntry;
-use crate::operations::common::MutationLogs;
+use crate::statistics::reducers::merge_statistics_mut;
 use crate::table_functions::cmp_with_null;
+use crate::SegmentLocation;
 
 #[derive(Clone)]
 pub struct ReclusterMutator {
-    memory_threshold: usize,
-    depth_threshold: f64,
-    block_thresholds: BlockThresholds,
+    pub(crate) ctx: Arc<dyn TableContext>,
+    pub(crate) depth_threshold: f64,
+    pub(crate) block_thresholds: BlockThresholds,
+    pub(crate) cluster_key_id: u32,
 
-    mutation_logs: MutationLogs,
-    selected_blocks: Vec<Arc<BlockMeta>>,
+    pub(crate) selected_blocks: Vec<Arc<BlockMeta>>,
+    pub(crate) remained_blocks: Vec<Arc<BlockMeta>>,
+    pub(crate) removed_segment_indexes: Vec<usize>,
+    pub(crate) removed_segment_summary: Statistics,
 
     pub(crate) total_rows: usize,
     pub(crate) total_bytes: usize,
@@ -52,17 +60,17 @@ impl ReclusterMutator {
         ctx: Arc<dyn TableContext>,
         depth_threshold: f64,
         block_thresholds: BlockThresholds,
+        cluster_key_id: u32,
     ) -> Result<Self> {
-        let mem_info = sys_info::mem_info().map_err(ErrorCode::from_std_error)?;
-        let max_memory_usage = ctx.get_settings().get_max_memory_usage()? as usize;
-        let memory_threshold =
-            cmp::min(mem_info.avail as usize * 1024, max_memory_usage) * 50 / 100;
         Ok(Self {
-            memory_threshold,
+            ctx,
             depth_threshold,
             block_thresholds,
-            mutation_logs: Default::default(),
+            cluster_key_id,
             selected_blocks: Vec::new(),
+            remained_blocks: Vec::new(),
+            removed_segment_indexes: Vec::new(),
+            removed_segment_summary: Statistics::default(),
             total_rows: 0,
             total_bytes: 0,
             level: 0,
@@ -73,24 +81,43 @@ impl ReclusterMutator {
         std::mem::take(&mut self.selected_blocks)
     }
 
-    pub fn mutation_logs(&self) -> MutationLogs {
-        self.mutation_logs.clone()
-    }
-
     #[async_backtrace::framed]
     pub async fn target_select(
         &mut self,
-        blocks_map: BTreeMap<i32, Vec<(BlockMetaIndex, Arc<BlockMeta>)>>,
+        compact_segments: Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>,
     ) -> Result<bool> {
+        let mut selected_segments = Vec::with_capacity(compact_segments.len());
+        let mut selected_indices = Vec::with_capacity(compact_segments.len());
+        let mut selected_statistics = Vec::with_capacity(compact_segments.len());
+        compact_segments.into_iter().for_each(|(loc, info)| {
+            selected_statistics.push(info.summary.clone());
+            selected_segments.push(info);
+            selected_indices.push(loc.segment_idx);
+        });
+
+        let blocks_map = self.gather_block_map(selected_segments).await?;
+        if blocks_map.is_empty() {
+            return Ok(false);
+        }
+
+        let mem_info = sys_info::mem_info().map_err(ErrorCode::from_std_error)?;
+        let max_memory_usage = self.ctx.get_settings().get_max_memory_usage()? as usize;
+        let memory_threshold =
+            cmp::min(mem_info.avail as usize * 1024, max_memory_usage) * 50 / 100;
+
+        let mut remained_blocks = Vec::new();
+        let mut selected = false;
         for (level, block_metas) in blocks_map.into_iter() {
-            if block_metas.len() < 2 {
+            let len = block_metas.len();
+            if level == -1 || selected || len < 2 {
+                remained_blocks.extend(block_metas.into_iter());
                 continue;
             }
 
             let mut total_rows = 0;
             let mut total_bytes = 0;
             let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
-            for (i, (_, meta)) in block_metas.iter().enumerate() {
+            for (i, meta) in block_metas.iter().enumerate() {
                 if let Some(stats) = &meta.cluster_stats {
                     points_map
                         .entry(stats.min())
@@ -110,104 +137,234 @@ impl ReclusterMutator {
                 .block_thresholds
                 .check_for_recluster(total_rows as usize, total_bytes as usize)
             {
-                self.selected_blocks = block_metas
-                    .into_iter()
-                    .map(|(block_idx, block_meta)| {
-                        self.mutation_logs
-                            .entries
-                            .push(MutationLogEntry::DeletedBlock { index: block_idx });
-                        block_meta
-                    })
-                    .collect();
+                self.selected_blocks = block_metas;
                 self.total_rows = total_rows as usize;
                 self.total_bytes = total_bytes as usize;
                 self.level = level;
-                return Ok(true);
-            }
-
-            let mut max_depth = 0;
-            let mut max_points = Vec::new();
-            let mut block_depths = Vec::new();
-            let mut point_overlaps: Vec<Vec<usize>> = Vec::new();
-            let mut unfinished_parts: HashMap<usize, usize> = HashMap::new();
-            for (i, (_, (start, end))) in points_map
-                .into_iter()
-                .sorted_by(|(a, _), (b, _)| a.iter().cmp_by(b.iter(), cmp_with_null))
-                .enumerate()
-            {
-                let point_depth = if unfinished_parts.len() == 1 && Self::check_point(&start, &end)
-                {
-                    1
-                } else {
-                    unfinished_parts.len() + start.len()
-                };
-
-                match point_depth.cmp(&max_depth) {
-                    Ordering::Greater => {
-                        max_depth = point_depth;
-                        max_points = vec![i];
-                    }
-                    Ordering::Equal => max_points.push(i),
-                    Ordering::Less => (),
-                }
-
-                unfinished_parts
-                    .values_mut()
-                    .for_each(|val| *val = cmp::max(*val, point_depth));
-
-                start.iter().for_each(|&idx| {
-                    unfinished_parts.insert(idx, point_depth);
-                });
-
-                point_overlaps.push(unfinished_parts.keys().cloned().collect());
-
-                end.iter().for_each(|idx| {
-                    if let Some(v) = unfinished_parts.remove(idx) {
-                        block_depths.push(v);
-                    }
-                });
-            }
-            assert!(unfinished_parts.is_empty());
-            assert!(!max_points.is_empty());
-
-            let sum_depth: usize = block_depths.iter().sum();
-            // round the float to 4 decimal places.
-            let average_depth =
-                (10000.0 * sum_depth as f64 / block_depths.len() as f64).round() / 10000.0;
-            debug!(
-                "recluster: average_depth: {} in level {}",
-                average_depth, level
-            );
-            if average_depth <= self.depth_threshold {
+                selected = true;
                 continue;
             }
 
-            // find the max point, gather the blocks.
-            let mut selected_idx = HashSet::new();
-            point_overlaps[max_points[0]].iter().for_each(|idx| {
-                selected_idx.insert(*idx);
-            });
+            let selected_idx = Self::fetch_max_depth(points_map, self.depth_threshold);
+            if selected_idx.is_empty() {
+                remained_blocks.extend(block_metas.into_iter());
+                continue;
+            }
 
+            let blocks_idx: IndexSet<usize> = IndexSet::from_iter(0..len);
+            let diff = blocks_idx.difference(&selected_idx);
+            diff.into_iter()
+                .for_each(|v| remained_blocks.push(block_metas[*v].clone()));
+
+            let mut over_memory = false;
             for idx in selected_idx {
-                let (block_idx, block_meta) = block_metas[idx].clone();
-                let memory_usage = self.total_bytes + block_meta.block_size as usize;
-                if memory_usage > self.memory_threshold {
-                    break;
+                let block_meta = block_metas[idx].clone();
+                if over_memory {
+                    remained_blocks.push(block_meta);
+                    continue;
                 }
 
-                self.mutation_logs
-                    .entries
-                    .push(MutationLogEntry::DeletedBlock { index: block_idx });
+                let memory_usage = self.total_bytes + block_meta.block_size as usize;
+                if memory_usage > memory_threshold {
+                    remained_blocks.push(block_meta);
+                    over_memory = true;
+                    continue;
+                }
+
                 self.total_rows += block_meta.row_count as usize;
                 self.total_bytes = memory_usage;
                 self.selected_blocks.push(block_meta);
             }
 
             self.level = level;
-            return Ok(true);
+            selected = true;
         }
 
-        Ok(false)
+        if selected {
+            self.remained_blocks = remained_blocks;
+
+            selected_indices.sort_by(|a, b| b.cmp(a));
+            self.removed_segment_indexes = selected_indices;
+
+            let default_cluster_key_id = Some(self.cluster_key_id);
+            selected_statistics.iter().for_each(|v| {
+                merge_statistics_mut(&mut self.removed_segment_summary, v, default_cluster_key_id)
+            });
+        }
+        Ok(selected)
+    }
+
+    pub fn select_segments(
+        compact_segments: &[(SegmentLocation, Arc<CompactSegmentInfo>)],
+        block_per_seg: usize,
+        max_len: usize,
+        cluster_key_id: u32,
+    ) -> IndexSet<usize> {
+        let mut blocks_num = 0;
+        let mut indices = IndexSet::new();
+        let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
+        for (i, (_, compact_segment)) in compact_segments.iter().enumerate() {
+            if !ReclusterMutator::segment_can_recluster(
+                &compact_segment.summary,
+                block_per_seg,
+                cluster_key_id,
+            ) {
+                continue;
+            }
+
+            if let Some(stats) = &compact_segment.summary.cluster_stats {
+                blocks_num += compact_segment.summary.block_count as usize;
+                indices.insert(i);
+                points_map
+                    .entry(stats.min())
+                    .and_modify(|v| v.0.push(i))
+                    .or_insert((vec![i], vec![]));
+                points_map
+                    .entry(stats.max())
+                    .and_modify(|v| v.1.push(i))
+                    .or_insert((vec![], vec![i]));
+            }
+        }
+
+        if indices.len() < 2 || blocks_num < block_per_seg {
+            return indices;
+        }
+
+        let mut selected_segs = ReclusterMutator::fetch_max_depth(points_map, 1.0);
+        selected_segs.truncate(max_len);
+        selected_segs
+    }
+
+    pub fn segment_can_recluster(
+        summary: &Statistics,
+        block_per_seg: usize,
+        cluster_key_id: u32,
+    ) -> bool {
+        if let Some(stats) = &summary.cluster_stats {
+            stats.cluster_key_id == cluster_key_id
+                && (stats.level >= 0 || (summary.block_count as usize) >= block_per_seg)
+        } else {
+            false
+        }
+    }
+
+    #[async_backtrace::framed]
+    async fn gather_block_map(
+        &self,
+        compact_segments: Vec<Arc<CompactSegmentInfo>>,
+    ) -> Result<BTreeMap<i32, Vec<Arc<BlockMeta>>>> {
+        // combine all the tasks.
+        let mut iter = compact_segments.into_iter();
+        let tasks = std::iter::from_fn(|| {
+            iter.next().map(|v| {
+                async move {
+                    SegmentInfo::try_from(v)
+                        .map_err(|_| ErrorCode::Internal("Failed to convert compact segment info"))
+                }
+                .in_span(Span::enter_with_local_parent("try_from_segments"))
+            })
+        });
+
+        let thread_nums = self.ctx.get_settings().get_max_threads()? as usize;
+        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+        let segments = execute_futures_in_parallel(
+            tasks,
+            thread_nums,
+            permit_nums,
+            "convert-segments-worker".to_owned(),
+        )
+        .await?
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+
+        let mut blocks_map: BTreeMap<i32, Vec<Arc<BlockMeta>>> = BTreeMap::new();
+        for segment in segments.into_iter() {
+            for block in segment.blocks.into_iter() {
+                match &block.cluster_stats {
+                    Some(stats) if stats.cluster_key_id == self.cluster_key_id => {
+                        blocks_map.entry(stats.level).or_default().push(block)
+                    }
+                    _ => {
+                        return Ok(BTreeMap::new());
+                    }
+                }
+            }
+        }
+        Ok(blocks_map)
+    }
+
+    fn fetch_max_depth(
+        points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)>,
+        depth_threshold: f64,
+    ) -> IndexSet<usize> {
+        let mut max_depth = 0;
+        let mut max_points = Vec::new();
+        let mut block_depths = Vec::new();
+        let mut point_overlaps: Vec<Vec<usize>> = Vec::new();
+        let mut unfinished_parts: HashMap<usize, usize> = HashMap::new();
+        for (i, (_, (start, end))) in points_map
+            .into_iter()
+            .sorted_by(|(a, _), (b, _)| a.iter().cmp_by(b.iter(), cmp_with_null))
+            .enumerate()
+        {
+            let point_depth = if unfinished_parts.len() == 1 && Self::check_point(&start, &end) {
+                1
+            } else {
+                unfinished_parts.len() + start.len()
+            };
+
+            match point_depth.cmp(&max_depth) {
+                Ordering::Greater => {
+                    max_depth = point_depth;
+                    max_points = vec![i];
+                }
+                Ordering::Equal => max_points.push(i),
+                Ordering::Less => (),
+            }
+
+            unfinished_parts
+                .values_mut()
+                .for_each(|val| *val = cmp::max(*val, point_depth));
+
+            start.iter().for_each(|&idx| {
+                unfinished_parts.insert(idx, point_depth);
+            });
+
+            point_overlaps.push(unfinished_parts.keys().cloned().collect());
+
+            end.iter().for_each(|idx| {
+                if let Some(v) = unfinished_parts.remove(idx) {
+                    block_depths.push(v);
+                }
+            });
+        }
+        assert!(unfinished_parts.is_empty());
+        assert!(!max_points.is_empty());
+
+        let sum_depth: usize = block_depths.iter().sum();
+        // round the float to 4 decimal places.
+        let average_depth =
+            (10000.0 * sum_depth as f64 / block_depths.len() as f64).round() / 10000.0;
+
+        // find the max point, gather the indices.
+        let mut selected_idx = IndexSet::new();
+        if average_depth > depth_threshold {
+            let mut point = max_points[0];
+            point_overlaps[point].iter().for_each(|idx| {
+                selected_idx.insert(*idx);
+            });
+            for next in max_points.into_iter().skip(1) {
+                point += 1;
+                if next != point {
+                    break;
+                }
+
+                point_overlaps[next].iter().for_each(|idx| {
+                    selected_idx.insert(*idx);
+                });
+            }
+        }
+        selected_idx
     }
 
     // block1: [1, 2], block2: [2, 3]. The depth of point '2' is 1.

--- a/src/query/storages/fuse/src/operations/mutation/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/recluster_mutator.rs
@@ -45,14 +45,14 @@ pub struct ReclusterMutator {
     pub(crate) block_thresholds: BlockThresholds,
     pub(crate) cluster_key_id: u32,
 
-    pub(crate) selected_blocks: Vec<Arc<BlockMeta>>,
-    pub(crate) remained_blocks: Vec<Arc<BlockMeta>>,
-    pub(crate) removed_segment_indexes: Vec<usize>,
-    pub(crate) removed_segment_summary: Statistics,
-
     pub(crate) total_rows: usize,
     pub(crate) total_bytes: usize,
     pub(crate) level: i32,
+
+    pub selected_blocks: Vec<Arc<BlockMeta>>,
+    pub remained_blocks: Vec<Arc<BlockMeta>>,
+    pub removed_segment_indexes: Vec<usize>,
+    pub removed_segment_summary: Statistics,
 }
 
 impl ReclusterMutator {
@@ -103,7 +103,7 @@ impl ReclusterMutator {
         let mem_info = sys_info::mem_info().map_err(ErrorCode::from_std_error)?;
         let max_memory_usage = self.ctx.get_settings().get_max_memory_usage()? as usize;
         let memory_threshold =
-            cmp::min(mem_info.avail as usize * 1024, max_memory_usage) * 50 / 100;
+            cmp::min(mem_info.avail as usize * 1024, max_memory_usage) * 45 / 100;
 
         let mut remained_blocks = Vec::new();
         let mut selected = false;

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -140,7 +140,7 @@ impl FuseTable {
                 block_per_seg,
                 max_threads * 4,
                 default_cluster_key_id,
-            );
+            )?;
             // select the blocks with the highest depth.
             if selected_segs.is_empty() {
                 for compact_segment in compact_segments.into_iter() {

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -12,40 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use common_base::runtime::TrySpawn;
 use common_catalog::plan::DataSourceInfo;
 use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PruningStatistics;
 use common_catalog::plan::PushDownInfo;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
+use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::DataField;
 use common_expression::DataSchemaRefExt;
 use common_expression::SortColumnDescription;
+use common_expression::TableSchemaRef;
 use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_transforms::processors::transforms::build_merge_sort_pipeline;
 use common_pipeline_transforms::processors::transforms::AsyncAccumulatingTransformer;
 use common_sql::evaluator::CompoundBlockOperator;
-use common_sql::executor::MutationKind;
+use common_sql::BloomIndexColumns;
 use log::info;
-use storages_common_table_meta::meta::BlockMeta;
+use log::warn;
+use opendal::Operator;
+use storages_common_table_meta::meta::CompactSegmentInfo;
 
-use crate::operations::common::BlockMetaIndex;
 use crate::operations::common::CommitSink;
 use crate::operations::common::MutationGenerator;
-use crate::operations::common::TableMutationAggregator;
 use crate::operations::common::TransformSerializeBlock;
-use crate::operations::common::TransformSerializeSegment;
-use crate::operations::mutation::MAX_BLOCK_COUNT;
+use crate::operations::mutation::ReclusterAggregator;
 use crate::operations::ReclusterMutator;
 use crate::pipelines::Pipeline;
 use crate::pruning::create_segment_location_vector;
-use crate::pruning::FusePruner;
+use crate::pruning::PruningContext;
+use crate::pruning::SegmentPruner;
 use crate::FuseTable;
+use crate::SegmentLocation;
 use crate::DEFAULT_AVG_DEPTH_THRESHOLD;
+use crate::DEFAULT_BLOCK_PER_SEGMENT;
+use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use crate::FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD;
 
 impl FuseTable {
@@ -91,6 +96,8 @@ impl FuseTable {
 
         let default_cluster_key_id = self.cluster_key_meta.clone().unwrap().0;
         let block_thresholds = self.get_block_thresholds();
+        let block_per_seg =
+            self.get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT);
         let avg_depth_threshold = self.get_option(
             FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD,
             DEFAULT_AVG_DEPTH_THRESHOLD,
@@ -99,42 +106,66 @@ impl FuseTable {
         let threshold = (block_count as f64 * avg_depth_threshold)
             .max(1.0)
             .min(64.0);
-        let mut mutator = ReclusterMutator::try_create(ctx.clone(), threshold, block_thresholds)?;
-
-        let schema = self.table_info.schema();
-        let segment_locations = snapshot.segments.clone();
-        let segment_locations = create_segment_location_vector(segment_locations, None);
-        let mut pruner = FusePruner::create(
-            &ctx,
-            self.operator.clone(),
-            schema,
-            &push_downs,
-            self.bloom_index_cols(),
+        let mut mutator = ReclusterMutator::try_create(
+            ctx.clone(),
+            threshold,
+            block_thresholds,
+            default_cluster_key_id,
         )?;
 
-        let max_threads = ctx.get_settings().get_max_threads()? as usize;
-        let limit = limit.unwrap_or(max_threads * 4);
-        for chunk in segment_locations.chunks(limit) {
-            let mut block_metas = pruner.read_pruning(chunk.to_vec()).await?;
-            block_metas.truncate(MAX_BLOCK_COUNT);
+        let segment_locations = snapshot.segments.clone();
+        let segment_locations = create_segment_location_vector(segment_locations, None);
 
-            let mut blocks_map: BTreeMap<i32, Vec<(BlockMetaIndex, Arc<BlockMeta>)>> =
-                BTreeMap::new();
-            block_metas.into_iter().for_each(|(idx, b)| {
-                if let Some(stats) = &b.cluster_stats {
-                    if stats.cluster_key_id == default_cluster_key_id && stats.level >= 0 {
-                        blocks_map.entry(stats.level).or_default().push((
-                            BlockMetaIndex {
-                                segment_idx: idx.segment_idx,
-                                block_idx: idx.block_idx,
-                            },
-                            b,
-                        ));
+        let max_threads = ctx.get_settings().get_max_threads()? as usize;
+        let limit = limit.unwrap_or(1000);
+
+        let mut need_recluster = false;
+        for chunk in segment_locations.chunks(limit) {
+            // read segments.
+            let compact_segments = Self::segment_pruning(
+                &ctx,
+                self.schema(),
+                self.get_operator(),
+                &push_downs,
+                chunk.to_vec(),
+            )
+            .await?;
+            if compact_segments.is_empty() {
+                continue;
+            }
+
+            // select the segments with the highest depth.
+            let selected_segs = ReclusterMutator::select_segments(
+                &compact_segments,
+                block_per_seg,
+                max_threads * 4,
+                default_cluster_key_id,
+            );
+            // select the blocks with the highest depth.
+            if selected_segs.is_empty() {
+                for compact_segment in compact_segments.into_iter() {
+                    if !ReclusterMutator::segment_can_recluster(
+                        &compact_segment.1.summary,
+                        block_per_seg,
+                        default_cluster_key_id,
+                    ) {
+                        continue;
+                    }
+
+                    if mutator.target_select(vec![compact_segment]).await? {
+                        need_recluster = true;
+                        break;
                     }
                 }
-            });
+            } else {
+                let mut selected_segments = Vec::with_capacity(selected_segs.len());
+                selected_segs.into_iter().for_each(|i| {
+                    selected_segments.push(compact_segments[i].clone());
+                });
+                need_recluster = mutator.target_select(selected_segments).await?;
+            }
 
-            if mutator.target_select(blocks_map).await? {
+            if need_recluster {
                 break;
             }
         }
@@ -261,23 +292,12 @@ impl FuseTable {
 
         pipeline.try_resize(1)?;
         pipeline.add_transform(|input, output| {
-            let proc =
-                TransformSerializeSegment::new(ctx.clone(), input, output, self, block_thresholds);
-            proc.into_processor()
-        })?;
-
-        pipeline.add_transform(|input, output| {
-            let mut aggregator = TableMutationAggregator::new(
-                self,
-                ctx.clone(),
-                snapshot.segments.clone(),
-                MutationKind::Recluster,
+            let aggregator = ReclusterAggregator::new(
+                &mutator,
+                self.get_operator(),
+                self.meta_location_generator().clone(),
+                block_per_seg,
             );
-            mutator
-                .mutation_logs()
-                .entries
-                .into_iter()
-                .for_each(|v| aggregator.accumulate_log_entry(v));
             Ok(ProcessorPtr::create(AsyncAccumulatingTransformer::create(
                 input, output, aggregator,
             )))
@@ -297,5 +317,73 @@ impl FuseTable {
             )
         })?;
         Ok(block_count as u64)
+    }
+
+    pub async fn segment_pruning(
+        ctx: &Arc<dyn TableContext>,
+        schema: TableSchemaRef,
+        dal: Operator,
+        push_down: &Option<PushDownInfo>,
+        mut segment_locs: Vec<SegmentLocation>,
+    ) -> Result<Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>> {
+        let max_concurrency = {
+            let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+            let v = std::cmp::max(max_io_requests, 10);
+            if v > max_io_requests {
+                warn!(
+                    "max_storage_io_requests setting is too low {}, increased to {}",
+                    max_io_requests, v
+                )
+            }
+            v
+        };
+
+        // Only use push_down here.
+        let pruning_ctx = PruningContext::try_create(
+            ctx,
+            dal,
+            schema.clone(),
+            push_down,
+            None,
+            vec![],
+            BloomIndexColumns::None,
+            max_concurrency,
+        )?;
+
+        let segment_pruner = SegmentPruner::create(pruning_ctx.clone(), schema)?;
+        let mut remain = segment_locs.len() % max_concurrency;
+        let batch_size = segment_locs.len() / max_concurrency;
+        let mut works = Vec::with_capacity(max_concurrency);
+
+        while !segment_locs.is_empty() {
+            let gap_size = std::cmp::min(1, remain);
+            let batch_size = batch_size + gap_size;
+            remain -= gap_size;
+
+            let batch = segment_locs.drain(0..batch_size).collect::<Vec<_>>();
+            works.push(pruning_ctx.pruning_runtime.spawn({
+                let segment_pruner = segment_pruner.clone();
+
+                async move {
+                    let pruned_segments = segment_pruner.pruning(batch).await?;
+                    Result::<_, ErrorCode>::Ok(pruned_segments)
+                }
+            }));
+        }
+
+        match futures::future::try_join_all(works).await {
+            Err(e) => Err(ErrorCode::StorageOther(format!(
+                "segment pruning failure, {}",
+                e
+            ))),
+            Ok(workers) => {
+                let mut metas = vec![];
+                for worker in workers {
+                    let res = worker?;
+                    metas.extend(res);
+                }
+                Ok(metas)
+            }
+        }
     }
 }

--- a/src/query/storages/fuse/src/pruning/mod.rs
+++ b/src/query/storages/fuse/src/pruning/mod.rs
@@ -28,3 +28,4 @@ pub use fuse_pruner::PruningContext;
 pub use pruner_location::create_segment_location_vector;
 pub use pruner_location::SegmentLocation;
 pub use pruning_statistics::FusePruningStatistics;
+pub use segment_pruner::SegmentPruner;

--- a/src/query/storages/fuse/src/table_functions/clustering_information/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_information/clustering_information.rs
@@ -32,6 +32,7 @@ use common_expression::TableSchemaRefExt;
 use common_expression::Value;
 use itertools::Itertools;
 use jsonb::Value as JsonbValue;
+use log::warn;
 use serde_json::json;
 use serde_json::Value as JsonValue;
 use storages_common_table_meta::meta::SegmentInfo;
@@ -164,7 +165,11 @@ impl<'a> ClusteringInformation<'a> {
                 }
             });
         }
-        assert!(unfinished_parts.is_empty());
+        if !unfinished_parts.is_empty() {
+            warn!(
+                "clustering_information: unfinished_parts is not empty after calculate the blocks overlaps"
+            );
+        }
 
         let mut sum_overlap = 0;
         let mut sum_depth = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Execute process:

1. read out a batch of segments (1000) .

2. based on the cluster stats of segment level, calculate and select the segments with the highest depth (limit max_threads * 4).

3. read the blocks, select the ones with the highest depth, and record the segments in which those blocks are located. 

4. do a recluster on the selected blocks to generate new blocks.

5. Sort the new blocks with the remaining blocks in the segments recorded in step 3, and generate new segments. 

6. In order to maintain the initial order as much as possible, replace the positions of the segments recorded in step 3 in the base snapshot with the newly generated segments. The extra newly generated segments are appended to the top.

7. commit

- Closes #12153

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12535)
<!-- Reviewable:end -->
