### PR TITLE
chore: add trait AsMap to get a handle of `MapApi<K>` for a specific type `K`

### DIFF
--- a/src/meta/raft-store/src/lib.rs
+++ b/src/meta/raft-store/src/lib.rs
@@ -14,10 +14,9 @@
 
 #![allow(clippy::uninlined_format_args)]
 #![feature(impl_trait_in_assoc_type)]
-// #![feature(type_alias_impl_trait)]
+#![feature(return_position_impl_trait_in_trait)]
 
 // #![allow(incomplete_features)]
-// #![feature(return_position_impl_trait_in_trait)]
 
 pub mod applier;
 pub(crate) mod compat07;

--- a/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
@@ -20,6 +20,7 @@ use common_meta_types::KVMeta;
 use futures_util::stream::BoxStream;
 use futures_util::StreamExt;
 
+use crate::sm_v002::leveled_store::map_api::AsMap;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
@@ -126,7 +127,7 @@ impl MapApi<String> for Level {
             Marked::new_tomb_stone(seq)
         };
 
-        let prev = MapApiRO::<String>::get(&*self, key.as_str()).await;
+        let prev = (*self).str_map().get(&key).await;
         self.kv.insert(key, marked.clone());
         (prev, marked)
     }
@@ -180,7 +181,7 @@ impl MapApi<ExpireKey> for Level {
             Marked::TombStone { internal_seq: seq }
         };
 
-        let prev = MapApiRO::<ExpireKey>::get(&*self, &key).await;
+        let prev = (*self).expire_map().get(&key).await;
         self.expire.insert(key, marked.clone());
         (prev, marked)
     }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map.rs
@@ -96,6 +96,7 @@ impl LeveledMap {
         RefMut::new(&mut self.writable, &self.frozen)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn to_ref(&self) -> Ref {
         Ref::new(Some(&self.writable), &self.frozen)
     }
@@ -143,7 +144,5 @@ where
     {
         let mut l = self.to_ref_mut();
         MapApi::set(&mut l, key, value).await
-
-        // (&mut l).set(key, value).await
     }
 }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
@@ -24,6 +24,7 @@ use stream_more::StreamMore;
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::util;
 use crate::sm_v002::marked::Marked;
+use crate::state_machine::ExpireKey;
 
 /// MapKey defines the behavior of a key in a map.
 ///
@@ -79,6 +80,43 @@ where K: MapKey
         Q: Ord + Send + Sync + ?Sized,
         R: RangeBounds<Q> + Send + Sync + Clone;
 }
+
+/// Trait for using Self as an implementation of the MapApi.
+pub(in crate::sm_v002) trait AsMap {
+    /// Use Self as an implementation of the [`MapApiRO`] (Read-Only) interface.
+    fn as_map<K: MapKey>(&self) -> &impl MapApiRO<K>
+    where Self: MapApiRO<K> + Sized {
+        self
+    }
+
+    /// Use Self as an implementation of the [`MapApi`] interface, allowing for mutation.
+    fn as_map_mut<K: MapKey>(&mut self) -> &mut impl MapApi<K>
+    where Self: MapApi<K> + Sized {
+        self
+    }
+
+    fn str_map(&self) -> &impl MapApiRO<String>
+    where Self: MapApiRO<String> + Sized {
+        self
+    }
+
+    fn expire_map(&self) -> &impl MapApiRO<ExpireKey>
+    where Self: MapApiRO<ExpireKey> + Sized {
+        self
+    }
+
+    fn str_map_mut(&mut self) -> &mut impl MapApi<String>
+    where Self: MapApi<String> + Sized {
+        self
+    }
+
+    fn expire_map_mut(&mut self) -> &mut impl MapApi<ExpireKey>
+    where Self: MapApi<ExpireKey> + Sized {
+        self
+    }
+}
+
+impl<T> AsMap for T {}
 
 /// Provide a read-write key-value map API set, used to access state machine data.
 #[async_trait::async_trait]

--- a/src/meta/raft-store/src/sm_v002/sm_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002.rs
@@ -52,6 +52,7 @@ use crate::applier::Applier;
 use crate::key_spaces::RaftStoreEntry;
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::leveled_map::LeveledMap;
+use crate::sm_v002::leveled_store::map_api::AsMap;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiExt;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
@@ -251,7 +252,7 @@ impl SMV002 {
     ///
     /// It does not check expiration of the returned entry.
     pub async fn get_kv(&self, key: &str) -> Option<SeqV> {
-        let got = MapApiRO::<String>::get(&self.levels.to_ref(), key).await;
+        let got = self.levels.str_map().get(key).await;
         Into::<Option<SeqV>>::into(got)
     }
 
@@ -261,7 +262,7 @@ impl SMV002 {
     pub async fn prefix_list_kv(&self, prefix: &str) -> Vec<(String, SeqV)> {
         let p = prefix.to_string();
         let mut res = Vec::new();
-        let strm = MapApiRO::<String>::range(&self.levels, p..).await;
+        let strm = self.levels.str_map().range(p..).await;
 
         {
             let mut strm = std::pin::pin!(strm);
@@ -297,7 +298,8 @@ impl SMV002 {
     /// List expiration index by expiration time.
     pub(crate) async fn list_expire_index(&self) -> impl Stream<Item = (ExpireKey, String)> + '_ {
         self.levels
-            .range::<ExpireKey, _>(&self.expire_cursor..)
+            .expire_map()
+            .range(&self.expire_cursor..)
             .await
             // Return only non-deleted records
             .filter_map(|(k, v)| async move {
@@ -390,9 +392,7 @@ impl SMV002 {
         &mut self,
         upsert_kv: &UpsertKV,
     ) -> (Marked<Vec<u8>>, Marked<Vec<u8>>) {
-        let prev = MapApiRO::<String>::get(&self.levels, &upsert_kv.key)
-            .await
-            .clone();
+        let prev = self.levels.str_map().get(&upsert_kv.key).await.clone();
 
         if upsert_kv.seq.match_seq(prev.seq()).is_err() {
             return (prev.clone(), prev);

--- a/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
@@ -18,6 +18,7 @@ use common_meta_types::UpsertKV;
 use futures_util::StreamExt;
 use pretty_assertions::assert_eq;
 
+use crate::sm_v002::leveled_store::map_api::AsMap;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::marked::Marked;
 use crate::sm_v002::SMV002;
@@ -183,7 +184,8 @@ async fn test_internal_expire_index() -> anyhow::Result<()> {
     // Check internal expire index
     let got = sm
         .levels
-        .range::<ExpireKey, _>(..)
+        .expire_map()
+        .range(..)
         .await
         .collect::<Vec<_>>()
         .await;
@@ -250,7 +252,8 @@ async fn test_inserting_expired_becomes_deleting() -> anyhow::Result<()> {
     // Check expire store
     let got = sm
         .levels
-        .range::<ExpireKey, _>(..)
+        .expire_map()
+        .range(..)
         .await
         .collect::<Vec<_>>()
         .await;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore: add trait AsMap to get a handle of `MapApi<K>` for a specific type `K`

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13106)
<!-- Reviewable:end -->
