### PR TITLE
refactor: change state machine api from ref based to value based

### DIFF
--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -29,6 +29,7 @@ use common_meta_types::KVMeta;
 use common_meta_types::MatchSeq;
 use common_meta_types::Node;
 use common_meta_types::SeqV;
+use common_meta_types::SeqValue;
 use common_meta_types::StoredMembership;
 use common_meta_types::TxnCondition;
 use common_meta_types::TxnDeleteByPrefixRequest;
@@ -251,7 +252,7 @@ impl<'a> Applier<'a> {
         debug!(cond = as_display!(cond); "txn_execute_one_condition");
 
         let key = &cond.key;
-        let seqv = self.sm.get_kv_ref(key).await;
+        let seqv = self.sm.get_kv(key).await;
 
         debug!(
             "txn_execute_one_condition: key: {} curr: seq:{} value:{:?}",

--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_store_test.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_store_test.rs
@@ -43,7 +43,7 @@ async fn test_new_level() -> anyhow::Result<()> {
         .await;
     assert_eq!(got, vec![
         //
-        (&s("a1"), &Marked::new_normal(2, b("b1"), None)),
+        (s("a1"), Marked::new_normal(2, b("b1"), None)),
     ]);
 
     // Listing from the base level sees the old value.
@@ -55,7 +55,7 @@ async fn test_new_level() -> anyhow::Result<()> {
         .await;
     assert_eq!(got, vec![
         //
-        (&s("a1"), &Marked::new_normal(1, b("b0"), None)),
+        (s("a1"), Marked::new_normal(1, b("b0"), None)),
     ]);
 
     Ok(())
@@ -102,19 +102,19 @@ async fn test_single_level() -> anyhow::Result<()> {
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
-        (&s("a1"), &Marked::new_normal(6, b("b1"), None)),
-        (&s("a2"), &Marked::new_normal(2, b("b2"), None)),
-        (&s("a3"), &Marked::new_tomb_stone(6)),
-        (&s("x1"), &Marked::new_normal(4, b("y1"), None)),
-        (&s("x2"), &Marked::new_normal(5, b("y2"), None)),
+        (s("a1"), Marked::new_normal(6, b("b1"), None)),
+        (s("a2"), Marked::new_normal(2, b("b2"), None)),
+        (s("a3"), Marked::new_tomb_stone(6)),
+        (s("x1"), Marked::new_normal(4, b("y1"), None)),
+        (s("x2"), Marked::new_normal(5, b("y2"), None)),
     ]);
 
     // Get
     let got = MapApiRO::<String>::get(&l, "a2").await;
-    assert_eq!(got, &Marked::new_normal(2, b("b2"), None));
+    assert_eq!(got, Marked::new_normal(2, b("b2"), None));
 
     let got = MapApiRO::<String>::get(&l, "a3").await;
-    assert_eq!(got, &Marked::new_tomb_stone(6));
+    assert_eq!(got, Marked::new_tomb_stone(6));
     Ok(())
 }
 
@@ -133,10 +133,10 @@ async fn test_two_levels() -> anyhow::Result<()> {
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
-        (&s("a1"), &Marked::new_normal(1, b("b1"), None)),
-        (&s("a2"), &Marked::new_normal(2, b("b2"), None)),
-        (&s("x1"), &Marked::new_normal(3, b("y1"), None)),
-        (&s("x2"), &Marked::new_normal(4, b("y2"), None)),
+        (s("a1"), Marked::new_normal(1, b("b1"), None)),
+        (s("a2"), Marked::new_normal(2, b("b2"), None)),
+        (s("x1"), Marked::new_normal(3, b("y1"), None)),
+        (s("x2"), Marked::new_normal(4, b("y2"), None)),
     ]);
 
     // Create a new level
@@ -168,22 +168,22 @@ async fn test_two_levels() -> anyhow::Result<()> {
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
-        (&s("a1"), &Marked::new_normal(7, b("b5"), None)),
-        (&s("a2"), &Marked::new_normal(6, b("b4"), None)),
-        (&s("x1"), &Marked::new_normal(3, b("y1"), None)),
-        (&s("x2"), &Marked::new_normal(4, b("y2"), None)),
+        (s("a1"), Marked::new_normal(7, b("b5"), None)),
+        (s("a2"), Marked::new_normal(6, b("b4"), None)),
+        (s("x1"), Marked::new_normal(3, b("y1"), None)),
+        (s("x2"), Marked::new_normal(4, b("y2"), None)),
     ]);
 
     // Get
 
     let got = MapApiRO::<String>::get(&l, "a1").await;
