### PR TITLE
chore: clean up useless comment about unused state-machine-id

### DIFF
--- a/src/meta/raft-store/src/key_spaces.rs
+++ b/src/meta/raft-store/src/key_spaces.rs
@@ -78,7 +78,7 @@ impl SledKeySpace for StateMachineMeta {
 }
 
 /// Key-Value Types for storing meta data of a raft in sled::Tree:
-/// node_id, vote, state_machine_id pairs:(a,b)
+/// node_id, vote
 pub struct RaftStateKV {}
 impl SledKeySpace for RaftStateKV {
     const PREFIX: u8 = 4;

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -138,9 +138,6 @@ impl StoreInner {
         let log = RaftLog::open(&db, config).await?;
         info!("RaftLog opened");
 
-        // TODO(1): remove read_state_machine_id();
-        // TODO(1): StateMachine::clean()
-
         fn to_startup_err(e: impl std::error::Error + 'static) -> MetaStartupError {
             let ae = AnyError::new(&e);
             let store_err = MetaStorageError::SnapshotError(ae);
@@ -371,8 +368,6 @@ impl StoreInner {
         &self,
         data: Box<SnapshotData>,
     ) -> Result<(), MetaStorageError> {
-        //
-
         SMV002::install_snapshot(self.state_machine.clone(), data)
             .await
             .map_err(|e| {
@@ -380,7 +375,7 @@ impl StoreInner {
                     AnyError::new(&e).add_context(|| "replacing state-machine with snapshot"),
                 )
             })?;
-        // TODO(1): read_state_machine_id() and write_state_machine_id() is no longer used.
+
         // TODO(xp): use checksum to check consistency?
 
         Ok(())

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -242,8 +242,6 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
 
         info!("--- install snapshot");
         {
-            // TODO(1): remove write_state_machine_id
-            // sto.raft_state.write_state_machine_id(&(0, 0)).await?;
             sto.do_install_snapshot(data).await?;
         }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore: clean up useless comment about unused state-machine-id

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13112)
<!-- Reviewable:end -->
