### PR TITLE
fix: support aggregation arguments in grouping sets.

### DIFF
--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -1306,6 +1306,7 @@ impl PipelineBuilder {
             .collect::<Result<Vec<_>>>()?;
         let grouping_sets = expand
             .grouping_sets
+            .sets
             .iter()
             .map(|sets| {
                 sets.iter()

--- a/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
@@ -188,7 +188,7 @@ impl WindowFunctionInfo {
                     agg.sig.args.clone(),
                 )?;
                 let args = agg
-                    .args
+                    .arg_indices
                     .iter()
                     .map(|p| {
                         let offset = schema.index_of(&p.to_string())?;

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -507,6 +507,7 @@ fn aggregate_expand_to_format_tree(
 ) -> Result<FormatTreeNode<String>> {
     let sets = plan
         .grouping_sets
+        .sets
         .iter()
         .map(|set| {
             set.iter()

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -289,6 +289,7 @@ impl ProjectSet {
     }
 }
 
+/// Add dummy data before `GROUPING SETS`.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct AggregateExpand {
     /// A unique id of operator in a `PhysicalPlan` tree.
@@ -306,16 +307,21 @@ impl AggregateExpand {
     pub fn output_schema(&self) -> Result<DataSchemaRef> {
         let input_schema = self.input.output_schema()?;
         let mut output_fields = input_schema.fields().clone();
+        // Add virtual columns to group by.
+        output_fields.reserve(self.group_bys.len() + 1);
 
-        for group_by in self
+        for (group_by, (actual, ty)) in self
             .group_bys
             .iter()
-            .filter(|&index| *index != self.grouping_sets.grouping_id_index)
+            .zip(self.grouping_sets.dup_group_items.iter())
         {
             // All group by columns will wrap nullable.
             let i = input_schema.index_of(&group_by.to_string())?;
             let f = &mut output_fields[i];
-            *f = DataField::new(f.name(), f.data_type().wrap_nullable())
+            debug_assert_eq!(f.data_type(), ty);
+            *f = DataField::new(f.name(), f.data_type().wrap_nullable());
+            let new_field = DataField::new(&actual.to_string(), ty.clone());
+            output_fields.push(new_field);
         }
 
         output_fields.push(DataField::new(
@@ -342,7 +348,8 @@ pub struct AggregatePartial {
 impl AggregatePartial {
     pub fn output_schema(&self) -> Result<DataSchemaRef> {
         let input_schema = self.input.output_schema()?;
-        let mut fields = Vec::with_capacity(self.agg_funcs.len() + self.group_by.len());
+        let mut fields =
+            Vec::with_capacity(self.agg_funcs.len() + self.group_by.is_empty() as usize);
         for agg in self.agg_funcs.iter() {
             fields.push(DataField::new(
                 &agg.output_column.to_string(),
@@ -1266,7 +1273,7 @@ impl PhysicalPlan {
 pub struct AggregateFunctionDesc {
     pub sig: AggregateFunctionSignature,
     pub output_column: IndexType,
-    pub args: Vec<usize>,
+    /// Bound indices of arguments. Only used in partial aggregation.
     pub arg_indices: Vec<IndexType>,
 }
 

--- a/src/query/sql/src/executor/physical_plan_display.rs
+++ b/src/query/sql/src/executor/physical_plan_display.rs
@@ -243,7 +243,7 @@ impl Display for AggregateFinal {
                 format!(
                     "{}({})",
                     item.sig.name,
-                    item.args
+                    item.arg_indices
                         .iter()
                         .map(|index| index.to_string())
                         .collect::<Vec<String>>()
@@ -276,7 +276,7 @@ impl Display for AggregatePartial {
                 format!(
                     "{}({})",
                     item.sig.name,
-                    item.args
+                    item.arg_indices
                         .iter()
                         .map(|index| index.to_string())
                         .collect::<Vec<String>>()

--- a/src/query/sql/src/executor/physical_plan_display.rs
+++ b/src/query/sql/src/executor/physical_plan_display.rs
@@ -212,6 +212,7 @@ impl Display for AggregateExpand {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let sets = self
             .grouping_sets
+            .sets
             .iter()
             .map(|set| {
                 set.iter()

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -145,7 +145,6 @@ pub trait PhysicalPlanReplacer {
             plan_id: plan.plan_id,
             input: Box::new(input),
             group_bys: plan.group_bys.clone(),
-            grouping_id_index: plan.grouping_id_index,
             grouping_sets: plan.grouping_sets.clone(),
             stat_info: plan.stat_info.clone(),
         }))

--- a/src/query/sql/src/executor/profile.rs
+++ b/src/query/sql/src/executor/profile.rs
@@ -205,6 +205,7 @@ fn flatten_plan_node_profile(
                 attribute: OperatorAttribute::AggregateExpand(AggregateExpandAttribute {
                     group_keys: expand
                         .grouping_sets
+                        .sets
                         .iter()
                         .map(|columns| {
                             format!(

--- a/src/query/sql/src/planner/binder/distinct.rs
+++ b/src/query/sql/src/planner/binder/distinct.rs
@@ -82,8 +82,7 @@ impl Binder {
             aggregate_functions: vec![],
             from_distinct: true,
             limit: None,
-            grouping_id_index: 0,
-            grouping_sets: vec![],
+            grouping_sets: None,
         };
 
         Ok(SExpr::create_unary(

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -59,7 +59,7 @@ impl Binder {
         let mut scalars = HashMap::new();
         for item in select_list.items.iter() {
             // This item is a grouping sets item, its data type should be nullable.
-            let is_grouping_sets_item = agg_info.grouping_id_column.is_some()
+            let is_grouping_sets_item = agg_info.grouping_sets.is_some()
                 && agg_info.group_items_map.contains_key(&item.scalar);
             let mut column_binding = if let ScalarExpr::BoundColumnRef(ref column_ref) = item.scalar
             {

--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -490,8 +490,7 @@ impl SubqueryRewriter {
                         aggregate_functions: vec![],
                         from_distinct: false,
                         limit: None,
-                        grouping_id_index: 0,
-                        grouping_sets: vec![],
+                        grouping_sets: None,
                     }
                     .into(),
                 ),
@@ -707,7 +706,6 @@ impl SubqueryRewriter {
                             aggregate_functions: agg_items,
                             from_distinct: aggregate.from_distinct,
                             limit: aggregate.limit,
-                            grouping_id_index: aggregate.grouping_id_index,
                             grouping_sets: aggregate.grouping_sets.clone(),
                         }
                         .into(),

--- a/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/subquery_rewriter.rs
@@ -407,8 +407,7 @@ impl SubqueryRewriter {
                     from_distinct: false,
                     mode: AggregateMode::Initial,
                     limit: None,
-                    grouping_id_index: 0,
-                    grouping_sets: vec![],
+                    grouping_sets: None,
                 };
 
                 let compare = FunctionCall {
@@ -610,8 +609,7 @@ impl SubqueryRewriter {
                     ],
                     from_distinct: false,
                     limit: None,
-                    grouping_id_index: 0,
-                    grouping_sets: vec![],
+                    grouping_sets: None,
                 }
                 .into(),
             ),

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/agg_index/query_rewrite.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/agg_index/query_rewrite.rs
@@ -624,7 +624,7 @@ impl RewriteInfomartion<'_> {
 
     fn can_apply_index(&self) -> bool {
         if let Some((agg, _)) = self.aggregation {
-            if !agg.grouping_sets.is_empty() {
+            if agg.grouping_sets.is_some() {
                 // Grouping sets is not supported.
                 return false;
             }

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_expression::types::DataType;
 
 use crate::optimizer::ColumnSet;
 use crate::optimizer::Distribution;
@@ -41,12 +42,16 @@ pub enum AggregateMode {
     Initial,
 }
 
+/// Information for `GROUPING SETS`.
+/// See the comment of [`crate::planner::binder::aggregate::GroupingSetsInfo`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct GroupingSets {
     /// The index of the virtual column `_grouping_id`. It's valid only if `grouping_sets` is not empty.
     pub grouping_id_index: IndexType,
-    /// The grouping sets, each grouping set is a list of `group_items` indices.
+    /// See the comment in `GroupingSetsInfo`.
     pub sets: Vec<Vec<IndexType>>,
+    /// See the comment in `GroupingSetsInfo`.
+    pub dup_group_items: Vec<(IndexType, DataType)>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -41,6 +41,14 @@ pub enum AggregateMode {
     Initial,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct GroupingSets {
+    /// The index of the virtual column `_grouping_id`. It's valid only if `grouping_sets` is not empty.
+    pub grouping_id_index: IndexType,
+    /// The grouping sets, each grouping set is a list of `group_items` indices.
+    pub sets: Vec<Vec<IndexType>>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Aggregate {
     pub mode: AggregateMode,
@@ -51,10 +59,7 @@ pub struct Aggregate {
     // True if the plan is generated from distinct, else the plan is a normal aggregate;
     pub from_distinct: bool,
     pub limit: Option<usize>,
-    /// The index of the virtual column `_grouping_id`. It's valid only if `grouping_sets` is not empty.
-    pub grouping_id_index: IndexType,
-    /// The grouping sets, each grouping set is a list of `group_items` indices.
-    pub grouping_sets: Vec<Vec<IndexType>>,
+    pub grouping_sets: Option<GroupingSets>,
 }
 
 impl Aggregate {

--- a/src/query/sql/src/planner/semantic/grouping_check.rs
+++ b/src/query/sql/src/planner/semantic/grouping_check.rs
@@ -56,8 +56,8 @@ impl<'a> GroupingChecker<'a> {
                 .build()
             };
 
-            if let Some(grouping_id) = &self.bind_context.aggregate_info.grouping_id_column {
-                if grouping_id.index != column_binding.index {
+            if let Some(grouping_sets) = &self.bind_context.aggregate_info.grouping_sets {
+                if grouping_sets.grouping_id_column.index != column_binding.index {
                     column_binding.data_type = Box::new(column_binding.data_type.wrap_nullable());
                 }
             }

--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
@@ -148,8 +148,107 @@ a NULL 7 1 0 1 2
 b NULL 11 1 0 1 2
 NULL NULL 18 1 1 3 3
 
+# ISSUE-12852. Aggregation function argument is in grouping sets.
+query TT
+SELECT arg_min(c, 10), c FROM t GROUP BY CUBE (c) ORDER BY c;
+----
+1 1
+2 2
+3 3
+4 4
+5 5
+1 NULL
+
+query TT
+SELECT min(c), c FROM t GROUP BY CUBE (c) ORDER BY c;
+----
+1 1
+2 2
+3 3
+4 4
+5 5
+1 NULL
+
+query TT
+SELECT min(c + 1), c + 1 FROM t GROUP BY CUBE (c + 1) ORDER BY c + 1;
+----
+2 2
+3 3
+4 4
+5 5
+6 6
+2 NULL
+
+query TTTTTT
+SELECT min(a), min(b), min(c), max(c), a, b FROM t GROUP BY CUBE (a, b) ORDER BY a, b;
+----
+a A 1 2 a A
+a B 1 3 a B
+a A 1 3 a NULL
+b A 1 4 b A
+b B 1 5 b B
+b A 1 5 b NULL
+a A 1 4 NULL A
+a B 1 5 NULL B
+a A 1 5 NULL NULL
+
+statement ok
+drop table if exists tt;
+
+statement ok
+create table tt (a string not null, b string not null, c int not null);
+
+statement ok
+insert into tt select *  from t;
+
+query TT
+SELECT arg_min(c, 10), c FROM tt GROUP BY CUBE (c) ORDER BY c;
+----
+1 1
+2 2
+3 3
+4 4
+5 5
+1 NULL
+
+query TT
+SELECT min(c), c FROM tt GROUP BY CUBE (c) ORDER BY c;
+----
+1 1
+2 2
+3 3
+4 4
+5 5
+1 NULL
+
+query TT
+SELECT min(c + 1), c + 1 FROM tt GROUP BY CUBE (c + 1) ORDER BY c + 1;
+----
+2 2
+3 3
+4 4
+5 5
+6 6
+2 NULL
+
+query TTTTTT
+SELECT min(a), min(b), min(c), max(c), a, b FROM tt GROUP BY CUBE (a, b) ORDER BY a, b;
+----
+a A 1 2 a A
+a B 1 3 a B
+a A 1 3 a NULL
+b A 1 4 b A
+b B 1 5 b B
+b A 1 5 b NULL
+a A 1 4 NULL A
+a B 1 5 NULL B
+a A 1 5 NULL NULL
+
 statement ok
 drop table t all;
+
+statement ok
+drop table tt all;
 
 statement ok
 drop database grouping_sets;

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_grouping_sets.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_grouping_sets.test
@@ -2,11 +2,11 @@ query T
 explain select number % 2 as a, number % 3 as b, number % 5 as c from numbers(1) group by rollup(a, b, c);
 ----
 EvalScalar
-├── output columns: [a (#5), b (#6), c (#7)]
+├── output columns: [a (#8), b (#9), c (#10)]
 ├── expressions: [group_item (#1), group_item (#2), group_item (#3)]
 ├── estimated rows: 1.00
 └── AggregateFinal
-    ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#4)]
+    ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#7)]
     ├── group by: [a, b, c, _grouping_id]
     ├── aggregate functions: []
     ├── estimated rows: 1.00
@@ -16,7 +16,7 @@ EvalScalar
         ├── aggregate functions: []
         ├── estimated rows: 1.00
         └── AggregateExpand
-            ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#4)]
+            ├── output columns: [a (#1), b (#2), c (#3), _dup_group_item_0 (#4), _dup_group_item_1 (#5), _dup_group_item_2 (#6), _grouping_id (#7)]
             ├── grouping sets: [(a, b, c), (a, b), (a), ()]
             ├── estimated rows: 1.00
             └── EvalScalar
@@ -37,11 +37,11 @@ query T
 explain select number % 2 as a, number % 3 as b, number % 5 as c from numbers(1) group by cube(a, b, c);
 ----
 EvalScalar
-├── output columns: [a (#5), b (#6), c (#7)]
+├── output columns: [a (#8), b (#9), c (#10)]
 ├── expressions: [group_item (#1), group_item (#2), group_item (#3)]
 ├── estimated rows: 1.00
 └── AggregateFinal
-    ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#4)]
+    ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#7)]
     ├── group by: [a, b, c, _grouping_id]
     ├── aggregate functions: []
     ├── estimated rows: 1.00
@@ -51,7 +51,7 @@ EvalScalar
         ├── aggregate functions: []
         ├── estimated rows: 1.00
         └── AggregateExpand
-            ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#4)]
+            ├── output columns: [a (#1), b (#2), c (#3), _dup_group_item_0 (#4), _dup_group_item_1 (#5), _dup_group_item_2 (#6), _grouping_id (#7)]
             ├── grouping sets: [(), (a), (b), (c), (a, b), (a, c), (b, c), (a, b, c)]
             ├── estimated rows: 1.00
             └── EvalScalar

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain_grouping_sets.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain_grouping_sets.test
@@ -2,11 +2,11 @@ query T
 explain select number % 2 as a, number % 3 as b, number % 5 as c from numbers(1) group by rollup(a, b, c);
 ----
 EvalScalar
-├── output columns: [a (#5), b (#6), c (#7)]
+├── output columns: [a (#8), b (#9), c (#10)]
 ├── expressions: [group_item (#1), group_item (#2), group_item (#3)]
 ├── estimated rows: 1.00
 └── AggregateFinal
-    ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#4)]
+    ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#7)]
     ├── group by: [a, b, c, _grouping_id]
     ├── aggregate functions: []
     ├── estimated rows: 1.00
@@ -16,7 +16,7 @@ EvalScalar
         ├── aggregate functions: []
         ├── estimated rows: 1.00
         └── AggregateExpand
-            ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#4)]
+            ├── output columns: [a (#1), b (#2), c (#3), _dup_group_item_0 (#4), _dup_group_item_1 (#5), _dup_group_item_2 (#6), _grouping_id (#7)]
             ├── grouping sets: [(a, b, c), (a, b), (a), ()]
             ├── estimated rows: 1.00
             └── EvalScalar
@@ -37,11 +37,11 @@ query T
 explain select number % 2 as a, number % 3 as b, number % 5 as c from numbers(1) group by cube(a, b, c);
 ----
 EvalScalar
-├── output columns: [a (#5), b (#6), c (#7)]
+├── output columns: [a (#8), b (#9), c (#10)]
 ├── expressions: [group_item (#1), group_item (#2), group_item (#3)]
 ├── estimated rows: 1.00
 └── AggregateFinal
-    ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#4)]
+    ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#7)]
     ├── group by: [a, b, c, _grouping_id]
     ├── aggregate functions: []
     ├── estimated rows: 1.00
@@ -51,7 +51,7 @@ EvalScalar
         ├── aggregate functions: []
         ├── estimated rows: 1.00
         └── AggregateExpand
-            ├── output columns: [a (#1), b (#2), c (#3), _grouping_id (#4)]
+            ├── output columns: [a (#1), b (#2), c (#3), _dup_group_item_0 (#4), _dup_group_item_1 (#5), _dup_group_item_2 (#6), _grouping_id (#7)]
             ├── grouping sets: [(), (a), (b), (c), (a, b), (a, c), (b, c), (a, b, c)]
             ├── estimated rows: 1.00
             └── EvalScalar


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The main idea of the implementation of grouping sets and what this PR fixed are described in the comments above the definition of `GroupingSetsInfo`.

### Binder

- Wrap grouping sets variables into one struct.
- Add a new field `dup_group_items`.
- Add detail comments about grouping sets.

### Physical Plan

- Only hold bound indices of aggregation functions' arguments in  `AggregateFunctionDesc`. The deleted field `args` is the column offsets of the input schema, postpone this generation until pipeline building (to be same with other indices like `group_bys`).
- Rewrite aggregation functions' arguments' descriptions (index and data type) to read duplicated columns instead of the original column (which will be filled with dummy NULLs)

### Pipeline Builder

- Compute column offset of aggregation functions' arguments here.

### TransformExpandGroupingSets

- Duplicate group item columns and them to output columns.

Closes #12852

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12939)
<!-- Reviewable:end -->
