### PR TITLE
fix(users): enable system.users table again

### DIFF
--- a/src/query/service/src/databases/system/system_database.rs
+++ b/src/query/service/src/databases/system/system_database.rs
@@ -70,8 +70,6 @@ impl SystemDatabase {
         let mut map = HashMap::new();
         map.insert("configs".to_string(), true);
         map.insert("clusters".to_string(), true);
-        // Add 2023-08-01 by BohuTANG, due to it may leak the auth_string in the output.
-        map.insert("users".to_string(), true);
         map
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

now we've removed the auth_string infomation in the `system.users` table and `SHOW USERS` statement, it's saft to have `system.users` enabled again. otherwise it would produce a confusing error message on `SHOW USERS` like this:

```
1025=>
error: 
  --> SQL:1:12
  |
1 | show users;
  |              Unknown table `system`.`users` in catalog 'default'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13171)
<!-- Reviewable:end -->
