### PR TITLE
fix: TableReference::Join unreachable cause databend-query panic

### DIFF
--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -577,7 +577,21 @@ impl Binder {
                 self.bind_stage_table(table_ctx, bind_context, stage_info, files_info, alias, None)
                     .await
             }
-            TableReference::Join { .. } => unreachable!(),
+            TableReference::Join { join, .. } => {
+                let (left_expr, left_bind_ctx) =
+                    self.bind_table_reference(bind_context, &join.left).await?;
+                let (right_expr, right_bind_ctx) =
+                    self.bind_table_reference(bind_context, &join.right).await?;
+                self.bind_join(
+                    bind_context,
+                    left_bind_ctx,
+                    right_bind_ctx,
+                    left_expr,
+                    right_expr,
+                    join,
+                )
+                .await
+            }
         }
     }
 

--- a/tests/sqllogictests/suites/query/join.test
+++ b/tests/sqllogictests/suites/query/join.test
@@ -715,3 +715,41 @@ drop table t1;
 
 statement ok
 drop table t2;
+
+statement ok
+create table t(id int);
+
+statement ok
+insert into t values(1), (2);
+
+statement ok
+create table t1(id int, col1 varchar);
+
+statement ok
+insert into t1 values(1, 'c'), (3, 'd');
+
+query I rowsort
+SELECT * FROM t JOIN t1, t as t2 JOIN t1 as t3;
+----
+1 1 c 1 1 c
+1 1 c 1 3 d
+1 1 c 2 1 c
+1 1 c 2 3 d
+1 3 d 1 1 c
+1 3 d 1 3 d
+1 3 d 2 1 c
+1 3 d 2 3 d
+2 1 c 1 1 c
+2 1 c 1 3 d
+2 1 c 2 1 c
+2 1 c 2 3 d
+2 3 d 1 1 c
+2 3 d 1 3 d
+2 3 d 2 1 c
+2 3 d 2 3 d
+
+statement ok
+drop table t;
+
+statement ok
+drop table t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

- Closes https://github.com/datafuselabs/databend/issues/12941

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13012)
<!-- Reviewable:end -->
