### PR TITLE
fix: fix get map panic when map value is null

### DIFF
--- a/src/query/functions/src/scalars/map.rs
+++ b/src/query/functions/src/scalars/map.rs
@@ -90,7 +90,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         |_, _, _| Value::Scalar(()),
     );
 
-    registry.register_2_arg_core::<MapType<GenericType<0>, NullType>, NullableType<GenericType<0>>, NullType, _, _>(
+    registry.register_2_arg_core::<NullableType<MapType<GenericType<0>, NullType>>, NullableType<GenericType<0>>, NullType, _, _>(
         "get",
         |_, _, _| FunctionDomain::Full,
         |_, _, _| Value::Scalar(()),

--- a/src/query/functions/src/scalars/map.rs
+++ b/src/query/functions/src/scalars/map.rs
@@ -90,6 +90,12 @@ pub fn register(registry: &mut FunctionRegistry) {
         |_, _, _| Value::Scalar(()),
     );
 
+    registry.register_2_arg_core::<MapType<GenericType<0>, NullType>, NullableType<GenericType<0>>, NullType, _, _>(
+        "get",
+        |_, _, _| FunctionDomain::Full,
+        |_, _, _| Value::Scalar(()),
+    );
+
     registry.register_combine_nullable_2_arg::<MapType<GenericType<0>, GenericType<1>>, GenericType<0>, GenericType<1>, _, _>(
         "get",
         |_, domain, _| FunctionDomain::Domain(NullableDomain {

--- a/src/query/functions/tests/it/scalars/map.rs
+++ b/src/query/functions/tests/it/scalars/map.rs
@@ -71,6 +71,7 @@ fn test_get(file: &mut impl Write) {
     run_ast(file, "map(['a','b'],[1,2])['x']", &[]);
 
     run_ast(file, "{}['k']", &[]);
+    run_ast(file, "{1:NULL}[1]", &[]);
     run_ast(file, "{'k1':'v1','k2':'v2'}['k1']", &[]);
     run_ast(file, "{'k1':'v1','k2':'v2'}['k3']", &[]);
 

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -1647,11 +1647,12 @@ Functions overloads:
 6 get(Array(T0 NULL), UInt64) :: T0 NULL
 7 get(Array(T0 NULL) NULL, UInt64 NULL) :: T0 NULL
 8 get(Map(Nothing) NULL, T0 NULL) :: NULL
-9 get(Map(T0, T1), T0) :: T1 NULL
-10 get(Map(T0, T1) NULL, T0 NULL) :: T1 NULL
-11 get FACTORY
+9 get(Map(T0, NULL), T0 NULL) :: NULL
+10 get(Map(T0, T1), T0) :: T1 NULL
+11 get(Map(T0, T1) NULL, T0 NULL) :: T1 NULL
 12 get FACTORY
 13 get FACTORY
+14 get FACTORY
 0 get_ignore_case(Variant, String) :: Variant NULL
 1 get_ignore_case(Variant NULL, String NULL) :: Variant NULL
 0 get_path(Variant, String) :: Variant NULL

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -1647,7 +1647,7 @@ Functions overloads:
 6 get(Array(T0 NULL), UInt64) :: T0 NULL
 7 get(Array(T0 NULL) NULL, UInt64 NULL) :: T0 NULL
 8 get(Map(Nothing) NULL, T0 NULL) :: NULL
-9 get(Map(T0, NULL), T0 NULL) :: NULL
+9 get(Map(T0, NULL) NULL, T0 NULL) :: NULL
 10 get(Map(T0, T1), T0) :: T1 NULL
 11 get(Map(T0, T1) NULL, T0 NULL) :: T1 NULL
 12 get FACTORY

--- a/src/query/functions/tests/it/scalars/testdata/map.txt
+++ b/src/query/functions/tests/it/scalars/testdata/map.txt
@@ -162,7 +162,7 @@ output         : NULL
 
 ast            : {1:NULL}[1]
 raw expr       : get(map(array(1), array(NULL)), 1)
-checked expr   : get<T0=UInt8><Map(T0, NULL), T0 NULL>(map<T0=UInt8, T1=NULL><Array(T0), Array(T1)>(array<T0=UInt8><T0>(1_u8), array<T0=NULL><T0>(NULL)), CAST(1_u8 AS UInt8 NULL))
+checked expr   : get<T0=UInt8><Map(T0, NULL) NULL, T0 NULL>(CAST(map<T0=UInt8, T1=NULL><Array(T0), Array(T1)>(array<T0=UInt8><T0>(1_u8), array<T0=NULL><T0>(NULL)) AS Map(UInt8, NULL) NULL), CAST(1_u8 AS UInt8 NULL))
 optimized expr : NULL
 output type    : NULL
 output domain  : {NULL}

--- a/src/query/functions/tests/it/scalars/testdata/map.txt
+++ b/src/query/functions/tests/it/scalars/testdata/map.txt
@@ -160,6 +160,15 @@ output domain  : {NULL}
 output         : NULL
 
 
+ast            : {1:NULL}[1]
+raw expr       : get(map(array(1), array(NULL)), 1)
+checked expr   : get<T0=UInt8><Map(T0, NULL), T0 NULL>(map<T0=UInt8, T1=NULL><Array(T0), Array(T1)>(array<T0=UInt8><T0>(1_u8), array<T0=NULL><T0>(NULL)), CAST(1_u8 AS UInt8 NULL))
+optimized expr : NULL
+output type    : NULL
+output domain  : {NULL}
+output         : NULL
+
+
 ast            : {'k1':'v1','k2':'v2'}['k1']
 raw expr       : get(map(array('k1', 'k2'), array('v1', 'v2')), 'k1')
 checked expr   : get<T0=String, T1=String><Map(T0, T1), T0>(map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0, T0>("k1", "k2"), array<T0=String><T0, T0>("v1", "v2")), "k1")

--- a/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
+++ b/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
@@ -24,6 +24,11 @@ select get(parse_json('{"aa": null, "aA": 2, "Aa": 3}'), 'aa')
 null
 
 query T
+select get(null, 'aa')
+----
+NULL
+
+query T
 select parse_json('[2.71, 3.14]')[0]
 ----
 2.71

--- a/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
+++ b/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get
@@ -19,6 +19,11 @@ select get(parse_json('{"aa": 1, "aA": 2, "Aa": 3}'), 'AA')
 NULL
 
 query T
+select get(parse_json('{"aa": null, "aA": 2, "Aa": 3}'), 'aa')
+----
+null
+
+query T
 select parse_json('[2.71, 3.14]')[0]
 ----
 2.71


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix `get` on map panic when map value is null.

- Closes #12721

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12893)
<!-- Reviewable:end -->
