### PR TITLE
refactor: creating 30,000 tables may timeout unit test, reduce it to DEFAULT_MGET_SIZE+20

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -127,6 +127,7 @@ use crate::testing::get_kv_data;
 use crate::DatamaskApi;
 use crate::SchemaApi;
 use crate::ShareApi;
+use crate::DEFAULT_MGET_SIZE;
 
 /// Test suite of `SchemaApi`.
 ///
@@ -286,7 +287,7 @@ impl SchemaApiTestSuite {
         suite.table_update_mask_policy(&b.build().await).await?;
         suite.table_upsert_option(&b.build().await).await?;
         suite.table_list(&b.build().await).await?;
-        suite.table_list_30_000(&b.build().await).await?;
+        suite.table_list_many(&b.build().await).await?;
         suite.table_list_all(&b.build().await).await?;
         suite
             .table_drop_undrop_list_history(&b.build().await)
@@ -4733,11 +4734,12 @@ impl SchemaApiTestSuite {
         Ok(())
     }
 
-    /// Test listing 30,000 tables
+    /// Test listing many tables that exceeds default mget chunk size.
     #[minitrace::trace]
-    async fn table_list_30_000<MT>(&self, mt: &MT) -> anyhow::Result<()>
+    async fn table_list_many<MT>(&self, mt: &MT) -> anyhow::Result<()>
     where MT: SchemaApi + kvapi::AsKVApi<Error = MetaError> {
-        let n = 30_000;
+        // Create tables that exceeds the default mget chunk size
+        let n = DEFAULT_MGET_SIZE + 20;
 
         let mut util = Util::new(mt, "tenant1", "db1", "tb1", "eng1");
 

--- a/src/meta/raft-store/tests/it/state_machine/schema_api_impl.rs
+++ b/src/meta/raft-store/tests/it/state_machine/schema_api_impl.rs
@@ -59,5 +59,7 @@ async fn test_meta_embedded_single() -> anyhow::Result<()> {
 
     SchemaApiTestSuite::test_single_node(builder.clone()).await?;
     ShareApiTestSuite::test_single_node_share(builder.clone()).await?;
-    BackgroundApiTestSuite::test_single_node(builder).await
+    BackgroundApiTestSuite::test_single_node(builder).await?;
+
+    Ok(())
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: creating 30,000 tables may timeout unit test, reduce it to DEFAULT_MGET_SIZE+20

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13147)
<!-- Reviewable:end -->
