### PR TITLE
feat(planner): support infer col ref equal predicate

### DIFF
--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_infer_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_infer_filter.rs
@@ -403,8 +403,8 @@ impl PredicateSet {
             let equal_set_len = equal_set.len();
             for i in 0..equal_set_len {
                 for j in i + 1..equal_set_len {
-                    new_equal_pairs.push((i, j));
-                    new_equal_pairs.push((j, i));
+                    new_equal_pairs.push((equal_set[i], equal_set[j]));
+                    new_equal_pairs.push((equal_set[j], equal_set[i]));
                     result.push(ScalarExpr::FunctionCall(FunctionCall {
                         span: None,
                         func_name: String::from(ComparisonOp::Equal.to_func_name()),

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_infer_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_infer_filter.rs
@@ -42,7 +42,7 @@ use crate::plans::ScalarExpr;
 // The rule tries to infer new predicates from existing predicates, for example:
 // 1. [A > 1 and A > 5] => [A > 5], [A > 1 and A <= 1 => false], [A = 1 and A < 10] => [A = 1]
 // 2. [A = 10 and A = B] => [B = 10]
-// TODO(Dousir9): [A = B and A = C] => [B = C]
+// 3. [A = B and A = C] => [B = C]
 pub struct RuleInferFilter {
     id: RuleID,
     patterns: Vec<SExpr>,

--- a/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
@@ -636,58 +636,58 @@ query T
 explain select * from t1, t2, t3 where t1.a = t2.a and t1.a = t3.a and t1.a > 5 and t3.a < 10;
 ----
 HashJoin
-├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t2.a (#2), t3.b (#5), t3.a (#4)]
+├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t3.b (#5), t2.a (#2), t3.a (#4)]
 ├── join type: INNER
-├── build keys: [t3.a (#4)]
-├── probe keys: [t1.a (#0)]
+├── build keys: [t3.a (#4), t2.a (#2)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 0.00
-├── Filter(Build)
-│   ├── output columns: [t3.a (#4), t3.b (#5)]
-│   ├── filters: [t3.a (#4) > 5, t3.a (#4) < 10]
+├── HashJoin(Build)
+│   ├── output columns: [t2.a (#2), t2.b (#3), t3.b (#5), t3.a (#4)]
+│   ├── join type: INNER
+│   ├── build keys: [t3.a (#4)]
+│   ├── probe keys: [t2.a (#2)]
+│   ├── filters: []
 │   ├── estimated rows: 0.00
-│   └── TableScan
-│       ├── table: default.default.t3
-│       ├── output columns: [a (#4), b (#5)]
-│       ├── read rows: 0
-│       ├── read bytes: 0
-│       ├── partitions total: 0
-│       ├── partitions scanned: 0
-│       ├── push downs: [filters: [and_filters(t3.a (#4) > 5, t3.a (#4) < 10)], limit: NONE]
-│       └── estimated rows: 0.00
-└── HashJoin(Probe)
-    ├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t2.a (#2)]
-    ├── join type: INNER
-    ├── build keys: [t2.a (#2)]
-    ├── probe keys: [t1.a (#0)]
-    ├── filters: []
+│   ├── Filter(Build)
+│   │   ├── output columns: [t3.a (#4), t3.b (#5)]
+│   │   ├── filters: [t3.a (#4) > 5, t3.a (#4) < 10]
+│   │   ├── estimated rows: 0.00
+│   │   └── TableScan
+│   │       ├── table: default.default.t3
+│   │       ├── output columns: [a (#4), b (#5)]
+│   │       ├── read rows: 0
+│   │       ├── read bytes: 0
+│   │       ├── partitions total: 0
+│   │       ├── partitions scanned: 0
+│   │       ├── push downs: [filters: [and_filters(t3.a (#4) > 5, t3.a (#4) < 10)], limit: NONE]
+│   │       └── estimated rows: 0.00
+│   └── Filter(Probe)
+│       ├── output columns: [t2.a (#2), t2.b (#3)]
+│       ├── filters: [t2.a (#2) > 5, t2.a (#2) < 10]
+│       ├── estimated rows: 0.00
+│       └── TableScan
+│           ├── table: default.default.t2
+│           ├── output columns: [a (#2), b (#3)]
+│           ├── read rows: 0
+│           ├── read bytes: 0
+│           ├── partitions total: 0
+│           ├── partitions scanned: 0
+│           ├── push downs: [filters: [and_filters(t2.a (#2) > 5, t2.a (#2) < 10)], limit: NONE]
+│           └── estimated rows: 0.00
+└── Filter(Probe)
+    ├── output columns: [t1.a (#0), t1.b (#1)]
+    ├── filters: [t1.a (#0) > 5, t1.a (#0) < 10]
     ├── estimated rows: 0.00
-    ├── Filter(Build)
-    │   ├── output columns: [t2.a (#2), t2.b (#3)]
-    │   ├── filters: [t2.a (#2) > 5, t2.a (#2) < 10]
-    │   ├── estimated rows: 0.00
-    │   └── TableScan
-    │       ├── table: default.default.t2
-    │       ├── output columns: [a (#2), b (#3)]
-    │       ├── read rows: 0
-    │       ├── read bytes: 0
-    │       ├── partitions total: 0
-    │       ├── partitions scanned: 0
-    │       ├── push downs: [filters: [and_filters(t2.a (#2) > 5, t2.a (#2) < 10)], limit: NONE]
-    │       └── estimated rows: 0.00
-    └── Filter(Probe)
-        ├── output columns: [t1.a (#0), t1.b (#1)]
-        ├── filters: [t1.a (#0) > 5, t1.a (#0) < 10]
-        ├── estimated rows: 0.00
-        └── TableScan
-            ├── table: default.default.t1
-            ├── output columns: [a (#0), b (#1)]
-            ├── read rows: 0
-            ├── read bytes: 0
-            ├── partitions total: 0
-            ├── partitions scanned: 0
-            ├── push downs: [filters: [and_filters(t1.a (#0) > 5, t1.a (#0) < 10)], limit: NONE]
-            └── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.t1
+        ├── output columns: [a (#0), b (#1)]
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [and_filters(t1.a (#0) > 5, t1.a (#0) < 10)], limit: NONE]
+        └── estimated rows: 0.00
 
 # t1.a > 5 and t2.a > 10
 query T
@@ -854,6 +854,52 @@ HashJoin
             ├── partitions scanned: 0
             ├── push downs: [filters: [false], limit: NONE]
             └── estimated rows: 0.00
+
+# t1.a = t2.a, t1.a = t3.a => t2.a = t3.a
+query T
+explain select * from t1, t2, t3 where t1.a = t2.a and t1.a = t3.a;
+----
+HashJoin
+├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t3.b (#5), t2.a (#2), t3.a (#4)]
+├── join type: INNER
+├── build keys: [t3.a (#4), t2.a (#2)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
+├── filters: []
+├── estimated rows: 0.00
+├── HashJoin(Build)
+│   ├── output columns: [t2.a (#2), t2.b (#3), t3.b (#5), t3.a (#4)]
+│   ├── join type: INNER
+│   ├── build keys: [t3.a (#4)]
+│   ├── probe keys: [t2.a (#2)]
+│   ├── filters: []
+│   ├── estimated rows: 0.00
+│   ├── TableScan(Build)
+│   │   ├── table: default.default.t3
+│   │   ├── output columns: [a (#4), b (#5)]
+│   │   ├── read rows: 0
+│   │   ├── read bytes: 0
+│   │   ├── partitions total: 0
+│   │   ├── partitions scanned: 0
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 0.00
+│   └── TableScan(Probe)
+│       ├── table: default.default.t2
+│       ├── output columns: [a (#2), b (#3)]
+│       ├── read rows: 0
+│       ├── read bytes: 0
+│       ├── partitions total: 0
+│       ├── partitions scanned: 0
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 0.00
+└── TableScan(Probe)
+    ├── table: default.default.t1
+    ├── output columns: [a (#0), b (#1)]
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 0.00
 
 statement ok
 drop table if exists t1;

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -29,10 +29,10 @@ query T
 explain select * from t, t1, t2 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#2), t.a (#0), t1.a (#1)]
+├── output columns: [t2.a (#2), t1.a (#1), t.a (#0)]
 ├── join type: INNER
-├── build keys: [t1.a (#1)]
-├── probe keys: [t2.a (#2)]
+├── build keys: [t.a (#0), t1.a (#1)]
+├── probe keys: [t2.a (#2), t2.a (#2)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -77,17 +77,17 @@ query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t.a (#0), t1.a (#2)]
+├── output columns: [t1.a (#2), t2.a (#1), t.a (#0)]
 ├── join type: INNER
-├── build keys: [t1.a (#2)]
-├── probe keys: [t2.a (#1)]
+├── build keys: [t.a (#0), t2.a (#1)]
+├── probe keys: [t1.a (#2), t1.a (#2)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#2), t.a (#0)]
+│   ├── output columns: [t2.a (#1), t.a (#0)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
-│   ├── probe keys: [t1.a (#2)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -101,41 +101,41 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── output columns: [a (#2)]
-│       ├── read rows: 10
-│       ├── read bytes: 65
+│       ├── table: default.join_reorder.t2
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
+│       ├── read bytes: 172
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
-    ├── read bytes: 172
+    ├── table: default.join_reorder.t1
+    ├── output columns: [a (#2)]
+    ├── read rows: 10
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#2), t.a (#1), t1.a (#0)]
+├── output columns: [t1.a (#0), t2.a (#2), t.a (#1)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#2)]
+├── build keys: [t2.a (#2), t.a (#1)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#1)]
+│   ├── output columns: [t2.a (#2), t.a (#1)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#2)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -149,41 +149,41 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
-│       ├── read bytes: 65
+│       ├── table: default.join_reorder.t2
+│       ├── output columns: [a (#2)]
+│       ├── read rows: 100
+│       ├── read bytes: 172
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── output columns: [a (#2)]
-    ├── read rows: 100
-    ├── read bytes: 172
+    ├── table: default.join_reorder.t1
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t.a (#2), t1.a (#0)]
+├── output columns: [t1.a (#0), t2.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#1)]
+├── build keys: [t.a (#2), t2.a (#1)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#2)]
+│   ├── output columns: [t2.a (#1), t.a (#2)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -197,34 +197,34 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
-│       ├── read bytes: 65
+│       ├── table: default.join_reorder.t2
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
+│       ├── read bytes: 172
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
-    ├── read bytes: 172
+    ├── table: default.join_reorder.t1
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
+    ├── read bytes: 65
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#0), t.a (#2), t1.a (#1)]
+├── output columns: [t2.a (#0), t1.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#1)]
-├── probe keys: [t2.a (#0)]
+├── build keys: [t.a (#2), t1.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -269,10 +269,10 @@ query T
 explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#0), t.a (#1), t1.a (#2)]
+├── output columns: [t2.a (#0), t1.a (#2), t.a (#1)]
 ├── join type: INNER
-├── build keys: [t1.a (#2)]
-├── probe keys: [t2.a (#0)]
+├── build keys: [t1.a (#2), t.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -20,17 +20,17 @@ query T
 explain select * from t, t1, t2 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#1), t.a (#0), t2.a (#2)]
+├── output columns: [t2.a (#2), t1.a (#1), t.a (#0)]
 ├── join type: INNER
-├── build keys: [t2.a (#2)]
-├── probe keys: [t1.a (#1)]
+├── build keys: [t.a (#0), t1.a (#1)]
+├── probe keys: [t2.a (#2), t2.a (#2)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t2.a (#2), t.a (#0)]
+│   ├── output columns: [t1.a (#1), t.a (#0)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
-│   ├── probe keys: [t2.a (#2)]
+│   ├── probe keys: [t1.a (#1)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -44,34 +44,34 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t2
-│       ├── output columns: [a (#2)]
-│       ├── read rows: 100
-│       ├── read bytes: 172
+│       ├── table: default.join_reorder.t1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 10
+│       ├── read bytes: 65
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 100.00
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t1
-    ├── output columns: [a (#1)]
-    ├── read rows: 10
-    ├── read bytes: 65
+    ├── table: default.join_reorder.t2
+    ├── output columns: [a (#2)]
+    ├── read rows: 100
+    ├── read bytes: 172
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 10.00
+    └── estimated rows: 100.00
 
 query T
 explain select * from t, t2, t1 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#2), t.a (#0), t2.a (#1)]
+├── output columns: [t1.a (#2), t2.a (#1), t.a (#0)]
 ├── join type: INNER
-├── build keys: [t2.a (#1)]
-├── probe keys: [t1.a (#2)]
+├── build keys: [t.a (#0), t2.a (#1)]
+├── probe keys: [t1.a (#2), t1.a (#2)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -116,10 +116,10 @@ query T
 explain select * from t1, t, t2 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#0), t.a (#1), t2.a (#2)]
+├── output columns: [t1.a (#0), t2.a (#2), t.a (#1)]
 ├── join type: INNER
-├── build keys: [t2.a (#2)]
-├── probe keys: [t1.a (#0)]
+├── build keys: [t2.a (#2), t.a (#1)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -164,10 +164,10 @@ query T
 explain select * from t1, t2, t where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#0), t.a (#2), t2.a (#1)]
+├── output columns: [t1.a (#0), t2.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t2.a (#1)]
-├── probe keys: [t1.a (#0)]
+├── build keys: [t.a (#2), t2.a (#1)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -212,17 +212,17 @@ query T
 explain select * from t2, t1, t where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#1), t.a (#2), t2.a (#0)]
+├── output columns: [t2.a (#0), t1.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t2.a (#0)]
-├── probe keys: [t1.a (#1)]
+├── build keys: [t.a (#2), t1.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t2.a (#0), t.a (#2)]
+│   ├── output columns: [t1.a (#1), t.a (#2)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
-│   ├── probe keys: [t2.a (#0)]
+│   ├── probe keys: [t1.a (#1)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -236,41 +236,41 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t2
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 100
-│       ├── read bytes: 172
+│       ├── table: default.join_reorder.t1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 10
+│       ├── read bytes: 65
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 100.00
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t1
-    ├── output columns: [a (#1)]
-    ├── read rows: 10
-    ├── read bytes: 65
+    ├── table: default.join_reorder.t2
+    ├── output columns: [a (#0)]
+    ├── read rows: 100
+    ├── read bytes: 172
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 10.00
+    └── estimated rows: 100.00
 
 query T
 explain select * from t2, t, t1 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#2), t.a (#1), t2.a (#0)]
+├── output columns: [t2.a (#0), t1.a (#2), t.a (#1)]
 ├── join type: INNER
-├── build keys: [t2.a (#0)]
-├── probe keys: [t1.a (#2)]
+├── build keys: [t1.a (#2), t.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t2.a (#0), t.a (#1)]
+│   ├── output columns: [t1.a (#2), t.a (#1)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
-│   ├── probe keys: [t2.a (#0)]
+│   ├── probe keys: [t1.a (#2)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -284,25 +284,25 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t2
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 100
-│       ├── read bytes: 172
+│       ├── table: default.join_reorder.t1
+│       ├── output columns: [a (#2)]
+│       ├── read rows: 10
+│       ├── read bytes: 65
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 100.00
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t1
-    ├── output columns: [a (#2)]
-    ├── read rows: 10
-    ├── read bytes: 65
+    ├── table: default.join_reorder.t2
+    ├── output columns: [a (#0)]
+    ├── read rows: 100
+    ├── read bytes: 172
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 10.00
+    └── estimated rows: 100.00
 
 statement ok
 drop database join_reorder

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
@@ -500,46 +500,46 @@ query T
 explain select * from t1, t2, t3 where t1.a = t2.a and t1.a = t3.a and t1.a > 5 and t3.a < 10;
 ----
 HashJoin
-├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t2.a (#2), t3.b (#5), t3.a (#4)]
+├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t3.b (#5), t2.a (#2), t3.a (#4)]
 ├── join type: INNER
-├── build keys: [t3.a (#4)]
-├── probe keys: [t1.a (#0)]
+├── build keys: [t3.a (#4), t2.a (#2)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 0.00
-├── TableScan(Build)
-│   ├── table: default.default.t3
-│   ├── output columns: [a (#4), b (#5)]
-│   ├── read rows: 0
-│   ├── read bytes: 0
-│   ├── partitions total: 0
-│   ├── partitions scanned: 0
-│   ├── push downs: [filters: [and_filters(t3.a (#4) > 5, t3.a (#4) < 10)], limit: NONE]
-│   └── estimated rows: 0.00
-└── HashJoin(Probe)
-    ├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t2.a (#2)]
-    ├── join type: INNER
-    ├── build keys: [t2.a (#2)]
-    ├── probe keys: [t1.a (#0)]
-    ├── filters: []
-    ├── estimated rows: 0.00
-    ├── TableScan(Build)
-    │   ├── table: default.default.t2
-    │   ├── output columns: [a (#2), b (#3)]
-    │   ├── read rows: 0
-    │   ├── read bytes: 0
-    │   ├── partitions total: 0
-    │   ├── partitions scanned: 0
-    │   ├── push downs: [filters: [and_filters(t2.a (#2) > 5, t2.a (#2) < 10)], limit: NONE]
-    │   └── estimated rows: 0.00
-    └── TableScan(Probe)
-        ├── table: default.default.t1
-        ├── output columns: [a (#0), b (#1)]
-        ├── read rows: 0
-        ├── read bytes: 0
-        ├── partitions total: 0
-        ├── partitions scanned: 0
-        ├── push downs: [filters: [and_filters(t1.a (#0) > 5, t1.a (#0) < 10)], limit: NONE]
-        └── estimated rows: 0.00
+├── HashJoin(Build)
+│   ├── output columns: [t2.a (#2), t2.b (#3), t3.b (#5), t3.a (#4)]
+│   ├── join type: INNER
+│   ├── build keys: [t3.a (#4)]
+│   ├── probe keys: [t2.a (#2)]
+│   ├── filters: []
+│   ├── estimated rows: 0.00
+│   ├── TableScan(Build)
+│   │   ├── table: default.default.t3
+│   │   ├── output columns: [a (#4), b (#5)]
+│   │   ├── read rows: 0
+│   │   ├── read bytes: 0
+│   │   ├── partitions total: 0
+│   │   ├── partitions scanned: 0
+│   │   ├── push downs: [filters: [and_filters(t3.a (#4) > 5, t3.a (#4) < 10)], limit: NONE]
+│   │   └── estimated rows: 0.00
+│   └── TableScan(Probe)
+│       ├── table: default.default.t2
+│       ├── output columns: [a (#2), b (#3)]
+│       ├── read rows: 0
+│       ├── read bytes: 0
+│       ├── partitions total: 0
+│       ├── partitions scanned: 0
+│       ├── push downs: [filters: [and_filters(t2.a (#2) > 5, t2.a (#2) < 10)], limit: NONE]
+│       └── estimated rows: 0.00
+└── TableScan(Probe)
+    ├── table: default.default.t1
+    ├── output columns: [a (#0), b (#1)]
+    ├── read rows: 0
+    ├── read bytes: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    ├── push downs: [filters: [and_filters(t1.a (#0) > 5, t1.a (#0) < 10)], limit: NONE]
+    └── estimated rows: 0.00
 
 # t1.a > 5 and t2.a > 10
 query T

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
@@ -29,10 +29,10 @@ query T
 explain select * from t, t1, t2 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#2), t.a (#0), t1.a (#1)]
+├── output columns: [t2.a (#2), t1.a (#1), t.a (#0)]
 ├── join type: INNER
-├── build keys: [t1.a (#1)]
-├── probe keys: [t2.a (#2)]
+├── build keys: [t.a (#0), t1.a (#1)]
+├── probe keys: [t2.a (#2), t2.a (#2)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -77,17 +77,17 @@ query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t.a (#0), t1.a (#2)]
+├── output columns: [t1.a (#2), t2.a (#1), t.a (#0)]
 ├── join type: INNER
-├── build keys: [t1.a (#2)]
-├── probe keys: [t2.a (#1)]
+├── build keys: [t.a (#0), t2.a (#1)]
+├── probe keys: [t1.a (#2), t1.a (#2)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#2), t.a (#0)]
+│   ├── output columns: [t2.a (#1), t.a (#0)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
-│   ├── probe keys: [t1.a (#2)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -101,41 +101,41 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── output columns: [a (#2)]
-│       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── table: default.join_reorder.t2
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
+│       ├── read bytes: 414
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
-    ├── read bytes: 414
+    ├── table: default.join_reorder.t1
+    ├── output columns: [a (#2)]
+    ├── read rows: 10
+    ├── read bytes: 54
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#2), t.a (#1), t1.a (#0)]
+├── output columns: [t1.a (#0), t2.a (#2), t.a (#1)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#2)]
+├── build keys: [t2.a (#2), t.a (#1)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#1)]
+│   ├── output columns: [t2.a (#2), t.a (#1)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#2)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -149,41 +149,41 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── table: default.join_reorder.t2
+│       ├── output columns: [a (#2)]
+│       ├── read rows: 100
+│       ├── read bytes: 414
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── output columns: [a (#2)]
-    ├── read rows: 100
-    ├── read bytes: 414
+    ├── table: default.join_reorder.t1
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
+    ├── read bytes: 54
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t.a (#2), t1.a (#0)]
+├── output columns: [t1.a (#0), t2.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#1)]
+├── build keys: [t.a (#2), t2.a (#1)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#2)]
+│   ├── output columns: [t2.a (#1), t.a (#2)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -197,34 +197,34 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── table: default.join_reorder.t2
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
+│       ├── read bytes: 414
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
-    ├── read bytes: 414
+    ├── table: default.join_reorder.t1
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
+    ├── read bytes: 54
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#0), t.a (#2), t1.a (#1)]
+├── output columns: [t2.a (#0), t1.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#1)]
-├── probe keys: [t2.a (#0)]
+├── build keys: [t.a (#2), t1.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -269,10 +269,10 @@ query T
 explain select * from t2, t, t1 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#0), t.a (#1), t1.a (#2)]
+├── output columns: [t2.a (#0), t1.a (#2), t.a (#1)]
 ├── join type: INNER
-├── build keys: [t1.a (#2)]
-├── probe keys: [t2.a (#0)]
+├── build keys: [t1.a (#2), t.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/star.test
@@ -20,17 +20,17 @@ query T
 explain select * from t, t1, t2 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#1), t.a (#0), t2.a (#2)]
+├── output columns: [t2.a (#2), t1.a (#1), t.a (#0)]
 ├── join type: INNER
-├── build keys: [t2.a (#2)]
-├── probe keys: [t1.a (#1)]
+├── build keys: [t.a (#0), t1.a (#1)]
+├── probe keys: [t2.a (#2), t2.a (#2)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t2.a (#2), t.a (#0)]
+│   ├── output columns: [t1.a (#1), t.a (#0)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
-│   ├── probe keys: [t2.a (#2)]
+│   ├── probe keys: [t1.a (#1)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -44,34 +44,34 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t2
-│       ├── output columns: [a (#2)]
-│       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── table: default.join_reorder.t1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 10
+│       ├── read bytes: 54
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 100.00
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t1
-    ├── output columns: [a (#1)]
-    ├── read rows: 10
-    ├── read bytes: 54
+    ├── table: default.join_reorder.t2
+    ├── output columns: [a (#2)]
+    ├── read rows: 100
+    ├── read bytes: 414
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 10.00
+    └── estimated rows: 100.00
 
 query T
 explain select * from t, t2, t1 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#2), t.a (#0), t2.a (#1)]
+├── output columns: [t1.a (#2), t2.a (#1), t.a (#0)]
 ├── join type: INNER
-├── build keys: [t2.a (#1)]
-├── probe keys: [t1.a (#2)]
+├── build keys: [t.a (#0), t2.a (#1)]
+├── probe keys: [t1.a (#2), t1.a (#2)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -116,10 +116,10 @@ query T
 explain select * from t1, t, t2 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#0), t.a (#1), t2.a (#2)]
+├── output columns: [t1.a (#0), t2.a (#2), t.a (#1)]
 ├── join type: INNER
-├── build keys: [t2.a (#2)]
-├── probe keys: [t1.a (#0)]
+├── build keys: [t2.a (#2), t.a (#1)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -164,10 +164,10 @@ query T
 explain select * from t1, t2, t where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#0), t.a (#2), t2.a (#1)]
+├── output columns: [t1.a (#0), t2.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t2.a (#1)]
-├── probe keys: [t1.a (#0)]
+├── build keys: [t.a (#2), t2.a (#1)]
+├── probe keys: [t1.a (#0), t1.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -212,17 +212,17 @@ query T
 explain select * from t2, t1, t where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#1), t.a (#2), t2.a (#0)]
+├── output columns: [t2.a (#0), t1.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t2.a (#0)]
-├── probe keys: [t1.a (#1)]
+├── build keys: [t.a (#2), t1.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t2.a (#0), t.a (#2)]
+│   ├── output columns: [t1.a (#1), t.a (#2)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
-│   ├── probe keys: [t2.a (#0)]
+│   ├── probe keys: [t1.a (#1)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -236,41 +236,41 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t2
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── table: default.join_reorder.t1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 10
+│       ├── read bytes: 54
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 100.00
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t1
-    ├── output columns: [a (#1)]
-    ├── read rows: 10
-    ├── read bytes: 54
+    ├── table: default.join_reorder.t2
+    ├── output columns: [a (#0)]
+    ├── read rows: 100
+    ├── read bytes: 414
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 10.00
+    └── estimated rows: 100.00
 
 query T
 explain select * from t2, t, t1 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t1.a (#2), t.a (#1), t2.a (#0)]
+├── output columns: [t2.a (#0), t1.a (#2), t.a (#1)]
 ├── join type: INNER
-├── build keys: [t2.a (#0)]
-├── probe keys: [t1.a (#2)]
+├── build keys: [t1.a (#2), t.a (#1)]
+├── probe keys: [t2.a (#0), t2.a (#0)]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t2.a (#0), t.a (#1)]
+│   ├── output columns: [t1.a (#2), t.a (#1)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
-│   ├── probe keys: [t2.a (#0)]
+│   ├── probe keys: [t1.a (#2)]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -284,25 +284,25 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t2
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── table: default.join_reorder.t1
+│       ├── output columns: [a (#2)]
+│       ├── read rows: 10
+│       ├── read bytes: 54
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
 │       ├── push downs: [filters: [], limit: NONE]
-│       └── estimated rows: 100.00
+│       └── estimated rows: 10.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t1
-    ├── output columns: [a (#2)]
-    ├── read rows: 10
-    ├── read bytes: 54
+    ├── table: default.join_reorder.t2
+    ├── output columns: [a (#0)]
+    ├── read rows: 100
+    ├── read bytes: 414
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 10.00
+    └── estimated rows: 100.00
 
 statement ok
 drop database join_reorder


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support inferring column ref predicate: `[A = B and A = C] => [B = C]`, for example: `select * from t1, t2, t3 where t1.A = t2.B and t1.A = t3.C`, we will derive new predicate `t2.B = t3.C`, but we need to prune out redundant predicates.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13078)
<!-- Reviewable:end -->
