### PR TITLE
chore(http): both accept stage_name and stage-name as args on upload_to_stage

### DIFF
--- a/docs/doc/12-load-data/00-transform/06-querying-metadata.md
+++ b/docs/doc/12-load-data/00-transform/06-querying-metadata.md
@@ -37,7 +37,7 @@ CREATE STAGE my_internal_stage;
 2. Use cURL to make a request to the File Upload API:
 
 ```shell title='Put books.parquet to stage'
-curl -u root: -H "stage-name:my_internal_stage" -F "upload=@books.parquet" -XPUT "http://localhost:8000/v1/upload_to_stage"
+curl -u root: -H "x-databend-stage-name:my_internal_stage" -F "upload=@books.parquet" -XPUT "http://localhost:8000/v1/upload_to_stage"
 ```
 
 3. Query the column definitions from the staged sample file:

--- a/docs/doc/12-load-data/00-transform/06-querying-metadata.md
+++ b/docs/doc/12-load-data/00-transform/06-querying-metadata.md
@@ -37,7 +37,7 @@ CREATE STAGE my_internal_stage;
 2. Use cURL to make a request to the File Upload API:
 
 ```shell title='Put books.parquet to stage'
-curl -u root: -H "stage_name:my_internal_stage" -F "upload=@books.parquet" -XPUT "http://localhost:8000/v1/upload_to_stage"
+curl -u root: -H "stage-name:my_internal_stage" -F "upload=@books.parquet" -XPUT "http://localhost:8000/v1/upload_to_stage"
 ```
 
 3. Query the column definitions from the staged sample file:

--- a/docs/doc/14-sql-commands/10-dml/dml-insert.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-insert.md
@@ -152,7 +152,7 @@ Upload `values.csv` to a stage:
 ```
 
 ```shell title='Request /v1/upload_to_stage' API
-curl -H "stage-name:my_int_stage" -F "upload=@./values.csv" -XPUT http://root:@localhost:8000/v1/upload_to_stage
+curl -H "x-databend-stage-name:my_int_stage" -F "upload=@./values.csv" -XPUT http://root:@localhost:8000/v1/upload_to_stage
 ```
 
 Insert with the uploaded file:

--- a/docs/doc/14-sql-commands/10-dml/dml-insert.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-insert.md
@@ -152,7 +152,7 @@ Upload `values.csv` to a stage:
 ```
 
 ```shell title='Request /v1/upload_to_stage' API
-curl -H "stage_name:my_int_stage" -F "upload=@./values.csv" -XPUT http://root:@localhost:8000/v1/upload_to_stage
+curl -H "stage-name:my_int_stage" -F "upload=@./values.csv" -XPUT http://root:@localhost:8000/v1/upload_to_stage
 ```
 
 Insert with the uploaded file:

--- a/docs/doc/14-sql-commands/10-dml/dml-replace.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-replace.md
@@ -103,7 +103,7 @@ CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV);
 ```
 
 ```shell
-curl -u root: -H "stage-name:s1" -F "upload=@sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage"
+curl -u root: -H "x-databend-stage-name:s1" -F "upload=@sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage"
 
 {"id":"b8305187-c816-4bb5-8350-c441b85baaf9","stage_name":"s1","state":"SUCCESS","files":["sample_3_replace.csv"]}   
 ```

--- a/docs/doc/14-sql-commands/10-dml/dml-replace.md
+++ b/docs/doc/14-sql-commands/10-dml/dml-replace.md
@@ -103,7 +103,7 @@ CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV);
 ```
 
 ```shell
-curl -u root: -H "stage_name:s1" -F "upload=@sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage"
+curl -u root: -H "stage-name:s1" -F "upload=@sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage"
 
 {"id":"b8305187-c816-4bb5-8350-c441b85baaf9","stage_name":"s1","state":"SUCCESS","files":["sample_3_replace.csv"]}   
 ```