-    assert_eq!(got, &Marked::new_normal(7, b("b5"), None));
+    assert_eq!(got, Marked::new_normal(7, b("b5"), None));
 
     let got = MapApiRO::<String>::get(&l, "a2").await;
-    assert_eq!(got, &Marked::new_normal(6, b("b4"), None));
+    assert_eq!(got, Marked::new_normal(6, b("b4"), None));
 
     let got = MapApiRO::<String>::get(&l, "w1").await;
-    assert_eq!(got, &Marked::new_tomb_stone(0));
+    assert_eq!(got, Marked::new_tomb_stone(0));
 
     // Check base level
 
@@ -193,10 +193,10 @@ async fn test_two_levels() -> anyhow::Result<()> {
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
-        (&s("a1"), &Marked::new_normal(1, b("b1"), None)),
-        (&s("a2"), &Marked::new_normal(2, b("b2"), None)),
-        (&s("x1"), &Marked::new_normal(3, b("y1"), None)),
-        (&s("x2"), &Marked::new_normal(4, b("y2"), None)),
+        (s("a1"), Marked::new_normal(1, b("b1"), None)),
+        (s("a2"), Marked::new_normal(2, b("b2"), None)),
+        (s("x1"), Marked::new_normal(3, b("y1"), None)),
+        (s("x2"), Marked::new_normal(4, b("y2"), None)),
     ]);
 
     Ok(())
