### PR TITLE
feat: add copy option return_failed_only.

### DIFF
--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -475,6 +475,7 @@ pub struct CopyOptions {
     pub single: bool,
     pub max_file_size: usize,
     pub disable_variant_check: bool,
+    pub return_failed_only: bool,
 }
 
 impl CopyOptions {
@@ -524,6 +525,15 @@ impl CopyOptions {
                         ))
                     })?;
                     self.disable_variant_check = disable_variant_check;
+                }
+                "return_failed_only" => {
+                    let return_failed_only = bool::from_str(v).map_err(|_| {
+                        ErrorCode::StrParseError(format!(
+                            "Cannot parse return_failed_only: {} as bool",
+                            v
+                        ))
+                    })?;
+                    self.return_failed_only = return_failed_only;
                 }
                 _ => {
                     if !ignore_unknown {

--- a/src/meta/proto-conv/src/stage_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/stage_from_to_protobuf_impl.rs
@@ -134,6 +134,7 @@ impl FromToProto for mt::principal::CopyOptions {
             single: p.single,
             max_file_size,
             disable_variant_check: p.disable_variant_check,
+            return_failed_only: p.return_failed_only,
         })
     }
 
@@ -163,6 +164,7 @@ impl FromToProto for mt::principal::CopyOptions {
             single: self.single,
             max_file_size,
             disable_variant_check: self.disable_variant_check,
+            return_failed_only: self.return_failed_only,
         })
     }
 }

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -89,6 +89,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (57, "2023-09-05: Add: catalog.proto add hdfs config", ),
     (58, "2023-09-06: Add: udf.proto/UserDefinedFunction", ),
     (59, "2023-08-17: Add: user.proto/CsvFileFormatParams add field `allow_column_count_mismatch`", ),
+    (60, "2023-08-17: Add: user.proto/CopyOptions add field `return_failed_only`", ),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -64,3 +64,4 @@ mod v056_least_visible_time;
 mod v057_hdfs_storage;
 mod v058_udf;
 mod v059_csv_format_params;
+mod v060_copy_options;

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -93,6 +93,7 @@ pub(crate) fn test_fs_stage_info() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
 
