### PR TITLE
chore: bump opensrv-mysql to v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8346,8 +8346,9 @@ dependencies = [
 
 [[package]]
 name = "opensrv-mysql"
-version = "0.4.0"
-source = "git+https://github.com/datafuselabs/opensrv?rev=bcfcf8e#bcfcf8e956a033f19c3a99fd7a88eebea385e550"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c66063eb6aca9e6b5354f91db29f7244a8e7f9c01219b3ce76a5340a78d9f6f"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -138,7 +138,7 @@ minitrace = { workspace = true }
 naive-cityhash = "0.2.0"
 once_cell = "1.15.0"
 opendal = { workspace = true }
-opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "bcfcf8e", features = ["tls"] }
+opensrv-mysql = { version = "0.4.1", features = ["tls"] }
 parking_lot = "0.12.1"
 paste = "1.0.9"
 petgraph = "0.6.2"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

in opensrv-mysql v0.4.1, we fixed a memory safety issue.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12766)
<!-- Reviewable:end -->
