### PR TITLE
chore: remove unused type ExportStream; Stream does not need to be Sync

### DIFF
--- a/src/meta/client/tests/it/grpc_server.rs
+++ b/src/meta/client/tests/it/grpc_server.rs
@@ -46,7 +46,7 @@ pub struct GrpcServiceForTestImpl {}
 #[tonic::async_trait]
 impl MetaService for GrpcServiceForTestImpl {
     type HandshakeStream =
-        Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send + Sync + 'static>>;
+        Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send + 'static>>;
 
     async fn handshake(
         &self,
@@ -69,7 +69,7 @@ impl MetaService for GrpcServiceForTestImpl {
     }
 
     type ExportStream =
-        Pin<Box<dyn Stream<Item = Result<ExportedChunk, tonic::Status>> + Send + Sync + 'static>>;
+        Pin<Box<dyn Stream<Item = Result<ExportedChunk, tonic::Status>> + Send + 'static>>;
 
     async fn export(
         &self,
@@ -79,7 +79,7 @@ impl MetaService for GrpcServiceForTestImpl {
     }
 
     type WatchStream =
-        Pin<Box<dyn Stream<Item = Result<WatchResponse, tonic::Status>> + Send + Sync + 'static>>;
+        Pin<Box<dyn Stream<Item = Result<WatchResponse, tonic::Status>> + Send + 'static>>;
 
     async fn watch(
         &self,

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -15,8 +15,6 @@
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Context;
-use std::task::Poll;
 
 use common_arrow::arrow_format::flight::data::BasicAuth;
 use common_base::base::tokio::sync::mpsc;
@@ -329,25 +327,5 @@ impl MetaService for MetaServiceImpl {
             return Ok(Response::new(resp));
         }
         Err(Status::unavailable("can not get client ip address"))
-    }
-}
-
-pub struct ExportStream {
-    pub data: Vec<String>,
-}
-
-impl Stream for ExportStream {
-    type Item = Vec<String>;
-
-    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let l = self.data.len();
-
-        if l == 0 {
-            return Poll::Ready(None);
-        }
-
-        let chunk_size = std::cmp::min(16, l);
-
-        Poll::Ready(Some(self.data.drain(0..chunk_size).collect()))
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore: remove unused type ExportStream; Stream does not need to be Sync

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13099)
<!-- Reviewable:end -->
