### PR TITLE
feat(query): support date_part function

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -40,6 +40,7 @@ pub enum IntervalKind {
     Minute,
     Second,
     Doy,
+    Week,
     Dow,
 }
 
@@ -139,6 +140,12 @@ pub enum Expr {
     },
     /// EXTRACT(IntervalKind FROM <expr>)
     Extract {
+        span: Span,
+        kind: IntervalKind,
+        expr: Box<Expr>,
+    },
+    /// DATE_PART(IntervalKind, <expr>)
+    DatePart {
         span: Span,
         kind: IntervalKind,
         expr: Box<Expr>,
@@ -503,6 +510,7 @@ impl Expr {
             | Expr::Cast { span, .. }
             | Expr::TryCast { span, .. }
             | Expr::Extract { span, .. }
+            | Expr::DatePart { span, .. }
             | Expr::Position { span, .. }
             | Expr::Substring { span, .. }
             | Expr::Trim { span, .. }
@@ -536,6 +544,7 @@ impl Display for IntervalKind {
             IntervalKind::Second => "SECOND",
             IntervalKind::Doy => "DOY",
             IntervalKind::Dow => "DOW",
+            IntervalKind::Week => "WEEK",
         })
     }
 }
@@ -1026,6 +1035,11 @@ impl Display for Expr {
                 kind: field, expr, ..
             } => {
                 write!(f, "EXTRACT({field} FROM {expr})")?;
+            }
+            Expr::DatePart {
+                kind: field, expr, ..
+            } => {
+                write!(f, "DATE_PART({field}, {expr})")?;
             }
             Expr::Position {
                 substr_expr,

--- a/src/query/ast/src/ast/format/syntax/expr.rs
+++ b/src/query/ast/src/ast/format/syntax/expr.rs
@@ -173,6 +173,15 @@ pub(crate) fn pretty_expr(expr: Expr) -> RcDoc<'static> {
             .append(RcDoc::space())
             .append(pretty_expr(*expr))
             .append(RcDoc::text(")")),
+        Expr::DatePart {
+            kind: field, expr, ..
+        } => RcDoc::text("DATE_PART(")
+            .append(RcDoc::text(field.to_string()))
+            .append(RcDoc::space())
+            .append(RcDoc::text(","))
+            .append(RcDoc::space())
+            .append(pretty_expr(*expr))
+            .append(RcDoc::text(")")),
         Expr::Position {
             substr_expr,
             str_expr,

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -415,6 +415,8 @@ pub enum TokenKind {
     DATE,
     #[token("DATE_ADD", ignore(ascii_case))]
     DATE_ADD,
+    #[token("DATE_PART", ignore(ascii_case))]
+    DATE_PART,
     #[token("DATE_SUB", ignore(ascii_case))]
     DATE_SUB,
     #[token("DATE_TRUNC", ignore(ascii_case))]
@@ -449,6 +451,8 @@ pub enum TokenKind {
     DOUBLE,
     #[token("DOW", ignore(ascii_case))]
     DOW,
+    #[token("WEEK", ignore(ascii_case))]
+    WEEK,
     #[token("DOY", ignore(ascii_case))]
     DOY,
     #[token("DOWNLOAD", ignore(ascii_case))]
@@ -960,8 +964,6 @@ pub enum TokenKind {
     VIEW,
     #[token("VIRTUAL", ignore(ascii_case))]
     VIRTUAL,
-    #[token("WEEK", ignore(ascii_case))]
-    WEEK,
     #[token("WHEN", ignore(ascii_case))]
     WHEN,
     #[token("WHERE", ignore(ascii_case))]
@@ -1125,6 +1127,7 @@ impl TokenKind {
             | TokenKind::END
             | TokenKind::EXISTS
             | TokenKind::EXTRACT
+            | TokenKind::DATE_PART
             | TokenKind::FALSE
             | TokenKind::FLOAT
             // | TokenKind::FOREIGN

--- a/src/query/ast/src/visitors/walk.rs
+++ b/src/query/ast/src/visitors/walk.rs
@@ -68,6 +68,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expr: &'a Expr) {
             target_type,
         } => visitor.visit_try_cast(*span, expr, target_type),
         Expr::Extract { span, kind, expr } => visitor.visit_extract(*span, kind, expr),
+        Expr::DatePart { span, kind, expr } => visitor.visit_extract(*span, kind, expr),
         Expr::Position {
             span,
             substr_expr,

--- a/src/query/ast/src/visitors/walk_mut.rs
+++ b/src/query/ast/src/visitors/walk_mut.rs
@@ -68,6 +68,7 @@ pub fn walk_expr_mut<V: VisitorMut>(visitor: &mut V, expr: &mut Expr) {
             target_type,
         } => visitor.visit_try_cast(*span, expr, target_type),
         Expr::Extract { span, kind, expr } => visitor.visit_extract(*span, kind, expr),
+        Expr::DatePart { span, kind, expr } => visitor.visit_extract(*span, kind, expr),
         Expr::Position {
             span,
             substr_expr,

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -687,6 +687,7 @@ fn test_expr() {
         r#"TRY_CAST(col1 AS TUPLE(BIGINT UNSIGNED NULL, BOOLEAN))"#,
         r#"trim(leading 'abc' from 'def')"#,
         r#"extract(year from d)"#,
+        r#"date_part(year, d)"#,
         r#"position('a' in str)"#,
         r#"substring(a from b for c)"#,
         r#"substring(a, b, c)"#,

--- a/src/query/ast/tests/it/testdata/expr-error.txt
+++ b/src/query/ast/tests/it/testdata/expr-error.txt
@@ -53,7 +53,7 @@ error:
   --> SQL:1:10
   |
 1 | CAST(col1)
-  | ----     ^ expected `AS`, `,`, `(`, `.`, `IS`, `NOT`, `IN`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `LIKE`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `DATE_ADD`, `DATE_SUB`, `DATE_TRUNC`, `DATE`, `TIMESTAMP`, `INTERVAL`, `::`, `EXTRACT`, `POSITION`, `SUBSTRING`, `SUBSTR`, `TRIM`, `COUNT`, <Ident>, <QuotedString>, or 16 more ...
+  | ----     ^ expected `AS`, `,`, `(`, `.`, `IS`, `NOT`, `IN`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `LIKE`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `DATE_ADD`, `DATE_SUB`, `DATE_TRUNC`, `DATE`, `TIMESTAMP`, `INTERVAL`, `::`, `EXTRACT`, `DATE_PART`, `POSITION`, `SUBSTRING`, `SUBSTR`, `TRIM`, `COUNT`, <Ident>, or 17 more ...
   | |         
   | while parsing `CAST(... AS ...)`
   | while parsing expression

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -1575,6 +1575,35 @@ Extract {
 
 
 ---------- Input ----------
+date_part(year, d)
+---------- Output ---------
+DATE_PART(YEAR, d)
+---------- AST ------------
+DatePart {
+    span: Some(
+        0..18,
+    ),
+    kind: Year,
+    expr: ColumnRef {
+        span: Some(
+            16..17,
+        ),
+        database: None,
+        table: None,
+        column: Name(
+            Identifier {
+                name: "d",
+                quote: None,
+                span: Some(
+                    16..17,
+                ),
+            },
+        ),
+    },
+}
+
+
+---------- Input ----------
 position('a' in str)
 ---------- Output ---------
 POSITION('a' IN str)

--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -383,7 +383,7 @@ error:
   --> SQL:1:41
   |
 1 | SELECT * FROM t GROUP BY GROUPING SETS ()
-  | ------                                  ^ expected `(`, `IS`, `IN`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `LIKE`, `NOT`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `DATE_ADD`, `DATE_SUB`, `DATE_TRUNC`, `DATE`, `TIMESTAMP`, `INTERVAL`, `::`, `EXTRACT`, `POSITION`, `SUBSTRING`, `SUBSTR`, `TRIM`, `COUNT`, <Ident>, <QuotedString>, `CASE`, `ColumnPosition`, `[`, or 14 more ...
+  | ------                                  ^ expected `(`, `IS`, `IN`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `LIKE`, `NOT`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `DATE_ADD`, `DATE_SUB`, `DATE_TRUNC`, `DATE`, `TIMESTAMP`, `INTERVAL`, `::`, `EXTRACT`, `DATE_PART`, `POSITION`, `SUBSTRING`, `SUBSTR`, `TRIM`, `COUNT`, <Ident>, <QuotedString>, `CASE`, `ColumnPosition`, or 15 more ...
   | |                                        
   | while parsing `SELECT ...`
 

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1042,6 +1042,10 @@ impl<'a> TypeChecker<'a> {
                 span, kind, expr, ..
             } => self.resolve_extract_expr(*span, kind, expr).await?,
 
+            Expr::DatePart {
+                span, kind, expr, ..
+            } => self.resolve_extract_expr(*span, kind, expr).await?,
+
             Expr::Interval { span, .. } => {
                 return Err(ErrorCode::SemanticError(
                     "Unsupported interval expression yet".to_string(),
@@ -1960,6 +1964,10 @@ impl<'a> TypeChecker<'a> {
             }
             ASTIntervalKind::Dow => {
                 self.resolve_function(span, "to_day_of_week", vec![], &[arg])
+                    .await
+            }
+            ASTIntervalKind::Week => {
+                self.resolve_function(span, "to_week_of_year", vec![], &[arg])
                     .await
             }
         }
@@ -3346,6 +3354,13 @@ impl<'a> TypeChecker<'a> {
                     target_type: target_type.clone(),
                 }),
                 Expr::Extract { span, kind, expr } => Ok(Expr::Extract {
+                    span: *span,
+                    kind: *kind,
+                    expr: Box::new(
+                        self.clone_expr_with_replacement(expr.as_ref(), replacement_fn)?,
+                    ),
+                }),
+                Expr::DatePart { span, kind, expr } => Ok(Expr::DatePart {
                     span: *span,
                     kind: *kind,
                     expr: Box::new(

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -482,7 +482,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                         DataType::Timestamp
                     };
                     let expr = self.gen_expr(&expr_ty);
-                    let kind = match self.rng.gen_range(0..=6) {
+                    let kind = match self.rng.gen_range(0..=9) {
                         0 => IntervalKind::Year,
                         1 => IntervalKind::Quarter,
                         2 => IntervalKind::Month,
@@ -492,6 +492,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                         6 => IntervalKind::Second,
                         7 => IntervalKind::Doy,
                         8 => IntervalKind::Dow,
+                        9 => IntervalKind::Week,
                         _ => unreachable!(),
                     };
                     Expr::Extract {

--- a/tests/sqllogictests/suites/base/20+_others/20_0001_planner
+++ b/tests/sqllogictests/suites/base/20+_others/20_0001_planner
@@ -30,6 +30,20 @@ select extract(day from to_date('2022-05-13'))
 ----
 13
 
+query I
+select date_part(day, to_date('2022-05-13'))
+----
+13
+
+query I
+select extract(week from to_timestamp('2016-01-02T23:39:20.123-07:00'))
+----
+53
+
+query I
+select date_part(week, to_timestamp('2016-01-02T23:39:20.123-07:00'))
+----
+53
 
 query T
 select date_trunc(month, to_date('2022-07-07'))
@@ -964,6 +978,11 @@ select number from temp
 statement ok
 drop view temp
 
+statement ok
+drop table if exists t1;
+
+statement ok
+drop table if exists t2;
 
 statement ok
 create table t1(a int, b int)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. Databend has already support Extract, so we can convert date_part to extract


- Closes #13167

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13196)
<!-- Reviewable:end -->
