### PR TITLE
fix: skip empty small files while deserializing parquet

### DIFF
--- a/src/query/storages/parquet/src/parquet2/processors/deserialize_transform.rs
+++ b/src/query/storages/parquet/src/parquet2/processors/deserialize_transform.rs
@@ -400,7 +400,9 @@ impl Processor for Parquet2DeserializeTransform {
                 }
                 (ParquetPart::ParquetFiles(p), Parquet2PartData::SmallFiles(buffers)) => {
                     let blocks = self.process_small_files(p, buffers)?;
-                    self.add_block(DataBlock::concat(&blocks)?)?;
+                    if !blocks.is_empty() {
+                        self.add_block(DataBlock::concat(&blocks)?)?;
+                    }
                 }
                 _ => {
                     unreachable!("wrong type ParquetPartData for ParquetPart")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

skip empty small files while deserializing parquet files.

- Closes #12725

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12726)
<!-- Reviewable:end -->
