### PR TITLE
chore: remove redundant `Arc` and use atomic to replace lock

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -73,7 +73,7 @@ pub struct HashJoinBuildState {
     /// To make the size of each chunk suitable, it's better to define a threshold to the size of each chunk.
     /// Before putting the input data into `Chunk`, we will add them to buffer of `RowSpace`
     /// After buffer's size hits the threshold, we will flush the buffer to `Chunk`.
-    pub(crate) chunk_size_limit: Arc<usize>,
+    pub(crate) chunk_size_limit: usize,
     /// Wait util all processors finish row space build, then go to next phase.
     pub(crate) barrier: Barrier,
     /// It will be increased by 1 when a new hash join build processor is created.
@@ -82,17 +82,17 @@ pub struct HashJoinBuildState {
     /// When the counter is 0, it means all hash join build processors have input their data to `RowSpace`.
     pub(crate) row_space_builders: Mutex<usize>,
     /// Hash method for hash join keys.
-    pub(crate) method: Arc<HashMethodKind>,
+    pub(crate) method: HashMethodKind,
     /// The size of each entry in HashTable.
-    pub(crate) entry_size: Arc<AtomicUsize>,
+    pub(crate) entry_size: AtomicUsize,
     pub(crate) raw_entry_spaces: Mutex<Vec<Vec<u8>>>,
     /// `build_projections` only contains the columns from upstream required columns
     /// and columns from other_condition which are in build schema.
-    pub(crate) build_projections: Arc<ColumnSet>,
+    pub(crate) build_projections: ColumnSet,
     /// FIXME: the field can be removed later
-    pub(crate) build_worker_num: Arc<AtomicU32>,
+    pub(crate) build_worker_num: AtomicU32,
     /// Tasks for building hash table.
-    pub(crate) build_hash_table_tasks: Arc<RwLock<VecDeque<(usize, usize)>>>,
+    pub(crate) build_hash_table_tasks: RwLock<VecDeque<(usize, usize)>>,
 
     /// Spill related states
     /// `send_val` is the message which will be send into `build_done_watcher` channel.
@@ -120,16 +120,16 @@ impl HashJoinBuildState {
             ctx: ctx.clone(),
             hash_join_state,
             _processor_count: processor_count,
-            chunk_size_limit: Arc::new(ctx.get_settings().get_max_block_size()? as usize * 16),
+            chunk_size_limit: ctx.get_settings().get_max_block_size()? as usize * 16,
             barrier,
             restore_barrier,
             row_space_builders: Default::default(),
-            method: Arc::new(method),
-            entry_size: Arc::new(Default::default()),
+            method,
+            entry_size: Default::default(),
             raw_entry_spaces: Default::default(),
-            build_projections: Arc::new(build_projections.clone()),
-            build_worker_num: Arc::new(Default::default()),
-            build_hash_table_tasks: Arc::new(Default::default()),
+            build_projections: build_projections.clone(),
+            build_worker_num: Default::default(),
+            build_hash_table_tasks: Default::default(),
             send_val: AtomicU8::new(1),
         }))
     }
