### PR TITLE
feat: generate sync agg indexes after copy into

### DIFF
--- a/src/query/ee/tests/it/aggregating_index/index_refresh.rs
+++ b/src/query/ee/tests/it/aggregating_index/index_refresh.rs
@@ -319,7 +319,6 @@ async fn test_sync_agg_index_after_insert() -> Result<()> {
         .set_enable_refresh_aggregating_index_after_write(true)?;
     let fixture = TestFixture::new_with_ctx(_guard, ctx).await;
     let ctx = fixture.ctx();
-    execute_sql(ctx.clone(), "DROP TABLE IF EXISTS t0").await?;
     // Create table
     execute_sql(
         ctx.clone(),
@@ -329,12 +328,6 @@ async fn test_sync_agg_index_after_insert() -> Result<()> {
 
     // Create agg index `index0`
     let index_name = "index0";
-
-    execute_sql(
-        ctx.clone(),
-        &format!("DROP AGGREGATING INDEX IF EXISTS {}", index_name),
-    )
-    .await?;
 
     let index_id0 = create_index(
         ctx.clone(),
@@ -346,12 +339,6 @@ async fn test_sync_agg_index_after_insert() -> Result<()> {
 
     // Create agg index `index1`
     let index_name = "index1";
-
-    execute_sql(
-        ctx.clone(),
-        &format!("DROP AGGREGATING INDEX IF EXISTS {}", index_name),
-    )
-    .await?;
 
     let index_id1 = create_index(
         ctx.clone(),
@@ -456,7 +443,6 @@ async fn test_sync_agg_index_after_copy_into() -> Result<()> {
     let fixture = TestFixture::new_with_ctx(_guard, ctx).await;
     let ctx = fixture.ctx();
 
-    execute_sql(ctx.clone(), "DROP TABLE IF EXISTS books").await?;
     // Create table
     execute_sql(
         ctx.clone(),
@@ -466,12 +452,6 @@ async fn test_sync_agg_index_after_copy_into() -> Result<()> {
 
     // Create agg index `index0`
     let index_name = "index0";
-
-    execute_sql(
-        ctx.clone(),
-        &format!("DROP AGGREGATING INDEX IF EXISTS {}", index_name),
-    )
-    .await?;
 
     let index_id0 = create_index(
         ctx.clone(),

--- a/src/query/ee/tests/it/aggregating_index/index_refresh.rs
+++ b/src/query/ee/tests/it/aggregating_index/index_refresh.rs
@@ -305,17 +305,24 @@ async fn test_refresh_agg_index_with_limit() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "flaky"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_agg_index() -> Result<()> {
+    test_sync_agg_index_after_insert().await?;
+    test_sync_agg_index_after_copy_into().await?;
+
+    Ok(())
+}
+
+async fn test_sync_agg_index_after_insert() -> Result<()> {
     let (_guard, ctx, root) = create_ee_query_context(None).await.unwrap();
     ctx.get_settings()
         .set_enable_refresh_aggregating_index_after_write(true)?;
     let fixture = TestFixture::new_with_ctx(_guard, ctx).await;
-
+    let ctx = fixture.ctx();
+    execute_sql(ctx.clone(), "DROP TABLE IF EXISTS t0").await?;
     // Create table
     execute_sql(
-        fixture.ctx(),
+        ctx.clone(),
         "CREATE TABLE t0 (a int, b int, c int) storage_format = 'parquet'",
     )
     .await?;
@@ -323,8 +330,14 @@ async fn test_sync_agg_index() -> Result<()> {
     // Create agg index `index0`
     let index_name = "index0";
 
+    execute_sql(
+        ctx.clone(),
+        &format!("DROP AGGREGATING INDEX IF EXISTS {}", index_name),
+    )
+    .await?;
+
     let index_id0 = create_index(
-        fixture.ctx(),
+        ctx.clone(),
         index_name,
         "SELECT b, SUM(a) from t0 WHERE c > 1 GROUP BY b",
         true,
@@ -334,8 +347,14 @@ async fn test_sync_agg_index() -> Result<()> {
     // Create agg index `index1`
     let index_name = "index1";
 
+    execute_sql(
+        ctx.clone(),
+        &format!("DROP AGGREGATING INDEX IF EXISTS {}", index_name),
+    )
+    .await?;
+
     let index_id1 = create_index(
-        fixture.ctx(),
+        ctx.clone(),
         index_name,
         "SELECT a, SUM(b) from t0 WHERE c > 1 GROUP BY a",
         true,
@@ -344,7 +363,7 @@ async fn test_sync_agg_index() -> Result<()> {
 
     // Insert data
     execute_sql(
-        fixture.ctx(),
+        ctx.clone(),
         "INSERT INTO t0 VALUES (1,1,4), (1,2,1), (1,2,4), (2,2,5)",
     )
     .await?;
@@ -365,14 +384,14 @@ async fn test_sync_agg_index() -> Result<()> {
     // Check aggregating index_0 is correct.
     {
         let res = execute_sql(
-            fixture.ctx(),
+            ctx.clone(),
             "SELECT b, SUM_STATE(a) from t0 WHERE c > 1 GROUP BY b",
         )
         .await?;
         let data_blocks: Vec<DataBlock> = res.try_collect().await?;
 
         let agg_res = execute_sql(
-            fixture.ctx(),
+            ctx.clone(),
             &format!(
                 "SELECT * FROM 'fs://{}'",
                 agg_index_path_0.join(&indexes_0[0]).to_str().unwrap()
@@ -381,20 +400,24 @@ async fn test_sync_agg_index() -> Result<()> {
         .await?;
         let agg_data_blocks: Vec<DataBlock> = agg_res.try_collect().await?;
 
-        assert_two_blocks_sorted_eq_with_name("refresh index", &data_blocks, &agg_data_blocks);
+        assert_two_blocks_sorted_eq_with_name(
+            "test_sync_agg_index_after_insert",
+            &data_blocks,
+            &agg_data_blocks,
+        );
     }
 
     // Check aggregating index_1 is correct.
     {
         let res = execute_sql(
-            fixture.ctx(),
+            ctx.clone(),
             "SELECT a, SUM_STATE(b) from t0 WHERE c > 1 GROUP BY a",
         )
         .await?;
         let data_blocks: Vec<DataBlock> = res.try_collect().await?;
 
         let agg_res = execute_sql(
-            fixture.ctx(),
+            ctx.clone(),
             &format!(
                 "SELECT * FROM 'fs://{}'",
                 agg_index_path_1.join(&indexes_1[0]).to_str().unwrap()
@@ -403,11 +426,15 @@ async fn test_sync_agg_index() -> Result<()> {
         .await?;
         let agg_data_blocks: Vec<DataBlock> = agg_res.try_collect().await?;
 
-        assert_two_blocks_sorted_eq_with_name("refresh index", &data_blocks, &agg_data_blocks);
+        assert_two_blocks_sorted_eq_with_name(
+            "test_sync_agg_index_after_insert",
+            &data_blocks,
+            &agg_data_blocks,
+        );
     }
 
     // Insert more data with insert into ... select ...
-    execute_sql(fixture.ctx(), "INSERT INTO t0 SELECT * FROM t0").await?;
+    execute_sql(ctx.clone(), "INSERT INTO t0 SELECT * FROM t0").await?;
 
     let blocks = collect_file_names(&block_path)?;
 
@@ -418,6 +445,79 @@ async fn test_sync_agg_index() -> Result<()> {
     // check index1
     let indexes_1 = collect_file_names(&agg_index_path_1)?;
     assert_eq!(blocks, indexes_1);
+
+    Ok(())
+}
+
+async fn test_sync_agg_index_after_copy_into() -> Result<()> {
+    let (_guard, ctx, root) = create_ee_query_context(None).await.unwrap();
+    ctx.get_settings()
+        .set_enable_refresh_aggregating_index_after_write(true)?;
+    let fixture = TestFixture::new_with_ctx(_guard, ctx).await;
+    let ctx = fixture.ctx();
+
+    execute_sql(ctx.clone(), "DROP TABLE IF EXISTS books").await?;
+    // Create table
+    execute_sql(
+        ctx.clone(),
+        "CREATE TABLE books (title VARCHAR, author VARCHAR, date VARCHAR) storage_format = 'parquet'",
+    )
+        .await?;
+
+    // Create agg index `index0`
+    let index_name = "index0";
+
+    execute_sql(
+        ctx.clone(),
+        &format!("DROP AGGREGATING INDEX IF EXISTS {}", index_name),
+    )
+    .await?;
+
+    let index_id0 = create_index(
+        ctx.clone(),
+        index_name,
+        "SELECT MAX(title) from books",
+        true,
+    )
+    .await?;
+
+    // Copy into data
+    execute_sql(
+        ctx.clone(),
+        "COPY INTO books FROM 'https://datafuse-1253727613.cos.ap-hongkong.myqcloud.com/data/books.csv' FILE_FORMAT = (TYPE = CSV);",
+    )
+        .await?;
+
+    let block_path = find_block_path(&root)?.unwrap();
+    let blocks = collect_file_names(&block_path)?;
+
+    // Get aggregating index files
+    let agg_index_path_0 = find_agg_index_path(&root, index_id0)?.unwrap();
+    let indexes_0 = collect_file_names(&agg_index_path_0)?;
+
+    assert_eq!(blocks, indexes_0);
+
+    // Check aggregating index_0 is correct.
+    {
+        let res = execute_sql(ctx.clone(), "SELECT MAX_STATE(title) from books").await?;
+        let data_blocks: Vec<DataBlock> = res.try_collect().await?;
+
+        let agg_res = execute_sql(
+            ctx.clone(),
+            &format!(
+                "SELECT * FROM 'fs://{}'",
+                agg_index_path_0.join(&indexes_0[0]).to_str().unwrap()
+            ),
+        )
+        .await?;
+        let agg_data_blocks: Vec<DataBlock> = agg_res.try_collect().await?;
+
+        assert_two_blocks_sorted_eq_with_name(
+            "test_sync_agg_index_after_copy_into",
+            &data_blocks,
+            &agg_data_blocks,
+        );
+    }
 
     Ok(())
 }

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -16,12 +16,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use common_catalog::table::AppendMode;
-use common_catalog::table::Table;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::DataSchema;
 use common_meta_app::principal::StageFileFormatType;
-use common_pipeline_core::Pipeline;
 use common_pipeline_sources::AsyncSourcer;
 use common_sql::executor::DistributedInsertSelect;
 use common_sql::executor::PhysicalPlan;
@@ -239,11 +237,16 @@ impl Interpreter for InsertInterpreter {
                     None,
                 )?;
 
-                hook_refresh_indexes(
+                let refresh_agg_index_desc = RefreshAggIndexDesc {
+                    catalog: self.plan.catalog.clone(),
+                    database: self.plan.database.clone(),
+                    table: self.plan.table.clone(),
+                };
+
+                hook_refresh_agg_index(
                     self.ctx.clone(),
-                    &self.plan,
-                    table.as_ref(),
                     &mut build_res.main_pipeline,
+                    refresh_agg_index_desc,
                 )
                 .await?;
 
@@ -267,31 +270,19 @@ impl Interpreter for InsertInterpreter {
             append_mode,
         )?;
 
-        hook_refresh_indexes(
+        let refresh_agg_index_desc = RefreshAggIndexDesc {
+            catalog: self.plan.catalog.clone(),
+            database: self.plan.database.clone(),
+            table: self.plan.table.clone(),
+        };
+
+        hook_refresh_agg_index(
             self.ctx.clone(),
-            &self.plan,
-            table.as_ref(),
             &mut build_res.main_pipeline,
+            refresh_agg_index_desc,
         )
         .await?;
 
         Ok(build_res)
     }
-}
-
-#[async_backtrace::framed]
-async fn hook_refresh_indexes(
-    ctx: Arc<QueryContext>,
-    plan: &Insert,
-    table: &dyn Table,
-    pipeline: &mut Pipeline,
-) -> Result<()> {
-    let refresh_agg_index_desc = RefreshAggIndexDesc {
-        catalog: plan.catalog.clone(),
-        database: plan.database.clone(),
-        table: plan.table.clone(),
-        table_id: table.get_id(),
-    };
-
-    hook_refresh_agg_index(ctx, pipeline, refresh_agg_index_desc).await
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* Generates sync agg index after `copy into`.
* Clean code for `hook_refresh_agg_index`.
* Add associated tests.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13152)
<!-- Reviewable:end -->
