### PR TITLE
refactor: move extension protobuf methods to separate file

### DIFF
--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -39,6 +39,7 @@ mod seq_value;
 mod with;
 
 mod proto_display;
+mod proto_ext;
 
 // reexport
 
@@ -140,75 +141,3 @@ pub use crate::raft_types::TypeConfig;
 pub use crate::raft_types::Vote;
 pub use crate::raft_types::VoteRequest;
 pub use crate::raft_types::VoteResponse;
-// pub use crate::raft_types::InitializeError;
-// pub use crate::raft_types::RaftChangeMembershipError;
-// pub use crate::raft_types::RaftWriteError;
-
-impl TxnCondition {
-    /// Create a txn condition that checks if the `seq` matches.
-    pub fn eq_seq(key: impl ToString, seq: u64) -> Self {
-        Self {
-            key: key.to_string(),
-            expected: ConditionResult::Eq as i32,
-            target: Some(txn_condition::Target::Seq(seq)),
-        }
-    }
-}
-
-impl TxnOp {
-    /// Create a txn operation that puts a record.
-    pub fn put(key: impl ToString, value: Vec<u8>) -> TxnOp {
-        Self::put_with_expire(key, value, None)
-    }
-
-    /// Create a txn operation that puts a record with expiration time.
-    pub fn put_with_expire(key: impl ToString, value: Vec<u8>, expire_at: Option<u64>) -> TxnOp {
-        TxnOp {
-            request: Some(txn_op::Request::Put(TxnPutRequest {
-                key: key.to_string(),
-                value,
-                prev_value: true,
-                expire_at,
-            })),
-        }
-    }
-
-    /// Create a new `TxnOp` with a `Delete` operation.
-    pub fn delete(key: impl ToString) -> Self {
-        Self::delete_exact(key, None)
-    }
-
-    /// Create a new `TxnOp` with a `Delete` operation that will be executed only when the `seq` matches.
-    pub fn delete_exact(key: impl ToString, seq: Option<u64>) -> Self {
-        TxnOp {
-            request: Some(txn_op::Request::Delete(TxnDeleteRequest {
-                key: key.to_string(),
-                prev_value: true,
-                match_seq: seq,
-            })),
-        }
-    }
-}
-
-impl TxnOpResponse {
-    /// Create a new `TxnOpResponse` of a `Delete` operation.
-    pub fn delete(key: impl ToString, success: bool, prev_value: Option<protobuf::SeqV>) -> Self {
-        TxnOpResponse {
-            response: Some(txn_op_response::Response::Delete(TxnDeleteResponse {
-                key: key.to_string(),
-                success,
-                prev_value,
-            })),
-        }
-    }
-
-    /// Create a new `TxnOpResponse` of a `Put` operation.
-    pub fn put(key: impl ToString, prev_value: Option<protobuf::SeqV>) -> Self {
-        TxnOpResponse {
-            response: Some(txn_op_response::Response::Put(TxnPutResponse {
-                key: key.to_string(),
-                prev_value,
-            })),
-        }
-    }
-}

--- a/src/meta/types/src/proto_ext/mod.rs
+++ b/src/meta/types/src/proto_ext/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Extend protobuf generated code with some useful methods.
+
+mod txn_ext;

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -1,0 +1,90 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::protobuf as pb;
+
+impl pb::TxnCondition {
+    /// Create a txn condition that checks if the `seq` matches.
+    pub fn eq_seq(key: impl ToString, seq: u64) -> Self {
+        Self {
+            key: key.to_string(),
+            expected: pb::txn_condition::ConditionResult::Eq as i32,
+            target: Some(pb::txn_condition::Target::Seq(seq)),
+        }
+    }
+}
+
+impl pb::TxnOp {
+    /// Create a txn operation that puts a record.
+    pub fn put(key: impl ToString, value: Vec<u8>) -> pb::TxnOp {
+        Self::put_with_expire(key, value, None)
+    }
+
+    /// Create a txn operation that puts a record with expiration time.
+    pub fn put_with_expire(
+        key: impl ToString,
+        value: Vec<u8>,
+        expire_at: Option<u64>,
+    ) -> pb::TxnOp {
+        pb::TxnOp {
+            request: Some(pb::txn_op::Request::Put(pb::TxnPutRequest {
+                key: key.to_string(),
+                value,
+                prev_value: true,
+                expire_at,
+            })),
+        }
+    }
+
+    /// Create a new `TxnOp` with a `Delete` operation.
+    pub fn delete(key: impl ToString) -> Self {
+        Self::delete_exact(key, None)
+    }
+
+    /// Create a new `TxnOp` with a `Delete` operation that will be executed only when the `seq` matches.
+    pub fn delete_exact(key: impl ToString, seq: Option<u64>) -> Self {
+        pb::TxnOp {
+            request: Some(pb::txn_op::Request::Delete(pb::TxnDeleteRequest {
+                key: key.to_string(),
+                prev_value: true,
+                match_seq: seq,
+            })),
+        }
+    }
+}
+
+impl pb::TxnOpResponse {
+    /// Create a new `TxnOpResponse` of a `Delete` operation.
+    pub fn delete(key: impl ToString, success: bool, prev_value: Option<pb::SeqV>) -> Self {
+        pb::TxnOpResponse {
+            response: Some(pb::txn_op_response::Response::Delete(
+                pb::TxnDeleteResponse {
+                    key: key.to_string(),
+                    success,
+                    prev_value,
+                },
+            )),
+        }
+    }
+
+    /// Create a new `TxnOpResponse` of a `Put` operation.
+    pub fn put(key: impl ToString, prev_value: Option<pb::SeqV>) -> Self {
+        pb::TxnOpResponse {
+            response: Some(pb::txn_op_response::Response::Put(pb::TxnPutResponse {
+                key: key.to_string(),
+                prev_value,
+            })),
+        }
+    }
+}


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: move extension protobuf methods to separate file

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13191)
<!-- Reviewable:end -->
