### PR TITLE
fix: Rollback to warning instead of hard error when stage region is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "flagset",
  "futures",
  "lazy_static",
+ "log",
  "metrics",
  "opendal",
  "ordered-float 3.7.0",

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -28,6 +28,7 @@ dashmap = { version = "5.5.1", features = ["serde"] }
 flagset = "0.4"
 futures = "0.3"
 lazy_static = { workspace = true }
+log = { workspace = true }
 metrics = "0.20.1"
 opendal = { workspace = true }
 ordered-float = { workspace = true }

--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -39,6 +39,7 @@ use common_meta_app::storage::StorageRedisConfig;
 use common_meta_app::storage::StorageS3Config;
 use common_meta_app::storage::StorageWebhdfsConfig;
 use common_metrics::load_global_prometheus_registry;
+use log::warn;
 use opendal::layers::ImmutableIndexLayer;
 use opendal::layers::LoggingLayer;
 use opendal::layers::MinitraceLayer;
@@ -234,12 +235,9 @@ fn init_s3_operator(cfg: &StorageS3Config) -> Result<impl Builder> {
         // Try to load region from env if not set.
         builder.region(&region);
     } else {
-        return Err(Error::new(
-            ErrorKind::InvalidInput,
-            anyhow!(
-                "region for s3 storage is not set and failed to auto detect, please check and set it manually"
-            ),
-        ));
+        warn!(
+            "Region is not specified for S3 storage, we will attempt to load it from profiles. If it is still not found, we will use the default region of `us-east-1`."
+        )
     }
 
     // Credential.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Rollback to warning instead of hard error

PR https://github.com/datafuselabs/databend/pull/13002 introduces a strict error when a stage lacks a region. However, this modification causes issues with numerous existing stages. This PR ensures their continued usability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13143)
<!-- Reviewable:end -->
