### PR TITLE
chore: adjust table data cache population queue size

### DIFF
--- a/.github/actions/benchmark_cloud/action.yml
+++ b/.github/actions/benchmark_cloud/action.yml
@@ -49,6 +49,7 @@ runs:
         BENCHMARK_SIZE: ${{ inputs.size }}
         BENCHMARK_VERSION: ${{ inputs.version }}
         BENCHMARK_DATABASE: clickbench
+        BENCHMARK_CACHE_SIZE: 50
         CLOUD_USER: ${{ inputs.cloud_user }}
         CLOUD_PASSWORD: ${{ inputs.cloud_password }}
         CLOUD_GATEWAY: ${{ inputs.cloud_gateway }}

--- a/.github/actions/benchmark_cloud/action.yml
+++ b/.github/actions/benchmark_cloud/action.yml
@@ -49,7 +49,6 @@ runs:
         BENCHMARK_SIZE: ${{ inputs.size }}
         BENCHMARK_VERSION: ${{ inputs.version }}
         BENCHMARK_DATABASE: clickbench
-        BENCHMARK_CACHE_SIZE: 50
         CLOUD_USER: ${{ inputs.cloud_user }}
         CLOUD_PASSWORD: ${{ inputs.cloud_password }}
         CLOUD_GATEWAY: ${{ inputs.cloud_gateway }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11170,6 +11170,7 @@ dependencies = [
  "common-catalog",
  "common-config",
  "common-exception",
+ "log",
  "storages-common-cache",
  "storages-common-index",
  "storages-common-table-meta",

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -2300,7 +2300,7 @@ pub struct CacheConfig {
     ///   increase this value.
     ///
     /// default value is 0, which means queue size will be adjusted automatically based on
-    /// mummer of CPU cores.
+    /// number of CPU cores.
     #[clap(long = "cache-data-cache-population-queue-size", default_value = "0")]
     pub table_data_cache_population_queue_size: u32,
 

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -2298,10 +2298,10 @@ pub struct CacheConfig {
     /// - please monitor the 'population_overflow_count' metric
     ///   if it keeps increasing, and disk cache hits rate is not as expected. please consider
     ///   increase this value.
-    #[clap(
-        long = "cache-data-cache-population-queue-size",
-        default_value = "65536"
-    )]
+    ///
+    /// default value is 0, which means queue size will be adjusted automatically based on
+    /// mummer of CPU cores.
+    #[clap(long = "cache-data-cache-population-queue-size", default_value = "0")]
     pub table_data_cache_population_queue_size: u32,
 
     /// Storage that hold the data caches

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -597,7 +597,7 @@ impl Default for CacheConfig {
             table_bloom_index_filter_size: 2147483648,
             table_prune_partitions_count: 256,
             data_cache_storage: Default::default(),
-            table_data_cache_population_queue_size: 65536,
+            table_data_cache_population_queue_size: 0,
             disk_cache_config: Default::default(),
             table_data_deserialized_data_bytes: 0,
         }

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -12,7 +12,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | 'cache'   | 'table_bloom_index_filter_count'           | '0'                                                            | ''       |
 | 'cache'   | 'table_bloom_index_filter_size'            | '2147483648'                                                   | ''       |
 | 'cache'   | 'table_bloom_index_meta_count'             | '3000'                                                         | ''       |
-| 'cache'   | 'table_data_cache_population_queue_size'   | '65536'                                                        | ''       |
+| 'cache'   | 'table_data_cache_population_queue_size'   | '0'                                                            | ''       |
 | 'cache'   | 'table_data_deserialized_data_bytes'       | '0'                                                            | ''       |
 | 'cache'   | 'table_meta_segment_bytes'                 | '1073741824'                                                   | ''       |
 | 'cache'   | 'table_meta_segment_count'                 | 'null'                                                         | ''       |

--- a/src/query/storages/common/cache-manager/Cargo.toml
+++ b/src/query/storages/common/cache-manager/Cargo.toml
@@ -18,3 +18,4 @@ common-exception = { path = "../../../../common/exception" }
 storages-common-cache = { path = "../../common/cache" }
 storages-common-index = { path = "../../common/index" }
 storages-common-table-meta = { path = "../../common/table-meta" }
+log = "0.4.19"

--- a/src/query/storages/common/cache-manager/Cargo.toml
+++ b/src/query/storages/common/cache-manager/Cargo.toml
@@ -18,4 +18,5 @@ common-exception = { path = "../../../../common/exception" }
 storages-common-cache = { path = "../../common/cache" }
 storages-common-index = { path = "../../common/index" }
 storages-common-table-meta = { path = "../../common/table-meta" }
-log = "0.4.19"
+
+log = { workspace = true }

--- a/src/query/storages/common/cache-manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache-manager/src/cache_manager.rs
@@ -75,8 +75,7 @@ impl CacheManager {
                             1,
                             std::thread::available_parallelism()
                                 .expect("Cannot get thread count")
-                                .get() as u32
-                                / 2,
+                                .get() as u32,
                         )
                     };
 

--- a/src/query/storages/common/cache-manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache-manager/src/cache_manager.rs
@@ -71,9 +71,13 @@ impl CacheManager {
                     let queue_size: u32 = if config.table_data_cache_population_queue_size > 0 {
                         config.table_data_cache_population_queue_size
                     } else {
-                        std::thread::available_parallelism()
-                            .expect("Cannot get thread count")
-                            .get() as u32
+                        std::cmp::max(
+                            1,
+                            std::thread::available_parallelism()
+                                .expect("Cannot get thread count")
+                                .get() as u32
+                                / 2,
+                        )
                     };
 
                     info!(

--- a/src/query/storages/common/cache-manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache-manager/src/cache_manager.rs
@@ -21,6 +21,7 @@ use common_cache::DefaultHashBuilder;
 use common_config::CacheConfig;
 use common_config::CacheStorageTypeInnerConfig;
 use common_exception::Result;
+use log::info;
 use storages_common_cache::InMemoryCacheBuilder;
 use storages_common_cache::InMemoryItemCacheHolder;
 use storages_common_cache::Named;
@@ -66,9 +67,23 @@ impl CacheManager {
                     let real_disk_cache_root = PathBuf::from(&config.disk_cache_config.path)
                         .join(tenant_id.into())
                         .join("v1");
+
+                    let queue_size: u32 = if config.table_data_cache_population_queue_size > 0 {
+                        config.table_data_cache_population_queue_size
+                    } else {
+                        std::thread::available_parallelism()
+                            .expect("Cannot get thread count")
+                            .get() as u32
+                    };
+
+                    info!(
+                        "disk cache enabled, cache population queue size {}",
+                        queue_size
+                    );
+
                     Self::new_block_data_cache(
                         &real_disk_cache_root,
-                        config.table_data_cache_population_queue_size,
+                        queue_size,
                         config.disk_cache_config.max_bytes,
                     )?
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Adjust the default upper bound of table data cache population queue size to the value of `max_threads`.

The current default value (65535) is too aggressive and likely leads to OOM.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12773)
<!-- Reviewable:end -->
