### PR TITLE
fix: disallow nested general window function

### DIFF
--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -702,5 +702,11 @@ select max(sum(salary) over(ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)) f
 statement error 1065
 select to_date('2022-02-02') over(order by (to_date('2017-12-04') - to_date('2017-02-02')))
 
+statement error 1065
+select last_value(last_value(salary) over ()) over () from empsalary
+
+statement error 1065
+select sum(sum(salary) over()) over() from empsalary
+
 statement ok
 DROP DATABASE test_window_basic


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

disallow nested general window function, after this pr:
```
root@localhost:8000/default> select last_value(last_value(a) over ()) over () from t;
APIError: ResponseError with 1065: error:
  --> SQL:1:19
  |
1 | select last_value(last_value(a) over ()) over () from t
  |                   ^^^^^^^^^^^^^^^^^^^^^ window function calls cannot be nested
```

- Closes #12922

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12973)
<!-- Reviewable:end -->
