### PR TITLE
feat(query): support DATABEND_DATA_PATH in bendpy and bend-local

### DIFF
--- a/src/bendpy/src/lib.rs
+++ b/src/bendpy/src/lib.rs
@@ -21,6 +21,7 @@ mod schema;
 mod utils;
 
 use std::env;
+use std::path::Path;
 
 use common_config::Config;
 use common_config::InnerConfig;
@@ -37,15 +38,20 @@ use utils::RUNTIME;
 /// A Python module implemented in Rust.
 #[pymodule]
 fn databend(_py: Python, m: &PyModule) -> PyResult<()> {
-    env::set_var("META_EMBEDDED_DIR", ".databend/_meta");
+    let data_path = env::var("DATABEND_DATA_PATH").unwrap_or(".databend/".to_string());
+    let path = Path::new(&data_path);
+
+    env::set_var("META_EMBEDDED_DIR", path.join("_meta"));
+
     let mut conf: InnerConfig = Config::load(false).unwrap().try_into().unwrap();
     conf.storage.allow_insecure = true;
     conf.storage.params = StorageParams::Fs(StorageFsConfig {
-        root: ".databend/_data".to_string(),
+        root: path.join("_data").to_str().unwrap().to_owned(),
     });
 
     RUNTIME.block_on(async {
-        MetaEmbedded::init_global_meta_store(".databend/_meta".to_string())
+        let meta_dir = path.join("_meta");
+        MetaEmbedded::init_global_meta_store(meta_dir.to_string_lossy().to_string())
             .await
             .unwrap();
         GlobalServices::init(conf.clone()).await.unwrap();

--- a/src/query/service/src/local/mod.rs
+++ b/src/query/service/src/local/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod helper;
 use std::env;
 use std::io::stdin;
 use std::io::IsTerminal;
+use std::path::Path;
 
 use common_config::Config;
 use common_config::InnerConfig;
@@ -35,14 +36,20 @@ use crate::GlobalServices;
 
 pub async fn query_local(query_sql: &str, output_format: &str) -> Result<()> {
     let temp_dir = tempfile::tempdir()?;
-    env::set_var("META_EMBEDDED_DIR", temp_dir.path().join("_meta"));
+    let p = env::var("DATABEND_DATA_PATH");
+    let path = match &p {
+        Ok(p) => Path::new(p),
+        Err(_) => temp_dir.path(),
+    };
+
+    env::set_var("META_EMBEDDED_DIR", path.join("_meta"));
     let mut conf: InnerConfig = Config::load(true).unwrap().try_into().unwrap();
     conf.storage.allow_insecure = true;
     conf.storage.params = StorageParams::Fs(StorageFsConfig {
-        root: temp_dir.path().join("_data").to_str().unwrap().to_owned(),
+        root: path.join("_data").to_str().unwrap().to_owned(),
     });
 
-    let meta_dir = temp_dir.path().join("_meta");
+    let meta_dir = path.join("_meta");
     MetaEmbedded::init_global_meta_store(meta_dir.to_string_lossy().to_string())
         .await
         .unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR



 `bend-local` now respect env `DATABEND_DATA_PATH`, if it's set, meta and data will be persistent in that path.
 
 ```bash
❯ DATABEND_DATA_PATH=/tmp/abc/ ./target/debug/databend-query local -q "create table abc(a int); insert into abc values(3);"
❯ DATABEND_DATA_PATH=/tmp/abc/ ./target/debug/databend-query local -q "select * from abc"
3
 ```
 
 
 `bendpy` will also respect this env, but you must set the env before import databend 
 
 ```python
 
import os
os.environ["DATABEND_DATA_PATH"] = "/tmp/def/"

from databend import SessionContext

...
 ```
 
 

- Closes #12992

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13089)
<!-- Reviewable:end -->
