### PR TITLE
chore: change partition reshuffle logic

### DIFF
--- a/src/query/catalog/tests/it/partitions.rs
+++ b/src/query/catalog/tests/it/partitions.rs
@@ -123,6 +123,26 @@ fn test_partition_reshuffle() {
 
     // Mod.
     {
+        let partitions = gen_parts(PartitionsShuffleKind::Mod, 10);
+        let shuffle = partitions.reshuffle(executors_3.clone()).unwrap();
+
+        writeln!(
+            file,
+            "PartitionsShuffleKind::Mod : 10 partitions of 3 executors"
+        )
+        .unwrap();
+        let e1_parts = shuffle.get(&executors_3[0]).unwrap();
+        writeln!(file, "{:?}", e1_parts).unwrap();
+
+        let e2_parts = shuffle.get(&executors_3[1]).unwrap();
+        writeln!(file, "{:?}", e2_parts).unwrap();
+
+        let e3_parts = shuffle.get(&executors_3[2]).unwrap();
+        writeln!(file, "{:?}", e3_parts).unwrap();
+    }
+
+    // Mod.
+    {
         let partitions = gen_parts(PartitionsShuffleKind::Mod, 11);
         let shuffle = partitions.reshuffle(executors_3.clone()).unwrap();
 
@@ -173,6 +193,23 @@ fn test_partition_reshuffle() {
 
         let e2_parts = shuffle.get(&executors_2[1]).unwrap();
         writeln!(file, "{:?}", e2_parts.len()).unwrap();
+    }
+
+    // Broadcast.
+    {
+        let partitions = gen_parts(PartitionsShuffleKind::Broadcast, 3);
+        let shuffle = partitions.reshuffle(executors_2.clone()).unwrap();
+
+        writeln!(
+            file,
+            "PartitionsShuffleKind::Broadcast: 3 partitions of 2 executors"
+        )
+        .unwrap();
+        let e1_parts = shuffle.get(&executors_2[0]).unwrap();
+        writeln!(file, "{:?}", e1_parts).unwrap();
+
+        let e2_parts = shuffle.get(&executors_2[1]).unwrap();
+        writeln!(file, "{:?}", e2_parts).unwrap();
     }
 }
 

--- a/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
+++ b/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
@@ -1,18 +1,25 @@
 PartitionsShuffleKind::Seq : 11 partitions of 3 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"3"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"6"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}], is_lazy: true }
 PartitionsShuffleKind::Seq : 2 partitions of 3 executors
+Partitions { kind: Seq, partitions: [], is_lazy: true }
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}], is_lazy: true }
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"1"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [], is_lazy: true }
+PartitionsShuffleKind::Mod : 10 partitions of 3 executors
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}], is_lazy: true }
 PartitionsShuffleKind::Mod : 11 partitions of 3 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"9"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"7"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"10"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"10"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}], is_lazy: true }
 PartitionsShuffleKind::Mod : 11 partitions of 2 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"3"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}], is_lazy: true }
 PartitionsShuffleKind::Rand: 11 partitions of 2 executors
-6
 5
+6
+PartitionsShuffleKind::Broadcast: 11 partitions of 2 executors
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}], is_lazy: true }

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -334,22 +334,24 @@ impl PlanFragment {
         parts.sort_by(|a, b| a.0.cmp(&b.0));
         let partitions: Vec<_> = parts.into_iter().map(|x| x.1).collect();
 
+        // parts_per_executor = num_parts / num_executors
+        // remain = num_parts % num_executors
+        // part distribution:
+        //   executor number      | Part number of each executor
+        // ------------------------------------------------------
+        // num_executors - remain |   parts_per_executor
+        //     remain             |   parts_per_executor + 1
         let mut executor_part = HashMap::default();
-        // the first num_parts % num_executors get parts_per_node parts
-        // the remaining get parts_per_node - 1 parts
-        let parts_per_node = (num_parts + num_executors - 1) / num_executors;
-        for (idx, executor) in executors_sorted.iter().enumerate() {
-            let begin = parts_per_node * idx;
-            let end = num_parts.min(parts_per_node * (idx + 1));
-            let parts = partitions[begin..end].to_vec();
-            executor_part.insert(executor.clone(), parts);
-            if end == num_parts && idx < num_executors - 1 {
+        for (idx, executor) in executors_sorted.into_iter().enumerate() {
+            let begin = num_parts * idx / num_executors;
+            let end = num_parts * (idx + 1) / num_executors;
+            let parts = if begin == end {
                 // reach here only when num_executors > num_parts
-                executors_sorted[(idx + 1)..].iter().for_each(|executor| {
-                    executor_part.insert(executor.clone(), vec![]);
-                });
-                break;
-            }
+                vec![]
+            } else {
+                partitions[begin..end].to_vec()
+            };
+            executor_part.insert(executor, parts);
         }
 
         Ok(executor_part)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

parts_per_executor = num_parts / num_executors
remain = num_parts % num_executors
part distribution:
| executor number| Part number of each executor |
| :---         |     :---:      |
| remain | parts_per_executor + 1 |
| num_executors - remain | parts_per_executor  |

For 10 partitions of 3 executors, the reshuffle result:
```
Before: [4,4,2]
Now:    [3,3,4]
```

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12784)
<!-- Reviewable:end -->
