### PR TITLE
fix(query): fix copy tuple cast to variant lost field name

### DIFF
--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3641,6 +3641,8 @@ Functions overloads:
 1 try_inet_aton(String NULL) :: UInt32 NULL
 0 try_inet_ntoa(Int64) :: String NULL
 1 try_inet_ntoa(Int64 NULL) :: String NULL
+0 try_json_object FACTORY
+0 try_json_object_keep_null FACTORY
 0 try_parse_json(Variant) :: Variant NULL
 1 try_parse_json(Variant NULL) :: Variant NULL
 2 try_parse_json(String) :: Variant NULL

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -2073,6 +2073,86 @@ evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
+ast            : try_json_object()
+raw expr       : try_json_object()
+checked expr   : try_json_object<>()
+optimized expr : 0x40000000
+output type    : Variant NULL
+output domain  : Undefined
+output         : {}
+
+
+ast            : try_json_object('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})
+raw expr       : try_json_object('a', true, 'b', 1, 'c', 'str', 'd', array(1, 2), 'e', map(array('k'), array('v')))
+checked expr   : try_json_object<T0=String, T1=Boolean, T2=String, T3=UInt8, T4=String, T5=String, T6=String, T7=Array(UInt8), T8=String, T9=Map(String, String)><T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>("a", true, "b", 1_u8, "c", "str", "d", array<T0=UInt8><T0, T0>(1_u8, 2_u8), "e", map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0>("k"), array<T0=String><T0>("v")))
+optimized expr : 0x400000051000000110000001100000011000000110000001400000002000000210000003500000105000000e61626364655001737472800000022000000220000002500150024000000110000001100000016b76
+output type    : Variant NULL
+output domain  : Undefined
+output         : {"a":true,"b":1,"c":"str","d":[1,2],"e":{"k":"v"}}
+
+
+ast            : try_json_object('k1', 1, 'k2', null, 'k3', 2, null, 3)
+raw expr       : try_json_object('k1', 1, 'k2', NULL, 'k3', 2, NULL, 3)
+checked expr   : try_json_object<T0=String, T1=UInt8, T2=String, T3=NULL, T4=String, T5=UInt8, T6=NULL, T7=UInt8><T0, T1, T2, T3, T4, T5, T6, T7>("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+optimized expr : 0x40000002100000021000000220000002200000026b316b3350015002
+output type    : Variant NULL
+output domain  : Undefined
+output         : {"k1":1,"k3":2}
+
+
+ast            : try_json_object('k1', 1, 'k1')
+raw expr       : try_json_object('k1', 1, 'k1')
+checked expr   : try_json_object<T0=String, T1=UInt8, T2=String><T0, T1, T2>("k1", 1_u8, "k1")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_json_object('k1', 1, 'k1', 2)
+raw expr       : try_json_object('k1', 1, 'k1', 2)
+checked expr   : try_json_object<T0=String, T1=UInt8, T2=String, T3=UInt8><T0, T1, T2, T3>("k1", 1_u8, "k1", 2_u8)
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_json_object(1, 'k1', 2, 'k2')
+raw expr       : try_json_object(1, 'k1', 2, 'k2')
+checked expr   : try_json_object<T0=UInt8, T1=String, T2=UInt8, T3=String><T0, T1, T2, T3>(1_u8, "k1", 2_u8, "k2")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_json_object(k1, v1, k2, v2)
+raw expr       : try_json_object(k1::String NULL, v1::String NULL, k2::String NULL, v2::String NULL)
+checked expr   : try_json_object<T0=String NULL, T1=String NULL, T2=String NULL, T3=String NULL><T0, T1, T2, T3>(k1, v1, k2, v2)
+evaluation:
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+|        | k1                   | v1                   | k2                   | v2            | Output                |
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+| Type   | String NULL          | String NULL          | String NULL          | String NULL   | Variant NULL          |
+| Domain | {""..="d1"} ∪ {NULL} | {""..="l1"} ∪ {NULL} | {""..="d2"} ∪ {NULL} | {"j2"..="m2"} | Undefined ∪ {NULL}    |
+| Row 0  | 'a1'                 | 'j1'                 | 'a2'                 | 'j2'          | {"a1":"j1","a2":"j2"} |
+| Row 1  | 'b1'                 | 'k1'                 | NULL                 | 'k2'          | {"b1":"k1"}           |
+| Row 2  | NULL                 | 'l1'                 | 'c2'                 | 'l2'          | {"c2":"l2"}           |
+| Row 3  | 'd1'                 | NULL                 | 'd2'                 | 'm2'          | {"d2":"m2"}           |
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                                               |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| k1     | NullableColumn { column: StringColumn { data: 0x613162316431, offsets: [0, 2, 4, 4, 6] }, validity: [0b____1011] }                                                                                                                                                 |
+| v1     | NullableColumn { column: StringColumn { data: 0x6a316b316c31, offsets: [0, 2, 4, 6, 6] }, validity: [0b____0111] }                                                                                                                                                 |
+| k2     | NullableColumn { column: StringColumn { data: 0x613263326432, offsets: [0, 2, 2, 4, 6] }, validity: [0b____1101] }                                                                                                                                                 |
+| v2     | NullableColumn { column: StringColumn { data: 0x6a326b326c326d32, offsets: [0, 2, 4, 6, 8] }, validity: [0b____1111] }                                                                                                                                             |
+| Output | NullableColumn { column: StringColumn { data: 0x4000000210000002100000021000000210000002613161326a316a3240000001100000021000000262316b3140000001100000021000000263326c3240000001100000021000000264326d32, offsets: [0, 28, 44, 60, 76] }, validity: [0b____1111] } |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
 ast            : json_object_keep_null()
 raw expr       : json_object_keep_null()
 checked expr   : json_object_keep_null<>()
@@ -2148,6 +2228,86 @@ evaluation (internal):
 | v2     | NullableColumn { column: StringColumn { data: 0x6a326b326c326d32, offsets: [0, 2, 4, 6, 8] }, validity: [0b____1111] }                                                                                                              |
 | Output | StringColumn { data: 0x4000000210000002100000021000000210000002613161326a316a3240000001100000021000000262316b3140000001100000021000000263326c324000000210000002100000020000000010000002643164326d32, offsets: [0, 28, 44, 60, 86] } |
 +--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : try_json_object_keep_null()
+raw expr       : try_json_object_keep_null()
+checked expr   : try_json_object_keep_null<>()
+optimized expr : 0x40000000
+output type    : Variant NULL
+output domain  : Undefined
+output         : {}
+
+
+ast            : try_json_object_keep_null('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})
+raw expr       : try_json_object_keep_null('a', true, 'b', 1, 'c', 'str', 'd', array(1, 2), 'e', map(array('k'), array('v')))
+checked expr   : try_json_object_keep_null<T0=String, T1=Boolean, T2=String, T3=UInt8, T4=String, T5=String, T6=String, T7=Array(UInt8), T8=String, T9=Map(String, String)><T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>("a", true, "b", 1_u8, "c", "str", "d", array<T0=UInt8><T0, T0>(1_u8, 2_u8), "e", map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0>("k"), array<T0=String><T0>("v")))
+optimized expr : 0x400000051000000110000001100000011000000110000001400000002000000210000003500000105000000e61626364655001737472800000022000000220000002500150024000000110000001100000016b76
+output type    : Variant NULL
+output domain  : Undefined
+output         : {"a":true,"b":1,"c":"str","d":[1,2],"e":{"k":"v"}}
+
+
+ast            : try_json_object_keep_null('k1', 1, 'k2', null, 'k3', 2, null, 3)
+raw expr       : try_json_object_keep_null('k1', 1, 'k2', NULL, 'k3', 2, NULL, 3)
+checked expr   : try_json_object_keep_null<T0=String, T1=UInt8, T2=String, T3=NULL, T4=String, T5=UInt8, T6=NULL, T7=UInt8><T0, T1, T2, T3, T4, T5, T6, T7>("k1", 1_u8, "k2", NULL, "k3", 2_u8, NULL, 3_u8)
+optimized expr : 0x400000031000000210000002100000022000000200000000200000026b316b326b3350015002
+output type    : Variant NULL
+output domain  : Undefined
+output         : {"k1":1,"k2":null,"k3":2}
+
+
+ast            : try_json_object_keep_null('k1', 1, 'k1')
+raw expr       : try_json_object_keep_null('k1', 1, 'k1')
+checked expr   : try_json_object_keep_null<T0=String, T1=UInt8, T2=String><T0, T1, T2>("k1", 1_u8, "k1")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_json_object_keep_null('k1', 1, 'k1', 2)
+raw expr       : try_json_object_keep_null('k1', 1, 'k1', 2)
+checked expr   : try_json_object_keep_null<T0=String, T1=UInt8, T2=String, T3=UInt8><T0, T1, T2, T3>("k1", 1_u8, "k1", 2_u8)
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_json_object_keep_null(1, 'k1', 2, 'k2')
+raw expr       : try_json_object_keep_null(1, 'k1', 2, 'k2')
+checked expr   : try_json_object_keep_null<T0=UInt8, T1=String, T2=UInt8, T3=String><T0, T1, T2, T3>(1_u8, "k1", 2_u8, "k2")
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : try_json_object_keep_null(k1, v1, k2, v2)
+raw expr       : try_json_object_keep_null(k1::String NULL, v1::String NULL, k2::String NULL, v2::String NULL)
+checked expr   : try_json_object_keep_null<T0=String NULL, T1=String NULL, T2=String NULL, T3=String NULL><T0, T1, T2, T3>(k1, v1, k2, v2)
+evaluation:
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+|        | k1                   | v1                   | k2                   | v2            | Output                |
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+| Type   | String NULL          | String NULL          | String NULL          | String NULL   | Variant NULL          |
+| Domain | {""..="d1"} ∪ {NULL} | {""..="l1"} ∪ {NULL} | {""..="d2"} ∪ {NULL} | {"j2"..="m2"} | Undefined ∪ {NULL}    |
+| Row 0  | 'a1'                 | 'j1'                 | 'a2'                 | 'j2'          | {"a1":"j1","a2":"j2"} |
+| Row 1  | 'b1'                 | 'k1'                 | NULL                 | 'k2'          | {"b1":"k1"}           |
+| Row 2  | NULL                 | 'l1'                 | 'c2'                 | 'l2'          | {"c2":"l2"}           |
+| Row 3  | 'd1'                 | NULL                 | 'd2'                 | 'm2'          | {"d1":null,"d2":"m2"} |
++--------+----------------------+----------------------+----------------------+---------------+-----------------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                                                                                                   |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| k1     | NullableColumn { column: StringColumn { data: 0x613162316431, offsets: [0, 2, 4, 4, 6] }, validity: [0b____1011] }                                                                                                                                                                     |
+| v1     | NullableColumn { column: StringColumn { data: 0x6a316b316c31, offsets: [0, 2, 4, 6, 6] }, validity: [0b____0111] }                                                                                                                                                                     |
+| k2     | NullableColumn { column: StringColumn { data: 0x613263326432, offsets: [0, 2, 2, 4, 6] }, validity: [0b____1101] }                                                                                                                                                                     |
+| v2     | NullableColumn { column: StringColumn { data: 0x6a326b326c326d32, offsets: [0, 2, 4, 6, 8] }, validity: [0b____1111] }                                                                                                                                                                 |
+| Output | NullableColumn { column: StringColumn { data: 0x4000000210000002100000021000000210000002613161326a316a3240000001100000021000000262316b3140000001100000021000000263326c324000000210000002100000020000000010000002643164326d32, offsets: [0, 28, 44, 60, 86] }, validity: [0b____1111] } |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
 ast            : json_path_query_array(parse_json('[1, 2, 3, 4, 5, 6]'), '$[0, 2 to last, 4]')

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -546,6 +546,48 @@ fn test_json_object(file: &mut impl Write) {
             ]),
         ),
     ]);
