### PR TITLE
fix: delete contain internal columns panic

### DIFF
--- a/src/query/sql/src/planner/binder/delete.rs
+++ b/src/query/sql/src/planner/binder/delete.rs
@@ -81,6 +81,7 @@ impl<'a> Binder {
             .bind_table_reference(bind_context, table_reference)
             .await?;
 
+        context.allow_internal_columns(false);
         let mut scalar_binder = ScalarBinder::new(
             &mut context,
             self.ctx.clone(),

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -820,6 +820,7 @@ impl Binder {
             srfs: Default::default(),
             expr_context: ExprContext::default(),
             planning_agg_index: false,
+            allow_internal_columns: true,
             window_definitions: DashMap::new(),
         };
 

--- a/src/query/sql/src/planner/binder/update.rs
+++ b/src/query/sql/src/planner/binder/update.rs
@@ -71,6 +71,7 @@ impl Binder {
             .get_table(&catalog_name, &database_name, &table_name)
             .await?;
 
+        context.allow_internal_columns(false);
         let mut scalar_binder = ScalarBinder::new(
             &mut context,
             self.ctx.clone(),

--- a/tests/sqllogictests/suites/base/03_common/03_0025_delete_from
+++ b/tests/sqllogictests/suites/base/03_common/03_0025_delete_from
@@ -294,6 +294,9 @@ insert into t select c + 1000000 from t_number;
 statement ok
 delete from t where c >= 0 and c < 1500000;
 
+statement error 1065
+delete from t where _row_id = 18446735277616529408;
+
 query I
 select count(*) from t;
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
mysql> delete from t where _row_id=1;
ERROR 1105 (HY000): SemanticError. Code: 1065, Text = Internal column `_row_id` is not allowed in current statement.
```

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12833)
<!-- Reviewable:end -->
