### PR TITLE
chore: replace max_io_request

### DIFF
--- a/src/query/ee/src/storages/fuse/io/snapshots.rs
+++ b/src/query/ee/src/storages/fuse/io/snapshots.rs
@@ -49,7 +49,7 @@ where
     }
 
     // 1. Get all the snapshot by chunks, save all the segments location.
-    let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+    let max_io_requests = ctx.get_settings().get_max_threads()? as usize;
 
     let start = Instant::now();
     let mut count = 1;

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -526,7 +526,7 @@ impl PipelineBuilder {
             self.main_pipeline.add_pipe(builder.finalize());
         }
 
-        let max_io_request = self.ctx.get_settings().get_max_storage_io_requests()?;
+        let max_io_request = self.ctx.get_settings().get_max_threads()?;
         let io_request_semaphore = Arc::new(Semaphore::new(max_io_request as usize));
 
         let pipe_items = vec![
@@ -606,7 +606,7 @@ impl PipelineBuilder {
                 .add_pipe(Pipe::create(1, segment_partition_num, vec![
                     broadcast_processor.into_pipe_item(),
                 ]));
-            let max_io_request = self.ctx.get_settings().get_max_storage_io_requests()?;
+            let max_io_request = self.ctx.get_settings().get_max_threads()?;
             let io_request_semaphore = Arc::new(Semaphore::new(max_io_request as usize));
 
             let merge_into_operation_aggregators = table.merge_into_mutators(
@@ -687,7 +687,7 @@ impl PipelineBuilder {
             // setup the dummy transform
             pipe_items.push(serialize_segment_transform.into_pipe_item());
 
-            let max_io_request = self.ctx.get_settings().get_max_storage_io_requests()?;
+            let max_io_request = self.ctx.get_settings().get_max_threads()?;
             let io_request_semaphore = Arc::new(Semaphore::new(max_io_request as usize));
 
             // setup the merge into operation aggregators

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -388,11 +388,10 @@ async fn generage_segments(
     }
 
     let threads_nums = ctx.get_settings().get_max_threads()? as usize;
-    let permit_nums = ctx.get_settings().get_max_storage_io_requests()? as usize;
     execute_futures_in_parallel(
         tasks,
         threads_nums,
-        permit_nums,
+        threads_nums,
         "fuse-write-segments-worker".to_owned(),
     )
     .await?

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -659,7 +659,7 @@ impl CompactSegmentTestFixture {
 
         let schema = TestFixture::default_table_schema();
         let fuse_segment_io = SegmentsIO::create(self.ctx.clone(), data_accessor.clone(), schema);
-        let max_io_requests = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+        let max_io_requests = self.ctx.get_settings().get_max_threads()? as usize;
 
         let segment_writer = SegmentWriter::new(data_accessor, location_gen);
         let seg_acc = SegmentCompactor::new(
@@ -705,7 +705,6 @@ impl CompactSegmentTestFixture {
         let location_gen = TableMetaLocationGenerator::with_prefix("test/".to_owned());
         let data_accessor = ctx.get_data_operator()?.operator();
         let threads_nums = ctx.get_settings().get_max_threads()? as usize;
-        let permit_nums = ctx.get_settings().get_max_storage_io_requests()? as usize;
 
         let mut tasks = vec![];
         for (num_blocks, rows_per_block) in block_num_of_segments
@@ -788,7 +787,7 @@ impl CompactSegmentTestFixture {
         let res = execute_futures_in_parallel(
             tasks,
             threads_nums,
-            permit_nums,
+            threads_nums,
             "fuse-write-segments-worker".to_owned(),
         )
         .await?

--- a/src/query/storages/fuse/src/io/files.rs
+++ b/src/query/storages/fuse/src/io/files.rs
@@ -54,11 +54,11 @@ impl Files {
             });
 
             let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
-            let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+
             execute_futures_in_parallel(
                 tasks,
                 threads_nums,
-                permit_nums,
+                threads_nums,
                 "batch-remove-files-worker".to_owned(),
             )
             .await?;

--- a/src/query/storages/fuse/src/io/segments.rs
+++ b/src/query/storages/fuse/src/io/segments.rs
@@ -106,11 +106,10 @@ impl SegmentsIO {
         });
 
         let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
-        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
         execute_futures_in_parallel(
             tasks,
             threads_nums,
-            permit_nums,
+            threads_nums,
             "fuse-req-segments-worker".to_owned(),
         )
         .await
@@ -143,11 +142,11 @@ impl SegmentsIO {
         });
 
         let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
-        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+
         execute_futures_in_parallel(
             tasks,
             threads_nums,
-            permit_nums,
+            threads_nums,
             "write-segments-worker".to_owned(),
         )
         .await?

--- a/src/query/storages/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/src/io/snapshots.rs
@@ -141,11 +141,11 @@ impl SnapshotsIO {
         });
 
         let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
-        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+
         execute_futures_in_parallel(
             tasks,
             threads_nums,
-            permit_nums,
+            threads_nums,
             "fuse-req-snapshots-worker".to_owned(),
         )
         .await
@@ -173,7 +173,7 @@ impl SnapshotsIO {
         }
 
         // 1. Get all the snapshot by chunks.
-        let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+        let max_io_requests = ctx.get_settings().get_max_threads()? as usize;
         let mut snapshot_lites = Vec::with_capacity(snapshot_files.len());
 
         let start = Instant::now();
@@ -311,11 +311,11 @@ impl SnapshotsIO {
         });
 
         let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
-        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+
         execute_futures_in_parallel(
             tasks,
             threads_nums,
-            permit_nums,
+            threads_nums,
             "fuse-req-snapshots-worker".to_owned(),
         )
         .await

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -229,7 +229,7 @@ impl TableMutationAggregator {
 
                 let mut replaced_segments = HashMap::new();
                 let mut merged_statistics = Statistics::default();
-                let chunk_size = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+                let chunk_size = self.ctx.get_settings().get_max_threads()? as usize;
                 let segment_indices = self.mutations.keys().cloned().collect::<Vec<_>>();
                 for chunk in segment_indices.chunks(chunk_size) {
                     let results = self.partial_apply(chunk.to_vec()).await?;
@@ -373,11 +373,11 @@ impl TableMutationAggregator {
         }
 
         let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
-        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+
         execute_futures_in_parallel(
             tasks,
             threads_nums,
-            permit_nums,
+            threads_nums,
             "fuse-req-segments-worker".to_owned(),
         )
         .await?

--- a/src/query/storages/fuse/src/operations/mutation/recluster_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/recluster_aggregator.rs
@@ -193,11 +193,11 @@ impl ReclusterAggregator {
         }
 
         let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
-        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+
         execute_futures_in_parallel(
             tasks,
             threads_nums,
-            permit_nums,
+            threads_nums,
             "fuse-write-segments-worker".to_owned(),
         )
         .await?

--- a/src/query/storages/fuse/src/operations/mutation/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/recluster_mutator.rs
@@ -20,6 +20,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use common_base::runtime::execute_futures_in_parallel;
+use common_base::runtime::Runtime;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -265,11 +266,11 @@ impl ReclusterMutator {
         });
 
         let thread_nums = self.ctx.get_settings().get_max_threads()? as usize;
-        let permit_nums = self.ctx.get_settings().get_max_storage_io_requests()? as usize;
+
         let blocks = execute_futures_in_parallel(
             tasks,
             thread_nums,
-            permit_nums,
+            thread_nums,
             "convert-segments-worker".to_owned(),
         )
         .await?

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -328,7 +328,7 @@ impl FuseTable {
         mut segment_locs: Vec<SegmentLocation>,
     ) -> Result<Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>> {
         let max_concurrency = {
-            let max_io_requests = ctx.get_settings().get_max_storage_io_requests()? as usize;
+            let max_io_requests = ctx.get_settings().get_max_threads()? as usize;
             let v = std::cmp::max(max_io_requests, 10);
             if v > max_io_requests {
                 warn!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/
we need to use thread_nums to limit the permit_nums , in some cases, if the permit num is too large, we will get oom. 
## Summary

Summary about this PR

- Closes #issue
