### PR TITLE
chore: fix typo of setting name, `repalce` should be `replace`

### DIFF
--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -397,7 +397,7 @@ impl Settings {
     }
 
     pub fn set_enable_distributed_replace(&self, val: bool) -> Result<()> {
-        self.try_set_u64("enable_distributed_repalce_into", u64::from(val))
+        self.try_set_u64("enable_distributed_replace_into", u64::from(val))
     }
 
     pub fn get_enable_aggregating_index_scan(&self) -> Result<bool> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix typo of setting name, `repalce` should be `replace`

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12730)
<!-- Reviewable:end -->
