### PR TITLE
fix: fix nested decimal read and write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.4"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=231a6fa#231a6fa61c3aad9d766165557501e28d73cf6b9a"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=dd80c89#dd80c891850213104c8c0d11b76b56401cb1ce52"
 dependencies = [
  "ahash 0.8.3",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,7 @@ rpath = false
 [patch.crates-io]
 # If there are dependencies that need patching, they can be listed below.
 
-arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", rev = "231a6fa" }
+arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", rev = "dd80c89" }
 arrow-format = { git = "https://github.com/sundy-li/arrow-format", rev = "c8e11341" }
 parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "b0e6545" }
 metrics = { git = "https://github.com/datafuse-extras/metrics.git", rev = "fc2ecd1" }

--- a/tests/sqllogictests/suites/base/11_data_type/11_0006_data_type_decimal
+++ b/tests/sqllogictests/suites/base/11_data_type/11_0006_data_type_decimal
@@ -955,3 +955,34 @@ select to_uint64(b), b::uint64, b  from t;
 
 statement ok
 drop table t
+
+# decimal 128
+statement ok
+CREATE TABLE t (c1 TUPLE(ARRAY(ARRAY(DECIMAL(20, 10)) NULL)))
+
+statement ok
+insert into t values (([NULL,NULL])), (([[1, 3]]))
+
+query T
+select * from t
+----
+([NULL,NULL])
+([[1.0000000000,3.0000000000]])
+
+statement ok
+drop table t
+
+# decimal 258
+statement ok
+CREATE TABLE t (c1 TUPLE(ARRAY(ARRAY(DECIMAL(40, 10)) NULL)))
+
+statement ok
+insert into t values (([NULL,NULL]))
+
+query T
+select * from t
+----
+([NULL,NULL])
+
+statement ok
+drop table t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
The arrow2 encode different precision of decimal with different physical types. The bug happened when we did fixed_len_bytes encoding.

For decimal 128, precision:
```
<=9  -> i32
<=18 -> i64
else -> fixed_len_bytes
``` 

For decimal 256, precision:
```
<=9  -> i32
<=18 -> i64
<=38 -> fixed_len_bytes of decimal 128
else -> fixed_len_bytes of decimal 256
```


- Closes #13058

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13074)
<!-- Reviewable:end -->
