### PR TITLE
feat(http): add metrics on panics & query

### DIFF
--- a/src/query/service/src/servers/http/http_services.rs
+++ b/src/query/service/src/servers/http/http_services.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
@@ -32,10 +33,12 @@ use poem::middleware::TrailingSlash;
 use poem::put;
 use poem::Endpoint;
 use poem::EndpointExt;
+use poem::IntoResponse;
 use poem::Route;
 
 use super::v1::upload_to_stage;
 use crate::auth::AuthMgr;
+use crate::servers::http::metrics::metrics_incr_http_response_panics_count;
 use crate::servers::http::middleware::HTTPSessionMiddleware;
 use crate::servers::http::v1::clickhouse_router;
 use crate::servers::http::v1::list_suggestions;
@@ -122,7 +125,7 @@ impl HttpHandler {
                 .nest("/health", ep_health),
         };
         ep.with(NormalizePath::new(TrailingSlash::Trim))
-            .with(CatchPanic::new())
+            .with(CatchPanic::new().with_handler(panic_handler))
             .boxed()
     }
 
@@ -200,4 +203,11 @@ impl Server for HttpHandler {
             }
         })
     }
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub(crate) async fn panic_handler(_err: Box<dyn Any + Send + 'static>) -> impl IntoResponse {
+    metrics_incr_http_response_panics_count();
+    (500, "internal server error")
 }

--- a/src/query/service/src/servers/http/metrics.rs
+++ b/src/query/service/src/servers/http/metrics.rs
@@ -30,6 +30,5 @@ pub fn metrics_incr_http_response_errors_count(err: String, code: u16) {
 }
 
 pub fn metrics_incr_http_response_panics_count() {
-    let labels = [];
-    counter!("query_http_response_panics_count", 1, &labels);
+    counter!("query_http_response_panics_count", 1);
 }

--- a/src/query/service/src/servers/http/metrics.rs
+++ b/src/query/service/src/servers/http/metrics.rs
@@ -23,3 +23,8 @@ pub fn metrics_incr_http_slow_request_count(method: String, api: String, status:
     let labels = [("method", method), ("api", api), ("status", status)];
     counter!("query_http_slow_requests_count", 1, &labels);
 }
+
+pub fn metrics_incr_http_response_failed_count(err: String, code: u16) {
+    let labels = [("err", err), ("code", code.to_string())];
+    counter!("query_http_response_failed_count", 1, &labels);
+}

--- a/src/query/service/src/servers/http/metrics.rs
+++ b/src/query/service/src/servers/http/metrics.rs
@@ -28,3 +28,8 @@ pub fn metrics_incr_http_response_failed_count(err: String, code: u16) {
     let labels = [("err", err), ("code", code.to_string())];
     counter!("query_http_response_failed_count", 1, &labels);
 }
+
+pub fn metrics_incr_http_response_panics_count() {
+    let labels = [];
+    counter!("query_http_response_panic_count", 1, &labels);
+}

--- a/src/query/service/src/servers/http/metrics.rs
+++ b/src/query/service/src/servers/http/metrics.rs
@@ -31,5 +31,5 @@ pub fn metrics_incr_http_response_errors_count(err: String, code: u16) {
 
 pub fn metrics_incr_http_response_panics_count() {
     let labels = [];
-    counter!("query_http_response_panic_count", 1, &labels);
+    counter!("query_http_response_panics_count", 1, &labels);
 }

--- a/src/query/service/src/servers/http/metrics.rs
+++ b/src/query/service/src/servers/http/metrics.rs
@@ -24,9 +24,9 @@ pub fn metrics_incr_http_slow_request_count(method: String, api: String, status:
     counter!("query_http_slow_requests_count", 1, &labels);
 }
 
-pub fn metrics_incr_http_response_failed_count(err: String, code: u16) {
+pub fn metrics_incr_http_response_errors_count(err: String, code: u16) {
     let labels = [("err", err), ("code", code.to_string())];
-    counter!("query_http_response_failed_count", 1, &labels);
+    counter!("query_http_response_errors_count", 1, &labels);
 }
 
 pub fn metrics_incr_http_response_panics_count() {

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -33,6 +33,7 @@ use serde_json::Value as JsonValue;
 use super::query::ExecuteStateKind;
 use super::query::HttpQueryRequest;
 use super::query::HttpQueryResponseInternal;
+use crate::servers::http::metrics::metrics_incr_http_response_failed_count;
 use crate::servers::http::middleware::MetricsMiddleware;
 use crate::servers::http::v1::query::Progresses;
 use crate::servers::http::v1::HttpQueryContext;
@@ -156,6 +157,10 @@ impl QueryResponse {
             }
         };
 
+        if let Some(err) = &r.state.error {
+            metrics_incr_http_response_failed_count(err.name(), err.code());
+        }
+
         let schema = data.schema().clone();
         let session_id = r.session_id.clone();
         let stats = QueryStats {
@@ -163,6 +168,7 @@ impl QueryResponse {
             running_time_ms: state.running_time_ms,
         };
         let rows = data.data.len();
+
         Json(QueryResponse {
             data: data.into(),
             state: state.state,
@@ -184,6 +190,7 @@ impl QueryResponse {
     }
 
     pub(crate) fn fail_to_start_sql(err: &ErrorCode) -> impl IntoResponse {
+        metrics_incr_http_response_failed_count(err.name(), err.code());
         Json(QueryResponse {
             id: "".to_string(),
             stats: QueryStats::default(),

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -33,7 +33,7 @@ use serde_json::Value as JsonValue;
 use super::query::ExecuteStateKind;
 use super::query::HttpQueryRequest;
 use super::query::HttpQueryResponseInternal;
-use crate::servers::http::metrics::metrics_incr_http_response_failed_count;
+use crate::servers::http::metrics::metrics_incr_http_response_errors_count;
 use crate::servers::http::middleware::MetricsMiddleware;
 use crate::servers::http::v1::query::Progresses;
 use crate::servers::http::v1::HttpQueryContext;
@@ -158,7 +158,7 @@ impl QueryResponse {
         };
 
         if let Some(err) = &r.state.error {
-            metrics_incr_http_response_failed_count(err.name(), err.code());
+            metrics_incr_http_response_errors_count(err.name(), err.code());
         }
 
         let schema = data.schema().clone();
@@ -190,7 +190,7 @@ impl QueryResponse {
     }
 
     pub(crate) fn fail_to_start_sql(err: &ErrorCode) -> impl IntoResponse {
-        metrics_incr_http_response_failed_count(err.name(), err.code());
+        metrics_incr_http_response_errors_count(err.name(), err.code());
         Json(QueryResponse {
             id: "".to_string(),
             stats: QueryStats::default(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

this pr add metrics for both errors & panics on query executions, thus may makes us easier to found out unexpected issues as fast as possible.

Closes #12628

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12629)
<!-- Reviewable:end -->
