### PR TITLE
fix(metrics): avoid leaking meta_client's error messages into metrics

### DIFF
--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -482,7 +482,7 @@ impl MetaGrpcClient {
                     grpc_metrics::incr_meta_grpc_client_request_failed(
                         &current_endpoint,
                         req_name,
-                        &err.to_string(),
+                        err,
                     );
                     error!(
                         request_id = as_display!(request_id);

--- a/src/meta/stoerr/src/meta_storage_errors.rs
+++ b/src/meta/stoerr/src/meta_storage_errors.rs
@@ -50,6 +50,15 @@ impl MetaStorageError {
     ) -> Self {
         MetaStorageError::SnapshotError(AnyError::new(error).add_context(context))
     }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            MetaStorageError::BytesError(_) => "BytesError",
+            MetaStorageError::SledError(_) => "SledError",
+            MetaStorageError::SnapshotError(_) => "SnapshotError",
+            MetaStorageError::TransactionConflict => "TransactionConflict",
+        }
+    }
 }
 
 impl From<std::string::FromUtf8Error> for MetaStorageError {

--- a/src/meta/types/src/errors/meta_api_errors.rs
+++ b/src/meta/types/src/errors/meta_api_errors.rs
@@ -84,6 +84,16 @@ impl MetaAPIError {
             },
         }
     }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            MetaAPIError::ForwardToLeader(_) => "ForwardToLeader",
+            MetaAPIError::CanNotForward(_) => "CanNotForward",
+            MetaAPIError::NetworkError(_) => "NetworkError",
+            MetaAPIError::DataError(_) => "DataError",
+            MetaAPIError::RemoteError(_) => "RemoteError",
+        }
+    }
 }
 
 /// Errors raised when handling a request by raft node.

--- a/src/meta/types/src/errors/meta_client_errors.rs
+++ b/src/meta/types/src/errors/meta_client_errors.rs
@@ -32,3 +32,14 @@ pub enum MetaClientError {
     #[error(transparent)]
     HandshakeError(MetaHandshakeError),
 }
+
+impl MetaClientError {
+    pub fn name(&self) -> &'static str {
+        match self {
+            MetaClientError::ClientRuntimeError(_) => "ClientRuntimeError",
+            MetaClientError::ConfigError(_) => "ConfigError",
+            MetaClientError::NetworkError(err) => err.name(),
+            MetaClientError::HandshakeError(_) => "MetaHandshakeError",
+        }
+    }
+}

--- a/src/meta/types/src/errors/meta_errors.rs
+++ b/src/meta/types/src/errors/meta_errors.rs
@@ -39,6 +39,17 @@ pub enum MetaError {
     APIError(#[from] MetaAPIError),
 }
 
+impl MetaError {
+    pub fn name(&self) -> &'static str {
+        match self {
+            MetaError::NetworkError(err) => err.name(),
+            MetaError::StorageError(err) => err.name(),
+            MetaError::ClientError(err) => err.name(),
+            MetaError::APIError(err) => err.name(),
+        }
+    }
+}
+
 impl From<tonic::Status> for MetaError {
     fn from(status: tonic::Status) -> Self {
         let net_err = MetaNetworkError::from(status);

--- a/src/meta/types/src/errors/meta_network_errors.rs
+++ b/src/meta/types/src/errors/meta_network_errors.rs
@@ -57,6 +57,18 @@ impl MetaNetworkError {
             Self::InvalidReply(e) => e.add_context(context).into(),
         }
     }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            MetaNetworkError::ConnectionError(_) => "ConnectionError",
+            MetaNetworkError::GetNodeAddrError(_) => "GetNodeAddrError",
+            MetaNetworkError::DnsParseError(_) => "DnsParseError",
+            MetaNetworkError::TLSConfigError(_) => "TLSConfigError",
+            MetaNetworkError::BadAddressFormat(_) => "BadAddressFormat",
+            MetaNetworkError::InvalidArgument(_) => "InvalidArgument",
+            MetaNetworkError::InvalidReply(_) => "InvalidReply",
+        }
+    }
 }
 
 pub type MetaNetworkResult<T> = std::result::Result<T, MetaNetworkError>;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

have a full error message into metrics' labels is not effective to the prometheus storage, and have dangerous for the metrics scraper like this:

```
expected equal, got "expired\"" ("LNAME") while parsing: "databend_meta_grpc_client_request_fail_total{endpoint=\"meta-service-0.meta-service.databend-system.svc:9191\",request=\"PrefixList\",error=\"ConnectionError: source: tonic::status::Status: status: Cancelled, message: \"Timeout expired\""
```

this PR added a `name()` method to MetaError, and put the name into the label instead of `err.to_string()` to reduce the cardinality of the metric labels on error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13131)
<!-- Reviewable:end -->
