### PR TITLE
fix: fix_null_cast_bug

### DIFF
--- a/src/query/sql/src/planner/plans/update.rs
+++ b/src/query/sql/src/planner/plans/update.rs
@@ -113,9 +113,10 @@ impl UpdatePlan {
                     }
 
                     let mut right = right.ok_or_else(|| ErrorCode::Internal("It's a bug"))?;
+                    let right_data_type = right.data_type()?;
                     // cornor case: for merge into, if target_table's fields are not null, when after bind_join, it will
                     // change into nullable, so we need to cast this.
-                    right = wrap_cast_scalar(&right, &data_type, target_type)?;
+                    right = wrap_cast_scalar(&right, &right_data_type, target_type)?;
 
                     ScalarExpr::FunctionCall(FunctionCall {
                         span: None,

--- a/src/query/sql/src/planner/plans/update.rs
+++ b/src/query/sql/src/planner/plans/update.rs
@@ -112,7 +112,11 @@ impl UpdatePlan {
                         }
                     }
 
-                    let right = right.ok_or_else(|| ErrorCode::Internal("It's a bug"))?;
+                    let mut right = right.ok_or_else(|| ErrorCode::Internal("It's a bug"))?;
+                    // cornor case: for merge into, if target_table's fields are not null, when after bind_join, it will
+                    // change into nullable, so we need to cast this.
+                    right = wrap_cast_scalar(&right, &data_type, target_type)?;
+
                     ScalarExpr::FunctionCall(FunctionCall {
                         span: None,
                         func_name: "if".to_string(),

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0026_merge_into
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0026_merge_into
@@ -459,5 +459,27 @@ select * from salaries order by employee_id;
 3 55000.00
 4 55000.00
 
+## null cast bug fix
+statement ok
+create table t1(a int not null);
+
+statement ok
+create table t2(a int not null);
+
+statement ok
+insert into t1 values(1);
+
+statement ok
+insert into t2 values(1),(2);
+
+statement ok
+merge into t1 using (select * from t2) on t1.a = t2.a when matched then update * when not matched then insert *;
+
+query T
+select * from t1 order by a;
+----
+1
+2
+
 statement ok
 set enable_experimental_merge_into = 0;

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0026_merge_into
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0026_merge_into
@@ -461,22 +461,22 @@ select * from salaries order by employee_id;
 
 ## null cast bug fix
 statement ok
-create table t1(a int not null);
+create table t1_target(a int not null);
 
 statement ok
-create table t2(a int not null);
+create table t2_source(a int not null);
 
 statement ok
-insert into t1 values(1);
+insert into t1_target values(1);
 
 statement ok
-insert into t2 values(1),(2);
+insert into t2_source values(1),(2);
 
 statement ok
-merge into t1 using (select * from t2) on t1.a = t2.a when matched then update * when not matched then insert *;
+merge into t1_target using (select * from t2_source) on t1_target.a = t2_source.a when matched then update * when not matched then insert *;
 
 query T
-select * from t1 order by a;
+select * from t1_target order by a;
 ----
 1
 2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
Summary about this PR
          for merge into, if target_table's fields are not null, when after bind_join,
it will change into nullable, so we need to cast this.
- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13144)
<!-- Reviewable:end -->