@@ -133,6 +134,7 @@ pub(crate) fn test_s3_stage_info() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -170,6 +172,7 @@ pub(crate) fn test_s3_stage_info_v16() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -207,6 +210,7 @@ pub(crate) fn test_s3_stage_info_v14() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -240,6 +244,7 @@ pub(crate) fn test_gcs_stage_info() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -275,6 +280,7 @@ pub(crate) fn test_oss_stage_info() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -307,6 +313,7 @@ pub(crate) fn test_webhdfs_stage_info() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -340,6 +347,7 @@ pub(crate) fn test_obs_stage_info() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -373,6 +381,7 @@ pub(crate) fn test_cos_stage_info() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -814,6 +823,7 @@ pub(crate) fn test_internal_stage_info_v17() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -843,6 +853,7 @@ pub(crate) fn test_stage_info_v18() -> mt::principal::StageInfo {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()

--- a/src/meta/proto-conv/tests/it/user_stage.rs
+++ b/src/meta/proto-conv/tests/it/user_stage.rs
@@ -109,6 +109,7 @@ fn test_user_stage_webhdfs_v30() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -153,6 +154,7 @@ fn test_user_stage_fs_v22() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -196,6 +198,7 @@ fn test_user_stage_fs_v21() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -238,6 +241,7 @@ fn test_user_stage_fs_v20() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -281,6 +285,7 @@ fn test_user_stage_fs_v16() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -336,6 +341,7 @@ fn test_user_stage_s3_v16() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -385,6 +391,7 @@ fn test_user_stage_gcs_v16() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -437,6 +444,7 @@ fn test_user_stage_oss_v16() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -491,6 +499,7 @@ fn test_user_stage_oss_v13() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -545,6 +554,7 @@ fn test_user_stage_s3_v11() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -597,6 +607,7 @@ fn test_user_stage_s3_v8() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -640,6 +651,7 @@ fn test_user_stage_fs_v6() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -693,6 +705,7 @@ fn test_user_stage_s3_v6() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -742,6 +755,7 @@ fn test_user_stage_gcs_v6() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -784,6 +798,7 @@ fn test_user_stage_fs_v4() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -837,6 +852,7 @@ fn test_user_stage_s3_v4() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -885,6 +901,7 @@ fn test_user_stage_gcs_v4() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -935,6 +952,7 @@ fn test_user_stage_s3_v1() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -980,6 +998,7 @@ fn test_internal_stage_v17() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -1024,6 +1043,7 @@ fn test_user_stage_v19() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()

--- a/src/meta/proto-conv/tests/it/v025_user_stage.rs
+++ b/src/meta/proto-conv/tests/it/v025_user_stage.rs
@@ -63,6 +63,7 @@ fn test_decode_v25_user_stage() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         number_of_files: 100,

--- a/src/meta/proto-conv/tests/it/v030_user_stage.rs
+++ b/src/meta/proto-conv/tests/it/v030_user_stage.rs
@@ -68,6 +68,7 @@ fn test_decode_v30_user_stage() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()

--- a/src/meta/proto-conv/tests/it/v031_copy_max_file.rs
+++ b/src/meta/proto-conv/tests/it/v031_copy_max_file.rs
@@ -66,6 +66,7 @@ fn test_decode_v31_copy_max_file() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()

--- a/src/meta/proto-conv/tests/it/v035_user_stage.rs
+++ b/src/meta/proto-conv/tests/it/v035_user_stage.rs
@@ -60,6 +60,7 @@ fn test_decode_v35_user_stage() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: true,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         number_of_files: 100,

--- a/src/meta/proto-conv/tests/it/v042_s3_stage_new_field.rs
+++ b/src/meta/proto-conv/tests/it/v042_s3_stage_new_field.rs
@@ -64,6 +64,7 @@ fn test_decode_v42_s3_stage_new_field() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: true,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         number_of_files: 100,

--- a/src/meta/proto-conv/tests/it/v051_obs_and_cos_storage.rs
+++ b/src/meta/proto-conv/tests/it/v051_obs_and_cos_storage.rs
@@ -69,6 +69,7 @@ fn test_decode_v51_obs_stage() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()
@@ -117,6 +118,7 @@ fn test_decode_v51_cos_stage() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()

--- a/src/meta/proto-conv/tests/it/v057_hdfs_storage.rs
+++ b/src/meta/proto-conv/tests/it/v057_hdfs_storage.rs
@@ -62,6 +62,7 @@ fn test_decode_v57_hdfs_storage() -> anyhow::Result<()> {
             single: false,
             max_file_size: 0,
             disable_variant_check: false,
+            return_failed_only: false,
         },
         comment: "test".to_string(),
         ..Default::default()

--- a/src/meta/proto-conv/tests/it/v060_copy_options.rs
+++ b/src/meta/proto-conv/tests/it/v060_copy_options.rs
@@ -1,0 +1,48 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_meta_app::principal::CopyOptions;
+use common_meta_app::principal::OnErrorMode;
+
+use crate::common;
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+#[test]
+fn test_decode_v60_copy_options() -> anyhow::Result<()> {
+    let copy_options_v60 = vec![
+        10, 3, 32, 197, 24, 16, 142, 8, 24, 1, 32, 1, 40, 100, 48, 100, 56, 1, 64, 1,
+    ];
+    let want = || CopyOptions {
+        on_error: OnErrorMode::SkipFileNum(3141),
+        size_limit: 1038,
+        max_files: 0,
+        split_size: 100,
+        purge: true,
+        single: true,
+        max_file_size: 100,
+        disable_variant_check: true,
+        return_failed_only: true,
+    };
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), copy_options_v60.as_slice(), 0, want())?;
+    Ok(())
+}

--- a/src/meta/protos/proto/stage.proto
+++ b/src/meta/protos/proto/stage.proto
@@ -53,6 +53,7 @@ message StageInfo {
     uint64 max_file_size = 5;
     uint64 split_size = 6;
     bool disable_variant_check = 7;
+    bool return_failed_only = 8;
   }
 
 

--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -54,6 +54,7 @@ pub struct CopyStmt {
     pub purge: bool,
     pub force: bool,
     pub disable_variant_check: bool,
+    pub return_failed_only: bool,
     pub on_error: String,
 }
 
@@ -72,6 +73,7 @@ impl CopyStmt {
             CopyOption::Purge(v) => self.purge = v,
             CopyOption::Force(v) => self.force = v,
             CopyOption::DisableVariantCheck(v) => self.disable_variant_check = v,
+            CopyOption::ReturnFailedOnly(v) => self.return_failed_only = v,
             CopyOption::OnError(v) => self.on_error = v,
         }
     }