--- a/docs/doc/90-contributing/01-rfcs/20220704-presign.md
+++ b/docs/doc/90-contributing/01-rfcs/20220704-presign.md
@@ -14,7 +14,7 @@ Add a new SQL statement for `PRESIGN`, so users can generate a presigned URL for
 
 Databend supports [loading data](https://databend.rs/doc/load-data/load) via internal stage:
 
-- Call HTTP API `upload_to_stage` to upload files: `curl -H "stage-name:my_int_stage" -F "upload=@./books.csv" -XPUT http://localhost:8000/v1/upload_to_stage`
+- Call HTTP API `upload_to_stage` to upload files: `curl -H "x-databend-stage-name:my_int_stage" -F "upload=@./books.csv" -XPUT http://localhost:8000/v1/upload_to_stage`
 - Call `COPY INTO` to copy data: `COPY INTO books FROM '@my_int_stage'`
 
 This workflow's throughput is limited by databend's HTTP API: `upload_to_stage`. We can improve the throughput by allowing users to upload to our backend storage directly. For example, we can use [AWS Authenticating Requests: Using Query Parameters](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html) to generate a presigned URL. This way, users upload content to AWS s3 directly without going through the databend.

--- a/docs/doc/90-contributing/01-rfcs/20220704-presign.md
+++ b/docs/doc/90-contributing/01-rfcs/20220704-presign.md
@@ -14,7 +14,7 @@ Add a new SQL statement for `PRESIGN`, so users can generate a presigned URL for
 
 Databend supports [loading data](https://databend.rs/doc/load-data/load) via internal stage:
 
-- Call HTTP API `upload_to_stage` to upload files: `curl -H "stage_name:my_int_stage" -F "upload=@./books.csv" -XPUT http://localhost:8000/v1/upload_to_stage`
+- Call HTTP API `upload_to_stage` to upload files: `curl -H "stage-name:my_int_stage" -F "upload=@./books.csv" -XPUT http://localhost:8000/v1/upload_to_stage`
 - Call `COPY INTO` to copy data: `COPY INTO books FROM '@my_int_stage'`
 
 This workflow's throughput is limited by databend's HTTP API: `upload_to_stage`. We can improve the throughput by allowing users to upload to our backend storage directly. For example, we can use [AWS Authenticating Requests: Using Query Parameters](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html) to generate a presigned URL. This way, users upload content to AWS s3 directly without going through the databend.

--- a/src/query/service/src/servers/http/v1/stage.rs
+++ b/src/query/service/src/servers/http/v1/stage.rs
@@ -72,7 +72,7 @@ impl UploadToStageArgs {
         let mut arg = req.headers().get(name);
         // if "stage-name" is not found, try "stage_name", which is for backward compatibility
         if arg.is_none() {
-            arg = req.headers().get(name.replace("-", "_").as_str());
+            arg = req.headers().get(name.replace('-', "_").as_str());
         }
         // if both "stage-name" and "stage_name" are not found, try "X-Databend-Stage-Name"
         if arg.is_none() {

--- a/src/query/service/src/servers/http/v1/stage.rs
+++ b/src/query/service/src/servers/http/v1/stage.rs
@@ -66,17 +66,13 @@ impl UploadToStageArgs {
 
     // read_arg parses the http request to retrieve the arguments. In the before, we use
     // argument like `stage_name` in the header, but having underscore in the header is
-    // not a good practice. So we change the argument to `stage-name` and `x-databend-stage-name`
-    // in the header, but we still need to support the old argument for backward compatibility.
+    // not a good practice. So we change the argument to `x-databend-stage-name` in the
+    // header, but we still need to support the old argument for backward compatibility.
     fn read_arg<'a>(req: &'a Request, name: &str) -> Option<&'a str> {
-        let mut arg = req.headers().get(name);
-        // if "stage-name" is not found, try "stage_name", which is for backward compatibility
+        let mut arg = req.headers().get(format!("x-databend-{}", name).as_str());
+        // if "x-databend-stage-name" is not found, try "stage_name", which is for backward compatibility
         if arg.is_none() {
             arg = req.headers().get(name.replace('-', "_").as_str());
-        }
-        // if both "stage-name" and "stage_name" are not found, try "X-Databend-Stage-Name"
-        if arg.is_none() {
-            arg = req.headers().get(format!("x-databend-{}", name).as_str());
         }
         arg.and_then(|v| v.to_str().ok())
     }

--- a/tests/suites/1_stateful/00_copy/00_0011_distributed_copy_into_table_exection_test.sh
+++ b/tests/suites/1_stateful/00_copy/00_0011_distributed_copy_into_table_exection_test.sh
@@ -10,16 +10,16 @@ echo "CREATE STAGE s0011 FILE_FORMAT = (TYPE = CSV);" | $MYSQL_CLIENT_CONNECT
 echo "create table products (id int, name string, description string);" | $MYSQL_CLIENT_CONNECT
 
 #multi files to trigger distributed test
-curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/ttt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
-curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
-curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
-curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_3_duplicate.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/ttt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_3_duplicate.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
 
 echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv';" | $MYSQL_CLIENT_CONNECT
 echo "select * from products order by id,name,description;" | $MYSQL_CLIENT_CONNECT
 echo "select count(*) from products;" | $MYSQL_CLIENT_CONNECT
 ## error test!!!
-curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_2_columns.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_2_columns.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
 echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv' purge = true;"  | $MYSQL_CLIENT_CONNECT 2>&1 | grep -o 'Text = expect 3 fields, only found 2'
 echo "select count(*) from products;" | $MYSQL_CLIENT_CONNECT
 echo "list @s0011;" | $MYSQL_CLIENT_CONNECT | grep -o 'csv' | wc -l

--- a/tests/suites/1_stateful/00_copy/00_0011_distributed_copy_into_table_exection_test.sh
+++ b/tests/suites/1_stateful/00_copy/00_0011_distributed_copy_into_table_exection_test.sh
@@ -10,16 +10,16 @@ echo "CREATE STAGE s0011 FILE_FORMAT = (TYPE = CSV);" | $MYSQL_CLIENT_CONNECT
 echo "create table products (id int, name string, description string);" | $MYSQL_CLIENT_CONNECT
 
 #multi files to trigger distributed test
-curl -s -u root: -H "stage_name:s0011" -F "upload=@${CURDIR}/../../../data/ttt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
-curl -s -u root: -H "stage_name:s0011" -F "upload=@${CURDIR}/../../../data/sample.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
-curl -s -u root: -H "stage_name:s0011" -F "upload=@${CURDIR}/../../../data/sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
-curl -s -u root: -H "stage_name:s0011" -F "upload=@${CURDIR}/../../../data/sample_3_duplicate.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/ttt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_3_duplicate.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
 
 echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv';" | $MYSQL_CLIENT_CONNECT
 echo "select * from products order by id,name,description;" | $MYSQL_CLIENT_CONNECT
 echo "select count(*) from products;" | $MYSQL_CLIENT_CONNECT
 ## error test!!!
-curl -s -u root: -H "stage_name:s0011" -F "upload=@${CURDIR}/../../../data/sample_2_columns.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "stage-name:s0011" -F "upload=@${CURDIR}/../../../data/sample_2_columns.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
 echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv' purge = true;"  | $MYSQL_CLIENT_CONNECT 2>&1 | grep -o 'Text = expect 3 fields, only found 2'
 echo "select count(*) from products;" | $MYSQL_CLIENT_CONNECT
 echo "list @s0011;" | $MYSQL_CLIENT_CONNECT | grep -o 'csv' | wc -l

--- a/tests/suites/1_stateful/01_load/01_0001_upload_to_stage.sh
+++ b/tests/suites/1_stateful/01_load/01_0001_upload_to_stage.sh
@@ -8,7 +8,7 @@ echo "drop stage if exists s2;" | $MYSQL_CLIENT_CONNECT
 echo "CREATE STAGE if not exists s2;" | $MYSQL_CLIENT_CONNECT
 echo "list @s2" | $MYSQL_CLIENT_CONNECT
 
-# both stage_name and stage-name is allowed
+# both stage_name and x-databend-stage-name is allowed
 curl -u root: -XPUT -H "stage_name:s2" -F "upload=@${CURDIR}/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
 curl -u root: -XPUT -H "x-databend-stage-name:s2" -H "relative_path:test" -F "upload=@${CURDIR}/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
 

--- a/tests/suites/1_stateful/01_load/01_0001_upload_to_stage.sh
+++ b/tests/suites/1_stateful/01_load/01_0001_upload_to_stage.sh
@@ -10,7 +10,7 @@ echo "list @s2" | $MYSQL_CLIENT_CONNECT
 
 # both stage_name and stage-name is allowed
 curl -u root: -XPUT -H "stage_name:s2" -F "upload=@${CURDIR}/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
-curl -u root: -XPUT -H "stage-name:s2" -H "relative_path:test" -F "upload=@${CURDIR}/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
+curl -u root: -XPUT -H "x-databend-stage-name:s2" -H "relative_path:test" -F "upload=@${CURDIR}/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
 
 echo "list @s2" | $MYSQL_CLIENT_CONNECT | awk '{print $1,$2,$3}'
 echo "drop stage s2;" | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/01_load/01_0001_upload_to_stage.sh
+++ b/tests/suites/1_stateful/01_load/01_0001_upload_to_stage.sh
@@ -8,8 +8,9 @@ echo "drop stage if exists s2;" | $MYSQL_CLIENT_CONNECT
 echo "CREATE STAGE if not exists s2;" | $MYSQL_CLIENT_CONNECT
 echo "list @s2" | $MYSQL_CLIENT_CONNECT
 
+# both stage_name and stage-name is allowed
 curl -u root: -XPUT -H "stage_name:s2" -F "upload=@${CURDIR}/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
-curl -u root: -XPUT -H "stage_name:s2" -H "relative_path:test" -F "upload=@${CURDIR}/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
+curl -u root: -XPUT -H "stage-name:s2" -H "relative_path:test" -F "upload=@${CURDIR}/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
 
 echo "list @s2" | $MYSQL_CLIENT_CONNECT | awk '{print $1,$2,$3}'
 echo "drop stage s2;" | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/09_http_handler/09_0002_query_log.sh
+++ b/tests/suites/1_stateful/09_http_handler/09_0002_query_log.sh
@@ -8,6 +8,6 @@ echo "drop stage if exists s1;" | $MYSQL_CLIENT_CONNECT
 echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV);" | $MYSQL_CLIENT_CONNECT
 echo "create table products (id int, name string, description string);" | $MYSQL_CLIENT_CONNECT
 
-curl -s -u root: -H "stage-name:s1" -F "upload=@${CURDIR}/../../../data/ttt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "x-databend-stage-name:s1" -F "upload=@${CURDIR}/../../../data/ttt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
 curl -s -u root: -XPOST "http://localhost:8000/v1/query" --header 'Content-Type: application/json' -d '{"sql": "insert into products (id, name, description) VALUES(?,?,?)", "stage_attachment": {"location": "@s1/ttt.csv", "copy_options": {"purge": "false"}}, "pagination": { "wait_time_secs": 6}}' -u root: | jq ".data"
 echo "select query_kind from system.query_log where query_text =  'INSERT INTO products (id, name, description) VALUES (?,?,?)' limit 1;" | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/09_http_handler/09_0002_query_log.sh
+++ b/tests/suites/1_stateful/09_http_handler/09_0002_query_log.sh
@@ -8,6 +8,6 @@ echo "drop stage if exists s1;" | $MYSQL_CLIENT_CONNECT
 echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV);" | $MYSQL_CLIENT_CONNECT
 echo "create table products (id int, name string, description string);" | $MYSQL_CLIENT_CONNECT
 
-curl -s -u root: -H "stage_name:s1" -F "upload=@${CURDIR}/../../../data/ttt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -H "stage-name:s1" -F "upload=@${CURDIR}/../../../data/ttt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
 curl -s -u root: -XPOST "http://localhost:8000/v1/query" --header 'Content-Type: application/json' -d '{"sql": "insert into products (id, name, description) VALUES(?,?,?)", "stage_attachment": {"location": "@s1/ttt.csv", "copy_options": {"purge": "false"}}, "pagination": { "wait_time_secs": 6}}' -u root: | jq ".data"
 echo "select query_kind from system.query_log where query_text =  'INSERT INTO products (id, name, description) VALUES (?,?,?)' limit 1;" | $MYSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

having underscore in the http header seems to be not HTTP standard, and easy to get troubles on various HTTP proxies like nginx.

this PR makes `upload_to_stage` also accepts `stage-name` and `x-databend-stage-name` as arguments, and adjusted the related docs to encourage using `stage-name` instead of `stage_name`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12656)
<!-- Reviewable:end -->
