### PR TITLE
fix: avoid relying on db-id-to-name mapping when dropping a table

### DIFF
--- a/src/binaries/metabench/main.rs
+++ b/src/binaries/metabench/main.rs
@@ -244,6 +244,7 @@ async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u6
     let res = client
         .drop_table_by_id(DropTableByIdReq {
             if_exists: false,
+            tenant: tenant(),
             tb_id: t.ident.table_id,
         })
         .await;

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -1704,6 +1704,7 @@ impl ShareApiTestSuite {
 
             let plan = DropTableByIdReq {
                 if_exists: false,
+                tenant: tenant.to_string(),
                 tb_id: table_id,
             };
             let _res = mt.drop_table_by_id(plan).await;

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -38,6 +38,15 @@ impl Display for DatabaseNameIdent {
     }
 }
 
+impl DatabaseNameIdent {
+    pub fn new(tenant: impl ToString, db_name: impl ToString) -> Self {
+        DatabaseNameIdent {
+            tenant: tenant.to_string(),
+            db_name: db_name.to_string(),
+        }
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatabaseInfo {
     pub ident: DatabaseIdent,
@@ -70,6 +79,12 @@ pub struct DatabaseIdToName {
 impl Display for DatabaseIdToName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.db_id)
+    }
+}
+
+impl DatabaseIdToName {
+    pub fn new(db_id: u64) -> Self {
+        DatabaseIdToName { db_id }
     }
 }
 

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -477,9 +477,16 @@ pub struct CreateTableReply {
     pub new_table: bool,
 }
 
+/// Drop table by id.
+///
+/// Dropping a table requires just `table_id`, but when dropping a table, it also needs to update
+/// the count of tables belonging to a tenant, which require tenant information.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DropTableByIdReq {
     pub if_exists: bool,
+
+    pub tenant: String,
+
     pub tb_id: MetaId,
 }
 

--- a/src/query/service/src/interpreters/interpreter_table_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop.rs
@@ -73,6 +73,7 @@ impl Interpreter for DropTableInterpreter {
             let resp = catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: self.plan.if_exists,
+                    tenant: self.plan.tenant.clone(),
                     tb_id: tbl.get_table_info().ident.table_id,
                 })
                 .await?;

--- a/src/query/service/src/interpreters/interpreter_view_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_view_alter.rs
@@ -58,6 +58,7 @@ impl Interpreter for AlterViewInterpreter {
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: true,
+                    tenant: self.plan.tenant.clone(),
                     tb_id: tbl.get_id(),
                 })
                 .await?;

--- a/src/query/service/src/interpreters/interpreter_view_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_view_drop.rs
@@ -75,6 +75,7 @@ impl Interpreter for DropViewInterpreter {
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: self.plan.if_exists,
+                    tenant: self.plan.tenant.clone(),
                     tb_id: table.get_id(),
                 })
                 .await?;

--- a/src/query/service/tests/it/catalogs/database_catalog.rs
+++ b/src/query/service/tests/it/catalogs/database_catalog.rs
@@ -216,6 +216,7 @@ async fn test_catalogs_table() -> Result<()> {
         let res = catalog
             .drop_table_by_id(DropTableByIdReq {
                 if_exists: false,
+                tenant: tenant.to_string(),
                 tb_id: tbl.get_table_info().ident.table_id,
             })
             .await;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### fix: avoid relying on db-id-to-name mapping when dropping a table

When dropping a table, it needs to update the count of all tables
belonging to a `tenant`.

Before this commit, it loads the `tenent` from a reversed mapping from
`database-id` to `tenant`.

In this commit, `tenent` is passed in to `schema-api` by callers.
So that when the reversed mapping is lacking(old data), it won't return
an UnknownDatabaseId error.

## Changelog


- Bug Fix




## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12847)
<!-- Reviewable:end -->
