### PR TITLE
feat: use `zstd` compression for unloading data in parquet format 

### DIFF
--- a/src/query/formats/src/output_format/parquet.rs
+++ b/src/query/formats/src/output_format/parquet.rs
@@ -53,7 +53,7 @@ impl OutputFormat for ParquetOutputFormat {
             return Ok(vec![]);
         }
         let mut buf = Vec::with_capacity(DEFAULT_BLOCK_BUFFER_SIZE);
-        let _ = blocks_to_parquet(&self.schema, blocks, &mut buf, TableCompression::LZ4)?;
+        let _ = blocks_to_parquet(&self.schema, blocks, &mut buf, TableCompression::Zstd)?;
         Ok(buf)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

use `zstd` as compression for unloading data in parquet format 

- Closes #12697
