### PR TITLE
ci: add `nextest` to rust-tools.txt

### DIFF
--- a/scripts/setup/rust-tools.txt
+++ b/scripts/setup/rust-tools.txt
@@ -2,3 +2,4 @@ cargo-audit@0.17.6
 cargo-machete@0.5.0
 taplo-cli@0.8.1
 typos-cli@1.16.3
+nextest@0.9.58


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add `nextest` to rust-tools.txt, so that later we may use `nextest` to accelerate the unit testing phase.

- Closes #issue
