### PR TITLE
refactor: fetch table metas in small chunks

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -286,6 +286,7 @@ impl SchemaApiTestSuite {
         suite.table_update_mask_policy(&b.build().await).await?;
         suite.table_upsert_option(&b.build().await).await?;
         suite.table_list(&b.build().await).await?;
+        suite.table_list_30_000(&b.build().await).await?;
         suite.table_list_all(&b.build().await).await?;
         suite
             .table_drop_undrop_list_history(&b.build().await)
@@ -4727,6 +4728,53 @@ impl SchemaApiTestSuite {
                 assert_eq!(tb_ids[0], res[0].ident.table_id);
                 assert_eq!(tb_ids[1], res[1].ident.table_id);
             }
+        }
+
+        Ok(())
+    }
+
+    /// Test listing 30,000 tables
+    #[minitrace::trace]
+    async fn table_list_30_000<MT>(&self, mt: &MT) -> anyhow::Result<()>
+    where MT: SchemaApi + kvapi::AsKVApi<Error = MetaError> {
+        let n = 30_000;
+
+        let mut util = Util::new(mt, "tenant1", "db1", "tb1", "eng1");
+
+        info!("--- prepare db");
+        {
+            util.create_db().await?;
+        }
+
+        info!("--- create {} tables", n);
+        {
+            for i in 0..n {
+                let table_name = format!("tb_{:0>5}", i);
+
+                let table_meta = util.table_meta();
+                let req = CreateTableReq {
+                    if_not_exists: false,
+                    name_ident: TableNameIdent {
+                        tenant: util.tenant(),
+                        db_name: util.db_name(),
+                        table_name,
+                    },
+                    table_meta: table_meta.clone(),
+                };
+                let resp = util.mt.create_table(req).await?;
+
+                if i % 100 == 0 {
+                    info!("--- created {} tables: {:?}", i, resp);
+                }
+            }
+        }
+
+        info!("--- get_tables");
+        {
+            let res = mt
+                .list_tables(ListTableReq::new(util.tenant(), util.db_name()))
+                .await?;
+            assert_eq!(n, res.len());
         }
 
         Ok(())


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: fetch table metas in small chunks

When listing tables, every `mget()` for table meta should not request for more than 256
tables, in order to prevent a too large response body that exceeds gPRC
body limit(16MB currently).

A test is added to ensure listing `30_000` tables works as expected.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13138)
<!-- Reviewable:end -->
