### PR TITLE
feat: generate sync agg indexes after update

### DIFF
--- a/src/query/ee/tests/it/aggregating_index/index_refresh.rs
+++ b/src/query/ee/tests/it/aggregating_index/index_refresh.rs
@@ -307,8 +307,8 @@ async fn test_refresh_agg_index_with_limit() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_agg_index() -> Result<()> {
-    test_sync_agg_index_after_update().await?;
     test_sync_agg_index_after_insert().await?;
+    test_sync_agg_index_after_update().await?;
     test_sync_agg_index_after_copy_into().await?;
 
     Ok(())
@@ -497,7 +497,7 @@ async fn test_sync_agg_index_after_update() -> Result<()> {
         let agg_data_blocks: Vec<DataBlock> = agg_res.try_collect().await?;
 
         assert_two_blocks_sorted_eq_with_name(
-            "test_sync_agg_index_after_insert",
+            "test_sync_agg_index_after_update",
             &data_blocks,
             &agg_data_blocks,
         );
@@ -546,7 +546,7 @@ async fn test_sync_agg_index_after_update() -> Result<()> {
         let agg_data_blocks: Vec<DataBlock> = agg_res.try_collect().await?;
 
         assert_two_blocks_sorted_eq_with_name(
-            "test_sync_agg_index_after_insert",
+            "test_sync_agg_index_after_update",
             &data_blocks,
             &agg_data_blocks,
         );

--- a/src/query/service/src/interpreters/interpreter_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_index_refresh.rs
@@ -150,7 +150,7 @@ impl RefreshIndexInterpreter {
         } else {
             let mut source = source.remove(0);
             let partitions = match segments {
-                Some(segment_locs) => {
+                Some(segment_locs) if !segment_locs.is_empty() => {
                     let segment_locations = create_segment_location_vector(segment_locs, None);
                     self.get_partitions_with_given_segments(
                         &source,
@@ -160,7 +160,7 @@ impl RefreshIndexInterpreter {
                     )
                     .await?
                 }
-                None => self.get_partitions(&source, fuse_table, dal).await?,
+                Some(_) | None => self.get_partitions(&source, fuse_table, dal).await?,
             };
             if let Some(parts) = partitions {
                 source.parts = parts;

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -203,9 +203,9 @@ impl Interpreter for UpdateInterpreter {
         // generate sync aggregating indexes if `enable_refresh_aggregating_index_after_write` on.
         {
             let refresh_agg_index_desc = RefreshAggIndexDesc {
-                catalog: self.plan.catalog.clone(),
-                database: self.plan.database.clone(),
-                table: self.plan.table.clone(),
+                catalog: catalog_name.to_string(),
+                database: db_name.to_string(),
+                table: tbl_name.to_string(),
             };
 
             hook_refresh_agg_index(

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -237,6 +237,8 @@ impl TableMutationAggregator {
                     for result in results {
                         if let Some((location, summary)) = result.new_segment_info {
                             // replace the old segment location with the new one.
+                            self.ctx
+                                .add_segment_location((location.clone(), SegmentInfo::VERSION))?;
                             self.abort_operation.add_segment(location.clone());
                             merge_statistics_mut(
                                 &mut merged_statistics,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Generate sync agg indexes after update table.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13215)
<!-- Reviewable:end -->
