### PR TITLE
refactor: generalize compacted_get() and compacted_range()

### DIFF
--- a/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
@@ -116,8 +116,6 @@ impl MapApi<String> for Level {
         // The chance it is the bottom level is very low in a loaded system.
         // Thus we always tombstone the key if it is None.
 
-        // dbg!("set kv", &key, &value);
-
         let marked = if let Some((v, meta)) = value {
             let seq = self.sys_data_mut().next_seq();
             Marked::new_with_meta(seq, v, meta)

--- a/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
@@ -21,7 +21,6 @@ use futures_util::stream::BoxStream;
 use stream_more::KMerge;
 use stream_more::StreamMore;
 
-use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::util;
 use crate::sm_v002::marked::Marked;
 use crate::state_machine::ExpireKey;
@@ -184,15 +183,15 @@ impl MapApiExt {
 /// Get a key from multi levels data.
 ///
 /// Returns the first non-tombstone entry.
-pub(in crate::sm_v002) async fn compacted_get<'d, K, Q>(
+pub(in crate::sm_v002) async fn compacted_get<'d, K, Q, L>(
     key: &Q,
-    levels: impl Iterator<Item = &'d Level>,
+    levels: impl IntoIterator<Item = &'d L>,
 ) -> Marked<K::V>
 where
     K: MapKey,
     K: Borrow<Q>,
     Q: Ord + Send + Sync + ?Sized,
-    Level: MapApiRO<K>,
+    L: MapApiRO<K> + 'static,
 {
     for lvl in levels {
         let got = lvl.get(key).await;
@@ -207,16 +206,16 @@ where
 ///
 /// The returned iterator contains at most one entry for each key.
 /// There could be tombstone entries: [`Marked::TombStone`]
-pub(in crate::sm_v002) async fn compacted_range<'d, K, Q, R>(
+pub(in crate::sm_v002) async fn compacted_range<'d, K, Q, R, L>(
     range: R,
-    levels: impl Iterator<Item = &'d Level>,
+    levels: impl IntoIterator<Item = &'d L>,
 ) -> BoxStream<'d, (K, Marked<K::V>)>
 where
     K: MapKey,
     K: Borrow<Q>,
     R: RangeBounds<Q> + Clone + Send + Sync,
     Q: Ord + Send + Sync + ?Sized,
-    Level: MapApiRO<K>,
+    L: MapApiRO<K> + 'static,
 {
     let mut kmerge = KMerge::by(util::by_key_seq);
 
@@ -230,4 +229,85 @@ where
 
     let strm: BoxStream<'_, (K, Marked<K::V>)> = Box::pin(m);
     strm
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_util::StreamExt;
+
+    use crate::sm_v002::leveled_store::level::Level;
+    use crate::sm_v002::leveled_store::map_api::compacted_get;
+    use crate::sm_v002::leveled_store::map_api::compacted_range;
+    use crate::sm_v002::leveled_store::map_api::MapApi;
+    use crate::sm_v002::marked::Marked;
+
+    #[tokio::test]
+    async fn test_compacted_get() -> anyhow::Result<()> {
+        let mut l0 = Level::default();
+        l0.set(s("a"), Some((b("a"), None))).await;
+
+        let mut l1 = l0.new_level();
+        l1.set(s("a"), None).await;
+
+        let l2 = l1.new_level();
+
+        let got = compacted_get::<String, _, _>(&s("a"), [&l0, &l1, &l2]).await;
+        assert_eq!(got, Marked::new_normal(1, b("a")));
+
+        let got = compacted_get::<String, _, _>(&s("a"), [&l2, &l1, &l0]).await;
+        assert_eq!(got, Marked::new_tomb_stone(1));
+
+        let got = compacted_get::<String, _, _>(&s("a"), [&l1, &l0]).await;
+        assert_eq!(got, Marked::new_tomb_stone(1));
+
+        let got = compacted_get::<String, _, _>(&s("a"), [&l2, &l0]).await;
+        assert_eq!(got, Marked::new_normal(1, b("a")));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compacted_range() -> anyhow::Result<()> {
+        // ```
+        // l2 |    b
+        // l1 | a*    c*
+        // l0 | a  b
+        // ```
+        let mut l0 = Level::default();
+        l0.set(s("a"), Some((b("a"), None))).await;
+        l0.set(s("b"), Some((b("b"), None))).await;
+
+        let mut l1 = l0.new_level();
+        l1.set(s("a"), None).await;
+        l1.set(s("c"), None).await;
+
+        let mut l2 = l1.new_level();
+        l2.set(s("b"), Some((b("b2"), None))).await;
+
+        let got = compacted_range::<String, String, _, _>(&s("").., [&l2, &l1, &l0]).await;
+        let got = got.collect::<Vec<_>>().await;
+        assert_eq!(got, vec![
+            //
+            (s("a"), Marked::new_tomb_stone(2)),
+            (s("b"), Marked::new_normal(3, b("b2"))),
+            (s("c"), Marked::new_tomb_stone(2)),
+        ]);
+
+        let got = compacted_range::<String, String, _, _>(&s("b").., [&l2, &l1, &l0]).await;
+        let got = got.collect::<Vec<_>>().await;
+        assert_eq!(got, vec![
+            //
+            (s("b"), Marked::new_normal(3, b("b2"))),
+            (s("c"), Marked::new_tomb_stone(2)),
+        ]);
+
+        Ok(())
+    }
+
+    fn s(x: impl ToString) -> String {
+        x.to_string()
+    }
+
+    fn b(x: impl ToString) -> Vec<u8> {
+        x.to_string().as_bytes().to_vec()
+    }
 }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/ref_mut.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/ref_mut.rs
@@ -98,7 +98,7 @@ where
     where
         K: Ord,
     {
-        // Get from this level or the base level.
+        // Get from the newest level where there is a tombstone or normal record of this key.
         let prev = self.get(&key).await.clone();
 
         // No such entry at all, no need to create a tombstone for delete
@@ -106,7 +106,8 @@ where
             return (prev, Marked::new_tomb_stone(0));
         }
 
-        // The data is a single level map and the returned `_prev` is only from that level.
+        // `writeable` is a single level map and the returned `_prev` is only from that level.
+        // Therefore it should be ignored and we use the `prev` from the multi-level map.
         let (_prev, inserted) = self.writable.set(key, value).await;
         (prev, inserted)
     }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: generalize compacted_get() and compacted_range()

These two functions are the foundation for multi level data access.
This commit generalizes them by allowing them to take
`IntoIterator<Item = impl MapApiRO>` as input levels,
instead of `Iterator<Item = Level>`.

And add tests to these two functions

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13124)
<!-- Reviewable:end -->
