### PR TITLE
feat: parquet_rs supports small files reading 

### DIFF
--- a/src/query/catalog/tests/it/projection.rs
+++ b/src/query/catalog/tests/it/projection.rs
@@ -113,7 +113,7 @@ fn test_to_projection_mask() -> Result<()> {
     ];
 
     for (projection, expected_mask) in test_cases.iter() {
-        let mask = projection.to_arrow_projection(&schema_desc);
+        let (mask, _) = projection.to_arrow_projection(&schema_desc);
         for leaf in expected_mask {
             assert!(
                 mask.leaf_included(*leaf),

--- a/src/query/storages/parquet/src/parquet2/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet2/parquet_table/read.rs
@@ -162,8 +162,6 @@ impl Parquet2Table {
             )?;
         };
 
-        pipeline.try_resize(num_deserializer)?;
-
         pipeline.add_transform(|input, output| {
             Parquet2DeserializeTransform::create(
                 ctx.clone(),

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader.rs
@@ -263,9 +263,7 @@ impl ParquetRSReader {
         let bytes = Bytes::from(raw);
         let mut builder = ParquetRecordBatchReaderBuilder::try_new_with_options(
             bytes,
-            ArrowReaderOptions::new()
-                .with_page_index(self.need_page_index)
-                .with_skip_arrow_metadata(true),
+            ArrowReaderOptions::new().with_skip_arrow_metadata(true),
         )?
         .with_projection(self.projection.clone())
         .with_batch_size(self.batch_size);

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader.rs
@@ -18,6 +18,7 @@ use arrow_array::RecordBatch;
 use arrow_array::StructArray;
 use arrow_schema::ArrowError;
 use arrow_schema::FieldRef;
+use bytes::Bytes;
 use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::ParquetReadOptions;
 use common_catalog::plan::Projection;
@@ -37,6 +38,7 @@ use opendal::Reader;
 use parquet::arrow::arrow_reader::ArrowPredicateFn;
 use parquet::arrow::arrow_reader::ArrowReaderOptions;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::arrow_reader::RowFilter;
 use parquet::arrow::arrow_reader::RowSelection;
 use parquet::arrow::arrow_reader::RowSelector;
@@ -81,6 +83,10 @@ pub struct ParquetRSReader {
 }
 
 impl ParquetRSReader {
+    pub fn operator(&self) -> Operator {
+        self.op.clone()
+    }
+
     pub fn create(
         ctx: Arc<dyn TableContext>,
         op: Operator,
@@ -236,10 +242,7 @@ impl ParquetRSReader {
     }
 
     /// Read a [`DataBlock`] from parquet file using native apache arrow-rs reader API.
-    pub async fn read_block(
-        &self,
-        reader: &mut ParquetRecordBatchReader,
-    ) -> Result<Option<DataBlock>> {
+    pub fn read_block(&self, reader: &mut ParquetRecordBatchReader) -> Result<Option<DataBlock>> {
         let record_batch = reader.next().transpose()?;
 
         if let Some(batch) = record_batch {
@@ -252,6 +255,65 @@ impl ParquetRSReader {
             Ok(Some(blocks))
         } else {
             Ok(None)
+        }
+    }
+
+    /// Read a [`DataBlock`] from bytes.
+    pub fn read_blocks_from_binary(&self, raw: Vec<u8>) -> Result<Vec<DataBlock>> {
+        let bytes = Bytes::from(raw);
+        let mut builder = ParquetRecordBatchReaderBuilder::try_new_with_options(
+            bytes,
+            ArrowReaderOptions::new()
+                .with_page_index(self.need_page_index)
+                .with_skip_arrow_metadata(true),
+        )?
+        .with_projection(self.projection.clone())
+        .with_batch_size(self.batch_size);
+
+        // Prune row groups.
+        let file_meta = builder.metadata();
+
+        if let Some(pruner) = &self.pruner {
+            let selected_row_groups = pruner.prune_row_groups(file_meta)?;
+            let row_selection = pruner.prune_pages(file_meta, &selected_row_groups)?;
+
+            builder = builder.with_row_groups(selected_row_groups);
+            if let Some(row_selection) = row_selection {
+                builder = builder.with_row_selection(row_selection);
+            }
+        }
+
+        if let Some(predicate) = self.predicate.as_ref() {
+            let projection = predicate.projection().clone();
+            let predicate = predicate.clone();
+            let predicate_fn = move |batch| {
+                predicate
+                    .evaluate(&batch)
+                    .map_err(|e| ArrowError::from_external_error(Box::new(e)))
+            };
+            builder = builder.with_row_filter(RowFilter::new(vec![Box::new(
+                ArrowPredicateFn::new(projection, predicate_fn),
+            )]));
+        }
+
+        let reader = builder.build()?;
+        // Write `if` outside iteration to reduce branches.
+        if self.is_inner_project {
+            reader
+                .into_iter()
+                .map(|batch| {
+                    let batch = batch?;
+                    transform_record_batch(&batch, &self.field_paths)
+                })
+                .collect()
+        } else {
+            reader
+                .into_iter()
+                .map(|batch| {
+                    let batch = batch?;
+                    Ok(DataBlock::from_record_batch(&batch)?.0)
+                })
+                .collect()
         }
     }
 

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader.rs
@@ -122,7 +122,7 @@ impl ParquetRSReader {
                     .filter
                     .as_expr(&BUILTIN_FUNCTIONS)
                     .project_column_ref(|name| schema.index_of(name).unwrap());
-                let projection = prewhere.prewhere_columns.to_arrow_projection(schema_desc);
+                let (projection, _) = prewhere.prewhere_columns.to_arrow_projection(schema_desc);
                 let schema = to_arrow_schema(&schema);
                 let batch_schema =
                     parquet_to_arrow_schema_by_columns(schema_desc, projection.clone(), None)?;
@@ -140,7 +140,8 @@ impl ParquetRSReader {
             })
             .transpose()?;
         // Build projection mask and field paths for transforming `RecordBatch` to output block.
-        let projection = output_projection.to_arrow_projection(schema_desc);
+        // The number of columns in `output_projection` may be less than the number of actual read columns.
+        let (projection, _) = output_projection.to_arrow_projection(schema_desc);
         let batch_schema =
             parquet_to_arrow_schema_by_columns(schema_desc, projection.clone(), None)?;
         let output_schema = to_arrow_schema(&output_projection.project_schema(&table_schema));

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/partition.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/partition.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use common_base::runtime::execute_futures_in_parallel;
@@ -35,6 +36,7 @@ use parquet::schema::types::SchemaDescPtr;
 use parquet::schema::types::SchemaDescriptor;
 
 use super::table::ParquetRSTable;
+use crate::parquet_part::collect_small_file_parts;
 use crate::parquet_rs::partition::SerdePageLocation;
 use crate::parquet_rs::partition::SerdeRowSelector;
 use crate::parquet_rs::ParquetRSRowGroupPart;
@@ -65,6 +67,19 @@ impl ParquetRSTable {
         };
 
         let settings = ctx.get_settings();
+        // If a file size is less than `parquet_fast_read_bytes`,
+        // we treat it as a small file and it will be totally loaded into memory.
+        let fast_read_bytes = settings.get_parquet_fast_read_bytes()?;
+        let mut large_files = vec![];
+        let mut small_files = vec![];
+        for (location, size) in file_locations {
+            if size > fast_read_bytes {
+                large_files.push((location, size));
+            } else {
+                small_files.push((location, size));
+            }
+        }
+
         let pruner = Arc::new(ParquetRSPruner::try_create(
             ctx.get_function_context()?,
             self.schema(),
@@ -72,32 +87,146 @@ impl ParquetRSTable {
             self.read_options,
         )?);
 
-        // TODO(parquet):
-        // The second field of `file_locations` is size of the file.
-        // It will be used for judging if we need to read small parquet files at once to reduce IO.
-
         let copy_status = if ctx.get_query_kind().eq_ignore_ascii_case("copy") {
             Some(ctx.get_copy_status())
         } else {
             None
         };
-        read_and_prune_metas_in_parallel(
-            self.operator.clone(),
-            file_locations,
-            pruner,
-            self.schema_descr.clone(),
-            self.schema_from.clone(),
-            settings.get_max_threads()? as usize,
-            settings.get_max_memory_usage()?,
-            copy_status,
+
+        // Get columns needed to be read into memory.
+        // It will be used to calculate the memory will be used in reading.
+        let columns_to_read = if let Some(prewhere) =
+            PushDownInfo::prewhere_of_push_downs(&push_down)
+        {
+            let (_, prewhere_columns) = prewhere
+                .prewhere_columns
+                .to_arrow_projection(&self.schema_descr);
+            let (_, output_columns) = prewhere
+                .output_columns
+                .to_arrow_projection(&self.schema_descr);
+            let mut columns = HashSet::with_capacity(prewhere_columns.len() + output_columns.len());
+            columns.extend(prewhere_columns);
+            columns.extend(output_columns);
+            let mut columns = columns.into_iter().collect::<Vec<_>>();
+            columns.sort();
+            columns
+        } else {
+            let output_projection =
+                PushDownInfo::projection_of_push_downs(&self.schema(), &push_down);
+            let (_, columns) = output_projection.to_arrow_projection(&self.schema_descr);
+            columns
+        };
+
+        let num_columns_to_read = columns_to_read.len();
+
+        let (mut stats, mut partitions) = self
+            .read_and_prune_metas_in_parallel(
+                ctx,
+                large_files,
+                pruner,
+                columns_to_read,
+                copy_status,
+            )
+            .await?;
+
+        // If there are only row group parts, the `stats` is exact.
+        // It will be changed to `false` if there are small files parts.
+        if !small_files.is_empty() {
+            stats.is_exact = false;
+            let mut max_compression_ratio = self.compression_ratio;
+            let mut max_compressed_size = 0u64;
+            for part in partitions.partitions.iter() {
+                let p = part.as_any().downcast_ref::<ParquetPart>().unwrap();
+                max_compression_ratio = max_compression_ratio
+                    .max(p.uncompressed_size() as f64 / p.compressed_size() as f64);
+                max_compressed_size = max_compressed_size.max(p.compressed_size());
+            }
+
+            collect_small_file_parts(
+                small_files,
+                max_compression_ratio,
+                max_compressed_size,
+                &mut partitions,
+                &mut stats,
+                num_columns_to_read,
+            );
+        }
+
+        Ok((stats, partitions))
+    }
+
+    #[async_backtrace::framed]
+    async fn read_and_prune_metas_in_parallel(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        file_infos: Vec<(String, u64)>,
+        pruner: Arc<ParquetRSPruner>,
+        columns_to_read: Vec<usize>,
+        copy_status: Option<Arc<CopyStatus>>,
+    ) -> Result<(PartStatistics, Partitions)> {
+        let settings = ctx.get_settings();
+        let num_files = file_infos.len();
+        let num_threads = settings.get_max_threads()? as usize;
+        let max_memory_usage = settings.get_max_memory_usage()?;
+
+        let mut tasks = Vec::with_capacity(num_threads);
+
+        // Equally distribute the tasks
+        for i in 0..num_threads {
+            let begin = num_files * i / num_threads;
+            let end = num_files * (i + 1) / num_threads;
+            if begin == end {
+                continue;
+            }
+            let file_infos = file_infos[begin..end].to_vec();
+            let pruner = pruner.clone();
+            let op = self.operator.clone();
+            let columns_to_read = columns_to_read.clone();
+            let expect = self.schema_descr.clone();
+            let schema_from = self.schema_from.clone();
+            let copy_status = copy_status.clone();
+            tasks.push(async move {
+                let metas = read_parquet_metas_batch(
+                    file_infos,
+                    op,
+                    expect,
+                    schema_from,
+                    max_memory_usage,
+                    copy_status,
+                )
+                .await?;
+                prune_and_generate_partitions(&pruner, metas, columns_to_read)
+            });
+        }
+
+        let result = execute_futures_in_parallel(
+            tasks,
+            num_threads,
+            num_threads * 2,
+            "read-and-prune-parquet-metas-worker".to_owned(),
         )
-        .await
+        .await?
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .reduce(|(mut stats_acc, mut parts_acc), (stats, parts)| {
+            stats_acc.merge(&stats);
+            parts_acc.partitions.extend(parts.partitions);
+            (stats_acc, parts_acc)
+        })
+        .unwrap_or((
+            PartStatistics::default_exact(),
+            Partitions::create_nolazy(PartitionsShuffleKind::Mod, vec![]),
+        ));
+
+        Ok(result)
     }
 }
 
 fn prune_and_generate_partitions(
     pruner: &ParquetRSPruner,
     parquet_metas: Vec<(String, Arc<ParquetMetaData>)>,
+    columns_to_read: Vec<usize>,
 ) -> Result<(PartStatistics, Partitions)> {
     let mut parts = vec![];
     let mut part_stats = PartStatistics::default_exact();
@@ -134,12 +263,21 @@ fn prune_and_generate_partitions(
                     .collect()
             });
 
+            let mut compressed_size = 0;
+            let mut uncompressed_size = 0;
+            for col in columns_to_read.iter() {
+                compressed_size += rg_meta.column(*col).compressed_size() as u64;
+                uncompressed_size += rg_meta.column(*col).uncompressed_size() as u64;
+            }
+
             parts.push(Arc::new(
                 Box::new(ParquetPart::ParquetRSRowGroup(ParquetRSRowGroupPart {
                     location: location.clone(),
                     selectors: serde_selection,
                     meta: rg_meta.clone(),
                     page_locations,
+                    compressed_size,
+                    uncompressed_size,
                 })) as Box<dyn PartInfo>,
             ))
         }
@@ -212,69 +350,4 @@ async fn read_parquet_metas_batch(
     } else {
         Ok(metas)
     }
-}
-
-#[async_backtrace::framed]
-#[allow(clippy::too_many_arguments)]
-pub async fn read_and_prune_metas_in_parallel(
-    op: Operator,
-    file_infos: Vec<(String, u64)>,
-    pruner: Arc<ParquetRSPruner>,
-    expect: SchemaDescPtr,
-    schema_from: String,
-    num_threads: usize,
-    max_memory_usage: u64,
-    copy_status: Option<Arc<CopyStatus>>,
-) -> Result<(PartStatistics, Partitions)> {
-    let num_files = file_infos.len();
-    let mut tasks = Vec::with_capacity(num_threads);
-
-    // Equally distribute the tasks
-    for i in 0..num_threads {
-        let begin = num_files * i / num_threads;
-        let end = num_files * (i + 1) / num_threads;
-        if begin == end {
-            continue;
-        }
-        let file_infos = file_infos[begin..end].to_vec();
-        let pruner = pruner.clone();
-        let op = op.clone();
-        let expect = expect.clone();
-        let schema_from = schema_from.clone();
-        let copy_status = copy_status.clone();
-        tasks.push(async move {
-            let metas = read_parquet_metas_batch(
-                file_infos,
-                op,
-                expect,
-                schema_from,
-                max_memory_usage,
-                copy_status,
-            )
-            .await?;
-            prune_and_generate_partitions(&pruner, metas)
-        });
-    }
-
-    let result = execute_futures_in_parallel(
-        tasks,
-        num_threads,
-        num_threads * 2,
-        "read-and-prune-parquet-metas-worker".to_owned(),
-    )
-    .await?
-    .into_iter()
-    .collect::<Result<Vec<_>>>()?
-    .into_iter()
-    .reduce(|(mut stats_acc, mut parts_acc), (stats, parts)| {
-        stats_acc.merge(&stats);
-        parts_acc.partitions.extend(parts.partitions);
-        (stats_acc, parts_acc)
-    })
-    .unwrap_or((
-        PartStatistics::default_exact(),
-        Partitions::create_nolazy(PartitionsShuffleKind::Mod, vec![]),
-    ));
-
-    Ok(result)
 }

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/read.rs
@@ -23,6 +23,7 @@ use common_pipeline_core::Pipeline;
 use super::ParquetRSTable;
 use crate::parquet_rs::source::ParquetSource;
 use crate::utils::calc_parallelism;
+use crate::ParquetPart;
 use crate::ParquetRSReader;
 
 impl ParquetRSTable {
@@ -34,14 +35,24 @@ impl ParquetRSTable {
         pipeline: &mut Pipeline,
     ) -> Result<()> {
         let table_schema: TableSchemaRef = self.table_info.schema();
+        // If there is a `ParquetFilesPart`, we should create pruner for it.
+        // `ParquetFilesPart`s are always staying at the end of `parts`.
+        let need_pruner = matches!(
+            plan.parts
+                .partitions
+                .last()
+                .map(|p| p.as_any().downcast_ref::<ParquetPart>().unwrap()),
+            Some(ParquetPart::ParquetFiles(_)),
+        );
+
         let reader = Arc::new(ParquetRSReader::create_with_parquet_schema(
             ctx.clone(),
             self.operator.clone(),
             table_schema,
             &self.schema_descr,
             plan,
-            self.read_options,
-            false,
+            self.read_options.with_prune_pages(false), /* TODO(parquet): there is a bug in arrow-rs when reading page indexes. */
+            need_pruner,
         )?);
 
         let num_threads = calc_parallelism(&ctx, plan)?;

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/read.rs
@@ -33,8 +33,6 @@ impl ParquetRSTable {
         plan: &DataSourcePlan,
         pipeline: &mut Pipeline,
     ) -> Result<()> {
-        let parts_len = plan.parts.len();
-
         let table_schema: TableSchemaRef = self.table_info.schema();
         let reader = Arc::new(ParquetRSReader::create_with_parquet_schema(
             ctx.clone(),

--- a/src/query/storages/parquet/src/parquet_rs/partition.rs
+++ b/src/query/storages/parquet/src/parquet_rs/partition.rs
@@ -95,23 +95,20 @@ pub struct ParquetRSRowGroupPart {
     pub meta: RowGroupMetaData,
     pub selectors: Option<Vec<SerdeRowSelector>>,
     pub page_locations: Option<Vec<Vec<SerdePageLocation>>>,
+    // `uncompressed_size` and `compressed_size` are the sizes of the actually read columns.
+    pub uncompressed_size: u64,
+    pub compressed_size: u64,
 }
 
 impl Eq for ParquetRSRowGroupPart {}
 
 impl ParquetRSRowGroupPart {
-    // TODO(parquet): change to size after projection.
     pub fn uncompressed_size(&self) -> u64 {
-        self.meta
-            .columns()
-            .iter()
-            .map(|col| col.uncompressed_size() as u64)
-            .sum()
+        self.uncompressed_size
     }
 
-    // TODO(parquet): change to size after projection.
     pub fn compressed_size(&self) -> u64 {
-        self.meta.total_byte_size() as u64
+        self.compressed_size
     }
 }
 

--- a/src/query/storages/parquet/src/parquet_rs/pruning.rs
+++ b/src/query/storages/parquet/src/parquet_rs/pruning.rs
@@ -51,6 +51,7 @@ impl ParquetRSPruner {
         push_down: &Option<PushDownInfo>,
         options: ParquetReadOptions,
     ) -> Result<Self> {
+        // Build `RangePruner` by `filter`.
         let filter = push_down
             .as_ref()
             .and_then(|p| p.filter.as_ref().map(|f| f.as_expr(&BUILTIN_FUNCTIONS)));

--- a/src/query/storages/parquet/tests/it/parquet_rs/prune_pages.rs
+++ b/src/query/storages/parquet/tests/it/parquet_rs/prune_pages.rs
@@ -114,13 +114,12 @@ async fn test_int32_lt() {
     .await;
     // result of sql "SELECT * FROM t where i < 1" is same as
     // "SELECT * FROM t where -i > -1"
-    // TODO(parquet): uncomment until [ISSUE](https://github.com/datafuselabs/databend/issues/12489) fixed.
-    // test(
-    //     Scenario::Int32,
-    //     "where -i > -1",
-    //     RowSelection::from(vec![RowSelector::select(15), RowSelector::skip(5)]),
-    // )
-    // .await;
+    test(
+        Scenario::Int32,
+        "-i > -1",
+        RowSelection::from(vec![RowSelector::select(15), RowSelector::skip(5)]),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -132,13 +131,12 @@ async fn test_int32_gt() {
     )
     .await;
 
-    // TODO(parquet): uncomment until [ISSUE](https://github.com/datafuselabs/databend/issues/12489) fixed.
-    // test(
-    //     Scenario::Int32,
-    //     "where -i < -8",
-    //     RowSelection::from(vec![RowSelector::skip(15), RowSelector::select(5)]),
-    // )
-    // .await;
+    test(
+        Scenario::Int32,
+        "-i < -8",
+        RowSelection::from(vec![RowSelector::skip(15), RowSelector::select(5)]),
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/tests/suites/1_stateful/00_copy/00_0006_small_parquet.result
+++ b/tests/suites/1_stateful/00_copy/00_0006_small_parquet.result
@@ -1,3 +1,77 @@
+use_parquet2=0
+--- copy, threshold=0 stage=data_fs
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy from select, threshold=0 stage=data_fs
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy, threshold=0 stage=data_s3
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy from select, threshold=0 stage=data_s3
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy, threshold=3000 stage=data_fs
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy from select, threshold=3000 stage=data_fs
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy, threshold=3000 stage=data_s3
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy from select, threshold=3000 stage=data_s3
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy, threshold=10000 stage=data_fs
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy from select, threshold=10000 stage=data_fs
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy, threshold=10000 stage=data_s3
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+--- copy from select, threshold=10000 stage=data_s3
+multi_page_1.parquet	40	0	NULL	NULL
+multi_page_2.parquet	120	0	NULL	NULL
+multi_page_3.parquet	80	0	NULL	NULL
+multi_page_4.parquet	160	0	NULL	NULL
+400
+use_parquet2=1
 --- copy, threshold=0 stage=data_fs
 multi_page_1.parquet	40	0	NULL	NULL
 multi_page_2.parquet	120	0	NULL	NULL

--- a/tests/suites/1_stateful/00_copy/00_0006_small_parquet.sh
+++ b/tests/suites/1_stateful/00_copy/00_0006_small_parquet.sh
@@ -14,16 +14,19 @@ echo "create stage data_fs url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);"  
 echo "create table small_parquets(col_arr array(int), col_int int);" | $MYSQL_CLIENT_CONNECT
 
 ## all_large, mixed, all_small
-for threshold in "0" "3000" "10000"; do
-	for stage in "data_fs" "data_s3"; do
-		echo "--- copy, threshold=${threshold} stage=${stage}"
-		echo "set parquet_fast_read_bytes=${threshold}; copy into small_parquets from @${stage} PATTERN='.*parquet' force=true;" | $MYSQL_CLIENT_CONNECT
-		echo "select count(*) from small_parquets" | $MYSQL_CLIENT_CONNECT
-		echo "truncate table small_parquets" | $MYSQL_CLIENT_CONNECT
+for parquet in "0" "1"; do
+	echo "use_parquet2=${parquet}"
+	for threshold in "0" "3000" "10000"; do
+		for stage in "data_fs" "data_s3"; do
+			echo "--- copy, threshold=${threshold} stage=${stage}"
+			echo "set use_parquet2=${parquet}; set parquet_fast_read_bytes=${threshold}; copy into small_parquets from @${stage} PATTERN='.*parquet' force=true;" | $MYSQL_CLIENT_CONNECT
+			echo "select count(*) from small_parquets" | $MYSQL_CLIENT_CONNECT
+			echo "truncate table small_parquets" | $MYSQL_CLIENT_CONNECT
 
-		echo "--- copy from select, threshold=${threshold} stage=${stage}"
-		echo "set parquet_fast_read_bytes=${threshold}; copy into small_parquets from (select * from @${stage} t) PATTERN='.*parquet' force = true;" | $MYSQL_CLIENT_CONNECT
-		echo "select count(*) from small_parquets" | $MYSQL_CLIENT_CONNECT
-		echo "truncate table small_parquets" | $MYSQL_CLIENT_CONNECT
+			echo "--- copy from select, threshold=${threshold} stage=${stage}"
+			echo "set use_parquet2=${parquet}; set parquet_fast_read_bytes=${threshold}; copy into small_parquets from (select * from @${stage} t) PATTERN='.*parquet' force = true;" | $MYSQL_CLIENT_CONNECT
+			echo "select count(*) from small_parquets" | $MYSQL_CLIENT_CONNECT
+			echo "truncate table small_parquets" | $MYSQL_CLIENT_CONNECT
+		done
 	done
 done


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Collect small parquet files. Read them together to reduce IO numbers.
- Estimate memory consumption and adjust pipeline parallelism to avoid OOM.

Tracking in #12465

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12637)
<!-- Reviewable:end -->
