### PR TITLE
docs: set default value on modifying column type

### DIFF
--- a/docs/doc/13-monitor/10-metasrv-metrics.md
+++ b/docs/doc/13-monitor/10-metasrv-metrics.md
@@ -13,8 +13,9 @@ You can access the metrics through a web browser using the following URLs:
 - Query Metrics: `http://<metric_api_address>/metrics`. Defaults to `0.0.0.0:7070/metrics`.
 
 :::tip
-Alternatively, you can visualize the metrics with a third-party tool. For supported tools and integration tutorials, see **Monitor** > **Using 3rd-party Tools**.
+Alternatively, you can visualize the metrics using third-party tools. For information about supported tools and integration tutorials, refer to **Monitor** > **Using 3rd-party Tools**. When employing the Prometheus & Grafana solution, you can create dashboards using our provided dashboard templates, available [here](https://github.com/datafuselabs/helm-charts/tree/main/dashboards). For more details, check out the [Prometheus & Grafana](tools/prometheus-and-grafana.md) guide.
 :::
+
 ## Meta Metrics
 
 Here's a list of Meta metrics captured by Databend.

--- a/docs/doc/14-sql-commands/00-ddl/20-table/90-alter-table-column.md
+++ b/docs/doc/14-sql-commands/00-ddl/20-table/90-alter-table-column.md
@@ -3,7 +3,7 @@ title: ALTER TABLE COLUMN
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.50"/>
+<FunctionDescription description="Introduced or updated: v1.2.71"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -36,7 +36,7 @@ RENAME COLUMN <column_name> TO <new_column_name>;
 
 -- Change the data type of one or multiple columns
 ALTER TABLE [IF EXISTS] [database.]<table_name> 
-MODIFY COLUMN <column_name> <new_data_type>[, COLUMN <column_name> <new_data_type>, ...]
+MODIFY COLUMN <column_name> <new_data_type> [DEFAULT <constant_value>][, COLUMN <column_name> <new_data_type> [DEFAULT <constant_value>], ...]
 
 -- Set / Unset masking policy for a column
 ALTER TABLE [IF EXISTS] [database.]<table_name>
@@ -51,7 +51,7 @@ DROP COLUMN <column_name>;
 ```
 
 :::note
-- Only a constant value can be accepted as a default value when adding a new column. If a non-constant expression is used, an error will occur.
+- Only a constant value can be accepted as a default value when adding or modifying a column. If a non-constant expression is used, an error will occur.
 - Adding a stored computed column with ALTER TABLE is not supported yet.
 - When you change the data type of a table's columns, there's a risk of conversion errors. For example, if you try to convert a column with text (String) to numbers (Float), it might cause problems.
 - When you set a masking policy for a column, make sure that the data type (refer to the parameter *arg_type_to_mask* in the syntax of [CREATE MASKING POLICY](../102-mask-policy/create-mask-policy.md)) defined in the policy matches the column.
@@ -207,12 +207,14 @@ INSERT INTO students_info VALUES
   (2, 'Jane Smith', 28),
   (3, 'Michael Johnson', 22);
 
-ALTER TABLE students_info MODIFY COLUMN age VARCHAR(10);
+ALTER TABLE students_info MODIFY COLUMN age VARCHAR(10) DEFAULT '0';
+INSERT INTO students_info (id, name) VALUES  (4, 'Eric McMond');
 
 SELECT * FROM students_info;
 
 id|name           |age|
 --+---------------+---+
+ 4|Eric McMond    |0  |
  1|John Doe       |25 |
  2|Jane Smith     |28 |
  3|Michael Johnson|22 |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ALTER TABLE [IF EXISTS] [database.]<table_name> 
MODIFY COLUMN <column_name> <new_data_type> [DEFAULT <constant_value>][, COLUMN <column_name> <new_data_type> [DEFAULT <constant_value>], ...]

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12558)
<!-- Reviewable:end -->
