### PR TITLE
chore: move grpc helper functions to GrpcHelper

### DIFF
--- a/src/meta/service/src/grpc_helper.rs
+++ b/src/meta/service/src/grpc_helper.rs
@@ -1,0 +1,53 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helper functions for handling grpc.
+
+use std::error::Error;
+
+use common_meta_types::protobuf::RaftReply;
+use common_meta_types::protobuf::RaftRequest;
+
+pub struct GrpcHelper;
+
+impl GrpcHelper {
+    /// Parse tonic::Request and decode it into required type.
+    pub fn parse_req<T>(request: tonic::Request<RaftRequest>) -> Result<T, tonic::Status>
+    where T: serde::de::DeserializeOwned {
+        let raft_req = request.into_inner();
+        let req: T = serde_json::from_str(&raft_req.data).map_err(Self::invalid_arg)?;
+        Ok(req)
+    }
+
+    /// Create an Ok response for raft API.
+    pub fn ok_response<D>(d: D) -> Result<tonic::Response<RaftReply>, tonic::Status>
+    where D: serde::Serialize {
+        let data = serde_json::to_string(&d).expect("fail to serialize resp");
+        let reply = RaftReply {
+            data,
+            error: "".to_string(),
+        };
+        Ok(tonic::Response::new(reply))
+    }
+
+    /// Create a tonic::Status with invalid argument error.
+    pub fn invalid_arg(e: impl Error) -> tonic::Status {
+        tonic::Status::invalid_argument(e.to_string())
+    }
+
+    /// Create a tonic::Status with internal error.
+    pub fn internal_err(e: impl Error) -> tonic::Status {
+        tonic::Status::internal(e.to_string())
+    }
+}

--- a/src/meta/service/src/lib.rs
+++ b/src/meta/service/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod api;
 pub mod configs;
 pub mod export;
+pub(crate) mod grpc_helper;
 pub mod message;
 pub mod meta_service;
 pub mod metrics;

--- a/src/meta/service/src/meta_service/meta_service_impl.rs
+++ b/src/meta/service/src/meta_service/meta_service_impl.rs
@@ -15,7 +15,6 @@
 //! Meta service impl a grpc server that serves both raft protocol: append_entries, vote and install_snapshot.
 //! It also serves RPC for user-data access.
 
-use std::error::Error;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
@@ -27,6 +26,7 @@ use common_tracing::func_name;
 use minitrace::prelude::*;
 use tonic::codegen::futures_core::Stream;
 
+use crate::grpc_helper::GrpcHelper;
 use crate::message::ForwardRequest;
 use crate::meta_service::MetaNode;
 use crate::metrics::raft_metrics;
@@ -50,35 +50,6 @@ impl RaftServiceImpl {
             raft_metrics::network::incr_recv_bytes_from_peer(addr.to_string(), bytes);
         }
     }
-
-    /// Parse tonic::Request and decode it into required type.
-    fn parse_req<T>(request: tonic::Request<RaftRequest>) -> Result<T, tonic::Status>
-    where T: serde::de::DeserializeOwned {
-        let raft_req = request.into_inner();
-        let req: T = serde_json::from_str(&raft_req.data).map_err(Self::invalid_arg)?;
-        Ok(req)
-    }
-
-    /// Create an Ok response for raft API.
-    fn ok_response<D>(d: D) -> Result<tonic::Response<RaftReply>, tonic::Status>
-    where D: serde::Serialize {
-        let data = serde_json::to_string(&d).expect("fail to serialize resp");
-        let reply = RaftReply {
-            data,
-            error: "".to_string(),
-        };
-        Ok(tonic::Response::new(reply))
-    }
-
-    /// Create a tonic::Status with invalid argument error.
-    fn invalid_arg(e: impl Error) -> tonic::Status {
-        tonic::Status::invalid_argument(e.to_string())
-    }
-
-    /// Create a tonic::Status with internal error.
-    fn internal_err(e: impl Error) -> tonic::Status {
-        tonic::Status::internal(e.to_string())
-    }
 }
 
 #[async_trait::async_trait]
@@ -90,7 +61,7 @@ impl RaftService for RaftServiceImpl {
         let root = common_tracing::start_trace_for_remote_request(func_name!(), &request);
 
         async {
-            let forward_req: ForwardRequest = Self::parse_req(request)?;
+            let forward_req: ForwardRequest = GrpcHelper::parse_req(request)?;
 
             let res = self.meta_node.handle_forwardable_request(forward_req).await;
 
@@ -111,15 +82,15 @@ impl RaftService for RaftServiceImpl {
         async {
             self.incr_meta_metrics_recv_bytes_from_peer(&request);
 
-            let ae_req = Self::parse_req(request)?;
+            let ae_req = GrpcHelper::parse_req(request)?;
             let raft = &self.meta_node.raft;
 
             let resp = raft
                 .append_entries(ae_req)
                 .await
-                .map_err(Self::internal_err)?;
+                .map_err(GrpcHelper::internal_err)?;
 
-            Self::ok_response(resp)
+            GrpcHelper::ok_response(resp)
         }
         .in_span(root)
         .await
@@ -142,13 +113,13 @@ impl RaftService for RaftServiceImpl {
             self.incr_meta_metrics_recv_bytes_from_peer(&request);
             raft_metrics::network::incr_snapshot_recv_inflights_from_peer(addr.clone(), 1);
 
-            let is_req = Self::parse_req(request)?;
+            let is_req = GrpcHelper::parse_req(request)?;
             let raft = &self.meta_node.raft;
 
             let resp = raft
                 .install_snapshot(is_req)
                 .await
-                .map_err(Self::internal_err);
+                .map_err(GrpcHelper::internal_err);
 
             raft_metrics::network::sample_snapshot_recv(
                 addr.clone(),
@@ -158,7 +129,7 @@ impl RaftService for RaftServiceImpl {
             raft_metrics::network::incr_snapshot_recv_status_from_peer(addr.clone(), resp.is_ok());
 
             match resp {
-                Ok(resp) => Self::ok_response(resp),
+                Ok(resp) => GrpcHelper::ok_response(resp),
                 Err(e) => Err(e),
             }
         }
@@ -175,12 +146,12 @@ impl RaftService for RaftServiceImpl {
         async {
             self.incr_meta_metrics_recv_bytes_from_peer(&request);
 
-            let v_req = Self::parse_req(request)?;
+            let v_req = GrpcHelper::parse_req(request)?;
             let raft = &self.meta_node.raft;
 
-            let resp = raft.vote(v_req).await.map_err(Self::internal_err)?;
+            let resp = raft.vote(v_req).await.map_err(GrpcHelper::internal_err)?;
 
-            Self::ok_response(resp)
+            GrpcHelper::ok_response(resp)
         }
         .in_span(root)
         .await


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore: move grpc helper functions to GrpcHelper

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13221)
<!-- Reviewable:end -->
