### PR TITLE
refactor: using column name instead of column id for agg index schema

### DIFF
--- a/src/query/service/src/interpreters/interpreter_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_index_refresh.rs
@@ -332,7 +332,7 @@ impl Interpreter for RefreshIndexInterpreter {
             .map(|f| {
                 let pos = select_columns
                     .iter()
-                    .find(|col| col.index.to_string().eq_ignore_ascii_case(&f.name()))
+                    .find(|col| col.index.to_string().eq_ignore_ascii_case(f.name()))
                     .ok_or_else(|| ErrorCode::Internal("should find the corresponding column"))?;
                 Ok(DataField::new(&pos.column_name, f.data_type().clone()))
             })

--- a/src/query/service/src/interpreters/interpreter_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_index_refresh.rs
@@ -326,10 +326,23 @@ impl Interpreter for RefreshIndexInterpreter {
             })?;
         let block_name_offset = output_schema.index_of(&block_name_col.index.to_string())?;
 
+        let fields = output_schema
+            .fields()
+            .iter()
+            .map(|f| {
+                let pos = select_columns
+                    .iter()
+                    .find(|col| col.index.to_string().eq_ignore_ascii_case(&f.name()))
+                    .ok_or_else(|| ErrorCode::Internal("should find the corresponding column"))?;
+                Ok(DataField::new(&pos.column_name, f.data_type().clone()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let new_output_schema = Arc::new(output_schema.project_by_fields(fields));
+
         // Build the final sink schema.
-        let mut sink_schema = infer_table_schema(&output_schema)?.as_ref().clone();
+        let mut sink_schema = infer_table_schema(&new_output_schema)?.as_ref().clone();
         if !self.plan.user_defined_block_name {
-            sink_schema.drop_column(&block_name_col.index.to_string())?;
+            sink_schema.drop_column(&block_name_col.column_name)?;
         }
         let sink_schema = Arc::new(sink_schema);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Using column name instead of column id for agg index schema.

Assume we have an agg-index `select sum(a+1), b from t group by b` with table `t(a int, b int)`, after refresh index then do `select * from 'xxx_index.parquet'`

Before:
```
+------+--------------------+
|  2   |          6         |
+------+--------------------+
| NULL |               |
|    1 |               |
+------+--------------------+
```

After this PR:
```
+------+--------------------+
| b    | sum_state((a + 1)) |
+------+--------------------+
| NULL |               |
|    1 |               |
+------+--------------------+
```
- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13123)
<!-- Reviewable:end -->
