### PR TITLE
chore: add a setting to disable join reorder

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -154,6 +154,12 @@ impl DefaultSettings {
                     possible_values: None,
                     display_in_show_settings: true,
                 }),
+                ("disable_join_reorder", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Disable join reorder optimization.",
+                    possible_values: None,
+                    display_in_show_settings: true,
+                }),
                 ("enable_runtime_filter", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "Enables runtime filter optimization for JOIN.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -232,6 +232,14 @@ impl Settings {
         self.try_set_u64("enable_cbo", u64::from(val))
     }
 
+    pub fn get_disable_join_reorder(&self) -> Result<bool> {
+        Ok(self.try_get_u64("disable_join_reorder")? != 0)
+    }
+
+    pub fn set_disable_join_reorder(&self, val: bool) -> Result<()> {
+        self.try_set_u64("disable_join_reorder", u64::from(val))
+    }
+
     pub fn get_runtime_filter(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_runtime_filter")? != 0)
     }

--- a/src/query/sql/src/planner/optimizer/cascades/cascade.rs
+++ b/src/query/sql/src/planner/optimizer/cascades/cascade.rs
@@ -51,9 +51,12 @@ impl CascadesOptimizer {
     pub fn create(
         ctx: Arc<dyn TableContext>,
         metadata: MetadataRef,
-        optimized: bool,
+        mut optimized: bool,
     ) -> Result<Self> {
         let explore_rule_set = if ctx.get_settings().get_enable_cbo()? {
+            if ctx.get_settings().get_disable_join_reorder()? {
+                optimized = true;
+            }
             get_explore_rule_set(optimized)
         } else {
             RuleSet::create()

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -30,6 +30,7 @@ use crate::optimizer::hyper_dp::DPhpy;
 use crate::optimizer::runtime_filter::try_add_runtime_filter_nodes;
 use crate::optimizer::util::contains_local_table_scan;
 use crate::optimizer::HeuristicOptimizer;
+use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::optimizer::DEFAULT_REWRITE_RULES;
 use crate::optimizer::RESIDUAL_RULES;
@@ -152,7 +153,7 @@ pub fn optimize_query(
     let mut result = heuristic.pre_optimize(s_expr)?;
     result = heuristic.optimize_expression(&result, &DEFAULT_REWRITE_RULES)?;
     let mut dphyp_optimized = false;
-    if ctx.get_settings().get_enable_dphyp()? {
+    if ctx.get_settings().get_enable_dphyp()? && !ctx.get_settings().get_disable_join_reorder()? {
         let (dp_res, optimized) =
             DPhpy::new(ctx.clone(), metadata.clone()).optimize(Arc::new(result.clone()))?;
         if optimized {
@@ -176,8 +177,10 @@ pub fn optimize_query(
     if enable_distributed_query {
         result = optimize_distributed_query(ctx.clone(), &result)?;
     }
-    result = heuristic.optimize_expression(&result, &RESIDUAL_RULES)?;
-    Ok(result)
+    if ctx.get_settings().get_disable_join_reorder()? {
+        return heuristic.optimize_expression(&result, &vec![RuleID::EliminateEvalScalar]);
+    }
+    heuristic.optimize_expression(&result, &RESIDUAL_RULES)
 }
 
 // TODO(leiysky): reuse the optimization logic with `optimize_query`

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -765,3 +765,41 @@ drop table onecolumn;
 
 statement ok
 drop table twocolumn;
+
+# Check if `disable_join_reorder` takes effect
+statement ok
+set disable_join_reorder = 1;
+
+query T
+explain select * from numbers(10) as t1 join numbers(20) as t2 on t1.number = t2.number;
+----
+HashJoin
+├── output columns: [t1.number (#0), t2.number (#1)]
+├── join type: INNER
+├── build keys: [t2.number (#1)]
+├── probe keys: [t1.number (#0)]
+├── filters: []
+├── estimated rows: 200.00
+├── TableScan(Build)
+│   ├── table: default.system.numbers
+│   ├── output columns: [number (#1)]
+│   ├── read rows: 20
+│   ├── read bytes: 160
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 20.00
+└── TableScan(Probe)
+    ├── table: default.system.numbers
+    ├── output columns: [number (#0)]
+    ├── read rows: 10
+    ├── read bytes: 80
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10.00
+
+
+
+statement ok
+set disable_join_reorder = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add a setting that can disable join reorder.

There are two scenes that need to disable join reorder: testing and debug.

