### PR TITLE
chore: remove taplo-cli, build tool image no longer need it

### DIFF
--- a/scripts/setup/rust-tools.txt
+++ b/scripts/setup/rust-tools.txt
@@ -1,5 +1,4 @@
 cargo-audit@0.17.6
 cargo-machete@0.5.0
-taplo-cli@0.8.1
 typos-cli@1.16.3
 nextest@0.9.58


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

remove taplo-cli, build tool image no longer need it

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13115)
<!-- Reviewable:end -->
