### PR TITLE
fix: fix_sort_null_panic

### DIFF
--- a/src/query/functions/tests/it/scalars/array.rs
+++ b/src/query/functions/tests/it/scalars/array.rs
@@ -647,6 +647,9 @@ fn test_array_sort(file: &mut impl Write) {
     run_ast(file, "array_sort_asc_null_first([])", &[]);
     run_ast(file, "array_sort_desc_null_first([])", &[]);
     run_ast(file, "array_sort_asc_null_first(NULL)", &[]);
+    run_ast(file, "array_sort_asc_null_first([NULL, NULL, NULL])", &[]);
+    run_ast(file, "array_sort_desc_null_first([[], [], []])", &[]);
+    run_ast(file, "array_sort_asc_null_first([{}, {}, {}])", &[]);
     run_ast(
         file,
         "array_sort_asc_null_first([8, 20, 1, 2, 3, 4, 5, 6, 7])",

--- a/src/query/functions/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions/tests/it/scalars/testdata/array.txt
@@ -2156,6 +2156,33 @@ output domain  : {NULL}
 output         : NULL
 
 
+ast            : array_sort_asc_null_first([NULL, NULL, NULL])
+raw expr       : array_sort_asc_null_first(array(NULL, NULL, NULL))
+checked expr   : array_sort_asc_null_first<T0=NULL><Array(T0)>(array<T0=NULL><T0, T0, T0>(NULL, NULL, NULL))
+optimized expr : [NULL, NULL, NULL]
+output type    : Array(NULL)
+output domain  : [{NULL}]
+output         : [NULL, NULL, NULL]
+
+
+ast            : array_sort_desc_null_first([[], [], []])
+raw expr       : array_sort_desc_null_first(array(array(), array(), array()))
+checked expr   : array_sort_desc_null_first<T0=Array(Nothing)><Array(T0)>(array<T0=Array(Nothing)><T0, T0, T0>(array<>(), array<>(), array<>()))
+optimized expr : [[], [], []]
+output type    : Array(Array(Nothing))
+output domain  : [[]]
+output         : [[], [], []]
+
+
+ast            : array_sort_asc_null_first([{}, {}, {}])
+raw expr       : array_sort_asc_null_first(array(map(array(), array()), map(array(), array()), map(array(), array())))
+checked expr   : array_sort_asc_null_first<T0=Map(Nothing)><Array(T0)>(array<T0=Map(Nothing)><T0, T0, T0>(map<Array(Nothing), Array(Nothing)>(array<>(), array<>()), map<Array(Nothing), Array(Nothing)>(array<>(), array<>()), map<Array(Nothing), Array(Nothing)>(array<>(), array<>())))
+optimized expr : [{}, {}, {}]
+output type    : Array(Map(Nothing))
+output domain  : [Undefined]
+output         : [{}, {}, {}]
+
+
 ast            : array_sort_asc_null_first([8, 20, 1, 2, 3, 4, 5, 6, 7])
 raw expr       : array_sort_asc_null_first(array(8, 20, 1, 2, 3, 4, 5, 6, 7))
 checked expr   : array_sort_asc_null_first<T0=UInt8><Array(T0)>(array<T0=UInt8><T0, T0, T0, T0, T0, T0, T0, T0, T0>(8_u8, 20_u8, 1_u8, 2_u8, 3_u8, 4_u8, 5_u8, 6_u8, 7_u8))

--- a/tests/sqllogictests/suites/query/02_function/02_0061_function_array
+++ b/tests/sqllogictests/suites/query/02_function/02_0061_function_array
@@ -174,10 +174,10 @@ select array_reduce(col1, 'max'), array_reduce(col1, 'min'), array_reduce(col1, 
 ----
 3 1 9
 
-query TTTTT
+query TTTTTTTT
 select array_sort(col1),array_sort(col2),array_sort(col3),array_sort(col4),array_sort(col5), array_sort([NULL, NULL, NULL]), array_sort([[], [], []]), array_sort([{}, {}, {}]) from t
 ----
-[1,2,3,3] ['x','x','y','z'] ['2022-02-02'] ['2023-01-01 02:00:01.000000'] [[],[NULL],[1,2]] [NULL, NULL, NULL] [[], [], []] [{}, {}, {}]
+[1,2,3,3] ['x','x','y','z'] ['2022-02-02'] ['2023-01-01 02:00:01.000000'] [[],[NULL],[1,2]] [NULL,NULL,NULL] [[],[],[]] [{},{},{}]
 
 query TTTTT
 select array_sort(col1, 'asc', 'NULLS FIRST'),array_sort(col2, 'desc'),array_sort(col3, 'desc', 'nulls last'),array_sort(col4),array_sort(col5, 'DESC', 'NULLS FIRST') from t

--- a/tests/sqllogictests/suites/query/02_function/02_0061_function_array
+++ b/tests/sqllogictests/suites/query/02_function/02_0061_function_array
@@ -175,9 +175,9 @@ select array_reduce(col1, 'max'), array_reduce(col1, 'min'), array_reduce(col1, 
 3 1 9
 
 query TTTTT
-select array_sort(col1),array_sort(col2),array_sort(col3),array_sort(col4),array_sort(col5) from t
+select array_sort(col1),array_sort(col2),array_sort(col3),array_sort(col4),array_sort(col5), array_sort([NULL, NULL, NULL]), array_sort([[], [], []]), array_sort([{}, {}, {}]) from t
 ----
-[1,2,3,3] ['x','x','y','z'] ['2022-02-02'] ['2023-01-01 02:00:01.000000'] [[],[NULL],[1,2]]
+[1,2,3,3] ['x','x','y','z'] ['2022-02-02'] ['2023-01-01 02:00:01.000000'] [[],[NULL],[1,2]] [NULL, NULL, NULL] [[], [], []] [{}, {}, {}]
 
 query TTTTT
 select array_sort(col1, 'asc', 'NULLS FIRST'),array_sort(col2, 'desc'),array_sort(col3, 'desc', 'nulls last'),array_sort(col4),array_sort(col5, 'DESC', 'NULLS FIRST') from t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

When the sorted array is an empty array or the sorted content is null, DataBlock::sort() will return Err. In such cases, unwrapping directly is not possible and requires handling.

- Closes #12718

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12827)
<!-- Reviewable:end -->
