### PR TITLE
feat(query): add func: to_week_of_year

### DIFF
--- a/src/query/expression/src/utils/date_helper.rs
+++ b/src/query/expression/src/utils/date_helper.rs
@@ -427,9 +427,17 @@ pub struct ToMinute;
 pub struct ToSecond;
 pub struct ToUnixTimestamp;
 
+pub struct ToWeekOfYear;
+
 impl ToNumber<u32> for ToYYYYMM {
     fn to_number(dt: &DateTime<Tz>) -> u32 {
         dt.year() as u32 * 100 + dt.month()
+    }
+}
+
+impl ToNumber<u32> for ToWeekOfYear {
+    fn to_number(dt: &DateTime<Tz>) -> u32 {
+        dt.iso_week().week()
     }
 }
 

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -943,6 +943,13 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
             ToNumberImpl::eval_date::<ToDayOfWeek, _>(val, ctx.func_ctx.tz)
         }),
     );
+    registry.register_passthrough_nullable_1_arg::<DateType, UInt32Type, _, _>(
+        "to_week_of_year",
+        |_, _| FunctionDomain::Full,
+        vectorize_1_arg::<DateType, UInt32Type>(|val, ctx| {
+            ToNumberImpl::eval_date::<ToWeekOfYear, _>(val, ctx.func_ctx.tz)
+        }),
+    );
     // timestamp
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt32Type, _, _>(
         "to_yyyymm",
@@ -1012,6 +1019,13 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
         |_, _| FunctionDomain::Full,
         vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToDayOfWeek, _>(val, ctx.func_ctx.tz)
+        }),
+    );
+    registry.register_passthrough_nullable_1_arg::<TimestampType, UInt32Type, _, _>(
+        "to_week_of_year",
+        |_, _| FunctionDomain::Full,
+        vectorize_1_arg::<TimestampType, UInt32Type>(|val, ctx| {
+            ToNumberImpl::eval_timestamp::<ToWeekOfYear, _>(val, ctx.func_ctx.tz)
         }),
     );
     registry.register_passthrough_nullable_1_arg::<TimestampType, Int64Type, _, _>(

--- a/src/query/functions/tests/it/scalars/datetime.rs
+++ b/src/query/functions/tests/it/scalars/datetime.rs
@@ -475,6 +475,7 @@ fn test_to_number(file: &mut impl Write) {
     run_ast(file, "to_day_of_year(to_date(18875))", &[]);
     run_ast(file, "to_day_of_month(to_date(18875))", &[]);
     run_ast(file, "to_day_of_week(to_date(18875))", &[]);
+    run_ast(file, "to_week_of_year(to_date(18875))", &[]);
     run_ast(file, "to_yyyymm(a)", &[(
         "a",
         DateType::from_data(vec![-100, 0, 100]),
@@ -511,6 +512,10 @@ fn test_to_number(file: &mut impl Write) {
         "a",
         DateType::from_data(vec![-100, 0, 100]),
     )]);
+    run_ast(file, "to_week_of_year(a)", &[(
+        "a",
+        DateType::from_data(vec![-100, 0, 100]),
+    )]);
 
     // timestamp
     run_ast(file, "to_yyyymm(to_timestamp(1630812366))", &[]);
@@ -522,6 +527,7 @@ fn test_to_number(file: &mut impl Write) {
     run_ast(file, "to_day_of_year(to_timestamp(1630812366))", &[]);
     run_ast(file, "to_day_of_month(to_timestamp(1630812366))", &[]);
     run_ast(file, "to_day_of_week(to_timestamp(1630812366))", &[]);
+    run_ast(file, "to_week_of_year(to_timestamp(1630812366))", &[]);
     run_ast(file, "to_hour(to_timestamp(1630812366))", &[]);
     run_ast(file, "to_minute(to_timestamp(1630812366))", &[]);
     run_ast(file, "to_second(to_timestamp(1630812366))", &[]);
@@ -558,6 +564,10 @@ fn test_to_number(file: &mut impl Write) {
         TimestampType::from_data(vec![-100, 0, 100]),
     )]);
     run_ast(file, "to_day_of_week(a)", &[(
+        "a",
+        TimestampType::from_data(vec![-100, 0, 100]),
+    )]);
+    run_ast(file, "to_week_of_year(a)", &[(
         "a",
         TimestampType::from_data(vec![-100, 0, 100]),
     )]);

--- a/src/query/functions/tests/it/scalars/testdata/datetime.txt
+++ b/src/query/functions/tests/it/scalars/testdata/datetime.txt
@@ -2620,6 +2620,15 @@ output domain  : {7..=7}
 output         : 7
 
 
+ast            : to_week_of_year(to_date(18875))
+raw expr       : to_week_of_year(to_date(18875))
+checked expr   : to_week_of_year<Date>(to_date<Int64>(to_int64<UInt16>(18875_u16)))
+optimized expr : 35_u32
+output type    : UInt32
+output domain  : {35..=35}
+output         : 35
+
+
 ast            : to_yyyymm(a)
 raw expr       : to_yyyymm(a::Date)
 checked expr   : to_yyyymm<Date>(a)
@@ -2818,6 +2827,28 @@ evaluation (internal):
 +--------+------------------+
 
 
+ast            : to_week_of_year(a)
+raw expr       : to_week_of_year(a::Date)
+checked expr   : to_week_of_year<Date>(a)
+evaluation:
++--------+--------------+------------------+
+|        | a            | Output           |
++--------+--------------+------------------+
+| Type   | Date         | UInt32           |
+| Domain | {-100..=100} | {0..=4294967295} |
+| Row 0  | '1969-09-23' | 39               |
+| Row 1  | '1970-01-01' | 1                |
+| Row 2  | '1970-04-11' | 15               |
++--------+--------------+------------------+
+evaluation (internal):
++--------+---------------------+
+| Column | Data                |
++--------+---------------------+
+| a      | [-100, 0, 100]      |
+| Output | UInt32([39, 1, 15]) |
++--------+---------------------+
+
+
 ast            : to_yyyymm(to_timestamp(1630812366))
 raw expr       : to_yyyymm(to_timestamp(1630812366))
 checked expr   : to_yyyymm<Timestamp>(to_timestamp<Int64>(to_int64<UInt32>(1630812366_u32)))
@@ -2897,6 +2928,15 @@ optimized expr : 7_u8
 output type    : UInt8
 output domain  : {7..=7}
 output         : 7
+
+
+ast            : to_week_of_year(to_timestamp(1630812366))
+raw expr       : to_week_of_year(to_timestamp(1630812366))
+checked expr   : to_week_of_year<Timestamp>(to_timestamp<Int64>(to_int64<UInt32>(1630812366_u32)))
+optimized expr : 35_u32
+output type    : UInt32
+output domain  : {35..=35}
+output         : 35
 
 
 ast            : to_hour(to_timestamp(1630812366))
@@ -3122,6 +3162,28 @@ evaluation (internal):
 | a      | [-100, 0, 100]   |
 | Output | UInt8([3, 4, 4]) |
 +--------+------------------+
+
+
+ast            : to_week_of_year(a)
+raw expr       : to_week_of_year(a::Timestamp)
+checked expr   : to_week_of_year<Timestamp>(a)
+evaluation:
++--------+------------------------------+------------------+
+|        | a                            | Output           |
++--------+------------------------------+------------------+
+| Type   | Timestamp                    | UInt32           |
+| Domain | {-100..=100}                 | {0..=4294967295} |
+| Row 0  | '1969-12-31 23:59:59.999900' | 1                |
+| Row 1  | '1970-01-01 00:00:00.000000' | 1                |
+| Row 2  | '1970-01-01 00:00:00.000100' | 1                |
++--------+------------------------------+------------------+
+evaluation (internal):
++--------+-------------------+
+| Column | Data              |
++--------+-------------------+
+| a      | [-100, 0, 100]    |
+| Output | UInt32([1, 1, 1]) |
++--------+-------------------+
 
 
 ast            : to_hour(a)

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3567,6 +3567,10 @@ Functions overloads:
 1 to_unix_timestamp(Timestamp NULL) :: Int64 NULL
 0 to_variant(T0) :: Variant
 1 to_variant(T0 NULL) :: Variant NULL
+0 to_week_of_year(Date) :: UInt32
+1 to_week_of_year(Date NULL) :: UInt32 NULL
+2 to_week_of_year(Timestamp) :: UInt32
+3 to_week_of_year(Timestamp NULL) :: UInt32 NULL
 0 to_year(Date) :: UInt16
 1 to_year(Date NULL) :: UInt16 NULL
 2 to_year(Timestamp) :: UInt16

--- a/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
+++ b/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes
@@ -993,3 +993,18 @@ query T
 select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
 ----
 2022-02-04 00:58:59.000000
+
+query I
+select to_week_of_year('2017-01-01');
+----
+52
+
+query I
+SELECT to_week_of_year('1900-12-31 23:59:59.999900');
+----
+1
+
+query I
+SELECT to_week_of_year('2016-01-02T23:39:20.123-07:00');
+----
+53


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

support scalar func : to_week_of_year




Function Name | Date Part Extracted from Input Date / Timestamp | Possible Values
-- | -- | --
to_week_of_year | Same as sf WEEKISO, except uses ISO semantics | 1 to 53




- Part of #13167

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13173)
<!-- Reviewable:end -->
