### PR TITLE
[DO NOT MERGE] feat: table data disk cache using compressed arrow flight format

### DIFF
--- a/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
@@ -168,7 +168,7 @@ impl BlockReader {
             // populate array cache items
             for (item, field) in deserialized_column_arrays.iter() {
                 if let DeserializedArray::Deserialized((column_id, array, _size)) = item {
-                    let meta = column_metas.get(&column_id).unwrap();
+                    let meta = column_metas.get(column_id).unwrap();
                     let (offset, len) = meta.offset_length();
                     let key = TableDataCacheKey::new(block_path, *column_id, offset, len);
 

--- a/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
@@ -176,7 +176,8 @@ impl BlockReader {
 
                         // TODO make compression configable
                         let schema = Schema::from(vec![field.clone()]);
-                        let options = write::WriteOptions { compression: None };
+                        let lz4 = common_arrow::arrow::io::ipc::write::Compression::LZ4;
+                        let options = write::WriteOptions { compression: Some(lz4)};
                         let mut writer = write::FileWriter::new(&mut file, schema, None, options);
                         writer.start()?;
                         let chunk = Chunk::try_new(vec![array.clone()])?;
@@ -352,18 +353,6 @@ impl BlockReader {
             } else {
                 // the array is deserialized from raw bytes, should be cached
                 let column_id = column.leaf_column_ids[0];
-
-                // create a batch
-                let schema = Schema::from(vec![column.field.clone()]);
-                let chunk = Chunk::try_new(vec![array.clone()])?;
-                let options = WriteOptions { compression: None };
-                let mut write_buffer = Vec::<u8>::new();
-                let mut writer = write::FileWriter::new(&mut write_buffer, schema, None, options);
-
-                writer.start()?;
-                writer.write(&chunk, None)?;
-                writer.finish()?;
-
                 Ok(Some(DeserializedArray::Deserialized((
                     column_id,
                     array,

--- a/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
@@ -167,7 +167,7 @@ impl BlockReader {
             // populate array cache items
             for (item, field) in deserialized_column_arrays.iter() {
                 if let DeserializedArray::Deserialized((column_id, array, _size)) = item {
-                    let meta = column_metas.get(&column_id).unwrap();
+                    let meta = column_metas.get(column_id).unwrap();
                     let (offset, len) = meta.offset_length();
                     let key = TableDataCacheKey::new(block_path, *column_id, offset, len);
 

--- a/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
@@ -16,8 +16,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
+use bytes::Bytes;
 use common_arrow::arrow::chunk::Chunk;
 use common_arrow::arrow::datatypes::Field;
+use common_arrow::arrow::datatypes::Schema;
+use common_arrow::arrow::io::flight::WriteOptions;
+use common_arrow::arrow::io::ipc::write;
 use common_arrow::arrow::io::parquet::read::column_iter_to_arrays;
 use common_arrow::arrow::io::parquet::read::ArrayIter;
 use common_arrow::parquet::compression::Compression as ParquetCompression;
@@ -115,7 +119,7 @@ impl BlockReader {
                     need_default_vals.push(true);
                 }
                 Some(v) => {
-                    deserialized_column_arrays.push(v);
+                    deserialized_column_arrays.push((v, column_node.field.clone()));
                     need_default_vals.push(false);
                 }
             }
@@ -123,7 +127,7 @@ impl BlockReader {
 
         // assembly the arrays
         let mut chunk_arrays = vec![];
-        for array in &deserialized_column_arrays {
+        for (array, _field) in &deserialized_column_arrays {
             match array {
                 DeserializedArray::Deserialized((_, array, ..)) => {
                     chunk_arrays.push(array);
@@ -159,10 +163,37 @@ impl BlockReader {
             )?
         };
 
+        if let Some(cache) = CacheManager::instance().get_table_data_cache() {
+            // populate array cache items
+            for (item, field) in deserialized_column_arrays.iter() {
+                if let DeserializedArray::Deserialized((column_id, array, _size)) = item {
+                    let meta = column_metas.get(&column_id).unwrap();
+                    let (offset, len) = meta.offset_length();
+                    let key = TableDataCacheKey::new(block_path, *column_id, offset, len);
+
+                    let bytes = {
+                        let mut file = Vec::new();
+
+                        // TODO make compression configable
+                        let schema = Schema::from(vec![field.clone()]);
+                        let options = write::WriteOptions { compression: None };
+                        let mut writer = write::FileWriter::new(&mut file, schema, None, options);
+                        writer.start()?;
+                        let chunk = Chunk::try_new(vec![array.clone()])?;
+                        writer.write(&chunk, None)?;
+                        writer.finish()?;
+                        file
+                    };
+
+                    cache.put(key.into(), Arc::new(Bytes::from(bytes)))
+                }
+            }
+        }
+
         // populate cache if necessary
         if let Some(cache) = CacheManager::instance().get_table_data_array_cache() {
             // populate array cache items
-            for item in deserialized_column_arrays.into_iter() {
+            for (item, _field) in deserialized_column_arrays.into_iter() {
                 if let DeserializedArray::Deserialized((column_id, array, size)) = item {
                     let meta = column_metas.get(&column_id).unwrap();
                     let (offset, len) = meta.offset_length();
@@ -260,6 +291,16 @@ impl BlockReader {
                             field_column_descriptors.push(column_descriptor);
                             field_uncompressed_size += data.len();
                         }
+                        DataItem::ArrowIpc(column_array) => {
+                            if is_nested {
+                                // TODO more context info for error message
+                                return Err(ErrorCode::StorageOther(
+                                    "unexpected nested field: nested leaf field hits cached",
+                                ));
+                            }
+                            // since it is not nested, one column is enough
+                            return Ok(Some(DeserializedArray::Cached(column_array)));
+                        }
                         DataItem::ColumnArray(column_array) => {
                             if is_nested {
                                 // TODO more context info for error message
@@ -311,6 +352,18 @@ impl BlockReader {
             } else {
                 // the array is deserialized from raw bytes, should be cached
                 let column_id = column.leaf_column_ids[0];
+
+                // create a batch
+                let schema = Schema::from(vec![column.field.clone()]);
+                let chunk = Chunk::try_new(vec![array.clone()])?;
+                let options = WriteOptions { compression: None };
+                let mut write_buffer = Vec::<u8>::new();
+                let mut writer = write::FileWriter::new(&mut write_buffer, schema, None, options);
+
+                writer.start()?;
+                writer.write(&chunk, None)?;
+                writer.finish()?;
+
                 Ok(Some(DeserializedArray::Deserialized((
                     column_id,
                     array,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Evaluating the performance impact of changing disk cache format to arrow-ipc(with LZ4 compression).

--------
tpchs100:

- ec2(instance SSD storage for table data cache) + s3
- drop page cache before each query


| cache format    | time used(22 queries) |
| -------- | ------- |
|native column chun|123.124|
|parquet column chunk(lz4, no encoding)|137.489s|
|arrow ipc(lz4)|151.062s|

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13092)
<!-- Reviewable:end -->
