### PR TITLE
refactor: meta-service: re-implement export with Stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,6 +3768,7 @@ dependencies = [
  "derive_more",
  "env_logger",
  "futures",
+ "futures-async-stream",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -4814,6 +4815,28 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-async-stream"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f529ccdeacfa2446a9577041686cf1abb839b1b3e15fee4c1b1232ab3b7d799f"
+dependencies = [
+ "futures-async-stream-macro",
+ "futures-core",
+ "pin-project",
+]
+
+[[package]]
+name = "futures-async-stream-macro"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b48ee06dc8d2808ba5ebad075d06c3406085bb19deaac33be64c39113bf80"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ lazy_static = "1.4.0"
 # future and async
 futures = "0.3.24"
 futures-util = "0.3.24"
+futures-async-stream = { version = "0.2.7" }
 stream-more = "0.1.3"
 bytes = "1.5.0"
 

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -51,6 +51,7 @@ backon = "0.4"
 clap = { workspace = true }
 derive_more = { workspace = true }
 futures = "0.3.24"
+futures-async-stream = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
@@ -40,7 +41,9 @@ use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
 use common_metrics::counter::Count;
 use common_tracing::func_name;
+use futures::stream::TryChunksError;
 use futures::StreamExt;
+use futures::TryStreamExt;
 use log::debug;
 use log::info;
 use minitrace::prelude::*;
@@ -194,7 +197,7 @@ impl MetaService for MetaServiceImpl {
             let elapsed = t0.elapsed();
             info!("Handled(elapsed: {:?}) MetaGrpcReq: {:?}", elapsed, req);
 
-            Ok::<_, tonic::Status>(reply)
+            Ok::<_, Status>(reply)
         }
         .in_span(root)
         .await?;
@@ -243,13 +246,12 @@ impl MetaService for MetaServiceImpl {
         .await
     }
 
-    type ExportStream =
-        Pin<Box<dyn Stream<Item = Result<ExportedChunk, tonic::Status>> + Send + Sync + 'static>>;
+    type ExportStream = Pin<Box<dyn Stream<Item = Result<ExportedChunk, Status>> + Send + 'static>>;
 
-    // Export all meta data.
-    //
-    // Including raft hard state, logs and state machine.
-    // The exported data is a list of json strings in form of `(tree_name, sub_tree_prefix, key, value)`.
+    /// Export all meta data.
+    ///
+    /// Including header, raft state, logs and state machine.
+    /// The exported data is a series of JSON encoded strings of `RaftStoreEntry`.
     async fn export(
         &self,
         _request: Request<common_meta_types::protobuf::Empty>,
@@ -257,16 +259,21 @@ impl MetaService for MetaServiceImpl {
         let _guard = RequestInFlight::guard();
 
         let meta_node = &self.meta_node;
-        let res = meta_node.sto.export().await?;
+        let strm = meta_node.sto.inner().export();
 
-        let stream = ExportStream { data: res };
-        let s = stream.map(|strings| Ok(ExportedChunk { data: strings }));
+        let chunk_size = 32;
+        // - Chunk up upto 32 Ok items inside a Vec<String>;
+        // - Convert Vec<String> to ExportedChunk;
+        // - Convert TryChunkError<_, io::Error> to Status;
+        let s = strm
+            .try_chunks(chunk_size)
+            .map_ok(|chunk: Vec<String>| ExportedChunk { data: chunk })
+            .map_err(|e: TryChunksError<_, io::Error>| Status::internal(e.1.to_string()));
 
         Ok(Response::new(Box::pin(s)))
     }
 
-    type WatchStream =
-        Pin<Box<dyn Stream<Item = Result<WatchResponse, tonic::Status>> + Send + Sync + 'static>>;
+    type WatchStream = Pin<Box<dyn Stream<Item = Result<WatchResponse, Status>> + Send + 'static>>;
 
     #[minitrace::trace]
     async fn watch(

--- a/src/meta/service/src/lib.rs
+++ b/src/meta/service/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(generators)]
 #![allow(clippy::uninlined_format_args)]
 
 pub mod api;

--- a/src/meta/service/src/store/store.rs
+++ b/src/meta/service/src/store/store.rs
@@ -73,6 +73,10 @@ impl RaftStore {
         let sto = StoreInner::open_create(config, open, create).await?;
         Ok(Self::new(sto))
     }
+
+    pub fn inner(&self) -> Arc<StoreInner> {
+        self.inner.clone()
+    }
 }
 
 impl Deref for RaftStore {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: meta-service: re-implement export with Stream

- Updated the `export()` function in `grpc_service.rs` to use crate
  `futures-async-stream`, changed return type of the function to use a
  `BoxStream` that yields a series of JSON strings, instead of returning
  a big `Vec<String>`.

  This allows for more efficient handling of asynchronous streams, which
  can provide performance improvements.

  Note that `export(self: Arc<Sefl>)` takes an `Arc<Self>` as argument
  because the generated `gRPC` stream signature requires a `'static`
  lifetime. As a result, the `export(&self)` can not be used:

  ```
  type ExportStream: Stream<Item = Result<_, _>> + Send + 'static;
  ```

- Add dependency crate `futures-async-stream`;

- Enable unstable feature `#![feature(generators)]` for building a
  `Stream` from a generator(`yield ...`);

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13097)
<!-- Reviewable:end -->
