### PR TITLE
refactor: let Level manage multi level data instead of using a chain of Arc

### DIFF
--- a/src/meta/raft-store/src/sm_v002/importer.rs
+++ b/src/meta/raft-store/src/sm_v002/importer.rs
@@ -21,6 +21,7 @@ use common_meta_types::StoredMembership;
 
 use crate::key_spaces::RaftStoreEntry;
 use crate::sm_v002::leveled_store::level_data::LevelData;
+use crate::sm_v002::leveled_store::meta_api::MetaApiRO;
 use crate::sm_v002::marked::Marked;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::StateMachineMetaKey;

--- a/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
@@ -43,10 +43,6 @@ impl Level {
         Self { data, base }
     }
 
-    pub(crate) fn data(&self) -> &LevelData {
-        &self.data
-    }
-
     pub(crate) fn base(&self) -> Option<&Self> {
         self.base.as_ref().map(|x| x.as_ref())
     }
@@ -96,7 +92,7 @@ where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
     {
-        let api = self.data();
+        let api = self.data_ref();
         let got = api.get(key).await;
 
         if got.is_not_found() {
@@ -115,7 +111,7 @@ where
         T: Ord,
         R: RangeBounds<T> + Clone + Send + Sync,
     {
-        let a = self.data().range(range.clone()).await;
+        let a = self.data_ref().range(range.clone()).await;
 
         let km = KMerge::by(|a: &(K, Marked<Self::V>), b: &(K, Marked<Self::V>)| {
             let (k1, v1) = a;

--- a/src/meta/raft-store/src/sm_v002/leveled_store/level_data.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level_data.rs
@@ -27,6 +27,7 @@ use log::debug;
 
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
+use crate::sm_v002::leveled_store::meta_api::MetaApiRO;
 use crate::sm_v002::marked::Marked;
 use crate::state_machine::ExpireKey;
 
@@ -83,10 +84,6 @@ impl LevelData {
         self.expire = expire;
     }
 
-    pub(crate) fn curr_seq(&self) -> u64 {
-        self.sequence
-    }
-
     pub(crate) fn update_seq(&mut self, seq: u64) {
         self.sequence = seq;
     }
@@ -98,21 +95,6 @@ impl LevelData {
         // dbg!("next_seq", self.sequence);
 
         self.sequence
-    }
-
-    // Cloned data is accessed directly
-    pub fn last_applied_ref(&self) -> &Option<LogId> {
-        &self.last_applied
-    }
-
-    // Cloned data is accessed directly
-    pub fn last_membership_ref(&self) -> &StoredMembership {
-        &self.last_membership
-    }
-
-    // Cloned data is accessed directly
-    pub(crate) fn nodes_ref(&self) -> &BTreeMap<NodeId, Node> {
-        &self.nodes
     }
 
     // Cloned data is accessed directly
@@ -232,5 +214,23 @@ impl MapApi<ExpireKey> for LevelData {
         let prev = MapApiRO::<ExpireKey>::get(self, &key).await;
         self.expire.insert(key, marked.clone());
         (prev, marked)
+    }
+}
+
+impl MetaApiRO for LevelData {
+    fn curr_seq(&self) -> u64 {
+        self.sequence
+    }
+
+    fn last_applied_ref(&self) -> &Option<LogId> {
+        &self.last_applied
+    }
+
+    fn last_membership_ref(&self) -> &StoredMembership {
+        &self.last_membership
+    }
+
+    fn nodes_ref(&self) -> &BTreeMap<NodeId, Node> {
+        &self.nodes
     }
 }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map.rs
@@ -25,62 +25,65 @@ use stream_more::StreamMore;
 use crate::sm_v002::leveled_store::level_data::LevelData;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
+use crate::sm_v002::leveled_store::static_leveled_map::StaticLeveledMap;
+use crate::sm_v002::leveled_store::util;
 use crate::sm_v002::marked::Marked;
 
 /// One level of state machine data.
 ///
 /// State machine data is constructed from multiple levels of modifications, similar to leveldb.
 #[derive(Debug, Default)]
-pub struct Level {
-    data: LevelData,
+pub struct LeveledMap {
+    /// The top level is the newest and writable.
+    writable: LevelData,
 
-    /// This level is built with additional modifications `data` on top of the previous level.
-    base: Option<Arc<Level>>,
+    /// The base immutable levels from the oldest to the newest.
+    /// levels[0] is the bottom oldest level.
+    frozen_levels: StaticLeveledMap,
 }
 
-impl Level {
-    pub(crate) fn new(data: LevelData, base: Option<Arc<Self>>) -> Self {
-        Self { data, base }
+impl LeveledMap {
+    pub(crate) fn new(writable: LevelData) -> Self {
+        Self {
+            writable,
+            frozen_levels: Default::default(),
+        }
     }
 
-    pub(crate) fn base(&self) -> Option<&Self> {
-        self.base.as_ref().map(|x| x.as_ref())
+    /// Return an iterator of all levels in reverse order.
+    pub(in crate::sm_v002) fn iter_levels(&self) -> impl Iterator<Item = &LevelData> {
+        [&self.writable]
+            .into_iter()
+            .chain(self.frozen_levels.levels())
     }
 
-    pub fn new_level(&mut self) {
-        let new = Level {
-            data: self.data.new_level(),
-            base: None,
-        };
+    /// Freeze the current writable level and create a new writable level.
+    pub fn freeze_writable(&mut self) {
+        let new_level = self.writable.new_level();
 
-        let base = std::mem::replace(self, new);
-
-        self.base = Some(Arc::new(base));
+        let base = std::mem::replace(&mut self.writable, new_level);
+        self.frozen_levels.push(Arc::new(base));
     }
 
-    pub fn data_ref(&self) -> &LevelData {
-        &self.data
+    pub fn writable_ref(&self) -> &LevelData {
+        &self.writable
     }
 
-    pub fn data_mut(&mut self) -> &mut LevelData {
-        &mut self.data
+    pub fn writable_mut(&mut self) -> &mut LevelData {
+        &mut self.writable
     }
 
-    pub fn get_base(&self) -> Option<Arc<Self>> {
-        self.base.clone()
+    pub fn frozen_ref(&self) -> &StaticLeveledMap {
+        &self.frozen_levels
     }
 
-    pub(crate) fn replace_base(&mut self, b: Option<Arc<Level>>) {
-        self.base = b;
-    }
-
-    pub fn snapshot(&self) -> Option<Arc<Self>> {
-        self.base.clone()
+    pub(crate) fn replace_frozen_levels(&mut self, b: StaticLeveledMap) {
+        self.frozen_levels = b;
     }
 }
 
 #[async_trait::async_trait]
-impl<K> MapApiRO<K> for Level
+impl<K> MapApiRO<K> for LeveledMap
 where
     K: Ord + fmt::Debug + Send + Sync + Unpin + 'static,
     LevelData: MapApiRO<K>,
@@ -92,15 +95,13 @@ where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
     {
-        let api = self.data_ref();
-        let got = api.get(key).await;
-
-        if got.is_not_found() {
-            if let Some(base) = self.base() {
-                return base.get(key).await;
+        for level_data in self.iter_levels() {
+            let got = level_data.get(key).await;
+            if !got.is_not_found() {
+                return got;
             }
         }
-        got
+        return Marked::empty();
     }
 
     async fn range<'a, T: ?Sized, R>(&'a self, range: R) -> BoxStream<'a, (K, Marked<Self::V>)>
@@ -111,42 +112,22 @@ where
         T: Ord,
         R: RangeBounds<T> + Clone + Send + Sync,
     {
-        let a = self.data_ref().range(range.clone()).await;
+        let mut km = KMerge::by(util::by_key_seq);
 
-        let km = KMerge::by(|a: &(K, Marked<Self::V>), b: &(K, Marked<Self::V>)| {
-            let (k1, v1) = a;
-            let (k2, v2) = b;
-
-            assert_ne!((k1, v1.internal_seq()), (k2, v2.internal_seq()));
-
-            // Put entries with the same key together, smaller internal-seq first
-            // Tombstone is always greater.
-            (k1, v1.internal_seq()) <= (k2, v2.internal_seq())
-        })
-        .merge(a);
-
-        let km = if let Some(base) = self.base() {
-            let b = base.range(range).await;
-            km.merge(b)
-        } else {
-            km
-        };
+        for api in self.iter_levels() {
+            let a = api.range(range.clone()).await;
+            km = km.merge(a);
+        }
 
         // Merge entries with the same key, keep the one with larger internal-seq
-        let m = km.coalesce(|(k1, v1), (k2, v2)| {
-            if k1 == k2 {
-                Ok((k1, Marked::max(v1, v2)))
-            } else {
-                Err(((k1, v1), (k2, v2)))
-            }
-        });
+        let m = km.coalesce(util::choose_greater);
 
         Box::pin(m)
     }
 }
 
 #[async_trait::async_trait]
-impl<K> MapApi<K> for Level
+impl<K> MapApi<K> for LeveledMap
 where
     K: Ord + fmt::Debug + Send + Sync + Unpin + 'static,
     LevelData: MapApi<K>,
@@ -168,7 +149,7 @@ where
         }
 
         // The data is a single level map and the returned `_prev` is only from that level.
-        let (_prev, inserted) = self.data_mut().set(key, value).await;
+        let (_prev, inserted) = self.writable_mut().set(key, value).await;
         (prev, inserted)
     }
 }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
@@ -15,14 +15,14 @@
 use common_meta_types::KVMeta;
 use futures_util::StreamExt;
 
-use crate::sm_v002::leveled_store::level::Level;
+use crate::sm_v002::leveled_store::leveled_map::LeveledMap;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::marked::Marked;
 
 #[tokio::test]
-async fn test_new_level() -> anyhow::Result<()> {
-    let mut l = Level::default();
+async fn test_freeze() -> anyhow::Result<()> {
+    let mut l = LeveledMap::default();
 
     // Insert an entry at level 0
     let (prev, result) = MapApi::<String>::set(&mut l, s("a1"), Some((b("b0"), None))).await;
@@ -30,7 +30,7 @@ async fn test_new_level() -> anyhow::Result<()> {
     assert_eq!(result, Marked::new_normal(1, b("b0"), None));
 
     // Insert the same entry at level 1
-    l.new_level();
+    l.freeze_writable();
 
     let (prev, result) = MapApi::<String>::set(&mut l, s("a1"), Some((b("b1"), None))).await;
     assert_eq!(prev, Marked::new_normal(1, b("b0"), None));
@@ -47,9 +47,9 @@ async fn test_new_level() -> anyhow::Result<()> {
     ]);
 
     // Listing from the base level sees the old value.
-    let base = l.get_base().unwrap();
+    let base = l.frozen_ref();
 
-    let got = MapApiRO::<String>::range(base.as_ref(), s("")..)
+    let got = MapApiRO::<String>::range(base, s("")..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -63,7 +63,7 @@ async fn test_new_level() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_single_level() -> anyhow::Result<()> {
-    let mut l = Level::default();
+    let mut l = LeveledMap::default();
 
     // Write a1
     let (prev, result) = MapApi::<String>::set(&mut l, s("a1"), Some((b("b1"), None))).await;
@@ -122,7 +122,7 @@ async fn test_single_level() -> anyhow::Result<()> {
 async fn test_two_levels() -> anyhow::Result<()> {
     // Create the first level
 
-    let mut l = Level::default();
+    let mut l = LeveledMap::default();
 
     MapApi::<String>::set(&mut l, s("a1"), Some((b("b1"), None))).await;
     MapApi::<String>::set(&mut l, s("a2"), Some((b("b2"), None))).await;
@@ -141,7 +141,7 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     // Create a new level
 
-    l.new_level();
+    l.freeze_writable();
 
     // Override
     let (prev, result) = MapApi::<String>::set(&mut l, s("a2"), Some((b("b3"), None))).await;
@@ -187,9 +187,9 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     // Check base level
 
-    let base = l.get_base().unwrap();
+    let base = l.frozen_ref();
 
-    let it = MapApiRO::<String>::range(base.as_ref(), s("")..).await;
+    let it = MapApiRO::<String>::range(base, s("")..).await;
     let got = it.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         //
@@ -207,21 +207,21 @@ async fn test_two_levels() -> anyhow::Result<()> {
 /// l2 |         c(D) d
 /// l1 |    b(D) c        e
 /// l0 | a  b    c    d
-async fn build_3_levels() -> Level {
-    let mut l = Level::default();
+async fn build_3_levels() -> LeveledMap {
+    let mut l = LeveledMap::default();
     // internal_seq: 0
     MapApi::<String>::set(&mut l, s("a"), Some((b("a0"), None))).await;
     MapApi::<String>::set(&mut l, s("b"), Some((b("b0"), None))).await;
     MapApi::<String>::set(&mut l, s("c"), Some((b("c0"), None))).await;
     MapApi::<String>::set(&mut l, s("d"), Some((b("d0"), None))).await;
 
-    l.new_level();
+    l.freeze_writable();
     // internal_seq: 4
     MapApi::<String>::set(&mut l, s("b"), None).await;
     MapApi::<String>::set(&mut l, s("c"), Some((b("c1"), None))).await;
     MapApi::<String>::set(&mut l, s("e"), Some((b("e1"), None))).await;
 
-    l.new_level();
+    l.freeze_writable();
     // internal_seq: 6
     MapApi::<String>::set(&mut l, s("c"), None).await;
     MapApi::<String>::set(&mut l, s("d"), Some((b("d2"), None))).await;
@@ -358,8 +358,8 @@ async fn test_three_levels_delete() -> anyhow::Result<()> {
 
 /// |      b(m) c
 /// | a(m) b    c(m)
-async fn build_2_level_with_meta() -> Level {
-    let mut l = Level::default();
+async fn build_2_level_with_meta() -> LeveledMap {
+    let mut l = LeveledMap::default();
 
     // internal_seq: 0
     MapApi::<String>::set(
@@ -376,7 +376,7 @@ async fn build_2_level_with_meta() -> Level {
     )
     .await;
 
-    l.new_level();
+    l.freeze_writable();
 
     // internal_seq: 3
     MapApi::<String>::set(

--- a/src/meta/raft-store/src/sm_v002/leveled_store/meta_api.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/meta_api.rs
@@ -12,12 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod level_data;
-pub mod leveled_map;
-pub mod map_api;
-pub mod meta_api;
-pub mod static_leveled_map;
-pub mod util;
+use std::collections::BTreeMap;
 
-#[cfg(test)]
-mod leveled_map_test;
+use common_meta_types::LogId;
+use common_meta_types::Node;
+use common_meta_types::NodeId;
+use common_meta_types::StoredMembership;
+
+/// APIs to access the non-user-data of the state machine(leveled map).
+pub(in crate::sm_v002) trait MetaApiRO {
+    fn curr_seq(&self) -> u64;
+
+    fn last_applied_ref(&self) -> &Option<LogId>;
+
+    fn last_membership_ref(&self) -> &StoredMembership;
+
+    fn nodes_ref(&self) -> &BTreeMap<NodeId, Node>;
+}

--- a/src/meta/raft-store/src/sm_v002/leveled_store/static_leveled_map.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/static_leveled_map.rs
@@ -1,0 +1,98 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::RangeBounds;
+use std::sync::Arc;
+
+use futures_util::stream::BoxStream;
+use stream_more::KMerge;
+use stream_more::StreamMore;
+
+use crate::sm_v002::leveled_store::level_data::LevelData;
+use crate::sm_v002::leveled_store::map_api::MapApiRO;
+use crate::sm_v002::leveled_store::util;
+use crate::sm_v002::marked::Marked;
+
+#[derive(Debug, Default, Clone)]
+pub struct StaticLeveledMap {
+    /// From oldest to newest, i.e., levels[0] is the oldest
+    levels: Vec<Arc<LevelData>>,
+}
+
+impl StaticLeveledMap {
+    pub(in crate::sm_v002) fn new(levels: impl IntoIterator<Item = Arc<LevelData>>) -> Self {
+        Self {
+            levels: levels.into_iter().collect(),
+        }
+    }
+
+    /// Return an iterator of all levels from newest to oldest.
+    pub(in crate::sm_v002) fn levels(&self) -> impl Iterator<Item = &LevelData> {
+        self.levels.iter().map(|x| x.as_ref()).rev()
+    }
+
+    pub(in crate::sm_v002) fn newest(&self) -> Option<&Arc<LevelData>> {
+        self.levels.last()
+    }
+
+    pub(in crate::sm_v002) fn push(&mut self, level: Arc<LevelData>) {
+        self.levels.push(level);
+    }
+}
+
+#[async_trait::async_trait]
+impl<K> MapApiRO<K> for StaticLeveledMap
+where
+    K: Ord + fmt::Debug + Send + Sync + Unpin + 'static,
+    LevelData: MapApiRO<K>,
+{
+    type V = <LevelData as MapApiRO<K>>::V;
+
+    async fn get<Q>(&self, key: &Q) -> Marked<Self::V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + Send + Sync + ?Sized,
+    {
+        for level_data in self.levels() {
+            let got = level_data.get(key).await;
+            if !got.is_not_found() {
+                return got;
+            }
+        }
+        return Marked::empty();
+    }
+
+    async fn range<'a, T: ?Sized, R>(&'a self, range: R) -> BoxStream<'a, (K, Marked<Self::V>)>
+    where
+        K: 'a,
+        K: Borrow<T> + Clone,
+        Self::V: Unpin,
+        T: Ord,
+        R: RangeBounds<T> + Clone + Send + Sync,
+    {
+        let mut km = KMerge::by(util::by_key_seq::<K, Self::V>);
+
+        for api in self.levels() {
+            let a = api.range(range.clone()).await;
+            km = km.merge(a);
+        }
+
+        // keep one of the entries with the same key, which has larger internal-seq
+        let m = km.coalesce(util::choose_greater);
+
+        Box::pin(m)
+    }
+}

--- a/src/meta/raft-store/src/sm_v002/leveled_store/util.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/util.rs
@@ -1,0 +1,46 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use crate::sm_v002::marked::Marked;
+
+type Tuple<K, V> = (K, Marked<V>);
+
+/// Sort by key and internal_seq.
+/// Return `true` if `a` should be placed before `b`, e.g., `a` is smaller.
+pub(in crate::sm_v002) fn by_key_seq<K, V>((k1, v1): &Tuple<K, V>, (k2, v2): &Tuple<K, V>) -> bool
+where K: Ord + fmt::Debug {
+    assert_ne!((k1, v1.internal_seq()), (k2, v2.internal_seq()));
+
+    // Put entries with the same key together, smaller internal-seq first
+    // Tombstone is always greater.
+    (k1, v1.internal_seq()) <= (k2, v2.internal_seq())
+}
+
+/// Return `true` if `a` should be placed before `b`, e.g., `a` is smaller.
+#[allow(clippy::type_complexity)]
+pub(in crate::sm_v002) fn choose_greater<K, V>(
+    (k1, v1): Tuple<K, V>,
+    (k2, v2): Tuple<K, V>,
+) -> Result<Tuple<K, V>, (Tuple<K, V>, Tuple<K, V>)>
+where
+    K: Ord,
+{
+    if k1 == k2 {
+        Ok((k1, Marked::max(v1, v2)))
+    } else {
+        Err(((k1, v1), (k2, v2)))
+    }
+}

--- a/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
@@ -77,7 +77,7 @@ async fn test_two_level_upsert_get_range() -> anyhow::Result<()> {
     sm.upsert_kv(UpsertKV::update("a/b", b"b0")).await;
     sm.upsert_kv(UpsertKV::update("c", b"c0")).await;
 
-    sm.top.new_level();
+    sm.top.freeze_writable();
 
     // internal_seq = 3
     sm.upsert_kv(UpsertKV::delete("a/b")).await;
@@ -154,7 +154,7 @@ async fn build_sm_with_expire() -> SMV002 {
     sm.upsert_kv(UpsertKV::update("b", b"b0").with_expire_sec(5))
         .await;
 
-    sm.top.new_level();
+    sm.top.freeze_writable();
 
     sm.upsert_kv(UpsertKV::update("c", b"c0").with_expire_sec(20))
         .await;

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
@@ -26,9 +26,11 @@ use openraft::testing::log_id;
 use pretty_assertions::assert_eq;
 
 use crate::key_spaces::RaftStoreEntry;
-use crate::sm_v002::leveled_store::level::Level;
+use crate::sm_v002::leveled_store::leveled_map::LeveledMap;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
+use crate::sm_v002::leveled_store::meta_api::MetaApiRO;
+use crate::sm_v002::leveled_store::static_leveled_map::StaticLeveledMap;
 use crate::sm_v002::marked::Marked;
 use crate::sm_v002::sm_v002::SMV002;
 use crate::sm_v002::SnapshotViewV002;
@@ -36,17 +38,19 @@ use crate::state_machine::ExpireKey;
 
 #[tokio::test]
 async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
-    let l = build_3_levels().await;
+    let mut l = build_3_levels().await;
 
-    let mut snapshot = SnapshotViewV002::new(Arc::new(l));
+    l.freeze_writable();
+
+    let mut snapshot = SnapshotViewV002::new(l.frozen_ref().clone());
 
     snapshot.compact().await;
 
-    let top_level = snapshot.top();
+    let top_level = snapshot.compacted();
 
-    let d = top_level.data_ref();
+    let d = top_level.newest().unwrap().as_ref();
 
-    assert!(top_level.get_base().is_none());
+    assert_eq!(top_level.levels().count(), 1);
     assert_eq!(
         d.last_membership_ref(),
         &StoredMembership::new(Some(log_id(3, 3, 3)), Membership::new(vec![], ()))
@@ -85,9 +89,9 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
 
     snapshot.compact().await;
 
-    let top_level = snapshot.top();
+    let compacted = snapshot.compacted();
 
-    let d = top_level.data_ref();
+    let d = compacted.newest().unwrap().as_ref();
 
     let got = MapApiRO::<String>::range::<String, _>(d, ..)
         .await
@@ -146,9 +150,11 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_export_3_level() -> anyhow::Result<()> {
-    let l = build_3_levels().await;
+    let mut l = build_3_levels().await;
 
-    let snapshot = SnapshotViewV002::new(Arc::new(l));
+    l.freeze_writable();
+
+    let snapshot = SnapshotViewV002::new(l.frozen_ref().clone());
     let got = snapshot
         .export()
         .await
@@ -221,7 +227,7 @@ async fn test_import() -> anyhow::Result<()> {
 
     let d = SMV002::import(data)?;
 
-    let snapshot = SnapshotViewV002::new(Arc::new(Level::new(d, None)));
+    let snapshot = SnapshotViewV002::new(StaticLeveledMap::new([Arc::new(d)]));
 
     let got = snapshot
         .export()
@@ -240,13 +246,13 @@ async fn test_import() -> anyhow::Result<()> {
 /// l2 |         c(D) d
 /// l1 |    b(D) c        e
 /// l0 | a  b    c    d
-async fn build_3_levels() -> Level {
-    let mut l = Level::default();
+async fn build_3_levels() -> LeveledMap {
+    let mut l = LeveledMap::default();
 
-    *l.data_mut().last_membership_mut() =
+    *l.writable_mut().last_membership_mut() =
         StoredMembership::new(Some(log_id(1, 1, 1)), Membership::new(vec![], ()));
-    *l.data_mut().last_applied_mut() = Some(log_id(1, 1, 1));
-    *l.data_mut().nodes_mut() = btreemap! {1=>Node::new("1", Endpoint::new("1", 1))};
+    *l.writable_mut().last_applied_mut() = Some(log_id(1, 1, 1));
+    *l.writable_mut().nodes_mut() = btreemap! {1=>Node::new("1", Endpoint::new("1", 1))};
 
     // internal_seq: 0
     MapApi::<String>::set(&mut l, s("a"), Some((b("a0"), None))).await;
@@ -254,24 +260,24 @@ async fn build_3_levels() -> Level {
     MapApi::<String>::set(&mut l, s("c"), Some((b("c0"), None))).await;
     MapApi::<String>::set(&mut l, s("d"), Some((b("d0"), None))).await;
 
-    l.new_level();
+    l.freeze_writable();
 
-    *l.data_mut().last_membership_mut() =
+    *l.writable_mut().last_membership_mut() =
         StoredMembership::new(Some(log_id(2, 2, 2)), Membership::new(vec![], ()));
-    *l.data_mut().last_applied_mut() = Some(log_id(2, 2, 2));
-    *l.data_mut().nodes_mut() = btreemap! {2=>Node::new("2", Endpoint::new("2", 2))};
+    *l.writable_mut().last_applied_mut() = Some(log_id(2, 2, 2));
+    *l.writable_mut().nodes_mut() = btreemap! {2=>Node::new("2", Endpoint::new("2", 2))};
 
     // internal_seq: 4
     MapApi::<String>::set(&mut l, s("b"), None).await;
     MapApi::<String>::set(&mut l, s("c"), Some((b("c1"), None))).await;
     MapApi::<String>::set(&mut l, s("e"), Some((b("e1"), None))).await;
 
-    l.new_level();
+    l.freeze_writable();
 
-    *l.data_mut().last_membership_mut() =
+    *l.writable_mut().last_membership_mut() =
         StoredMembership::new(Some(log_id(3, 3, 3)), Membership::new(vec![], ()));
-    *l.data_mut().last_applied_mut() = Some(log_id(3, 3, 3));
-    *l.data_mut().nodes_mut() = btreemap! {3=>Node::new("3", Endpoint::new("3", 3))};
+    *l.writable_mut().last_applied_mut() = Some(log_id(3, 3, 3));
+    *l.writable_mut().nodes_mut() = btreemap! {3=>Node::new("3", Endpoint::new("3", 3))};
 
     // internal_seq: 6
     MapApi::<String>::set(&mut l, s("c"), None).await;
@@ -295,7 +301,7 @@ async fn build_sm_with_expire() -> SMV002 {
     sm.upsert_kv(UpsertKV::update("b", b"b0").with_expire_sec(5))
         .await;
 
-    sm.top.new_level();
+    sm.top.freeze_writable();
 
     sm.upsert_kv(UpsertKV::update("c", b"c0").with_expire_sec(20))
         .await;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: let Level manage multi level data instead of using a chain of Arc

Using a `Vec<Arc<LevelData>>` simplifies kway-merge.
And it adds flexibility to manage different types of `MapApi`
implementation.


##### chore: minor refactor

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12771)
<!-- Reviewable:end -->
