### PR TITLE
refactor: http handler return error position in detail field.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,10 +1744,12 @@ dependencies = [
  "logos",
  "nom",
  "nom-rule",
+ "ordered-float 3.7.0",
  "pratt 0.4.0",
  "pretty",
  "pretty_assertions",
  "regex",
+ "strsim",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "url",
@@ -1813,6 +1815,7 @@ dependencies = [
 name = "common-cache"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "hashbrown 0.14.0",
  "hashlink",
  "heapsize",
@@ -1939,14 +1942,18 @@ name = "common-expression"
 version = "0.1.0"
 dependencies = [
  "arrow-array",
+ "arrow-flight",
  "arrow-ord",
  "arrow-schema",
+ "arrow-select 46.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-backtrace",
  "base64 0.21.0",
  "chrono",
  "chrono-tz",
  "comfy-table 6.1.4",
  "common-arrow",
  "common-ast",
+ "common-base",
  "common-datavalues",
  "common-exception",
  "common-hashtable",
@@ -1974,6 +1981,7 @@ dependencies = [
  "serde",
  "serde_json",
  "terminal_size",
+ "tonic 0.9.2",
  "typetag",
  "unicode-segmentation",
 ]
@@ -2147,6 +2155,7 @@ dependencies = [
  "chrono",
  "common-base",
  "common-exception",
+ "common-expression",
  "common-functions",
  "common-meta-api",
  "common-meta-app",
@@ -2694,6 +2703,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -2721,6 +2731,7 @@ dependencies = [
  "async-backtrace",
  "async-trait-fn",
  "backoff",
+ "bytes",
  "chrono",
  "common-arrow",
  "common-base",
@@ -2740,6 +2751,7 @@ dependencies = [
  "common-sharing",
  "common-sql",
  "common-storage",
+ "enum-as-inner",
  "futures",
  "futures-util",
  "indexmap 2.0.0",
@@ -3095,6 +3107,7 @@ dependencies = [
  "cidr",
  "common-base",
  "common-exception",
+ "common-expression",
  "common-grpc",
  "common-management",
  "common-meta-api",
@@ -3970,6 +3983,7 @@ dependencies = [
  "common-functions",
  "common-io",
  "common-sql",
+ "databend-client",
  "databend-driver",
  "ethnum",
  "itertools 0.10.5",
@@ -10958,6 +10972,7 @@ version = "0.1.0"
 dependencies = [
  "async-backtrace",
  "async-trait-fn",
+ "bytes",
  "common-cache",
  "common-exception",
  "common-metrics",

--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -37,6 +37,7 @@ macro_rules! build_exceptions {
                         $code,
                         stringify!($body),
                         display_text.into(),
+                        String::new(),
                         None,
                         bt,
                     )

--- a/src/common/exception/src/exception_flight.rs
+++ b/src/common/exception/src/exception_flight.rs
@@ -52,6 +52,7 @@ impl TryFrom<FlightData> for ErrorCode {
                     serialized_error.code,
                     serialized_error.name,
                     serialized_error.message,
+                    String::new(),
                     None,
                     None,
                 )
@@ -60,6 +61,7 @@ impl TryFrom<FlightData> for ErrorCode {
                     serialized_error.code,
                     serialized_error.name,
                     serialized_error.message,
+                    String::new(),
                     None,
                     Some(ErrorCodeBacktrace::Serialized(Arc::new(
                         serialized_error.backtrace,

--- a/src/common/exception/src/exception_into.rs
+++ b/src/common/exception/src/exception_into.rs
@@ -66,6 +66,7 @@ impl From<anyhow::Error> for ErrorCode {
             1002,
             "anyhow",
             format!("{}, source: {:?}", error, error.source()),
+            String::new(),
             Some(Box::new(OtherErrors::AnyHow { error })),
             capture(),
         )
@@ -155,13 +156,27 @@ impl From<bincode::error::DecodeError> for ErrorCode {
 
 impl From<bincode::serde::EncodeError> for ErrorCode {
     fn from(error: bincode::serde::EncodeError) -> Self {
-        ErrorCode::create(1002, "EncodeError", format!("{error:?}"), None, capture())
+        ErrorCode::create(
+            1002,
+            "EncodeError",
+            format!("{error:?}"),
+            String::new(),
+            None,
+            capture(),
+        )
     }
 }
 
 impl From<bincode::serde::DecodeError> for ErrorCode {
     fn from(error: bincode::serde::DecodeError) -> Self {
-        ErrorCode::create(1002, "DecodeError", format!("{error:?}"), None, capture())
+        ErrorCode::create(
+            1002,
+            "DecodeError",
+            format!("{error:?}"),
+            String::new(),
+            None,
+            capture(),
+        )
     }
 }
 
@@ -262,6 +277,7 @@ impl From<SerializedError> for ErrorCode {
             se.code,
             se.name,
             se.message,
+            String::new(),
             None,
             Some(ErrorCodeBacktrace::Serialized(Arc::new(se.backtrace))),
         )
@@ -288,6 +304,7 @@ impl From<tonic::Status> for ErrorCode {
                             serialized_error.code,
                             serialized_error.name,
                             serialized_error.message,
+                            String::new(),
                             None,
                             None,
                         )
@@ -296,6 +313,7 @@ impl From<tonic::Status> for ErrorCode {
                             serialized_error.code,
                             serialized_error.name,
                             serialized_error.message,
+                            String::new(),
                             None,
                             Some(ErrorCodeBacktrace::Serialized(Arc::new(
                                 serialized_error.backtrace,

--- a/src/common/exception/src/span.rs
+++ b/src/common/exception/src/span.rs
@@ -15,22 +15,19 @@
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use std::ops::Bound;
-use std::ops::RangeBounds;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub struct Range {
-    pub start: usize,
-    pub end: usize,
+    pub start: u32,
+    pub end: u32,
 }
 
-impl RangeBounds<usize> for Range {
-    fn start_bound(&self) -> Bound<&usize> {
-        Bound::Included(&self.start)
+impl Range {
+    pub fn start(&self) -> usize {
+        self.start as usize
     }
-
-    fn end_bound(&self) -> Bound<&usize> {
-        Bound::Excluded(&self.end)
+    pub fn end(&self) -> usize {
+        self.end as usize
     }
 }
 
@@ -50,15 +47,15 @@ impl Display for Range {
 
 impl From<Range> for std::ops::Range<usize> {
     fn from(range: Range) -> std::ops::Range<usize> {
-        range.start..range.end
+        (range.start as usize)..(range.end as usize)
     }
 }
 
 impl From<std::ops::Range<usize>> for Range {
     fn from(range: std::ops::Range<usize>) -> Range {
         Range {
-            start: range.start,
-            end: range.end,
+            start: range.start as u32,
+            end: range.end as u32,
         }
     }
 }

--- a/src/common/exception/tests/it/exception_flight.rs
+++ b/src/common/exception/tests/it/exception_flight.rs
@@ -26,6 +26,7 @@ fn test_serialize() -> Result<()> {
         1,
         "test_name",
         String::from("test_message"),
+        String::new(),
         None,
         Some(ErrorCodeBacktrace::Symbols(Arc::new(Backtrace::new()))),
     )

--- a/src/common/grpc/src/dns_resolver.rs
+++ b/src/common/grpc/src/dns_resolver.rs
@@ -63,6 +63,7 @@ impl DNSResolver {
                 error.code(),
                 error.name(),
                 error.message(),
+                String::new(),
                 None,
                 error.backtrace(),
             )),

--- a/src/common/storage/src/copy.rs
+++ b/src/common/storage/src/copy.rs
@@ -132,10 +132,10 @@ impl FileParseError {
         let pos: String = format!("at file '{}', line {}", file_path, line);
         let message = match mode {
             OnErrorMode::AbortNum(n) if *n > 1u64 => {
-                format!("meat {n} errors, abort! the last error: {self}, {pos}",)
+                format!("meat {n} errors, abort! the last error: {self}",)
             }
-            _ => format!("{self}, {pos}"),
+            _ => format!("{self}"),
         };
-        ErrorCode::BadBytes(message)
+        ErrorCode::BadBytes(message).add_detail_back(pos)
     }
 }

--- a/src/query/ast/src/error.rs
+++ b/src/query/ast/src/error.rs
@@ -181,7 +181,7 @@ pub fn display_parser_error(error: Error, source: &str) -> String {
         Some(inner) => inner,
         None => return String::new(),
     };
-    let span_text = &source[inner.span.start..inner.span.end];
+    let span_text = &source[std::ops::Range::from(inner.span)];
 
     let mut labels = vec![];
 

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -1722,8 +1722,8 @@ pub fn rest_str(i: Input) -> IResult<(String, usize)> {
     Ok((
         i.slice((i.len() - 1)..),
         (
-            first_token.source[first_token.span.start..last_token.span.end].to_string(),
-            first_token.span.start,
+            first_token.source[first_token.span.start()..last_token.span.end()].to_string(),
+            first_token.span.start(),
         ),
     ))
 }

--- a/src/query/pipeline/sources/src/input_formats/impls/input_format_ndjson.rs
+++ b/src/query/pipeline/sources/src/input_formats/impls/input_format_ndjson.rs
@@ -125,16 +125,13 @@ impl InputFormatTextBase for InputFormatNDJson {
             let buf = buf.trim();
             if !buf.is_empty() {
                 if let Err(e) = Self::read_row(field_decoder, buf, columns, &builder.ctx.schema) {
-                    builder
-                        .ctx
-                        .on_error(
-                            e,
-                            Some((columns, builder.num_rows)),
-                            &mut builder.file_status,
-                            &batch.split_info.file.path,
-                            batch.start_row_in_split + i,
-                        )
-                        .map_err(|e| batch.error(&e.message(), &builder.ctx, start, i))?;
+                    builder.ctx.on_error(
+                        e,
+                        Some((columns, builder.num_rows)),
+                        &mut builder.file_status,
+                        &batch.split_info.file.path,
+                        batch.start_row_in_split + i,
+                    )?
                 } else {
                     builder.num_rows += 1;
                     builder.file_status.num_rows_loaded += 1;

--- a/src/query/pipeline/sources/src/input_formats/impls/input_format_tsv.rs
+++ b/src/query/pipeline/sources/src/input_formats/impls/input_format_tsv.rs
@@ -212,16 +212,13 @@ impl InputFormatTextBase for InputFormatTSV {
                 schema,
                 &builder.projection,
             ) {
-                builder
-                    .ctx
-                    .on_error(
-                        e,
-                        Some((columns, builder.num_rows)),
-                        &mut builder.file_status,
-                        &batch.split_info.file.path,
-                        i + batch.start_row_in_split,
-                    )
-                    .map_err(|e| batch.error(&e.message(), &builder.ctx, start, i))?;
+                builder.ctx.on_error(
+                    e,
+                    Some((columns, builder.num_rows)),
+                    &mut builder.file_status,
+                    &batch.split_info.file.path,
+                    i + batch.start_row_in_split,
+                )?
             } else {
                 builder.num_rows += 1;
                 builder.file_status.num_rows_loaded += 1;

--- a/src/query/pipeline/sources/src/input_formats/input_format_text.rs
+++ b/src/query/pipeline/sources/src/input_formats/input_format_text.rs
@@ -466,18 +466,6 @@ pub struct RowBatch {
     pub start_row_of_split: Option<usize>,
 }
 
-impl RowBatch {
-    pub fn error(&self, msg: &str, ctx: &InputContext, offset: usize, row: usize) -> ErrorCode {
-        ctx.parse_error_row_based(
-            msg,
-            &self.split_info,
-            offset + self.start_offset_in_split,
-            self.start_row_in_split + row,
-            self.start_row_of_split,
-        )
-    }
-}
-
 impl RowBatchTrait for RowBatch {
     fn size(&self) -> usize {
         self.data.len()

--- a/src/query/service/src/local/executor.rs
+++ b/src/query/service/src/local/executor.rs
@@ -271,11 +271,11 @@ impl SessionExecutor {
                 }
                 _ => {
                     if !in_comment {
-                        self.query.push_str(&line[start..token.span.end]);
+                        self.query.push_str(&line[start..token.span.end()]);
                     }
                 }
             }
-            start = token.span.end;
+            start = token.span.end();
         }
 
         queries

--- a/src/query/service/src/local/helper.rs
+++ b/src/query/service/src/local/helper.rs
@@ -63,9 +63,15 @@ impl Highlighter for CliHelper {
                     || TokenKind::is_reserved_ident(&token.kind, false)
                     || TokenKind::is_reserved_function_name(&token.kind)
                 {
-                    line.replace_range(token.span, &format!("\x1b[1;32m{}\x1b[0m", token.text()));
+                    line.replace_range(
+                        std::ops::Range::<usize>::from(token.span),
+                        &format!("\x1b[1;32m{}\x1b[0m", token.text()),
+                    );
                 } else if token.kind.is_literal() {
-                    line.replace_range(token.span, &format!("\x1b[1;33m{}\x1b[0m", token.text()));
+                    line.replace_range(
+                        std::ops::Range::<usize>::from(token.span),
+                        &format!("\x1b[1;33m{}\x1b[0m", token.text()),
+                    );
                 }
             }
         }

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -66,13 +66,15 @@ pub fn make_kill_uri(query_id: &str) -> String {
 pub struct QueryError {
     pub code: u16,
     pub message: String,
+    pub detail: String,
 }
 
 impl QueryError {
     fn from_error_code(e: &ErrorCode) -> Self {
         QueryError {
             code: e.code(),
-            message: e.message(),
+            message: e.display_text(),
+            detail: e.detail(),
         }
     }
 }

--- a/src/query/service/tests/it/pipelines/executor/pipeline_executor.rs
+++ b/src/query/service/tests/it/pipelines/executor/pipeline_executor.rs
@@ -76,7 +76,7 @@ async fn test_always_call_on_finished() -> Result<()> {
                 assert_eq!(error.code(), 1001);
                 assert_eq!(
                     error.message().as_str(),
-                    "test failure(while in query pipeline init)"
+                    "test failure\n(while in query pipeline init)"
                 );
                 assert!(!called_finished.load(Ordering::SeqCst));
                 drop(executor);

--- a/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.result
+++ b/tests/suites/0_stateless/14_clickhouse_http_handler/14_0007_http_clickhouse_input_format_diagnostic.result
@@ -1,1 +1,1 @@
-{"error":{"code":"500","message":"BadBytes. Code: 1046, Text = Number of columns in file (3) does not match that of the corresponding table (2), at file 'clickhouse_insert', line 0."}}
+{"error":{"code":"500","message":"BadBytes. Code: 1046, Text = Number of columns in file (3) does not match that of the corresponding table (2)\nat file 'clickhouse_insert', line 0."}}

--- a/tests/suites/1_stateful/00_stage/00_0011_distributed_copy_into_table_exection_test.result
+++ b/tests/suites/1_stateful/00_stage/00_0011_distributed_copy_into_table_exection_test.result
@@ -32,7 +32,8 @@ sample_3_replace.csv	5	0	NULL	NULL
 105	hammer	14oz carpenter's hammer
 24
 null
-Text = Number of columns in file (2) does not match that of the corresponding table (3), at file 'sample_2_columns.csv', line 0.
+ERROR 1105 (HY000) at line 1: BadBytes. Code: 1046, Text = Number of columns in file (2) does not match that of the corresponding table (3)
+at file 'sample_2_columns.csv', line 0.
 24
 5
 itt.csv	5	0	NULL	NULL

--- a/tests/suites/1_stateful/00_stage/00_0011_distributed_copy_into_table_exection_test.sh
+++ b/tests/suites/1_stateful/00_stage/00_0011_distributed_copy_into_table_exection_test.sh
@@ -20,7 +20,7 @@ echo "select * from products order by id,name,description;" | $MYSQL_CLIENT_CONN
 echo "select count(*) from products;" | $MYSQL_CLIENT_CONNECT
 ## error test!!!
 curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/csv/sample_2_columns.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
-echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv' purge = true;"  | $MYSQL_CLIENT_CONNECT 2>&1 | grep -o 'Text.*'
+echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv' purge = true;"  | $MYSQL_CLIENT_CONNECT 2>&1
 echo "select count(*) from products;" | $MYSQL_CLIENT_CONNECT
 echo "list @s0011;" | $MYSQL_CLIENT_CONNECT | grep -o 'csv' | wc -l | sed 's/ //g'
 echo "set enable_distributed_copy_into = 1;copy into products from (select \$1,\$2,\$3 from @s0011 as t2) force = true purge = true;"  | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/07_stage_attachment/07_0001_replace_with_stage.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0001_replace_with_stage.result
@@ -36,7 +36,8 @@ null
 10	'Hong Kong‘	88	China
 {
   "code": 4000,
-  "message": "duplicated data detected in the values being replaced into (only the first one will be described): at row 7, [\"id\":10]"
+  "message": "duplicated data detected in the values being replaced into (only the first one will be described): at row 7, [\"id\":10]",
+  "detail": ""
 }
 1	'Chengdu'	80	China
 2	'shanghai'	2	China

--- a/tests/suites/1_stateful/09_http_handler/09_0001_json_response.result
+++ b/tests/suites/1_stateful/09_http_handler/09_0001_json_response.result
@@ -1,3 +1,3 @@
-{"code":1025,"message":"error: \n  --> SQL:1:15\n  |\n1 | select * from t1\n  |               ^^ Unknown table `default`.`t1` in catalog 'default'\n\n"}
+{"code":1025,"message":"error: \n  --> SQL:1:15\n  |\n1 | select * from t1\n  |               ^^ Unknown table `default`.`t1` in catalog 'default'\n\n","detail":""}
 {"error":{"code":"400","message":"parse error: key must be a string at line 1 column 2"}}
 {"error":{"code":"404","message":"not found"}}

--- a/tests/suites/1_stateful/09_http_handler/09_0003_error_detail.result
+++ b/tests/suites/1_stateful/09_http_handler/09_0003_error_detail.result
@@ -1,0 +1,6 @@
+null
+{
+  "code": 1046,
+  "message": "Number of columns in file (2) does not match that of the corresponding table (3)",
+  "detail": "at file 'select.csv', line 1"
+}

--- a/tests/suites/1_stateful/09_http_handler/09_0003_error_detail.sh
+++ b/tests/suites/1_stateful/09_http_handler/09_0003_error_detail.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+echo "drop table if exists products;" | $MYSQL_CLIENT_CONNECT
+echo "drop stage if exists s1;" | $MYSQL_CLIENT_CONNECT
+echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV);" | $MYSQL_CLIENT_CONNECT
+echo "remove @s1;" | $MYSQL_CLIENT_CONNECT
+echo "create table products (id int, name string, description string);" | $MYSQL_CLIENT_CONNECT
+
+curl -s -u root: -H "x-databend-stage-name:s1" -F "upload=@${CURDIR}/../../../data/csv/select.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
+curl -s -u root: -XPOST "http://localhost:8000/v1/query" --header 'Content-Type: application/json' -d '{"sql": "copy into products (id, name, description) from @s1/", "pagination": { "wait_time_secs": 6}}' -u root: | jq ".error"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

e.g.

```
{
  "code": 1046,
  "message": "Number of columns in file (2) does not match that of the corresponding table (3)",
  "detail": "at file 'select.csv', line 1"
}
```

ErrorCode is 136 bytes after add another string field ,clippy warn about it, so I let Range use u32 instead of usize to reduce size to 128 bytes, to be more efficent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12899)
<!-- Reviewable:end -->
