### PR TITLE
fix: not only count aggregation function in subquery

### DIFF
--- a/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/heuristic/decorrelate.rs
@@ -682,7 +682,12 @@ impl SubqueryRewriter {
                     if let ScalarExpr::AggregateFunction(AggregateFunction { func_name, .. }) =
                         &scalar
                     {
-                        if func_name.eq_ignore_ascii_case("count") || func_name.eq("count_distinct")
+                        // For scalar subquery, we'll convert it to single join.
+                        // Single join is similar to left outer join, if there isn't matched row in the right side, we'll add NULL value for the right side.
+                        // But for count aggregation function, NULL values should be 0.
+                        if aggregate.aggregate_functions.len() == 1
+                            && (func_name.eq_ignore_ascii_case("count")
+                                || func_name.eq("count_distinct"))
                         {
                             flatten_info.from_count_func = true;
                         }

--- a/src/query/sql/src/planner/optimizer/hyper_dp/dphyp.rs
+++ b/src/query/sql/src/planner/optimizer/hyper_dp/dphyp.rs
@@ -50,6 +50,7 @@ pub struct DPhpy {
     dp_table: HashMap<Vec<IndexType>, JoinNode>,
     query_graph: QueryGraph,
     relation_set_tree: RelationSetTree,
+    // non-equi conditions
     filters: HashSet<Filter>,
 }
 

--- a/tests/sqllogictests/suites/tpch/queries.test
+++ b/tests/sqllogictests/suites/tpch/queries.test
@@ -823,6 +823,28 @@ where
 ----
 23512.75195312
 
+#Q17 variant
+query I
+SELECT
+  TRUNCATE(sum(l_extendedprice) / 7.0, 8) AS avg_yearly
+FROM
+  lineitem,
+  part
+WHERE
+  p_partkey = l_partkey
+  AND p_brand = 'Brand#23'
+  AND p_container = 'MED BOX'
+  AND l_quantity < (
+    SELECT
+      0.2 * (sum(l_quantity) / count(l_quantity))
+    FROM
+      lineitem
+    WHERE
+      l_partkey = p_partkey
+  )
+----
+23512.75195312
+
 #Q18
 query I
 select


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

![cd4cfc62-176f-4153-99dc-59b55202afa3](https://github.com/datafuselabs/databend/assets/41979257/a6add8e4-6515-48cf-bee6-df645f1d57f9)

For scalar subquery, we'll convert it to single join.

Single join is similar to left outer join, if there isn't matched row in the right side, we'll add NULL value for the right side.

for count aggregation function, NULL values should be 0.

But for count + other aggregations, we shouldn't consider NULL to 0.



- Closes https://github.com/datafuselabs/databend/issues/13108

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13179)
<!-- Reviewable:end -->
