### PR TITLE
refactor: meta/state-machine: extract MapApiRO from MapApi

### DIFF
--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_store_test.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_store_test.rs
@@ -17,6 +17,7 @@ use futures_util::StreamExt;
 
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::MapApi;
+use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::marked::Marked;
 
 #[tokio::test]
@@ -36,7 +37,7 @@ async fn test_new_level() -> anyhow::Result<()> {
     assert_eq!(result, Marked::new_normal(2, b("b1"), None));
 
     // Listing entries from all levels see the latest
-    let got = MapApi::<String>::range(&l, s("")..)
+    let got = MapApiRO::<String>::range(&l, s("")..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -48,7 +49,7 @@ async fn test_new_level() -> anyhow::Result<()> {
     // Listing from the base level sees the old value.
     let base = l.get_base().unwrap();
 
-    let got = MapApi::<String>::range(base.as_ref(), s("")..)
+    let got = MapApiRO::<String>::range(base.as_ref(), s("")..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -97,7 +98,7 @@ async fn test_single_level() -> anyhow::Result<()> {
     );
 
     // Range
-    let it = MapApi::<String>::range(&l, s("")..).await;
+    let it = MapApiRO::<String>::range(&l, s("")..).await;
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
@@ -109,10 +110,10 @@ async fn test_single_level() -> anyhow::Result<()> {
     ]);
 
     // Get
-    let got = MapApi::<String>::get(&l, "a2").await;
+    let got = MapApiRO::<String>::get(&l, "a2").await;
     assert_eq!(got, &Marked::new_normal(2, b("b2"), None));
 
-    let got = MapApi::<String>::get(&l, "a3").await;
+    let got = MapApiRO::<String>::get(&l, "a3").await;
     assert_eq!(got, &Marked::new_tomb_stone(6));
     Ok(())
 }
@@ -128,7 +129,7 @@ async fn test_two_levels() -> anyhow::Result<()> {
     MapApi::<String>::set(&mut l, s("x1"), Some((b("y1"), None))).await;
     MapApi::<String>::set(&mut l, s("x2"), Some((b("y2"), None))).await;
 
-    let it = MapApi::<String>::range(&l, s("")..).await;
+    let it = MapApiRO::<String>::range(&l, s("")..).await;
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
@@ -163,7 +164,7 @@ async fn test_two_levels() -> anyhow::Result<()> {
     assert_eq!(result, Marked::new_normal(7, b("b5"), None));
 
     // Range
-    let it = MapApi::<String>::range(&l, s("")..).await;
+    let it = MapApiRO::<String>::range(&l, s("")..).await;
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
@@ -175,20 +176,20 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     // Get
 
-    let got = MapApi::<String>::get(&l, "a1").await;
+    let got = MapApiRO::<String>::get(&l, "a1").await;
     assert_eq!(got, &Marked::new_normal(7, b("b5"), None));
 
-    let got = MapApi::<String>::get(&l, "a2").await;
+    let got = MapApiRO::<String>::get(&l, "a2").await;
     assert_eq!(got, &Marked::new_normal(6, b("b4"), None));
 
-    let got = MapApi::<String>::get(&l, "w1").await;
+    let got = MapApiRO::<String>::get(&l, "w1").await;
     assert_eq!(got, &Marked::new_tomb_stone(0));
 
     // Check base level
 
     let base = l.get_base().unwrap();
 
-    let it = MapApi::<String>::range(base.as_ref(), s("")..).await;
+    let it = MapApiRO::<String>::range(base.as_ref(), s("")..).await;
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
@@ -232,25 +233,25 @@ async fn build_3_levels() -> Level {
 async fn test_three_levels_get_range() -> anyhow::Result<()> {
     let l = build_3_levels().await;
 
-    let got = MapApi::<String>::get(&l, "a").await;
+    let got = MapApiRO::<String>::get(&l, "a").await;
     assert_eq!(got, &Marked::new_normal(1, b("a0"), None));
 
-    let got = MapApi::<String>::get(&l, "b").await;
+    let got = MapApiRO::<String>::get(&l, "b").await;
     assert_eq!(got, &Marked::new_tomb_stone(4));
 
-    let got = MapApi::<String>::get(&l, "c").await;
+    let got = MapApiRO::<String>::get(&l, "c").await;
     assert_eq!(got, &Marked::new_tomb_stone(6));
 
-    let got = MapApi::<String>::get(&l, "d").await;
+    let got = MapApiRO::<String>::get(&l, "d").await;
     assert_eq!(got, &Marked::new_normal(7, b("d2"), None));
 
-    let got = MapApi::<String>::get(&l, "e").await;
+    let got = MapApiRO::<String>::get(&l, "e").await;
     assert_eq!(got, &Marked::new_normal(6, b("e1"), None));
 
-    let got = MapApi::<String>::get(&l, "f").await;
+    let got = MapApiRO::<String>::get(&l, "f").await;
     assert_eq!(got, &Marked::new_tomb_stone(0));
 
-    let got = MapApi::<String>::range(&l, s("")..)
+    let got = MapApiRO::<String>::range(&l, s("")..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -294,7 +295,7 @@ async fn test_three_levels_override() -> anyhow::Result<()> {
     assert_eq!(prev, Marked::new_tomb_stone(0));
     assert_eq!(result, Marked::new_normal(13, b("w"), None));
 
-    let got = MapApi::<String>::range(&l, s("")..)
+    let got = MapApiRO::<String>::range(&l, s("")..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -339,7 +340,7 @@ async fn test_three_levels_delete() -> anyhow::Result<()> {
     assert_eq!(prev, Marked::new_tomb_stone(0));
     assert_eq!(result, Marked::new_tomb_stone(0));
 
-    let got = MapApi::<String>::range(&l, s("")..)
+    let got = MapApiRO::<String>::range(&l, s("")..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -410,7 +411,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
             Marked::new_normal(6, b("a1"), Some(KVMeta { expire_at: Some(1) }))
         );
 
-        let got = MapApi::<String>::get(&l, "a").await;
+        let got = MapApiRO::<String>::get(&l, "a").await;
         assert_eq!(
             got,
             &Marked::new_normal(6, b("a1"), Some(KVMeta { expire_at: Some(1) }))
@@ -443,7 +444,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
             )
         );
 
-        let got = MapApi::<String>::get(&l, "b").await;
+        let got = MapApiRO::<String>::get(&l, "b").await;
         assert_eq!(
             got,
             &Marked::new_normal(
@@ -464,7 +465,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         assert_eq!(prev, Marked::new_tomb_stone(0));
         assert_eq!(result, Marked::new_normal(6, b("d1"), None));
 
-        let got = MapApi::<String>::get(&l, "d").await;
+        let got = MapApiRO::<String>::get(&l, "d").await;
         assert_eq!(got, &Marked::new_normal(6, b("d1"), None));
     }
 
@@ -489,7 +490,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
             Marked::new_normal(6, b("a0"), Some(KVMeta { expire_at: Some(2) }))
         );
 
-        let got = MapApi::<String>::get(&l, "a").await;
+        let got = MapApiRO::<String>::get(&l, "a").await;
         assert_eq!(
             got,
             &Marked::new_normal(6, b("a0"), Some(KVMeta { expire_at: Some(2) }))
@@ -513,7 +514,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         );
         assert_eq!(result, Marked::new_normal(6, b("b1"), None));
 
-        let got = MapApi::<String>::get(&l, "b").await;
+        let got = MapApiRO::<String>::get(&l, "b").await;
         assert_eq!(got, &Marked::new_normal(6, b("b1"), None));
     }
 
@@ -541,7 +542,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
             )
         );
 
-        let got = MapApi::<String>::get(&l, "c").await;
+        let got = MapApiRO::<String>::get(&l, "c").await;
         assert_eq!(
             got,
             &Marked::new_normal(
@@ -564,7 +565,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         assert_eq!(prev, Marked::new_tomb_stone(0));
         assert_eq!(result, Marked::new_tomb_stone(0));
 
-        let got = MapApi::<String>::get(&l, "d").await;
+        let got = MapApiRO::<String>::get(&l, "d").await;
         assert_eq!(got, &Marked::new_tomb_stone(0));
     }
 

--- a/src/meta/raft-store/src/sm_v002/sm_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002.rs
@@ -53,6 +53,7 @@ use crate::key_spaces::RaftStoreEntry;
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::level_data::LevelData;
 use crate::sm_v002::leveled_store::map_api::MapApi;
+use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::marked::Marked;
 use crate::sm_v002::sm_v002;
 use crate::sm_v002::Importer;
@@ -243,7 +244,7 @@ impl SMV002 {
     ///
     /// It does not check expiration of the returned entry.
     pub async fn get_kv(&self, key: &str) -> Option<SeqV> {
-        let got = MapApi::<String>::get(&self.top, key).await.clone();
+        let got = MapApiRO::<String>::get(&self.top, key).await.clone();
         Into::<Option<SeqV>>::into(got)
     }
 
@@ -251,7 +252,7 @@ impl SMV002 {
     ///
     /// It is an internal API and does not examine the expiration time.
     pub(crate) async fn get_kv_ref(&self, key: &str) -> &dyn SeqValue {
-        MapApi::<String>::get(&self.top, key).await
+        MapApiRO::<String>::get(&self.top, key).await
     }
 
     // TODO(1): when get an applier, pass in a now_ms to ensure all expired are cleaned.
@@ -276,7 +277,7 @@ impl SMV002 {
     pub async fn prefix_list_kv(&self, prefix: &str) -> Vec<(String, SeqV)> {
         let p = prefix.to_string();
         let mut res = Vec::new();
-        let strm = MapApi::<String>::range(&self.top, p..).await;
+        let strm = MapApiRO::<String>::range(&self.top, p..).await;
 
         {
             let mut strm = std::pin::pin!(strm);
@@ -399,7 +400,7 @@ impl SMV002 {
         &mut self,
         upsert_kv: &UpsertKV,
     ) -> (Marked<Vec<u8>>, Marked<Vec<u8>>) {
-        let prev = MapApi::<String>::get(&self.top, &upsert_kv.key)
+        let prev = MapApiRO::<String>::get(&self.top, &upsert_kv.key)
             .await
             .clone();
 

--- a/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
@@ -17,7 +17,7 @@ use common_meta_types::UpsertKV;
 use futures_util::StreamExt;
 use pretty_assertions::assert_eq;
 
-use crate::sm_v002::leveled_store::map_api::MapApi;
+use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::marked::Marked;
 use crate::sm_v002::SMV002;
 use crate::state_machine::ExpireKey;

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
@@ -24,7 +24,7 @@ use crate::key_spaces::RaftStoreEntry;
 use crate::ondisk::Header;
 use crate::ondisk::OnDisk;
 use crate::sm_v002::leveled_store::level::Level;
-use crate::sm_v002::leveled_store::map_api::MapApi;
+use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::marked::Marked;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::ExpireValue;
@@ -88,7 +88,7 @@ impl SnapshotViewV002 {
         let mut data = self.top.data_ref().new_level();
 
         // `range()` will compact tombstone internally
-        let strm = MapApi::<String>::range::<String, _>(self.top.as_ref(), ..)
+        let strm = MapApiRO::<String>::range::<String, _>(self.top.as_ref(), ..)
             .await
             .filter(|(_k, v)| {
                 let x = !v.is_tomb_stone();
@@ -101,7 +101,7 @@ impl SnapshotViewV002 {
         data.replace_kv(btreemap);
 
         // `range()` will compact tombstone internally
-        let strm = MapApi::<ExpireKey>::range(self.top.as_ref(), ..)
+        let strm = MapApiRO::<ExpireKey>::range(self.top.as_ref(), ..)
             .await
             .filter(|(_k, v)| {
                 let x = !v.is_tomb_stone();
@@ -169,7 +169,7 @@ impl SnapshotViewV002 {
 
         // kv
 
-        let kv_iter = MapApi::<String>::range::<String, _>(self.top.as_ref(), ..)
+        let kv_iter = MapApiRO::<String>::range::<String, _>(self.top.as_ref(), ..)
             .await
             .filter_map(|(k, v)| async move {
                 if let Marked::Normal {
@@ -190,7 +190,7 @@ impl SnapshotViewV002 {
 
         // expire index
 
-        let expire_iter = MapApi::<ExpireKey>::range(self.top.as_ref(), ..)
+        let expire_iter = MapApiRO::<ExpireKey>::range(self.top.as_ref(), ..)
             .await
             .filter_map(|(k, v)| async move {
                 if let Marked::Normal {

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
@@ -28,6 +28,7 @@ use pretty_assertions::assert_eq;
 use crate::key_spaces::RaftStoreEntry;
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::MapApi;
+use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::marked::Marked;
 use crate::sm_v002::sm_v002::SMV002;
 use crate::sm_v002::SnapshotViewV002;
@@ -56,7 +57,7 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
         &btreemap! {3=>Node::new("3", Endpoint::new("3", 3))}
     );
 
-    let got = MapApi::<String>::range::<String, _>(d, ..)
+    let got = MapApiRO::<String>::range::<String, _>(d, ..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -67,7 +68,7 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
         (&s("e"), &Marked::new_normal(6, b("e1"), None)),
     ]);
 
-    let got = MapApi::<ExpireKey>::range(d, ..)
+    let got = MapApiRO::<ExpireKey>::range(d, ..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -88,7 +89,7 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
 
     let d = top_level.data_ref();
 
-    let got = MapApi::<String>::range::<String, _>(d, ..)
+    let got = MapApiRO::<String>::range::<String, _>(d, ..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -120,7 +121,7 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
         ),
     ]);
 
-    let got = MapApi::<ExpireKey>::range(d, ..)
+    let got = MapApiRO::<ExpireKey>::range(d, ..)
         .await
         .collect::<Vec<_>>()
         .await;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor(meta/state-machine): extract MapApiRO from MapApi

MapApi provides state machine read write APIs.
In order to distinguish between active memtable and read-only(static)
table(in memory or on-disk), `MetaApi` is split into a readonly API set
`MapApiRO` and the complete read-write API set `MapApi: MapApiRO`.

`MapApiRO` defines two methods `get()` and `range()`, while `MapApi`
provides `set()` methods.

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12732)
<!-- Reviewable:end -->
