### PR TITLE
ci: sqllogictest match both error code and error message.

### DIFF
--- a/tests/sqllogictests/suites/crdb/and_or
+++ b/tests/sqllogictests/suites/crdb/and_or
@@ -7,7 +7,7 @@ CREATE TABLE t (k INT null, a INT null, b INT null)
 statement ok
 INSERT INTO t VALUES (1, NULL, NULL), (2, NULL, 1), (3, 1, NULL), (4, 2, 0), (5, 3, 3)
 
-statement error 1001
+statement error (?s)1001.*divided by zero while evaluating function `divide\(3, 0\)`
 SELECT a <> 2 AND 3 / b = 1 FROM t ORDER BY k
 
 query I
@@ -15,10 +15,10 @@ SELECT a FROM t WHERE a <> 2 AND 3 / b = 1 ORDER BY k
 ----
 3
 
-statement error 1001
+statement error (?s)1001.*divided by zero while evaluating function `divide\(3, 0\)`
 SELECT a = 2 OR 3 / b = 1 FROM t ORDER BY k
 
-statement error 1001
+statement error (?s)1001.*divided by zero while evaluating function `divide\(3, 0\)`
 SELECT a FROM t WHERE a = 2 OR 3 / b = 1 ORDER BY k
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary


1.  format http error message, so the main part of it is the same as that of mysql/clickhouse handler.
2.  make full use of regex to match both code and message. note:   1. need `(?s)` to match multiline. 2. meta characters like `(` needs to be escaped.

if this pattern is ok, I will update the remaining sqllogictest files in next pr.



- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12904)
<!-- Reviewable:end -->
