### PR TITLE
refactor: do not continue if query just runs cli command with `--cmd`

### DIFF
--- a/src/binaries/query/ee_main.rs
+++ b/src/binaries/query/ee_main.rs
@@ -25,6 +25,7 @@ use common_exception::Result;
 use enterprise_query::enterprise_services::EnterpriseServices;
 
 use crate::entry::init_services;
+use crate::entry::run_cmd;
 use crate::entry::start_services;
 
 #[global_allocator]
@@ -47,6 +48,9 @@ fn main() {
 
 pub async fn main_entrypoint() -> Result<()> {
     let conf: InnerConfig = InnerConfig::load()?;
+    if run_cmd(&conf).await? {
+        return Ok(());
+    }
     init_services(&conf).await?;
     EnterpriseServices::init(conf.clone()).await?;
     start_services(&conf).await

--- a/src/binaries/query/entry.rs
+++ b/src/binaries/query/entry.rs
@@ -42,7 +42,7 @@ use log::info;
 
 use crate::local;
 
-async fn run_cmd(conf: &InnerConfig) -> Result<bool> {
+pub async fn run_cmd(conf: &InnerConfig) -> Result<bool> {
     if conf.cmd.is_empty() {
         return Ok(false);
     }
@@ -68,10 +68,6 @@ async fn run_cmd(conf: &InnerConfig) -> Result<bool> {
 }
 
 pub async fn init_services(conf: &InnerConfig) -> Result<()> {
-    if run_cmd(conf).await? {
-        return Ok(());
-    }
-
     init_default_metrics_recorder();
     set_panic_hook();
     set_alloc_error_hook();

--- a/src/binaries/query/oss_main.rs
+++ b/src/binaries/query/oss_main.rs
@@ -26,6 +26,7 @@ use common_license::license_manager::LicenseManager;
 use common_license::license_manager::OssLicenseManager;
 
 use crate::entry::init_services;
+use crate::entry::run_cmd;
 use crate::entry::start_services;
 
 #[global_allocator]
@@ -48,6 +49,9 @@ fn main() {
 
 async fn main_entrypoint() -> Result<()> {
     let conf: InnerConfig = InnerConfig::load()?;
+    if run_cmd(&conf).await? {
+        return Ok(());
+    }
     init_services(&conf).await?;
     // init oss license manager
     OssLicenseManager::init()?;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: do not continue if query just runs cli command with `--cmd`

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12561)
<!-- Reviewable:end -->