@@ -393,5 +395,6 @@ pub enum CopyOption {
     Purge(bool),
     Force(bool),
     DisableVariantCheck(bool),
+    ReturnFailedOnly(bool),
     OnError(String),
 }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -1113,6 +1113,7 @@ pub fn statement(i: Input) -> IResult<StatementMsg> {
                 force: Default::default(),
                 disable_variant_check: Default::default(),
                 on_error: "abort".to_string(),
+                return_failed_only: Default::default(),
             };
             for (opt, _) in opts {
                 copy_stmt.apply_option(opt);
@@ -2649,6 +2650,10 @@ pub fn copy_option(i: Input) -> IResult<CopyOption> {
         map(
             rule! { DISABLE_VARIANT_CHECK ~ "=" ~ #literal_bool },
             |(_, _, disable_variant_check)| CopyOption::DisableVariantCheck(disable_variant_check),
+        ),
+        map(
+            rule! { RETURN_FAILED_ONLY ~ "=" ~ #literal_bool },
+            |(_, _, return_failed_only)| CopyOption::ReturnFailedOnly(return_failed_only),
         ),
     ))(i)
 }

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -746,6 +746,8 @@ pub enum TokenKind {
     RENAME,
     #[token("REPLACE", ignore(ascii_case))]
     REPLACE,
+    #[token("RETURN_FAILED_ONLY", ignore(ascii_case))]
+    RETURN_FAILED_ONLY,
     #[token("MERGE", ignore(ascii_case))]
     MERGE,
     #[token("MATCHED", ignore(ascii_case))]

--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -307,7 +307,7 @@ error:
   --> SQL:1:38
   |
 1 | COPY INTO mytable FROM 's3://bucket' CREDENTIAL = ();
-  |                                      ^^^^^^^^^^ expected `CREDENTIALS`, `DISABLE_VARIANT_CHECK`, `CONNECTION`, `PURGE`, `VALIDATION_MODE`, `FORCE`, `LOCATION_PREFIX`, `SINGLE`, `FORMAT`, `PATTERN`, `FILES`, `MAX_FILES`, `SIZE_LIMIT`, `FILE_FORMAT`, `MAX_FILE_SIZE`, `ON_ERROR`, `SPLIT_SIZE`, or `;`
+  |                                      ^^^^^^^^^^ expected `CREDENTIALS`, `DISABLE_VARIANT_CHECK`, `RETURN_FAILED_ONLY`, `CONNECTION`, `PURGE`, `VALIDATION_MODE`, `FORCE`, `LOCATION_PREFIX`, `SINGLE`, `FORMAT`, `PATTERN`, `FILES`, `MAX_FILES`, `SIZE_LIMIT`, `FILE_FORMAT`, `MAX_FILE_SIZE`, `ON_ERROR`, `SPLIT_SIZE`, or `;`
 
 
 ---------- Input ----------
@@ -317,7 +317,7 @@ error:
   --> SQL:1:33
   |
 1 | COPY INTO mytable FROM @mystage CREDENTIALS = ();
-  |                                 ^^^^^^^^^^^ expected `DISABLE_VARIANT_CHECK`, `MAX_FILES`, `PURGE`, `VALIDATION_MODE`, `MAX_FILE_SIZE`, `FORCE`, `SINGLE`, `FORMAT`, `PATTERN`, `FILES`, `SIZE_LIMIT`, `SPLIT_SIZE`, `FILE_FORMAT`, `ON_ERROR`, or `;`
+  |                                 ^^^^^^^^^^^ expected `DISABLE_VARIANT_CHECK`, `RETURN_FAILED_ONLY`, `MAX_FILES`, `PURGE`, `VALIDATION_MODE`, `MAX_FILE_SIZE`, `FORCE`, `SINGLE`, `FORMAT`, `PATTERN`, `FILES`, `SIZE_LIMIT`, `SPLIT_SIZE`, `FILE_FORMAT`, `ON_ERROR`, or `;`
 
 
 ---------- Input ----------
@@ -503,7 +503,7 @@ error:
   --> SQL:1:22
   |
 1 | copy into t1 from "" FILE
-  |                      ^^^^ expected `FILES`, `FILE_FORMAT`, `MAX_FILE_SIZE`, `SINGLE`, `DISABLE_VARIANT_CHECK`, `FORCE`, `SIZE_LIMIT`, `PURGE`, `FORMAT`, `PATTERN`, `ON_ERROR`, `SPLIT_SIZE`, `VALIDATION_MODE`, `.`, `(`, `MAX_FILES`, or `;`
+  |                      ^^^^ expected `FILES`, `FILE_FORMAT`, `MAX_FILE_SIZE`, `SINGLE`, `RETURN_FAILED_ONLY`, `DISABLE_VARIANT_CHECK`, `FORCE`, `SIZE_LIMIT`, `PURGE`, `FORMAT`, `PATTERN`, `ON_ERROR`, `SPLIT_SIZE`, `VALIDATION_MODE`, `.`, `(`, `MAX_FILES`, or `;`
 
 
 ---------- Input ----------

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -9213,6 +9213,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9269,6 +9270,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9335,6 +9337,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9401,6 +9404,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9471,6 +9475,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9541,6 +9546,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9593,6 +9599,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9645,6 +9652,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9703,6 +9711,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9768,6 +9777,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9812,6 +9822,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9868,6 +9879,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9940,6 +9952,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -9996,6 +10009,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -10052,6 +10066,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -10108,6 +10123,7 @@ Copy(
         purge: false,
         force: true,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -10174,6 +10190,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: true,
+        return_failed_only: false,
         on_error: "abort",
     },
 )
@@ -10228,6 +10245,7 @@ Copy(
         purge: false,
         force: false,
         disable_variant_check: false,
+        return_failed_only: false,
         on_error: "abort",
     },
 )

