### PR TITLE
chore: rename cluster_by_keys to cluster_key

### DIFF
--- a/docs/doc/14-sql-commands/00-ddl/70-clusterkey/dml-recluster-table.md
+++ b/docs/doc/14-sql-commands/00-ddl/70-clusterkey/dml-recluster-table.md
@@ -48,7 +48,7 @@ insert into t values(4,4);
 
 select * from clustering_information('default','t')\G
 *************************** 1. row ***************************
-        cluster_by_keys: ((a + 1))
+            cluster_key: ((a + 1))
       total_block_count: 3
    constant_block_count: 1
 unclustered_block_count: 0
@@ -61,7 +61,7 @@ ALTER TABLE t RECLUSTER FINAL WHERE a != 4;
 
 select * from clustering_information('default','t')\G
 *************************** 1. row ***************************
-        cluster_by_keys: ((a + 1))
+            cluster_key: ((a + 1))
       total_block_count: 2
    constant_block_count: 1
 unclustered_block_count: 0

--- a/docs/doc/15-sql-functions/111-system-functions/clustering_information.md
+++ b/docs/doc/15-sql-functions/111-system-functions/clustering_information.md
@@ -21,7 +21,7 @@ INSERT INTO mytable VALUES(4,4);
 
 SELECT * FROM CLUSTERING_INFORMATION('default','mytable')\G
 *************************** 1. row ***************************
-        cluster_by_keys: ((a + 1))
+            cluster_key: ((a + 1))
       total_block_count: 3
    constant_block_count: 1
 unclustered_block_count: 0

--- a/src/query/storages/fuse/src/table_functions/clustering_information/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_information/clustering_information.rs
@@ -205,7 +205,7 @@ impl<'a> ClusteringInformation<'a> {
     }
 
     fn build_block(&self, info: ClusteringStatistics) -> Result<DataBlock> {
-        let cluster_by_keys = self
+        let cluster_key = self
             .table
             .cluster_key_str()
             .ok_or(ErrorCode::Internal("It's a bug"))?;
@@ -213,7 +213,7 @@ impl<'a> ClusteringInformation<'a> {
             vec![
                 BlockEntry::new(
                     DataType::String,
-                    Value::Scalar(Scalar::String(cluster_by_keys.as_bytes().to_vec())),
+                    Value::Scalar(Scalar::String(cluster_key.as_bytes().to_vec())),
                 ),
                 BlockEntry::new(
                     DataType::Number(NumberDataType::UInt64),
@@ -256,7 +256,7 @@ impl<'a> ClusteringInformation<'a> {
 
     pub fn schema() -> Arc<TableSchema> {
         TableSchemaRefExt::create(vec![
-            TableField::new("cluster_by_keys", TableDataType::String),
+            TableField::new("cluster_key", TableDataType::String),
             TableField::new(
                 "total_block_count",
                 TableDataType::Number(NumberDataType::UInt64),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```sql
select * from clustering_information('default','t')\G
*************************** 1. row ***************************
            cluster_key: ((a + 1))
      total_block_count: 3
   constant_block_count: 1
unclustered_block_count: 0
       average_overlaps: 1.3333
          average_depth: 2.0
  block_depth_histogram: {"00002":3}
```

- Closes #12598

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12600)
<!-- Reviewable:end -->