+
+    run_ast(file, "try_json_object()", &[]);
+    run_ast(
+        file,
+        "try_json_object('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})",
+        &[],
+    );
+    run_ast(
+        file,
+        "try_json_object('k1', 1, 'k2', null, 'k3', 2, null, 3)",
+        &[],
+    );
+    run_ast(file, "try_json_object('k1', 1, 'k1')", &[]);
+    run_ast(file, "try_json_object('k1', 1, 'k1', 2)", &[]);
+    run_ast(file, "try_json_object(1, 'k1', 2, 'k2')", &[]);
+
+    run_ast(file, "try_json_object(k1, v1, k2, v2)", &[
+        (
+            "k1",
+            StringType::from_data_with_validity(&["a1", "b1", "", "d1"], vec![
+                true, true, false, true,
+            ]),
+        ),
+        (
+            "v1",
+            StringType::from_data_with_validity(&["j1", "k1", "l1", ""], vec![
+                true, true, true, false,
+            ]),
+        ),
+        (
+            "k2",
+            StringType::from_data_with_validity(&["a2", "", "c2", "d2"], vec![
+                true, false, true, true,
+            ]),
+        ),
+        (
+            "v2",
+            StringType::from_data_with_validity(&["j2", "k2", "l2", "m2"], vec![
+                true, true, true, true,
+            ]),
+        ),
+    ]);
 }
 
 fn test_json_object_keep_null(file: &mut impl Write) {
@@ -565,6 +607,48 @@ fn test_json_object_keep_null(file: &mut impl Write) {
     run_ast(file, "json_object_keep_null(1, 'k1', 2, 'k2')", &[]);
 
     run_ast(file, "json_object_keep_null(k1, v1, k2, v2)", &[
+        (
+            "k1",
+            StringType::from_data_with_validity(&["a1", "b1", "", "d1"], vec![
+                true, true, false, true,
+            ]),
+        ),
+        (
+            "v1",
+            StringType::from_data_with_validity(&["j1", "k1", "l1", ""], vec![
+                true, true, true, false,
+            ]),
+        ),
+        (
+            "k2",
+            StringType::from_data_with_validity(&["a2", "", "c2", "d2"], vec![
+                true, false, true, true,
+            ]),
+        ),
+        (
+            "v2",
+            StringType::from_data_with_validity(&["j2", "k2", "l2", "m2"], vec![
+                true, true, true, true,
+            ]),
+        ),
+    ]);
+
+    run_ast(file, "try_json_object_keep_null()", &[]);
+    run_ast(
+        file,
+        "try_json_object_keep_null('a', true, 'b', 1, 'c', 'str', 'd', [1,2], 'e', {'k':'v'})",
+        &[],
+    );
+    run_ast(
+        file,
+        "try_json_object_keep_null('k1', 1, 'k2', null, 'k3', 2, null, 3)",
+        &[],
+    );
+    run_ast(file, "try_json_object_keep_null('k1', 1, 'k1')", &[]);
+    run_ast(file, "try_json_object_keep_null('k1', 1, 'k1', 2)", &[]);
+    run_ast(file, "try_json_object_keep_null(1, 'k1', 2, 'k2')", &[]);
+
+    run_ast(file, "try_json_object_keep_null(k1, v1, k2, v2)", &[
         (
             "k1",
             StringType::from_data_with_validity(&["a1", "b1", "", "d1"], vec![

--- a/src/query/storages/fuse/src/operations/agg_index_sink.rs
+++ b/src/query/storages/fuse/src/operations/agg_index_sink.rs
@@ -49,7 +49,6 @@ pub struct AggIndexSink {
 }
 
 impl AggIndexSink {
-    #[allow(clippy::too_many_arguments)]
     pub fn try_create(
         input: Arc<InputPort>,
         data_accessor: Operator,

--- a/src/query/storages/fuse/src/operations/merge.rs
+++ b/src/query/storages/fuse/src/operations/merge.rs
@@ -28,7 +28,6 @@ use crate::FuseTable;
 
 impl FuseTable {
     // todo: (JackTan25) add pipeline picture
-    #[allow(clippy::too_many_arguments)]
     pub fn matched_mutator(
         &self,
         ctx: Arc<dyn TableContext>,

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -123,7 +123,6 @@ impl FuseTable {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     #[minitrace::trace(name = "prune_snapshot_blocks")]
     #[async_backtrace::framed]
     pub async fn prune_snapshot_blocks(

--- a/src/query/storages/stage/src/parquet_file/sink_processor.rs
+++ b/src/query/storages/stage/src/parquet_file/sink_processor.rs
@@ -47,7 +47,6 @@ pub struct ParquetFileSink {
 }
 
 impl ParquetFileSink {
-    #[allow(clippy::too_many_arguments)]
     pub fn try_create(
         input: Arc<InputPort>,
         table_info: StageTableInfo,

--- a/src/query/storages/stage/src/row_based_file/sink_processor.rs
+++ b/src/query/storages/stage/src/row_based_file/sink_processor.rs
@@ -48,7 +48,6 @@ pub struct RowBasedFileSink {
 }
 
 impl RowBasedFileSink {
-    #[allow(clippy::too_many_arguments)]
     pub fn try_create(
         input: Arc<InputPort>,
         table_info: StageTableInfo,

--- a/tests/sqllogictests/suites/query/02_function/02_0048_function_semi_structureds_parse_json
+++ b/tests/sqllogictests/suites/query/02_function/02_0048_function_semi_structureds_parse_json
@@ -208,5 +208,17 @@ NULL abc
 NULL [1,
 
 statement ok
+CREATE TABLE IF NOT EXISTS t3(a int, b string, c tuple(id int, name string)) Engine = Fuse
+
+statement ok
+insert into t3 values (1, 'ab', (10, 'v1')),(2, 'cd', (20, 'v2'))
+
+query TTT
+select to_variant(a), to_variant(b), to_variant(c) from t3
+----
+1 "ab" {"id":10,"name":"v1"}
+2 "cd" {"id":20,"name":"v2"}
+
+statement ok
 DROP DATABASE db1
 

--- a/tests/sqllogictests/suites/query/02_function/02_0065_function_json
+++ b/tests/sqllogictests/suites/query/02_function/02_0065_function_json
@@ -63,6 +63,52 @@ SELECT json_array(true, 1, 'str', [1,2], {'k':'v'}, null)
 ----
 [true,1,"str",[1,2],{"k":"v"},null]
 
+query T
+SELECT json_object()
+----
+{}
+
+query T
+SELECT json_object('k1', 1, 'k2', 'str', 'k3', [1,2], 'k4', {'k':'v'}, 'k5', null)
+----
+{"k1":1,"k2":"str","k3":[1,2],"k4":{"k":"v"}}
+
+statement error 1001
+SELECT json_object('k1', 1, 'k2', 'str', 'k3')
+
+query T
+SELECT try_json_object('k1', 1, 'k2', 'str', 'k3', [1,2], 'k4', {'k':'v'}, 'k5', null)
+----
+{"k1":1,"k2":"str","k3":[1,2],"k4":{"k":"v"}}
+
+query T
+SELECT try_json_object('k1', 1, 'k2', 'str', 'k3')
+----
+NULL
+
+query T
+SELECT json_object_keep_null()
+----
+{}
+
+query T
+SELECT json_object_keep_null('k1', 1, 'k2', 'str', 'k3', [1,2], 'k4', {'k':'v'}, 'k5', null)
+----
+{"k1":1,"k2":"str","k3":[1,2],"k4":{"k":"v"},"k5":null}
+
+statement error 1001
+SELECT json_object_keep_null('k1', 1, 'k2', 'str', 'k3')
+
+query T
+SELECT try_json_object_keep_null('k1', 1, 'k2', 'str', 'k3', [1,2], 'k4', {'k':'v'}, 'k5', null)
+----
+{"k1":1,"k2":"str","k3":[1,2],"k4":{"k":"v"},"k5":null}
+
+query T
+SELECT try_json_object_keep_null('k1', 1, 'k2', 'str', 'k3')
+----
+NULL
+
 statement ok
 DROP TABLE IF EXISTS t1
 
@@ -80,6 +126,24 @@ SELECT json_array(id, tag) FROM t1
 [3,"c"]
 [4,"null"]
 [5,null]
+
+query T
+SELECT json_object('id', id, 'tag', tag) FROM t1
+----
+{"id":1,"tag":"a"}
+{"id":2,"tag":"b"}
+{"id":3,"tag":"c"}
+{"id":4,"tag":"null"}
+{"id":5}
+
+query T
+SELECT json_object_keep_null('id', id, 'tag', tag) FROM t1
+----
+{"id":1,"tag":"a"}
+{"id":2,"tag":"b"}
+{"id":3,"tag":"c"}
+{"id":4,"tag":"null"}
+{"id":5,"tag":null}
 
 statement ok
 DROP TABLE IF EXISTS t1

--- a/tests/sqllogictests/suites/stage_parquet/parquet_field_types
+++ b/tests/sqllogictests/suites/stage_parquet/parquet_field_types
@@ -149,3 +149,21 @@ select * from t order by id
 100051133 0 1.0 2.002 2021-09-21 16:00:00.000000 2021-09-22 [4,3,1,2,0,0]
 100051134 1 1.1 2.2 2021-10-09 16:00:00.000000 2021-10-10 [6,6,6]
 100051135 NULL NULL NULL NULL NULL [10]
+
+statement ok
+drop table if exists t1
+
+statement ok
+create table t1(id string null, t variant null)
+
+query 
+copy into t1 from @data/parquet/tuple.parquet
+----
+parquet/tuple.parquet 3 0 NULL NULL
+
+query 
+select * from t1 order by id
+----
+1 {"a":1,"b":"a"}
+2 {"a":3,"b":"b"}
+3 {"a":3,"b":"c"}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- rewrite tuple cast to variant as `json_object_keep_null` function to using inner fields name as object keys
- add `try_json_object` and `try_json_object_keep_null` functions
- remove unused `clippy::too_many_arguments`

- Closes #12966

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12983)
<!-- Reviewable:end -->