--- a/src/query/sql/src/planner/binder/copy.rs
+++ b/src/query/sql/src/planner/binder/copy.rs
@@ -535,6 +535,7 @@ impl<'a> Binder {
             stage.copy_options.single = stmt.single;
             stage.copy_options.purge = stmt.purge;
             stage.copy_options.disable_variant_check = stmt.disable_variant_check;
+            stage.copy_options.return_failed_only = stmt.return_failed_only;
         }
 
         Ok(())

--- a/src/query/sql/src/planner/plans/copy.rs
+++ b/src/query/sql/src/planner/plans/copy.rs
@@ -28,6 +28,7 @@ use common_expression::DataSchema;
 use common_expression::DataSchemaRef;
 use common_expression::DataSchemaRefExt;
 use common_expression::Scalar;
+use common_meta_app::principal::CopyOptions;
 use common_meta_app::principal::StageInfo;
 use common_meta_app::schema::CatalogInfo;
 use common_storage::init_stage_operator;
@@ -247,6 +248,13 @@ impl CopyPlan {
                 DataType::Nullable(Box::new(DataType::Number(NumberDataType::Int32))),
             ),
         ])
+    }
+
+    pub fn copy_into_table_options(&self) -> Option<CopyOptions> {
+        match self {
+            CopyPlan::IntoTable(p) => Some(p.stage_table_info.stage_info.copy_options.clone()),
+            _ => None,
+        }
     }
 
     pub fn schema(&self) -> DataSchemaRef {

--- a/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage
@@ -23,7 +23,7 @@ onlyif mysql
 query TTTTTITT
 desc stage test_stage_internal
 ----
-test_stage_internal Internal StageParams { storage: Fs(StorageFsConfig { root: "_data" }) } CopyOptions { on_error: AbortNum(1), size_limit: 0, max_files: 0, split_size: 0, purge: false, single: false, max_file_size: 0, disable_variant_check: false } Csv(CsvFileFormatParams { compression: Auto, headers: 0, field_delimiter: ",", record_delimiter: "\n", null_display: "\\N", nan_display: "NaN", escape: "\\", quote: "\"", error_on_column_count_mismatch: true }) 0 'root'@'%' (empty)
+test_stage_internal Internal StageParams { storage: Fs(StorageFsConfig { root: "_data" }) } CopyOptions { on_error: AbortNum(1), size_limit: 0, max_files: 0, split_size: 0, purge: false, single: false, max_file_size: 0, disable_variant_check: false, return_failed_only: false } Csv(CsvFileFormatParams { compression: Auto, headers: 0, field_delimiter: ",", record_delimiter: "\n", null_display: "\\N", nan_display: "NaN", escape: "\\", quote: "\"", error_on_column_count_mismatch: true }) 0 'root'@'%' (empty)
 
 query TTTTT
 SHOW STAGES

--- a/tests/sqllogictests/suites/base/06_show/06_0011_show_stages
+++ b/tests/sqllogictests/suites/base/06_show/06_0011_show_stages
@@ -13,8 +13,7 @@ skipif clickhouse
 query TTTTTITT
 DESC STAGE test_stage
 ----
-test_stage Internal StageParams { storage: Fs(StorageFsConfig { root: "_data" }) } CopyOptions { on_error: AbortNum(1), size_limit: 0, max_files: 0, split_size: 0, purge: false, single: false, max_file_size: 0, disable_variant_check: false } Parquet(ParquetFileFormatParams) 0 'root'@'%' (empty)
+test_stage Internal StageParams { storage: Fs(StorageFsConfig { root: "_data" }) } CopyOptions { on_error: AbortNum(1), size_limit: 0, max_files: 0, split_size: 0, purge: false, single: false, max_file_size: 0, disable_variant_check: false, return_failed_only: false } Parquet(ParquetFileFormatParams) 0 'root'@'%' (empty)
 
 statement ok
 DROP STAGE test_stage
-

--- a/tests/sqllogictests/suites/stage/options/return_failed_only
+++ b/tests/sqllogictests/suites/stage/options/return_failed_only
@@ -1,0 +1,10 @@
+statement ok
+drop table if exists ii
+
+statement ok
+create table ii (a int, b int)
+
+query
+copy into ii from @data/csv/ files = ('it.csv', 'ii_100.csv') file_format = (type = CSV) on_error=continue return_failed_only=true
+----
+csv/it.csv 0 2 Invalid value 'b' for column 1 (b Int32 NULL): invalid text for number 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Boolean that specifies whether to return only files that have failed to load in the statement result.


- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13122)
<!-- Reviewable:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13122)
<!-- Reviewable:end -->
