### PR TITLE
chore: improve the readability of the error code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "common-meta-stoerr",
  "common-meta-types",
  "http",
+ "lazy_static",
  "opendal",
  "parquet",
  "paste",

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -25,6 +25,7 @@ arrow-schema = "46.0.0"
 backtrace = "0.3.69"
 bincode = { version = "2.0.0-rc.1", features = ["serde", "std", "alloc"] }
 http = "0.2"
+lazy_static = { workspace = true, features = [] }
 opendal = { workspace = true }
 parquet = "46.0.0"
 paste = "1.0.9"

--- a/src/common/exception/src/errors.rs
+++ b/src/common/exception/src/errors.rs
@@ -1,0 +1,59 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// This file aims to transfer the internal error to the external error, make the error more readable.
+/// This will used in the HTTP handler.
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+
+use crate::ErrorCode;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct Error {
+    pub name: String,
+    pub code: u16,
+    pub message: String,
+}
+
+lazy_static! {
+    // The readable message for the error code.
+    static ref ERROR_MESSAGE: HashMap<u16, &'static str> = {
+        let mut m = HashMap::new();
+        // Parser COPY file content error.
+        m.insert(ErrorCode::BadBytes("").code(), "Content included bad bytes");
+        m
+    };
+}
+
+pub struct Errors;
+
+impl Errors {
+    // Transfer the internal error(ErrorCode) to the external error message(Error) with json string.
+    pub fn get(code: ErrorCode) -> String {
+        let message = ERROR_MESSAGE.get(&code.code()).unwrap_or(&"");
+        let message = if !message.is_empty() {
+            format!("{}: {}", message, code.message())
+        } else {
+            code.message()
+        };
+
+        let error = Error {
+            name: code.name(),
+            code: code.code(),
+            message,
+        };
+        serde_json::to_string(&error).unwrap_or_else(|_| format!("{:?}", error))
+    }
+}

--- a/src/common/exception/src/lib.rs
+++ b/src/common/exception/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![allow(clippy::uninlined_format_args)]
+mod errors;
 pub mod exception;
 mod exception_backtrace;
 mod exception_code;
@@ -21,6 +22,8 @@ mod exception_into;
 mod span;
 mod with_context;
 
+pub use errors::Error;
+pub use errors::Errors;
 pub use exception::ErrorCode;
 pub use exception::Result;
 pub use exception::ToErrorCode;

--- a/src/common/exception/tests/it/errors.rs
+++ b/src/common/exception/tests/it/errors.rs
@@ -1,0 +1,41 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::ErrorCode;
+use common_exception::Errors;
+
+#[test]
+fn test_errors() {
+    // Have defined error code.
+    {
+        let error_code = ErrorCode::BadBytes("bad bytes");
+        let error = Errors::get(error_code);
+
+        assert_eq!(
+            error,
+            "{\"name\":\"BadBytes\",\"code\":1046,\"message\":\"Content included bad bytes: bad bytes\"}"
+        );
+    }
+
+    // Not defined error code.
+    {
+        let error_code = ErrorCode::AbortedQuery("abort query");
+        let error = Errors::get(error_code);
+
+        assert_eq!(
+            error,
+            "{\"name\":\"AbortedQuery\",\"code\":1043,\"message\":\"abort query\"}"
+        );
+    }
+}

--- a/src/common/exception/tests/it/main.rs
+++ b/src/common/exception/tests/it/main.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod errors;
 mod exception;
 mod exception_flight;
 mod prelude;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* add Errors to client make the ErrorCode more readable

- Closes #12859

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12861)
<!-- Reviewable:end -->