@@ -140,7 +140,7 @@ impl HashJoinBuildState {
         let mut buffer_row_size = self.hash_join_state.row_space.buffer_row_size.write();
         *buffer_row_size += input.num_rows();
         buffer.push(input);
-        if *buffer_row_size < *self.chunk_size_limit {
+        if *buffer_row_size < self.chunk_size_limit {
             Ok(())
         } else {
             let data_block = DataBlock::concat(buffer.as_slice())?;
@@ -246,11 +246,9 @@ impl HashJoinBuildState {
                 && self.ctx.get_cluster().is_empty()
                 && !self.ctx.get_settings().get_enable_join_spill()?
             {
-                {
-                    let mut fast_return = self.hash_join_state.fast_return.write();
-                    *fast_return = true;
-                }
-
+                self.hash_join_state
+                    .fast_return
+                    .store(true, Ordering::Relaxed);
                 self.hash_join_state
                     .build_done_watcher
                     .send(self.send_val.load(Ordering::Relaxed))
@@ -259,7 +257,7 @@ impl HashJoinBuildState {
             }
 
             // Create a fixed size hash table.
-            let hashjoin_hashtable = match (*self.method).clone() {
+            let hashjoin_hashtable = match self.method.clone() {
                 HashMethodKind::Serializer(_) => {
                     self.entry_size
                         .store(std::mem::size_of::<StringRawEntry>(), Ordering::SeqCst);
@@ -469,9 +467,8 @@ impl HashJoinBuildState {
         let func_ctx = self.ctx.get_function_context()?;
         let chunks = unsafe { &mut *self.hash_join_state.chunks.get() };
         let mut has_null = false;
-        let interrupt = self.hash_join_state.interrupt.clone();
         for chunk_index in task.0..task.1 {
-            if interrupt.load(Ordering::Relaxed) {
+            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
                 return Err(ErrorCode::AbortedQuery(
                     "Aborted query, because the server is shutting down or the query was killed.",
                 ));

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -71,10 +71,10 @@ pub struct HashJoinProbeState {
     pub(crate) probe_schema: DataSchemaRef,
     /// `probe_projections` only contains the columns from upstream required columns
     /// and columns from other_condition which are in probe schema.
-    pub(crate) probe_projections: Arc<ColumnSet>,
+    pub(crate) probe_projections: ColumnSet,
     /// Todo(xudong): add more detailed comments for the following fields.
     /// Final scan tasks
-    pub(crate) final_scan_tasks: Arc<RwLock<VecDeque<usize>>>,
+    pub(crate) final_scan_tasks: RwLock<VecDeque<usize>>,
     pub(crate) mark_scan_map_lock: Mutex<bool>,
     /// Hash method
     pub(crate) hash_method: HashMethodKind,
@@ -85,7 +85,7 @@ pub struct HashJoinProbeState {
     /// Record final probe workers
     pub(crate) final_probe_workers: Mutex<usize>,
     /// Probe spilled partitions set
-    pub(crate) spill_partitions: Arc<RwLock<HashSet<u8>>>,
+    pub(crate) spill_partitions: RwLock<HashSet<u8>>,
     /// Wait all processors to restore spilled data, then go to new probe
     pub(crate) restore_barrier: Barrier,
 }
@@ -124,11 +124,11 @@ impl HashJoinProbeState {
             barrier,
             restore_barrier,
             probe_schema,
-            probe_projections: Arc::new(probe_projections.clone()),
-            final_scan_tasks: Arc::new(RwLock::new(VecDeque::new())),
+            probe_projections: probe_projections.clone(),
+            final_scan_tasks: RwLock::new(VecDeque::new()),
             mark_scan_map_lock: Mutex::new(false),
             hash_method: method,
-            spill_partitions: Arc::new(Default::default()),
+            spill_partitions: Default::default(),
         })
     }
 
@@ -230,7 +230,7 @@ impl HashJoinProbeState {
         let input = input.project(&self.probe_projections);
         let is_probe_projected = input.num_columns() > 0;
 
-        if self.hash_join_state.fast_return()?
+        if self.hash_join_state.fast_return.load(Ordering::Relaxed)
             && matches!(
                 self.hash_join_state.hash_join_desc.join_type,
                 JoinType::Left | JoinType::LeftSingle | JoinType::Full | JoinType::LeftAnti
@@ -284,17 +284,20 @@ impl HashJoinProbeState {
         if *count == 0 {
             // If build side has spilled data, we need to wait build side to next round.
             // Set partition id to `HashJoinState`
-            let mut partition_id = self.hash_join_state.partition_id.write();
             let mut spill_partitions = self.spill_partitions.write();
             if let Some(id) = spill_partitions.iter().next().cloned() {
                 spill_partitions.remove(&id);
-                *partition_id = id as i8;
+                self.hash_join_state
+                    .partition_id
+                    .store(id as i8, Ordering::Relaxed);
             } else {
-                *partition_id = -1;
+                self.hash_join_state
+                    .partition_id
+                    .store(-1, Ordering::Relaxed);
             }
             info!(
                 "next partition to read: {:?}, final probe done",
-                *partition_id
+                self.hash_join_state.partition_id.load(Ordering::Relaxed)
             );
             self.hash_join_state
                 .continue_build_watcher
@@ -321,17 +324,20 @@ impl HashJoinProbeState {
         *count -= 1;
         if *count == 0 {
             // Set partition id to `HashJoinState`
-            let mut partition_id = self.hash_join_state.partition_id.write();
             let mut spill_partitions = self.spill_partitions.write();
             if let Some(id) = spill_partitions.iter().next().cloned() {
                 spill_partitions.remove(&id);
-                *partition_id = id as i8;
+                self.hash_join_state
+                    .partition_id
+                    .store(id as i8, Ordering::Relaxed);
             } else {
-                *partition_id = -1;
+                self.hash_join_state
+                    .partition_id
+                    .store(-1, Ordering::Relaxed);
             };
             info!(
                 "next partition to read: {:?}, probe spill done",
-                *partition_id
+                self.hash_join_state.partition_id.load(Ordering::Relaxed)
             );
             self.hash_join_state
                 .continue_build_watcher
@@ -398,9 +404,8 @@ impl HashJoinProbeState {
         }
 
         let outer_scan_map = unsafe { &mut *self.hash_join_state.outer_scan_map.get() };
-        let interrupt = self.hash_join_state.interrupt.clone();
         let chunk_index = task;
-        if interrupt.load(Ordering::Relaxed) {
+        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
             return Err(ErrorCode::AbortedQuery(
                 "Aborted query, because the server is shutting down or the query was killed.",
             ));
@@ -418,7 +423,7 @@ impl HashJoinProbeState {
                 row_index += 1;
             }
 
-            if interrupt.load(Ordering::Relaxed) {
+            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
                 return Err(ErrorCode::AbortedQuery(
                     "Aborted query, because the server is shutting down or the query was killed.",
                 ));
@@ -498,9 +503,8 @@ impl HashJoinProbeState {
         let build_num_rows = unsafe { *self.hash_join_state.build_num_rows.get() };
 
         let outer_scan_map = unsafe { &mut *self.hash_join_state.outer_scan_map.get() };
-        let interrupt = self.hash_join_state.interrupt.clone();
         let chunk_index = task;
-        if interrupt.load(Ordering::Relaxed) {
+        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
             return Err(ErrorCode::AbortedQuery(
                 "Aborted query, because the server is shutting down or the query was killed.",
             ));
@@ -518,7 +522,7 @@ impl HashJoinProbeState {
                 row_index += 1;
             }
 
-            if interrupt.load(Ordering::Relaxed) {
+            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
                 return Err(ErrorCode::AbortedQuery(
                     "Aborted query, because the server is shutting down or the query was killed.",
                 ));
@@ -551,9 +555,8 @@ impl HashJoinProbeState {
         let build_num_rows = unsafe { *self.hash_join_state.build_num_rows.get() };
 
         let outer_scan_map = unsafe { &mut *self.hash_join_state.outer_scan_map.get() };
-        let interrupt = self.hash_join_state.interrupt.clone();
         let chunk_index = task;
-        if interrupt.load(Ordering::Relaxed) {
+        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
             return Err(ErrorCode::AbortedQuery(
                 "Aborted query, because the server is shutting down or the query was killed.",
             ));
@@ -571,7 +574,7 @@ impl HashJoinProbeState {
                 row_index += 1;
             }
 
-            if interrupt.load(Ordering::Relaxed) {
+            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
                 return Err(ErrorCode::AbortedQuery(
                     "Aborted query, because the server is shutting down or the query was killed.",
                 ));
@@ -600,9 +603,8 @@ impl HashJoinProbeState {
         let build_num_rows = unsafe { *self.hash_join_state.build_num_rows.get() };
 
         let mark_scan_map = unsafe { &mut *self.hash_join_state.mark_scan_map.get() };
-        let interrupt = self.hash_join_state.interrupt.clone();
         let chunk_index = task;
-        if interrupt.load(Ordering::Relaxed) {
+        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
             return Err(ErrorCode::AbortedQuery(
                 "Aborted query, because the server is shutting down or the query was killed.",
             ));
@@ -643,7 +645,7 @@ impl HashJoinProbeState {
                 row_index += 1;
             }
 
-            if interrupt.load(Ordering::Relaxed) {
+            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
                 return Err(ErrorCode::AbortedQuery(
                     "Aborted query, because the server is shutting down or the query was killed.",
                 ));

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/inner_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/inner_join.rs
@@ -112,7 +112,7 @@ impl HashJoinProbeState {
                     };
                     let mut result_block =
                         self.merge_eq_block(probe_block, build_block, matched_num);
-                    if self.hash_join_state.probe_to_build.len() > 0 {
+                    if !self.hash_join_state.probe_to_build.is_empty() {
                         for (index, (is_probe_nullable, is_build_nullable)) in
                             self.hash_join_state.probe_to_build.iter()
                         {
@@ -184,7 +184,7 @@ impl HashJoinProbeState {
                 None
             };
             let mut result_block = self.merge_eq_block(probe_block, build_block, matched_num);
-            if self.hash_join_state.probe_to_build.len() > 0 {
+            if !self.hash_join_state.probe_to_build.is_empty() {
                 for (index, (is_probe_nullable, is_build_nullable)) in
                     self.hash_join_state.probe_to_build.iter()
                 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. Whole `HashJoinState`, `HashJoinBuildState`, and `HashJoinProbeState` are in `Arc`, so no need to put their fields in `Arc`.
2. Replace some `Mutex/Lock` with `Atomic`.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/12988)
<!-- Reviewable:end -->
