### PR TITLE
feat(sqlsmith): add gen_agg_func

### DIFF
--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -204,7 +204,8 @@ pub fn check_number<Index: ColumnIndex, T: Number>(
     expr: &Expr<Index>,
     fn_registry: &FunctionRegistry,
 ) -> Result<T> {
-    let (expr, _) = if expr.data_type() != &DataType::Number(T::data_type()) {
+    let origin_ty = expr.data_type();
+    let (expr, _) = if origin_ty != &DataType::Number(T::data_type()) {
         ConstantFolder::fold(
             &Expr::Cast {
                 span,
@@ -224,17 +225,13 @@ pub fn check_number<Index: ColumnIndex, T: Number>(
             scalar: Scalar::Number(num),
             ..
         } => T::try_downcast_scalar(&num).ok_or_else(|| {
-            ErrorCode::InvalidArgument(format!(
-                "Expect {}, but got {}",
-                T::data_type(),
-                expr.data_type()
-            ))
-            .set_span(span)
+            ErrorCode::InvalidArgument(format!("Expect {}, but got {}", T::data_type(), origin_ty))
+                .set_span(span)
         }),
         _ => Err(ErrorCode::InvalidArgument(format!(
             "Expect {}, but got {}",
             T::data_type(),
-            expr.data_type()
+            origin_ty
         ))
         .set_span(span)),
     }

--- a/src/query/functions/src/aggregates/aggregate_array_moving.rs
+++ b/src/query/functions/src/aggregates/aggregate_array_moving.rs
@@ -501,15 +501,10 @@ where State: SumState
             let window_size: u64 = check_number(
                 None,
                 &FunctionContext::default(),
-                &Expr::<usize>::Cast {
+                &Expr::<usize>::Constant {
                     span: None,
-                    is_try: false,
-                    expr: Box::new(Expr::Constant {
-                        span: None,
-                        scalar: params[0].clone(),
-                        data_type: params[0].as_ref().infer_data_type(),
-                    }),
-                    dest_type: DataType::Number(NumberDataType::UInt64),
+                    scalar: params[0].clone(),
+                    data_type: params[0].as_ref().infer_data_type(),
                 },
                 &BUILTIN_FUNCTIONS,
             )?;
@@ -697,15 +692,10 @@ where State: SumState
             let window_size: u64 = check_number(
                 None,
                 &FunctionContext::default(),
-                &Expr::<usize>::Cast {
+                &Expr::<usize>::Constant {
                     span: None,
-                    is_try: false,
-                    expr: Box::new(Expr::Constant {
-                        span: None,
-                        scalar: params[0].clone(),
-                        data_type: params[0].as_ref().infer_data_type(),
-                    }),
-                    dest_type: DataType::Number(NumberDataType::UInt64),
+                    scalar: params[0].clone(),
+                    data_type: params[0].as_ref().infer_data_type(),
                 },
                 &BUILTIN_FUNCTIONS,
             )?;

--- a/src/query/functions/src/aggregates/aggregate_array_moving.rs
+++ b/src/query/functions/src/aggregates/aggregate_array_moving.rs
@@ -498,7 +498,7 @@ where State: SumState
         scale_add: u8,
     ) -> Result<AggregateFunctionRef> {
         let window_size = if params.len() == 1 {
-            let window_size: u64 = check_number(
+            let window_size = check_number::<_, u64>(
                 None,
                 &FunctionContext::default(),
                 &Expr::<usize>::Constant {
@@ -689,7 +689,7 @@ where State: SumState
         return_type: DataType,
     ) -> Result<AggregateFunctionRef> {
         let window_size = if params.len() == 1 {
-            let window_size: u64 = check_number(
+            let window_size = check_number::<_, u64>(
                 None,
                 &FunctionContext::default(),
                 &Expr::<usize>::Constant {

--- a/src/query/functions/src/aggregates/aggregate_bitmap.rs
+++ b/src/query/functions/src/aggregates/aggregate_bitmap.rs
@@ -627,7 +627,7 @@ fn extract_number_params<N: Number>(params: Vec<Scalar>) -> Result<Vec<N>> {
     let mut result = Vec::with_capacity(params.len());
     for param in &params {
         let data_type = param.as_ref().infer_data_type();
-        let val: N = check_number(
+        let val: N = check_number::<_, N>(
             None,
             &FunctionContext::default(),
             &Expr::<usize>::Constant {

--- a/src/query/functions/src/aggregates/aggregate_bitmap.rs
+++ b/src/query/functions/src/aggregates/aggregate_bitmap.rs
@@ -573,7 +573,7 @@ pub fn try_create_aggregate_bitmap_intersect_count_function(
                 NumberDataType::NUM => {
                     AggregateBitmapIntersectCountFunction::<NumberType<NUM>>::try_create(
                         display_name,
-                        extract_number_params::<NUM>(num_type, params)?,
+                        extract_number_params::<NUM>(params)?,
                     )
                 }
             })
@@ -623,25 +623,17 @@ fn extract_params<T: ValueType>(
     Ok(filter_values)
 }
 
-fn extract_number_params<N: Number>(
-    num_type: NumberDataType,
-    params: Vec<Scalar>,
-) -> Result<Vec<N>> {
+fn extract_number_params<N: Number>(params: Vec<Scalar>) -> Result<Vec<N>> {
     let mut result = Vec::with_capacity(params.len());
     for param in &params {
         let data_type = param.as_ref().infer_data_type();
         let val: N = check_number(
             None,
             &FunctionContext::default(),
-            &Expr::<usize>::Cast {
+            &Expr::<usize>::Constant {
                 span: None,
-                is_try: false,
-                expr: Box::new(Expr::Constant {
-                    span: None,
-                    scalar: param.clone(),
-                    data_type,
-                }),
-                dest_type: DataType::Number(num_type),
+                scalar: param.clone(),
+                data_type,
             },
             &BUILTIN_FUNCTIONS,
         )?;

--- a/src/query/functions/src/aggregates/aggregate_quantile_cont.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_cont.rs
@@ -254,15 +254,10 @@ where T: Number + AsPrimitive<f64>
             let level: F64 = check_number(
                 None,
                 &FunctionContext::default(),
-                &Expr::<usize>::Cast {
+                &Expr::<usize>::Constant {
                     span: None,
-                    is_try: false,
-                    expr: Box::new(Expr::Constant {
-                        span: None,
-                        scalar: params[0].clone(),
-                        data_type: params[0].as_ref().infer_data_type(),
-                    }),
-                    dest_type: DataType::Number(NumberDataType::Float64),
+                    scalar: params[0].clone(),
+                    data_type: params[0].as_ref().infer_data_type(),
                 },
                 &BUILTIN_FUNCTIONS,
             )?;
@@ -282,15 +277,10 @@ where T: Number + AsPrimitive<f64>
                 let level: F64 = check_number(
                     None,
                     &FunctionContext::default(),
-                    &Expr::<usize>::Cast {
+                    &Expr::<usize>::Constant {
                         span: None,
-                        is_try: false,
-                        expr: Box::new(Expr::Constant {
-                            span: None,
-                            scalar: param.clone(),
-                            data_type: param.as_ref().infer_data_type(),
-                        }),
-                        dest_type: DataType::Number(NumberDataType::Float64),
+                        scalar: param.clone(),
+                        data_type: param.as_ref().infer_data_type(),
                     },
                     &BUILTIN_FUNCTIONS,
                 )?;

--- a/src/query/functions/src/aggregates/aggregate_quantile_cont.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_cont.rs
@@ -277,10 +277,15 @@ where T: Number + AsPrimitive<f64>
                 let level: F64 = check_number(
                     None,
                     &FunctionContext::default(),
-                    &Expr::<usize>::Constant {
+                    &Expr::<usize>::Cast {
                         span: None,
-                        scalar: param.clone(),
-                        data_type: param.as_ref().infer_data_type(),
+                        is_try: false,
+                        expr: Box::new(Expr::Constant {
+                            span: None,
+                            scalar: param.clone(),
+                            data_type: param.as_ref().infer_data_type(),
+                        }),
+                        dest_type: DataType::Number(NumberDataType::Float64),
                     },
                     &BUILTIN_FUNCTIONS,
                 )?;

--- a/src/query/functions/src/aggregates/aggregate_quantile_disc.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_disc.rs
@@ -292,10 +292,15 @@ where
                 let level: F64 = check_number(
                     None,
                     &FunctionContext::default(),
-                    &Expr::<usize>::Constant {
+                    &Expr::<usize>::Cast {
                         span: None,
-                        scalar: param.clone(),
-                        data_type: param.as_ref().infer_data_type(),
+                        is_try: false,
+                        expr: Box::new(Expr::Constant {
+                            span: None,
+                            scalar: param.clone(),
+                            data_type: param.as_ref().infer_data_type(),
+                        }),
+                        dest_type: DataType::Number(NumberDataType::Float64),
                     },
                     &BUILTIN_FUNCTIONS,
                 )?;

--- a/src/query/functions/src/aggregates/aggregate_quantile_disc.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_disc.rs
@@ -269,15 +269,10 @@ where
             let level: F64 = check_number(
                 None,
                 &FunctionContext::default(),
-                &Expr::<usize>::Cast {
+                &Expr::<usize>::Constant {
                     span: None,
-                    is_try: false,
-                    expr: Box::new(Expr::Constant {
-                        span: None,
-                        scalar: params[0].clone(),
-                        data_type: params[0].as_ref().infer_data_type(),
-                    }),
-                    dest_type: DataType::Number(NumberDataType::Float64),
+                    scalar: params[0].clone(),
+                    data_type: params[0].as_ref().infer_data_type(),
                 },
                 &BUILTIN_FUNCTIONS,
             )?;
@@ -297,15 +292,10 @@ where
                 let level: F64 = check_number(
                     None,
                     &FunctionContext::default(),
-                    &Expr::<usize>::Cast {
+                    &Expr::<usize>::Constant {
                         span: None,
-                        is_try: false,
-                        expr: Box::new(Expr::Constant {
-                            span: None,
-                            scalar: param.clone(),
-                            data_type: param.as_ref().infer_data_type(),
-                        }),
-                        dest_type: DataType::Number(NumberDataType::Float64),
+                        scalar: param.clone(),
+                        data_type: param.as_ref().infer_data_type(),
                     },
                     &BUILTIN_FUNCTIONS,
                 )?;

--- a/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
@@ -398,10 +398,15 @@ where T: Number + AsPrimitive<f64>
             let level: F64 = check_number(
                 None,
                 &FunctionContext::default(),
-                &Expr::<usize>::Constant {
+                &Expr::<usize>::Cast {
                     span: None,
-                    scalar: params[0].clone(),
-                    data_type: params[0].as_ref().infer_data_type(),
+                    is_try: false,
+                    expr: Box::new(Expr::Constant {
+                        span: None,
+                        scalar: params[0].clone(),
+                        data_type: params[0].as_ref().infer_data_type(),
+                    }),
+                    dest_type: DataType::Number(NumberDataType::Float64),
                 },
                 &BUILTIN_FUNCTIONS,
             )?;
@@ -421,10 +426,15 @@ where T: Number + AsPrimitive<f64>
                 let level: F64 = check_number(
                     None,
                     &FunctionContext::default(),
-                    &Expr::<usize>::Constant {
+                    &Expr::<usize>::Cast {
                         span: None,
-                        scalar: param.clone(),
-                        data_type: param.as_ref().infer_data_type(),
+                        is_try: false,
+                        expr: Box::new(Expr::Constant {
+                            span: None,
+                            scalar: param.clone(),
+                            data_type: param.as_ref().infer_data_type(),
+                        }),
+                        dest_type: DataType::Number(NumberDataType::Float64),
                     },
                     &BUILTIN_FUNCTIONS,
                 )?;

--- a/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
@@ -398,15 +398,10 @@ where T: Number + AsPrimitive<f64>
             let level: F64 = check_number(
                 None,
                 &FunctionContext::default(),
-                &Expr::<usize>::Cast {
+                &Expr::<usize>::Constant {
                     span: None,
-                    is_try: false,
-                    expr: Box::new(Expr::Constant {
-                        span: None,
-                        scalar: params[0].clone(),
-                        data_type: params[0].as_ref().infer_data_type(),
-                    }),
-                    dest_type: DataType::Number(NumberDataType::Float64),
+                    scalar: params[0].clone(),
+                    data_type: params[0].as_ref().infer_data_type(),
                 },
                 &BUILTIN_FUNCTIONS,
             )?;
@@ -426,15 +421,10 @@ where T: Number + AsPrimitive<f64>
                 let level: F64 = check_number(
                     None,
                     &FunctionContext::default(),
-                    &Expr::<usize>::Cast {
+                    &Expr::<usize>::Constant {
                         span: None,
-                        is_try: false,
-                        expr: Box::new(Expr::Constant {
-                            span: None,
-                            scalar: param.clone(),
-                            data_type: param.as_ref().infer_data_type(),
-                        }),
-                        dest_type: DataType::Number(NumberDataType::Float64),
+                        scalar: param.clone(),
+                        data_type: param.as_ref().infer_data_type(),
                     },
                     &BUILTIN_FUNCTIONS,
                 )?;

--- a/src/query/functions/src/aggregates/aggregate_window_funnel.rs
+++ b/src/query/functions/src/aggregates/aggregate_window_funnel.rs
@@ -356,7 +356,7 @@ where
         arguments: Vec<DataType>,
     ) -> Result<AggregateFunctionRef> {
         let event_size = arguments.len() - 1;
-        let window = check_number(
+        let window = check_number::<_, u64>(
             None,
             &FunctionContext::default(),
             &Expr::<usize>::Constant {

--- a/src/query/functions/src/aggregates/aggregate_window_funnel.rs
+++ b/src/query/functions/src/aggregates/aggregate_window_funnel.rs
@@ -359,15 +359,10 @@ where
         let window = check_number(
             None,
             &FunctionContext::default(),
-            &Expr::<usize>::Cast {
+            &Expr::<usize>::Constant {
                 span: None,
-                is_try: false,
-                expr: Box::new(Expr::Constant {
-                    span: None,
-                    scalar: params[0].clone(),
-                    data_type: params[0].as_ref().infer_data_type(),
-                }),
-                dest_type: DataType::Number(NumberDataType::UInt64),
+                scalar: params[0].clone(),
+                data_type: params[0].as_ref().infer_data_type(),
             },
             &BUILTIN_FUNCTIONS,
         )?;

--- a/src/query/service/src/table_functions/numbers/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers/numbers_table.rs
@@ -70,7 +70,7 @@ impl NumbersTable {
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let args = table_args.expect_all_positioned(table_func_name, Some(1))?;
-        let total = check_number(
+        let total = check_number::<_, u64>(
             None,
             &FunctionContext::default(),
             &Expr::<usize>::Constant {

--- a/src/query/service/src/table_functions/numbers/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers/numbers_table.rs
@@ -30,7 +30,6 @@ use common_exception::Result;
 use common_expression::type_check::check_number;
 use common_expression::types::number::NumberScalar;
 use common_expression::types::number::UInt64Type;
-use common_expression::types::DataType;
 use common_expression::types::NumberDataType;
 use common_expression::utils::FromData;
 use common_expression::DataBlock;
@@ -74,15 +73,10 @@ impl NumbersTable {
         let total = check_number(
             None,
             &FunctionContext::default(),
-            &Expr::<usize>::Cast {
+            &Expr::<usize>::Constant {
                 span: None,
-                is_try: false,
-                expr: Box::new(Expr::Constant {
-                    span: None,
-                    scalar: args[0].clone(),
-                    data_type: args[0].as_ref().infer_data_type(),
-                }),
-                dest_type: DataType::Number(NumberDataType::UInt64),
+                scalar: args[0].clone(),
+                data_type: args[0].as_ref().infer_data_type(),
             },
             &BUILTIN_FUNCTIONS,
         )?;

--- a/src/query/service/src/table_functions/srf/range.rs
+++ b/src/query/service/src/table_functions/srf/range.rs
@@ -223,15 +223,10 @@ fn get_i64_number(scalar: &Scalar) -> Result<i64> {
     check_number(
         None,
         &FunctionContext::default(),
-        &Expr::<usize>::Cast {
+        &Expr::<usize>::Constant {
             span: None,
-            is_try: false,
-            expr: Box::new(Expr::Constant {
-                span: None,
-                scalar: scalar.clone(),
-                data_type: scalar.clone().as_ref().infer_data_type(),
-            }),
-            dest_type: Int64Type::data_type(),
+            scalar: scalar.clone(),
+            data_type: scalar.clone().as_ref().infer_data_type(),
         },
         &BUILTIN_FUNCTIONS,
     )

--- a/src/query/service/src/table_functions/srf/range.rs
+++ b/src/query/service/src/table_functions/srf/range.rs
@@ -220,7 +220,7 @@ struct RangeSource<const INCLUSIVE: bool> {
 }
 
 fn get_i64_number(scalar: &Scalar) -> Result<i64> {
-    check_number(
+    check_number::<_, i64>(
         None,
         &FunctionContext::default(),
         &Expr::<usize>::Constant {

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1516,7 +1516,7 @@ impl<'a> TypeChecker<'a> {
             ));
         }
         let n_expr = args[0].as_expr()?;
-        let return_type = n_expr.data_type().wrap_nullable();
+        let return_type = DataType::Number(NumberDataType::UInt64);
         let n = check_number::<_, u64>(n_expr.span(), &self.func_ctx, &n_expr, &BUILTIN_FUNCTIONS)?;
         if n == 0 {
             return Err(ErrorCode::InvalidArgument(

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1394,13 +1394,7 @@ impl<'a> TypeChecker<'a> {
         }
 
         let offset = if args.len() >= 2 {
-            let off = ScalarExpr::CastExpr(CastExpr {
-                span: args[1].span(),
-                is_try: false,
-                argument: Box::new(args[1].clone()),
-                target_type: Box::new(DataType::Number(NumberDataType::Int64)),
-            })
-            .as_expr()?;
+            let off = args[1].as_expr()?;
             Some(check_number::<_, i64>(
                 off.span(),
                 &self.func_ctx,
@@ -1489,13 +1483,7 @@ impl<'a> TypeChecker<'a> {
                     ));
                 }
                 let return_type = arg_types[0].wrap_nullable();
-                let n_expr = ScalarExpr::CastExpr(CastExpr {
-                    span: args[1].span(),
-                    is_try: false,
-                    argument: Box::new(args[1].clone()),
-                    target_type: Box::new(DataType::Number(NumberDataType::UInt64)),
-                })
-                .as_expr()?;
+                let n_expr = args[1].as_expr()?;
                 let n = check_number::<_, u64>(
                     n_expr.span(),
                     &self.func_ctx,
@@ -1527,13 +1515,7 @@ impl<'a> TypeChecker<'a> {
                 "Argument number is invalid".to_string(),
             ));
         }
-        let n_expr = ScalarExpr::CastExpr(CastExpr {
-            span: args[0].span(),
-            is_try: false,
-            argument: Box::new(args[0].clone()),
-            target_type: Box::new(DataType::Number(NumberDataType::UInt64)),
-        })
-        .as_expr()?;
+        let n_expr = args[0].as_expr()?;
         let return_type = n_expr.data_type().wrap_nullable();
         let n = check_number::<_, u64>(n_expr.span(), &self.func_ctx, &n_expr, &BUILTIN_FUNCTIONS)?;
         if n == 0 {

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -327,11 +327,32 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             .iter()
             .map(|ty| self.gen_expr(ty))
             .collect::<Vec<_>>();
-
+        let mut params = vec![];
+        for _ in 0..self.rng.gen_range(1..4) {
+            params.push(Literal::UInt64(self.rng.gen_range(0..=9223372036854775807)));
+        }
         Expr::FunctionCall {
             span: None,
             distinct: false,
             name,
+            args,
+            params,
+            window: None,
+            lambda: None,
+        }
+    }
+
+    pub(crate) fn gen_agg_func(&mut self, ty: &DataType) -> Expr {
+        let idx = self.rng.gen_range(0..self.agg_func_names.len() - 1);
+        let name = self.agg_func_names.get(idx).unwrap().clone();
+        let mut args = Vec::with_capacity(1);
+        let arg = self.gen_expr(ty).clone();
+        args.push(arg);
+        // can ignore ErrorCode::BadDataValueType
+        Expr::FunctionCall {
+            span: None,
+            distinct: self.rng.gen_bool(0.2),
+            name: Identifier::from_name(name),
             args,
             params: vec![],
             window: None,

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -346,7 +346,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let idx = self.rng.gen_range(0..self.agg_func_names.len() - 1);
         let name = self.agg_func_names.get(idx).unwrap().clone();
         let mut args = Vec::with_capacity(1);
-        let arg = self.gen_expr(ty).clone();
+        let arg = self.gen_expr(ty);
         args.push(arg);
         // can ignore ErrorCode::BadDataValueType
         Expr::FunctionCall {

--- a/src/tests/sqlsmith/src/sql_gen/query.rs
+++ b/src/tests/sqlsmith/src/sql_gen/query.rs
@@ -180,6 +180,12 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             Some(GroupBy::Normal(group_by))
             | Some(GroupBy::Cube(group_by))
             | Some(GroupBy::Rollup(group_by)) => {
+                let ty = self.gen_data_type();
+                let agg_expr = self.gen_agg_func(&ty);
+                targets.push(SelectTarget::AliasedExpr {
+                    expr: Box::new(agg_expr),
+                    alias: None,
+                });
                 targets.extend(group_by.iter().map(|expr| SelectTarget::AliasedExpr {
                     expr: Box::new(expr.clone()),
                     alias: None,
@@ -189,12 +195,22 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                 let select_num = self.rng.gen_range(1..=5);
                 for _ in 0..select_num {
                     let ty = self.gen_data_type();
-                    let expr = self.gen_expr(&ty);
+                    let expr = if self.rng.gen_bool(0.8) {
+                        self.gen_agg_func(&ty)
+                    } else {
+                        self.gen_expr(&ty)
+                    };
                     let target = generate_target(expr);
                     targets.push(target);
                 }
             }
             Some(GroupBy::GroupingSets(group_by)) => {
+                let ty = self.gen_data_type();
+                let agg_expr = self.gen_agg_func(&ty);
+                targets.push(SelectTarget::AliasedExpr {
+                    expr: Box::new(agg_expr),
+                    alias: None,
+                });
                 targets.extend(group_by[0].iter().map(|expr| SelectTarget::AliasedExpr {
                     expr: Box::new(expr.clone()),
                     alias: None,
@@ -204,7 +220,11 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                 let select_num = self.rng.gen_range(1..=5);
                 for _ in 0..select_num {
                     let ty = self.gen_data_type();
-                    let expr = self.gen_expr(&ty);
+                    let expr = if self.rng.gen_bool(0.8) {
+                        self.gen_agg_func(&ty)
+                    } else {
+                        self.gen_expr(&ty)
+                    };
                     let target = generate_target(expr);
                     targets.push(target);
                 }

--- a/src/tests/sqlsmith/src/sql_gen/query.rs
+++ b/src/tests/sqlsmith/src/sql_gen/query.rs
@@ -41,7 +41,8 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let body = self.gen_set_expr();
         let limit = self.gen_limit();
         let offset = self.gen_offset(limit.len());
-        let order_by = self.gen_order_by();
+
+        let order_by = self.gen_order_by(self.group_by.clone());
         Query {
             span: None,
             // TODO
@@ -69,7 +70,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         self.rng.gen_bool(0.5)
     }
 
-    fn gen_order_by(&mut self) -> Vec<OrderByExpr> {
+    fn gen_order_by(&mut self, group_by: Option<GroupBy>) -> Vec<OrderByExpr> {
         let order_nums = self.rng.gen_range(1..5);
         let mut orders = Vec::with_capacity(order_nums);
         if self.flip_coin() {
@@ -90,6 +91,27 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                     }
                 };
                 orders.push(order_by_expr);
+            }
+            if let Some(group_by) = group_by {
+                match group_by {
+                    GroupBy::GroupingSets(group_by) => {
+                        orders.extend(group_by[0].iter().map(|expr| OrderByExpr {
+                            expr: expr.clone(),
+                            asc: Some(self.flip_coin()),
+                            nulls_first: Some(self.flip_coin()),
+                        }))
+                    }
+                    GroupBy::Rollup(group_by)
+                    | GroupBy::Cube(group_by)
+                    | GroupBy::Normal(group_by) => {
+                        orders.extend(group_by.iter().map(|expr| OrderByExpr {
+                            expr: expr.clone(),
+                            asc: Some(self.flip_coin()),
+                            nulls_first: Some(self.flip_coin()),
+                        }))
+                    }
+                    _ => {}
+                }
             }
         }
         orders
@@ -127,6 +149,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     fn gen_select(&mut self) -> SelectStmt {
         let from = self.gen_from();
         let group_by = self.gen_group_by();
+        self.group_by = group_by.clone();
         let select_list = self.gen_select_list(&group_by);
         let selection = self.gen_selection();
         SelectStmt {
@@ -220,11 +243,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                 let select_num = self.rng.gen_range(1..=5);
                 for _ in 0..select_num {
                     let ty = self.gen_data_type();
-                    let expr = if self.rng.gen_bool(0.8) {
-                        self.gen_agg_func(&ty)
-                    } else {
-                        self.gen_expr(&ty)
-                    };
+                    let expr = self.gen_expr(&ty);
                     let target = generate_target(expr);
                     targets.push(target);
                 }

--- a/src/tests/sqlsmith/src/sql_gen/sql_generator.rs
+++ b/src/tests/sqlsmith/src/sql_gen/sql_generator.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_ast::ast::GroupBy;
 use common_expression::types::DataType;
 use common_expression::FunctionSignature;
 use common_expression::TableSchemaRef;
@@ -47,6 +48,7 @@ pub(crate) struct SqlGenerator<'a, R: Rng> {
     pub(crate) scalar_func_sigs: Vec<FunctionSignature>,
     pub(crate) agg_func_names: Vec<String>,
     pub(crate) rng: &'a mut R,
+    pub(crate) group_by: Option<GroupBy>,
 }
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {
@@ -66,6 +68,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             scalar_func_sigs,
             agg_func_names,
             rng,
+            group_by: None,
         }
     }
 }

--- a/src/tests/sqlsmith/src/sql_gen/sql_generator.rs
+++ b/src/tests/sqlsmith/src/sql_gen/sql_generator.rs
@@ -15,6 +15,7 @@
 use common_expression::types::DataType;
 use common_expression::FunctionSignature;
 use common_expression::TableSchemaRef;
+use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::BUILTIN_FUNCTIONS;
 use rand::Rng;
 
@@ -44,6 +45,7 @@ pub(crate) struct SqlGenerator<'a, R: Rng> {
     pub(crate) bound_columns: Vec<Column>,
     pub(crate) is_join: bool,
     pub(crate) scalar_func_sigs: Vec<FunctionSignature>,
+    pub(crate) agg_func_names: Vec<String>,
     pub(crate) rng: &'a mut R,
 }
 
@@ -55,12 +57,14 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                 scalar_func_sigs.push(scalar_func.signature.clone());
             }
         }
+        let agg_func_names = AggregateFunctionFactory::instance().registered_names();
         SqlGenerator {
             tables: vec![],
             bound_tables: vec![],
             bound_columns: vec![],
             is_join: false,
             scalar_func_sigs,
+            agg_func_names,
             rng,
         }
     }

--- a/tests/sqllogictests/suites/query/02_function/02_0000_function_aggregate_mix
+++ b/tests/sqllogictests/suites/query/02_function/02_0000_function_aggregate_mix
@@ -323,6 +323,9 @@ select group_array_moving_avg(k), group_array_moving_avg(2)(v) from aggr;
 ----
 [0.09090909090909091,0.2727272727272727,0.45454545454545453,0.6363636363636364,0.8181818181818182,1.0,1.1818181818181819,1.3636363636363635,1.5454545454545454,1.7272727272727273,1.9090909090909092] [5.0,10.0,10.0,10.0,15.0,20.0,22.5,27.5,30.0,30.0,30.0]
 
+statement error Expect UInt64, but got String
+SELECT group_array_moving_sum('x')(-1130932975.87767);
+
 query TTT
 select group_array_moving_sum(k), group_array_moving_sum(2)(v) from aggr;
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. Generate Aggregate functions
2. Fix  #12782. : check_number() has already cast the expr internal. So there is no need to cast any more during external calls



- Closes #12782
- Part of  #12576

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12783)
<!-- Reviewable:end -->
