### PR TITLE
fix: purge oom

### DIFF
--- a/src/query/storages/common/table-meta/src/meta/mod.rs
+++ b/src/query/storages/common/table-meta/src/meta/mod.rs
@@ -50,6 +50,8 @@ pub use versions::Versioned;
 // - export meta encoding to benchmarking tests
 pub mod testing {
     pub use super::format::MetaEncoding;
+    pub use super::v0::statistics::Statistics as StatisticsV0;
+    pub use super::v1::TableSnapshot as TableSnapshotV1;
     pub use super::v2::SegmentInfo as SegmentInfoV2;
     pub use super::v2::TableSnapshot as TableSnapshotV2;
     pub use super::v3::SegmentInfo as SegmentInfoV3;

--- a/src/query/storages/common/table-meta/src/meta/v2/snapshot.rs
+++ b/src/query/storages/common/table-meta/src/meta/v2/snapshot.rs
@@ -127,7 +127,7 @@ impl From<v1::TableSnapshot> for TableSnapshot {
             // carries the format_version of snapshot being converted.
             format_version: s.format_version,
             snapshot_id: s.snapshot_id,
-            timestamp: None,
+            timestamp: s.timestamp,
             prev_snapshot_id: s.prev_snapshot_id,
             schema,
             summary,

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -63,6 +63,12 @@ impl FuseTable {
             }
         }
         let root_snapshot_info = root_snapshot_info_op.unwrap();
+        if root_snapshot_info.snapshot_lite.timestamp.is_none() {
+            return Err(ErrorCode::StorageOther(format!(
+                "gc: snapshot timestamp is none, snapshot location: {}",
+                root_snapshot_info.snapshot_location
+            )));
+        }
 
         let snapshots_io = SnapshotsIO::create(ctx.clone(), self.operator.clone());
         let location_gen = self.meta_location_generator();
@@ -116,7 +122,7 @@ impl FuseTable {
             let mut segments_to_be_purged = HashSet::new();
             let mut ts_to_be_purged = HashSet::new();
             for s in snapshots.into_iter() {
-                if s.timestamp >= base_timestamp {
+                if s.timestamp.is_some() && s.timestamp >= base_timestamp {
                     remain_snapshots.push(s);
                     continue;
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This bug is caused by forgetting to convert the snapshot timestamp from v1 to v2. And thus the history snapshot is not purged in time, cause the oom.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12950)
<!-- Reviewable:end -->