@@ -234,22 +234,22 @@ async fn test_three_levels_get_range() -> anyhow::Result<()> {
     let l = build_3_levels().await;
 
     let got = MapApiRO::<String>::get(&l, "a").await;
-    assert_eq!(got, &Marked::new_normal(1, b("a0"), None));
+    assert_eq!(got, Marked::new_normal(1, b("a0"), None));
 
     let got = MapApiRO::<String>::get(&l, "b").await;
-    assert_eq!(got, &Marked::new_tomb_stone(4));
+    assert_eq!(got, Marked::new_tomb_stone(4));
 
     let got = MapApiRO::<String>::get(&l, "c").await;
-    assert_eq!(got, &Marked::new_tomb_stone(6));
+    assert_eq!(got, Marked::new_tomb_stone(6));
 
     let got = MapApiRO::<String>::get(&l, "d").await;
-    assert_eq!(got, &Marked::new_normal(7, b("d2"), None));
+    assert_eq!(got, Marked::new_normal(7, b("d2"), None));
 
     let got = MapApiRO::<String>::get(&l, "e").await;
-    assert_eq!(got, &Marked::new_normal(6, b("e1"), None));
+    assert_eq!(got, Marked::new_normal(6, b("e1"), None));
 
     let got = MapApiRO::<String>::get(&l, "f").await;
-    assert_eq!(got, &Marked::new_tomb_stone(0));
+    assert_eq!(got, Marked::new_tomb_stone(0));
 
     let got = MapApiRO::<String>::range(&l, s("")..)
         .await
@@ -257,11 +257,11 @@ async fn test_three_levels_get_range() -> anyhow::Result<()> {
         .await;
     assert_eq!(got, vec![
         //
-        (&s("a"), &Marked::new_normal(1, b("a0"), None)),
-        (&s("b"), &Marked::new_tomb_stone(4)),
-        (&s("c"), &Marked::new_tomb_stone(6)),
-        (&s("d"), &Marked::new_normal(7, b("d2"), None)),
-        (&s("e"), &Marked::new_normal(6, b("e1"), None)),
+        (s("a"), Marked::new_normal(1, b("a0"), None)),
+        (s("b"), Marked::new_tomb_stone(4)),
+        (s("c"), Marked::new_tomb_stone(6)),
+        (s("d"), Marked::new_normal(7, b("d2"), None)),
+        (s("e"), Marked::new_normal(6, b("e1"), None)),
     ]);
 
     Ok(())
@@ -301,12 +301,12 @@ async fn test_three_levels_override() -> anyhow::Result<()> {
         .await;
     assert_eq!(got, vec![
         //
-        (&s("a"), &Marked::new_normal(8, b("x"), None)),
-        (&s("b"), &Marked::new_normal(9, b("y"), None)),
-        (&s("c"), &Marked::new_normal(10, b("z"), None)),
-        (&s("d"), &Marked::new_normal(11, b("u"), None)),
-        (&s("e"), &Marked::new_normal(12, b("v"), None)),
-        (&s("f"), &Marked::new_normal(13, b("w"), None)),
+        (s("a"), Marked::new_normal(8, b("x"), None)),
+        (s("b"), Marked::new_normal(9, b("y"), None)),
+        (s("c"), Marked::new_normal(10, b("z"), None)),
+        (s("d"), Marked::new_normal(11, b("u"), None)),
+        (s("e"), Marked::new_normal(12, b("v"), None)),
+        (s("f"), Marked::new_normal(13, b("w"), None)),
     ]);
 
     Ok(())
@@ -346,11 +346,11 @@ async fn test_three_levels_delete() -> anyhow::Result<()> {
         .await;
     assert_eq!(got, vec![
         //
-        (&s("a"), &Marked::new_tomb_stone(7)),
-        (&s("b"), &Marked::new_tomb_stone(7)),
-        (&s("c"), &Marked::new_tomb_stone(7)),
-        (&s("d"), &Marked::new_tomb_stone(7)),
-        (&s("e"), &Marked::new_tomb_stone(7)),
+        (s("a"), Marked::new_tomb_stone(7)),
+        (s("b"), Marked::new_tomb_stone(7)),
+        (s("c"), Marked::new_tomb_stone(7)),
+        (s("d"), Marked::new_tomb_stone(7)),
+        (s("e"), Marked::new_tomb_stone(7)),
     ]);
 
     Ok(())
@@ -414,7 +414,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         let got = MapApiRO::<String>::get(&l, "a").await;
         assert_eq!(
             got,
-            &Marked::new_normal(6, b("a1"), Some(KVMeta { expire_at: Some(1) }))
+            Marked::new_normal(6, b("a1"), Some(KVMeta { expire_at: Some(1) }))
         );
     }
 
@@ -447,7 +447,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         let got = MapApiRO::<String>::get(&l, "b").await;
         assert_eq!(
             got,
-            &Marked::new_normal(
+            Marked::new_normal(
                 6,
                 b("x1"),
                 Some(KVMeta {
@@ -466,7 +466,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         assert_eq!(result, Marked::new_normal(6, b("d1"), None));
 
         let got = MapApiRO::<String>::get(&l, "d").await;
-        assert_eq!(got, &Marked::new_normal(6, b("d1"), None));
+        assert_eq!(got, Marked::new_normal(6, b("d1"), None));
     }
 
     Ok(())
@@ -493,7 +493,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let got = MapApiRO::<String>::get(&l, "a").await;
         assert_eq!(
             got,
-            &Marked::new_normal(6, b("a0"), Some(KVMeta { expire_at: Some(2) }))
+            Marked::new_normal(6, b("a0"), Some(KVMeta { expire_at: Some(2) }))
         );
     }
 
@@ -515,7 +515,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         assert_eq!(result, Marked::new_normal(6, b("b1"), None));
 
         let got = MapApiRO::<String>::get(&l, "b").await;
-        assert_eq!(got, &Marked::new_normal(6, b("b1"), None));
+        assert_eq!(got, Marked::new_normal(6, b("b1"), None));
     }
 
     // Update meta for c.
@@ -545,7 +545,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let got = MapApiRO::<String>::get(&l, "c").await;
         assert_eq!(
             got,
-            &Marked::new_normal(
+            Marked::new_normal(
                 6,
                 b("c1"),
                 Some(KVMeta {
@@ -566,7 +566,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         assert_eq!(result, Marked::new_tomb_stone(0));
 
         let got = MapApiRO::<String>::get(&l, "d").await;
-        assert_eq!(got, &Marked::new_tomb_stone(0));
+        assert_eq!(got, Marked::new_tomb_stone(0));
     }
 
     Ok(())

--- a/src/meta/raft-store/src/sm_v002/marked/marked_test.rs
+++ b/src/meta/raft-store/src/sm_v002/marked/marked_test.rs
@@ -77,13 +77,16 @@ fn test_internal_seq() -> anyhow::Result<()> {
 #[test]
 fn test_unpack() -> anyhow::Result<()> {
     let m = Marked::new_normal(1, 2, None);
-    assert_eq!(m.unpack(), Some((&2, None)));
+    assert_eq!(m.unpack_ref(), Some((&2, None)));
 
     let m = Marked::new_normal(1, 2, Some(KVMeta { expire_at: Some(3) }));
-    assert_eq!(m.unpack(), Some((&2, Some(&KVMeta { expire_at: Some(3) }))));
+    assert_eq!(
+        m.unpack_ref(),
+        Some((&2, Some(&KVMeta { expire_at: Some(3) })))
+    );
 
     let m: Marked<u64> = Marked::new_tomb_stone(1);
-    assert_eq!(m.unpack(), None);
+    assert_eq!(m.unpack_ref(), None);
 
     Ok(())
 }
@@ -95,13 +98,13 @@ fn test_max() -> anyhow::Result<()> {
     let m2 = Marked::new_normal(3, 2, None);
     let m3: Marked<u64> = Marked::new_tomb_stone(2);
 
-    assert_eq!(Marked::max(&m1, &m2), &m2);
-    assert_eq!(Marked::max(&m1, &m3), &m3);
-    assert_eq!(Marked::max(&m2, &m3), &m2);
+    assert_eq!(Marked::max_ref(&m1, &m2), &m2);
+    assert_eq!(Marked::max_ref(&m1, &m3), &m3);
+    assert_eq!(Marked::max_ref(&m2, &m3), &m2);
 
-    assert_eq!(Marked::max(&m1, &m1), &m1);
-    assert_eq!(Marked::max(&m2, &m2), &m2);
-    assert_eq!(Marked::max(&m3, &m3), &m3);
+    assert_eq!(Marked::max_ref(&m1, &m1), &m1);
+    assert_eq!(Marked::max_ref(&m2, &m2), &m2);
+    assert_eq!(Marked::max_ref(&m3, &m3), &m3);
 
     Ok(())
 }

--- a/src/meta/raft-store/src/sm_v002/marked/mod.rs
+++ b/src/meta/raft-store/src/sm_v002/marked/mod.rs
@@ -104,7 +104,18 @@ impl<T> Marked<T> {
         }
     }
 
-    pub fn unpack(&self) -> Option<(&T, Option<&KVMeta>)> {
+    pub fn unpack(self) -> Option<(T, Option<KVMeta>)> {
+        match self {
+            Marked::TombStone { internal_seq: _ } => None,
+            Marked::Normal {
+                internal_seq: _,
+                value,
+                meta,
+            } => Some((value, meta)),
+        }
+    }
+
+    pub fn unpack_ref(&self) -> Option<(&T, Option<&KVMeta>)> {
         match self {
             Marked::TombStone { internal_seq: _ } => None,
             Marked::Normal {
@@ -116,7 +127,16 @@ impl<T> Marked<T> {
     }
 
     /// Return the one with the larger sequence number.
-    pub fn max<'l>(a: &'l Self, b: &'l Self) -> &'l Self {
+    pub fn max(a: Self, b: Self) -> Self {
+        if a.internal_seq() > b.internal_seq() {
+            a
+        } else {
+            b
+        }
+    }
+
+    /// Return the one with the larger sequence number.
+    pub fn max_ref<'l>(a: &'l Self, b: &'l Self) -> &'l Self {
         if a.internal_seq() > b.internal_seq() {
             a
         } else {

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
@@ -93,8 +93,7 @@ impl SnapshotViewV002 {
             .filter(|(_k, v)| {
                 let x = !v.is_tomb_stone();
                 async move { x }
-            })
-            .map(|(k, v)| (k.clone(), v.clone()));
+            });
 
         let btreemap = strm.collect().await;
 
@@ -106,8 +105,7 @@ impl SnapshotViewV002 {
             .filter(|(_k, v)| {
                 let x = !v.is_tomb_stone();
                 async move { x }
-            })
-            .map(|(k, v)| (k.clone(), v.clone()));
+            });
 
         let btreemap = strm.collect().await;
 
@@ -178,7 +176,7 @@ impl SnapshotViewV002 {
                     meta,
                 } = v
                 {
-                    let seqv = SeqV::with_meta(*internal_seq, meta.clone(), value.clone());
+                    let seqv = SeqV::with_meta(internal_seq, meta, value);
                     Some(RaftStoreEntry::GenericKV {
                         key: k.clone(),
                         value: seqv,
@@ -199,7 +197,7 @@ impl SnapshotViewV002 {
                     meta: _,
                 } = v
                 {
-                    let ev = ExpireValue::new(value, *internal_seq);
+                    let ev = ExpireValue::new(value, internal_seq);
 
                     Some(RaftStoreEntry::Expire {
                         key: k.clone(),

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
@@ -63,9 +63,9 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
         .await;
     assert_eq!(got, vec![
         //
-        (&s("a"), &Marked::new_normal(1, b("a0"), None)),
-        (&s("d"), &Marked::new_normal(7, b("d2"), None)),
-        (&s("e"), &Marked::new_normal(6, b("e1"), None)),
+        (s("a"), Marked::new_normal(1, b("a0"), None)),
+        (s("d"), Marked::new_normal(7, b("d2"), None)),
+        (s("e"), Marked::new_normal(6, b("e1"), None)),
     ]);
 
     let got = MapApiRO::<ExpireKey>::range(d, ..)
@@ -96,8 +96,8 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
     assert_eq!(got, vec![
         //
         (
-            &s("a"),
-            &Marked::new_normal(
+            s("a"),
+            Marked::new_normal(
                 4,
                 b("a1"),
                 Some(KVMeta {
@@ -106,12 +106,12 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
             )
         ),
         (
-            &s("b"),
-            &Marked::new_normal(2, b("b0"), Some(KVMeta { expire_at: Some(5) }))
+            s("b"),
+            Marked::new_normal(2, b("b0"), Some(KVMeta { expire_at: Some(5) }))
         ),
         (
-            &s("c"),
-            &Marked::new_normal(
+            s("c"),
+            Marked::new_normal(
                 3,
                 b("c0"),
                 Some(KVMeta {
@@ -128,16 +128,16 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
     assert_eq!(got, vec![
         //
         (
-            &ExpireKey::new(5_000, 2),
-            &Marked::new_normal(2, s("b"), None)
+            ExpireKey::new(5_000, 2),
+            Marked::new_normal(2, s("b"), None)
         ),
         (
-            &ExpireKey::new(15_000, 4),
-            &Marked::new_normal(4, s("a"), None)
+            ExpireKey::new(15_000, 4),
+            Marked::new_normal(4, s("a"), None)
         ),
         (
-            &ExpireKey::new(20_000, 3),
-            &Marked::new_normal(3, s("c"), None)
+            ExpireKey::new(20_000, 3),
+            Marked::new_normal(3, s("c"), None)
         ),
     ]);
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### Refactor: change state machine api from ref based to value based

In order to adapt to the on-disk map API.

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12761)
<!-- Reviewable:end -->
