### PR TITLE
feat: add `join_spilled_bytes/rows` to query log

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -112,7 +112,9 @@ pub trait TableContext: Send + Sync {
     fn get_scan_progress(&self) -> Arc<Progress>;
     fn get_scan_progress_value(&self) -> ProgressValues;
     fn get_write_progress(&self) -> Arc<Progress>;
+    fn get_spill_progress(&self) -> Arc<Progress>;
     fn get_write_progress_value(&self) -> ProgressValues;
+    fn get_spill_progress_value(&self) -> ProgressValues;
     fn get_result_progress(&self) -> Arc<Progress>;
     fn get_result_progress_value(&self) -> ProgressValues;
     fn get_status_info(&self) -> String;

--- a/src/query/service/src/interpreters/interpreter_query_log.rs
+++ b/src/query/service/src/interpreters/interpreter_query_log.rs
@@ -105,6 +105,8 @@ impl InterpreterQueryLog {
         let result_bytes = 0u64;
         let cpu_usage = ctx.get_settings().get_max_threads()? as u32;
         let memory_usage = ctx.get_current_session().get_memory_usage() as u64;
+        let join_spilled_rows = 0u64;
+        let join_spilled_bytes = 0u64;
 
         // Client.
         let client_address = match ctx.get_client_address() {
@@ -161,6 +163,8 @@ impl InterpreterQueryLog {
             result_bytes,
             cpu_usage,
             memory_usage,
+            join_spilled_bytes,
+            join_spilled_rows,
             client_info: "".to_string(),
             client_address,
             user_agent,
@@ -211,6 +215,9 @@ impl InterpreterQueryLog {
         let total_partitions = data_metrics.get_partitions_total();
         let cpu_usage = ctx.get_settings().get_max_threads()? as u32;
         let memory_usage = ctx.get_current_session().get_memory_usage() as u64;
+
+        let join_spilled_rows = ctx.get_spill_progress_value().rows as u64;
+        let join_spilled_bytes = ctx.get_spill_progress_value().bytes as u64;
 
         // Result.
         let result_rows = ctx.get_result_progress_value().rows as u64;
@@ -275,6 +282,8 @@ impl InterpreterQueryLog {
             result_bytes,
             cpu_usage,
             memory_usage,
+            join_spilled_bytes,
+            join_spilled_rows,
             client_info: "".to_string(),
             client_address,
             user_agent,

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/build_spill/build_spill_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/build_spill/build_spill_state.rs
@@ -54,7 +54,7 @@ impl BuildSpillState {
         let tenant = ctx.get_tenant();
         let spill_config = SpillerConfig::create(query_spill_prefix(&tenant));
         let operator = DataOperator::instance().operator();
-        let spiller = Spiller::create(operator, spill_config, SpillerType::HashJoinBuild);
+        let spiller = Spiller::create(ctx, operator, spill_config, SpillerType::HashJoinBuild);
         Self {
             build_state,
             spill_coordinator,

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_spill/probe_spill_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_spill/probe_spill_state.rs
@@ -41,7 +41,7 @@ impl ProbeSpillState {
         let tenant = ctx.get_tenant();
         let spill_config = SpillerConfig::create(query_spill_prefix(&tenant));
         let operator = DataOperator::instance().operator();
-        let spiller = Spiller::create(operator, spill_config, SpillerType::HashJoinProbe);
+        let spiller = Spiller::create(ctx, operator, spill_config, SpillerType::HashJoinProbe);
         Self {
             probe_state,
             spiller,

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -319,8 +319,16 @@ impl TableContext for QueryContext {
         self.shared.write_progress.clone()
     }
 
+    fn get_spill_progress(&self) -> Arc<Progress> {
+        self.shared.spill_progress.clone()
+    }
+
     fn get_write_progress_value(&self) -> ProgressValues {
         self.shared.write_progress.as_ref().get_values()
+    }
+
+    fn get_spill_progress_value(&self) -> ProgressValues {
+        self.shared.spill_progress.as_ref().get_values()
     }
 
     fn get_result_progress(&self) -> Arc<Progress> {

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -58,6 +58,8 @@ pub struct QueryContextShared {
     pub(in crate::sessions) scan_progress: Arc<Progress>,
     /// write_progress for write/commit metrics of datablocks (uncompressed)
     pub(in crate::sessions) write_progress: Arc<Progress>,
+    /// Record how many bytes/rows have been spilled.
+    pub(in crate::sessions) spill_progress: Arc<Progress>,
     /// result_progress for metrics of result datablocks (uncompressed)
     pub(in crate::sessions) result_progress: Arc<Progress>,
     pub(in crate::sessions) error: Arc<Mutex<Option<ErrorCode>>>,
@@ -129,6 +131,7 @@ impl QueryContextShared {
             status: Arc::new(RwLock::new("null".to_string())),
             user_agent: Arc::new(RwLock::new("null".to_string())),
             materialized_cte_tables: Arc::new(Default::default()),
+            spill_progress: Arc::new(Progress::create()),
         }))
     }
 

--- a/src/query/service/tests/it/spillers/spiller.rs
+++ b/src/query/service/tests/it/spillers/spiller.rs
@@ -25,6 +25,7 @@ use common_expression::DataBlock;
 use common_expression::FromData;
 use common_expression::ScalarRef;
 use common_storage::DataOperator;
+use databend_query::sessions::QueryContext;
 use databend_query::spillers::Spiller;
 use databend_query::spillers::SpillerConfig;
 use databend_query::spillers::SpillerType;

--- a/src/query/service/tests/it/spillers/spiller.rs
+++ b/src/query/service/tests/it/spillers/spiller.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use common_base::base::tokio;
-use common_base::base::tokio::fs;
-use common_base::base::GlobalInstance;
-use common_config::InnerConfig;
+use common_catalog::table_context::TableContext;
 use common_exception::Result;
 use common_expression::types::DataType;
 use common_expression::types::Int32Type;
@@ -24,16 +22,23 @@ use common_expression::types::NumberScalar;
 use common_expression::DataBlock;
 use common_expression::FromData;
 use common_expression::ScalarRef;
+use common_pipeline_core::query_spill_prefix;
 use common_storage::DataOperator;
-use databend_query::sessions::QueryContext;
 use databend_query::spillers::Spiller;
 use databend_query::spillers::SpillerConfig;
 use databend_query::spillers::SpillerType;
-use databend_query::GlobalServices;
+use databend_query::test_kits::TestFixture;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_spill_with_partition() -> Result<()> {
-    let mut spiller = create_spiller().await?;
+    let fixture = TestFixture::new().await;
+    let ctx = fixture.ctx();
+    let tenant = ctx.get_tenant();
+    let spiller_config = SpillerConfig::create(query_spill_prefix(&tenant));
+    let operator = DataOperator::instance().operator();
+
+    let mut spiller = Spiller::create(ctx, operator, spiller_config, SpillerType::HashJoinBuild);
+
     spiller.partition_set = vec![0, 1, 2];
 
     // Generate data block: two columns, type is i32, 100 rows
@@ -45,7 +50,7 @@ async fn test_spill_with_partition() -> Result<()> {
     let res = spiller.spill_with_partition(&(0_u8), &data, 0).await;
 
     assert!(res.is_ok());
-    assert!(spiller.partition_location.get(&0).unwrap()[0].starts_with("_hash_join_build_spill"));
+    assert!(spiller.partition_location.get(&0).unwrap()[0].starts_with("_query_spill"));
 
     // Test read spilled data
     let data_blocks = spiller.read_spilled_data(&(0_u8)).await?;
@@ -66,28 +71,5 @@ async fn test_spill_with_partition() -> Result<()> {
             }
         }
     }
-    // Delete `_hash_join_build_spill` dir
-    fs::remove_dir_all("_data/_hash_join_build_spill").await?;
     Ok(())
-}
-
-#[cfg(debug_assertions)]
-async fn create_spiller() -> Result<Spiller> {
-    let thread_name = match std::thread::current().name() {
-        None => panic!("thread name is none"),
-        Some(thread_name) => thread_name.to_string(),
-    };
-
-    GlobalInstance::init_testing(&thread_name);
-    GlobalServices::init_with(InnerConfig::default()).await?;
-
-    let spiller_config = SpillerConfig {
-        location_prefix: "_hash_join_build_spill".to_string(),
-    };
-    let operator = DataOperator::instance().operator();
-    Ok(Spiller::create(
-        operator,
-        spiller_config,
-        SpillerType::HashJoinBuild,
-    ))
 }

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -369,7 +369,15 @@ impl TableContext for CtxDelegation {
         self.ctx.get_write_progress()
     }
 
+    fn get_spill_progress(&self) -> Arc<Progress> {
+        self.ctx.get_spill_progress()
+    }
+
     fn get_write_progress_value(&self) -> ProgressValues {
+        todo!()
+    }
+
+    fn get_spill_progress_value(&self) -> ProgressValues {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -152,6 +152,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'is_updatable'                  | 'information_schema' | 'views'               | 'UInt8'               | 'TINYINT UNSIGNED'  | ''       | ''       | 'NO'     | ''       |
 | 'job_state'                     | 'system'             | 'background_jobs'     | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'job_type'                      | 'system'             | 'background_jobs'     | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
+| 'join_spilled_bytes'            | 'system'             | 'query_log'           | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
+| 'join_spilled_rows'             | 'system'             | 'query_log'           | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'keywords'                      | 'information_schema' | 'keywords'            | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'kind'                          | 'system'             | 'metrics'             | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'labels'                        | 'system'             | 'metrics'             | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/storages/system/src/query_log_table.rs
+++ b/src/query/storages/system/src/query_log_table.rs
@@ -108,6 +108,8 @@ pub struct QueryLogElement {
     pub result_bytes: u64,
     pub cpu_usage: u32,
     pub memory_usage: u64,
+    pub join_spilled_bytes: u64,
+    pub join_spilled_rows: u64,
 
     // Client.
     pub client_info: String,
@@ -169,6 +171,14 @@ impl SystemLogElement for QueryLogElement {
             ),
             TableField::new(
                 "written_bytes",
+                TableDataType::Number(NumberDataType::UInt64),
+            ),
+            TableField::new(
+                "join_spilled_rows",
+                TableDataType::Number(NumberDataType::UInt64),
+            ),
+            TableField::new(
+                "join_spilled_bytes",
                 TableDataType::Number(NumberDataType::UInt64),
             ),
             TableField::new(
@@ -321,6 +331,14 @@ impl SystemLogElement for QueryLogElement {
             .next()
             .unwrap()
             .push(Scalar::Number(NumberScalar::UInt64(self.written_bytes)).as_ref());
+        columns
+            .next()
+            .unwrap()
+            .push(Scalar::Number(NumberScalar::UInt64(self.join_spilled_rows)).as_ref());
+        columns
+            .next()
+            .unwrap()
+            .push(Scalar::Number(NumberScalar::UInt64(self.join_spilled_bytes)).as_ref());
         columns
             .next()
             .unwrap()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

After executing hash join query with spilling, we can check how many bytes or rows are spilled to storage.

![image](https://github.com/datafuselabs/databend/assets/41979257/7de3b543-9674-4c60-8991-ed1651a7a197)


- Closes https://github.com/datafuselabs/databend/issues/12895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13018)
<!-- Reviewable:end -->
