### PR TITLE
chore: vectorize columns serialization.

### DIFF
--- a/src/common/hashtable/src/arena.rs
+++ b/src/common/hashtable/src/arena.rs
@@ -35,6 +35,10 @@ impl Area {
     pub fn alloc_layout(&mut self, layout: Layout) -> NonNull<u8> {
         self.bump.alloc_layout(layout)
     }
+
+    pub fn reset(&mut self) {
+        self.bump.reset();
+    }
 }
 
 unsafe impl Send for Area {}

--- a/src/common/hashtable/src/lib.rs
+++ b/src/common/hashtable/src/lib.rs
@@ -22,6 +22,7 @@
 
 extern crate core;
 
+mod arena;
 mod container;
 mod hashjoin_hashtable;
 mod hashjoin_string_hashtable;
@@ -41,6 +42,7 @@ mod table_empty;
 mod traits;
 mod utils;
 
+pub use arena::*;
 pub use table0::Entry as HashtableEntry;
 pub use traits::EntryMutRefLike as HashtableEntryMutRefLike;
 pub use traits::EntryRefLike as HashtableEntryRefLike;

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -21,7 +21,7 @@ use common_exception::Result;
 use itertools::Itertools;
 
 use crate::kernels::take::BIT_MASK;
-use crate::kernels::utils::copy_advance_aligned;
+use crate::kernels::utils::copy_aligned_advance;
 use crate::kernels::utils::set_vec_len_by_ptr;
 use crate::types::array::ArrayColumnBuilder;
 use crate::types::decimal::DecimalColumn;
@@ -293,7 +293,7 @@ impl Column {
         unsafe {
             for col in cols.iter() {
                 let col_data = col.data().as_slice();
-                copy_advance_aligned(col_data.as_ptr(), &mut data_ptr, col_data.len());
+                copy_aligned_advance(col_data.as_ptr(), &mut data_ptr, col_data.len());
             }
             set_vec_len_by_ptr(&mut data, data_ptr);
         }

--- a/src/query/expression/src/kernels/group_by_hash/keys_ref.rs
+++ b/src/query/expression/src/kernels/group_by_hash/keys_ref.rs
@@ -1,0 +1,79 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// [`KeysRef`]` is a mutable reference to a slice of bytes.
+///
+/// It's free to modify the fields by arbitrary data.
+/// Therefore, we should be careful when using this struct.
+#[derive(Debug)]
+pub struct KeysRef {
+    data: *mut u8,
+    len: usize,
+}
+
+impl KeysRef {
+    #[inline(always)]
+    pub fn new(data: *mut u8) -> Self {
+        Self { data, len: 0 }
+    }
+
+    #[inline(always)]
+    pub fn get(&self) -> *mut u8 {
+        self.data
+    }
+
+    #[inline(always)]
+    pub fn set_len(&mut self, len: usize) {
+        self.len = len;
+    }
+
+    /// Prepare a pointer to write data.
+    ///
+    /// **NOTES**: the length of the keys ref will be increased by `write_len` after calling this method.
+    #[inline(always)]
+    pub fn writer(&mut self, write_len: usize) -> *mut u8 {
+        let pointer = unsafe { self.data.add(self.len) };
+        self.len += write_len;
+        pointer
+    }
+
+    #[inline(always)]
+    pub fn slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.data, self.len) }
+    }
+}
+
+pub struct KeysRefIterator<'a> {
+    keys: std::slice::Iter<'a, KeysRef>,
+}
+
+impl<'a> From<std::slice::Iter<'a, KeysRef>> for KeysRefIterator<'a> {
+    fn from(iter: std::slice::Iter<'a, KeysRef>) -> Self {
+        Self { keys: iter }
+    }
+}
+
+impl<'a> Iterator for KeysRefIterator<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.keys.next().map(|key| key.slice())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.keys.size_hint()
+    }
+}
+
+unsafe impl<'a> std::iter::TrustedLen for KeysRefIterator<'a> {}

--- a/src/query/expression/src/kernels/group_by_hash/method.rs
+++ b/src/query/expression/src/kernels/group_by_hash/method.rs
@@ -18,6 +18,7 @@ use std::ptr::NonNull;
 
 use common_arrow::arrow::buffer::Buffer;
 use common_exception::Result;
+use common_hashtable::Area;
 use common_hashtable::DictionaryKeys;
 use common_hashtable::FastHash;
 use ethnum::i256;
@@ -71,11 +72,11 @@ pub trait HashMethod: Clone + Sync + Send + 'static {
         rows: usize,
     ) -> Result<KeysState>;
 
-    /// Some hash methods may need to modify the inner data while building the keys state (such as [`HashMethodSerializer`]).
-    fn mutable_build_keys_state(
-        &mut self,
+    fn build_keys_state_with_arena(
+        &self,
         group_columns: &[(Column, DataType)],
         rows: usize,
+        _arena: &mut Area,
     ) -> Result<KeysState> {
         self.build_keys_state(group_columns, rows)
     }

--- a/src/query/expression/src/kernels/group_by_hash/method.rs
+++ b/src/query/expression/src/kernels/group_by_hash/method.rs
@@ -23,6 +23,7 @@ use common_hashtable::FastHash;
 use ethnum::i256;
 use ethnum::u256;
 
+use super::keys_ref::KeysRef;
 use crate::types::decimal::Decimal;
 use crate::types::string::StringColumn;
 use crate::types::DataType;
@@ -41,6 +42,7 @@ use crate::HashMethodSingleString;
 
 #[derive(Debug)]
 pub enum KeysState {
+    KeysRef(Vec<KeysRef>),
     Column(Column),
     U128(Buffer<u128>),
     U256(Buffer<u256>),
@@ -68,6 +70,15 @@ pub trait HashMethod: Clone + Sync + Send + 'static {
         group_columns: &[(Column, DataType)],
         rows: usize,
     ) -> Result<KeysState>;
+
+    /// Some hash methods may need to modify the inner data while building the keys state (such as [`HashMethodSerializer`]).
+    fn mutable_build_keys_state(
+        &mut self,
+        group_columns: &[(Column, DataType)],
+        rows: usize,
+    ) -> Result<KeysState> {
+        self.build_keys_state(group_columns, rows)
+    }
 
     fn build_keys_iter<'a>(&self, keys_state: &'a KeysState) -> Result<Self::HashKeyIter<'a>>;
 

--- a/src/query/expression/src/kernels/group_by_hash/method_dict_serializer.rs
+++ b/src/query/expression/src/kernels/group_by_hash/method_dict_serializer.rs
@@ -44,24 +44,24 @@ impl HashMethod for HashMethodDictionarySerializer {
     ) -> Result<KeysState> {
         // fixed type serialize one column to dictionary
         let mut dictionary_columns = Vec::with_capacity(group_columns.len());
-        let mut columns = Vec::new();
+        let mut other_columns = Vec::new();
         for (group_column, _) in group_columns {
             match group_column {
                 Column::String(v) | Column::Variant(v) | Column::Bitmap(v) => {
                     debug_assert_eq!(v.len(), num_rows);
                     dictionary_columns.push(v.clone());
                 }
-                _ => columns.push(group_column.clone()),
+                _ => other_columns.push(group_column.clone()),
             }
         }
 
-        if !columns.is_empty() {
+        if !other_columns.is_empty() {
             // The serialize_size is equal to the number of bytes required by serialization.
             let mut serialize_size = 0;
-            for column in columns.iter() {
+            for column in other_columns.iter() {
                 serialize_size += column.serialize_size();
             }
-            dictionary_columns.push(serialize_columns(&columns, num_rows, serialize_size));
+            dictionary_columns.push(serialize_columns(&other_columns, num_rows, serialize_size));
         }
 
         let mut keys = Vec::with_capacity(num_rows * dictionary_columns.len());

--- a/src/query/expression/src/kernels/group_by_hash/method_serializer.rs
+++ b/src/query/expression/src/kernels/group_by_hash/method_serializer.rs
@@ -12,23 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::iter::TrustedLen;
+
 use common_exception::Result;
 use common_hashtable::FastHash;
 
+use super::keys_ref::KeysRef;
+use super::keys_ref::KeysRefIterator;
 use super::utils::serialize_columns;
+use super::utils::serialize_columns_in_batch;
 use crate::types::string::StringIterator;
 use crate::types::DataType;
 use crate::Column;
 use crate::HashMethod;
 use crate::KeysState;
 
+const BATCH_SERIALIZE_BYTES_LIMIT: usize = 16 * 1024 * 1024; // 16 MB
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct HashMethodSerializer {}
+pub struct HashMethodSerializer {
+    buffer: Vec<u8>,
+}
 
 impl HashMethod for HashMethodSerializer {
     type HashKey = [u8];
 
-    type HashKeyIter<'a> = StringIterator<'a>;
+    type HashKeyIter<'a> = SerializedIterator<'a>;
 
     fn name(&self) -> String {
         "Serializer".to_string()
@@ -41,11 +50,13 @@ impl HashMethod for HashMethodSerializer {
     ) -> Result<KeysState> {
         // The serialize_size is equal to the number of bytes required by serialization.
         let mut serialize_size = 0;
-        let mut columns = Vec::with_capacity(group_columns.len());
-        for (column, _) in group_columns {
-            serialize_size += column.serialize_size();
-            columns.push(column.clone());
-        }
+        let columns = group_columns
+            .iter()
+            .map(|(col, _)| {
+                serialize_size += col.serialize_size();
+                col.clone()
+            })
+            .collect::<Vec<_>>();
         Ok(KeysState::Column(Column::String(serialize_columns(
             &columns,
             num_rows,
@@ -53,9 +64,36 @@ impl HashMethod for HashMethodSerializer {
         ))))
     }
 
+    fn mutable_build_keys_state(
+        &mut self,
+        group_columns: &[(Column, DataType)],
+        num_rows: usize,
+    ) -> Result<KeysState> {
+        // We choose the maximum row memory of columns to guranntee that the memory of the serialized column will not exceed it.
+        let mut max_bytes_per_row = 0;
+        let columns = group_columns
+            .iter()
+            .map(|(col, _)| {
+                max_bytes_per_row += col.max_serialize_size_per_row();
+                col.clone()
+            })
+            .collect::<Vec<_>>();
+
+        if max_bytes_per_row * num_rows > BATCH_SERIALIZE_BYTES_LIMIT {
+            // If the memory consumption exceed the limit, we degragde to non-batch serialization,
+            // which will not use the buffer.
+            self.build_keys_state(group_columns, num_rows)
+        } else {
+            let keys_ref =
+                serialize_columns_in_batch(&columns, num_rows, max_bytes_per_row, &mut self.buffer);
+            Ok(KeysState::KeysRef(keys_ref))
+        }
+    }
+
     fn build_keys_iter<'a>(&self, key_state: &'a KeysState) -> Result<Self::HashKeyIter<'a>> {
         match key_state {
-            KeysState::Column(Column::String(col)) => Ok(col.iter()),
+            KeysState::KeysRef(keys_ref) => Ok(keys_ref.iter().into()),
+            KeysState::Column(Column::String(col)) => Ok(col.iter().into()),
             _ => unreachable!(),
         }
     }
@@ -65,12 +103,54 @@ impl HashMethod for HashMethodSerializer {
         keys_state: &'a KeysState,
     ) -> Result<(Self::HashKeyIter<'a>, Vec<u64>)> {
         match keys_state {
+            KeysState::KeysRef(keys_ref) => {
+                let mut hashes = Vec::with_capacity(keys_ref.len());
+                hashes.extend(keys_ref.iter().map(|key| key.slice().fast_hash()));
+                Ok((keys_ref.iter().into(), hashes))
+            }
             KeysState::Column(Column::String(col)) => {
                 let mut hashes = Vec::with_capacity(col.len());
                 hashes.extend(col.iter().map(|key| key.fast_hash()));
-                Ok((col.iter(), hashes))
+                Ok((col.iter().into(), hashes))
             }
             _ => unreachable!(),
         }
     }
 }
+
+pub enum SerializedIterator<'a> {
+    KeysRef(KeysRefIterator<'a>),
+    String(StringIterator<'a>),
+}
+
+impl<'a> From<std::slice::Iter<'a, KeysRef>> for SerializedIterator<'a> {
+    fn from(value: std::slice::Iter<'a, KeysRef>) -> Self {
+        Self::KeysRef(value.into())
+    }
+}
+
+impl<'a> From<StringIterator<'a>> for SerializedIterator<'a> {
+    fn from(value: StringIterator<'a>) -> Self {
+        Self::String(value)
+    }
+}
+
+impl<'a> Iterator for SerializedIterator<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::KeysRef(iter) => iter.next(),
+            Self::String(iter) => iter.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::KeysRef(iter) => iter.size_hint(),
+            Self::String(iter) => iter.size_hint(),
+        }
+    }
+}
+
+unsafe impl TrustedLen for SerializedIterator<'_> {}

--- a/src/query/expression/src/kernels/group_by_hash/method_serializer.rs
+++ b/src/query/expression/src/kernels/group_by_hash/method_serializer.rs
@@ -20,7 +20,7 @@ use common_hashtable::FastHash;
 use super::keys_ref::KeysRef;
 use super::keys_ref::KeysRefIterator;
 use super::utils::serialize_columns;
-use super::utils::serialize_columns_in_batch;
+use super::utils::serialize_columns_vec;
 use crate::types::string::StringIterator;
 use crate::types::DataType;
 use crate::Column;
@@ -85,7 +85,7 @@ impl HashMethod for HashMethodSerializer {
             self.build_keys_state(group_columns, num_rows)
         } else {
             let keys_ref =
-                serialize_columns_in_batch(&columns, num_rows, max_bytes_per_row, &mut self.buffer);
+                serialize_columns_vec(&columns, num_rows, max_bytes_per_row, &mut self.buffer);
             Ok(KeysState::KeysRef(keys_ref))
         }
     }

--- a/src/query/expression/src/kernels/group_by_hash/method_serializer.rs
+++ b/src/query/expression/src/kernels/group_by_hash/method_serializer.rs
@@ -53,13 +53,11 @@ impl HashMethod for HashMethodSerializer {
     ) -> Result<KeysState> {
         // The serialize_size is equal to the number of bytes required by serialization.
         let mut serialize_size = 0;
-        let columns = group_columns
-            .iter()
-            .map(|(col, _)| {
-                serialize_size += col.serialize_size();
-                col.clone()
-            })
-            .collect::<Vec<_>>();
+        let mut columns = Vec::with_capacity(group_columns.len());
+        for (col, _) in group_columns {
+            serialize_size += col.serialize_size();
+            columns.push(col.clone());
+        }
         Ok(KeysState::Column(Column::String(serialize_columns(
             &columns,
             num_rows,
@@ -75,13 +73,11 @@ impl HashMethod for HashMethodSerializer {
     ) -> Result<KeysState> {
         // We choose the maximum row memory of columns to guranntee that the memory of the serialized column will not exceed it.
         let mut max_bytes_per_row = 0;
-        let columns = group_columns
-            .iter()
-            .map(|(col, _)| {
-                max_bytes_per_row += col.max_serialize_size_per_row();
-                col.clone()
-            })
-            .collect::<Vec<_>>();
+        let mut columns = Vec::with_capacity(group_columns.len());
+        for (col, _) in group_columns {
+            max_bytes_per_row += col.max_serialize_size_per_row();
+            columns.push(col.clone());
+        }
         let total_bytes = max_bytes_per_row * num_rows;
 
         if total_bytes > BATCH_SERIALIZE_BYTES_LIMIT {

--- a/src/query/expression/src/kernels/group_by_hash/method_serializer.rs
+++ b/src/query/expression/src/kernels/group_by_hash/method_serializer.rs
@@ -15,7 +15,7 @@
 use common_exception::Result;
 use common_hashtable::FastHash;
 
-use super::utils::serialize_column;
+use super::utils::serialize_columns;
 use crate::types::string::StringIterator;
 use crate::types::DataType;
 use crate::Column;
@@ -41,13 +41,13 @@ impl HashMethod for HashMethodSerializer {
     ) -> Result<KeysState> {
         // The serialize_size is equal to the number of bytes required by serialization.
         let mut serialize_size = 0;
-        let mut serialize_columns = Vec::with_capacity(group_columns.len());
+        let mut columns = Vec::with_capacity(group_columns.len());
         for (column, _) in group_columns {
             serialize_size += column.serialize_size();
-            serialize_columns.push(column.clone());
+            columns.push(column.clone());
         }
-        Ok(KeysState::Column(Column::String(serialize_column(
-            &serialize_columns,
+        Ok(KeysState::Column(Column::String(serialize_columns(
+            &columns,
             num_rows,
             serialize_size,
         ))))

--- a/src/query/expression/src/kernels/group_by_hash/mod.rs
+++ b/src/query/expression/src/kernels/group_by_hash/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod keys_ref;
 mod method;
 mod method_dict_serializer;
 mod method_fixed_keys;

--- a/src/query/expression/src/kernels/group_by_hash/utils.rs
+++ b/src/query/expression/src/kernels/group_by_hash/utils.rs
@@ -117,17 +117,12 @@ pub fn serialize_columns_vec(
     columns: &[Column],
     num_rows: usize,
     max_bytes_per_row: usize,
-    buffer: &mut Vec<u8>,
+    buffer: *mut u8,
 ) -> Vec<KeysRef> {
-    // To serialize columns in batch, we need to preallocate a deterministic memory space for each row of the target column at once.
-    if buffer.capacity() < num_rows * max_bytes_per_row {
-        buffer.reserve(num_rows * max_bytes_per_row - buffer.capacity());
-    }
     unsafe {
         // Construct the pointer of each row in `data`.
-        let ptr = buffer.as_mut_ptr();
         let mut keys = (0..num_rows)
-            .map(|i| KeysRef::new(ptr.add(i * max_bytes_per_row)))
+            .map(|i| KeysRef::new(buffer.add(i * max_bytes_per_row)))
             .collect();
 
         for col in columns {

--- a/src/query/expression/src/kernels/take.rs
+++ b/src/query/expression/src/kernels/take.rs
@@ -18,7 +18,7 @@ use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::buffer::Buffer;
 use common_exception::Result;
 
-use crate::kernels::utils::copy_advance_aligned;
+use crate::kernels::utils::copy_aligned_advance;
 use crate::kernels::utils::set_vec_len_by_ptr;
 use crate::types::array::ArrayColumn;
 use crate::types::array::ArrayColumnBuilder;
@@ -251,7 +251,7 @@ impl Column {
 
         unsafe {
             for (str_ptr, len) in items.iter() {
-                copy_advance_aligned(*str_ptr as *const u8, &mut data_ptr, *len);
+                copy_aligned_advance(*str_ptr as *const u8, &mut data_ptr, *len);
             }
             set_vec_len_by_ptr(&mut data, data_ptr);
         }

--- a/src/query/expression/src/kernels/take_chunks.rs
+++ b/src/query/expression/src/kernels/take_chunks.rs
@@ -21,7 +21,7 @@ use common_hashtable::RowPtr;
 use itertools::Itertools;
 
 use crate::kernels::take::BIT_MASK;
-use crate::kernels::utils::copy_advance_aligned;
+use crate::kernels::utils::copy_aligned_advance;
 use crate::kernels::utils::set_vec_len_by_ptr;
 use crate::types::array::ArrayColumnBuilder;
 use crate::types::bitmap::BitmapType;
@@ -761,7 +761,7 @@ impl Column {
 
         unsafe {
             for (str_ptr, len) in items.iter() {
-                copy_advance_aligned(*str_ptr as *const u8, &mut data_ptr, *len);
+                copy_aligned_advance(*str_ptr as *const u8, &mut data_ptr, *len);
             }
             set_vec_len_by_ptr(&mut data, data_ptr);
         }

--- a/src/query/expression/src/kernels/utils.rs
+++ b/src/query/expression/src/kernels/utils.rs
@@ -19,12 +19,12 @@
 ///   bytes must *not* overlap with the region of memory beginning at `ptr`
 ///   with the same size.
 #[inline(always)]
-pub unsafe fn store<T>(val: &T, ptr: *mut u8) {
+pub unsafe fn store<T: 'static>(val: &T, ptr: *mut u8) {
     std::ptr::copy_nonoverlapping(val as *const T as *const u8, ptr, std::mem::size_of::<T>())
 }
 
 #[inline(always)]
-pub unsafe fn store_advance<T>(val: &T, ptr: &mut *mut u8) {
+pub unsafe fn store_advance<T: 'static>(val: &T, ptr: &mut *mut u8) {
     store(val, *ptr);
     *ptr = ptr.add(std::mem::size_of::<T>())
 }

--- a/src/query/expression/src/kernels/utils.rs
+++ b/src/query/expression/src/kernels/utils.rs
@@ -19,11 +19,14 @@
 ///   bytes must *not* overlap with the region of memory beginning at `ptr`
 ///   with the same size.
 #[inline(always)]
+pub unsafe fn store<T>(val: &T, ptr: *mut u8) {
+    std::ptr::copy_nonoverlapping(val as *const T as *const u8, ptr, std::mem::size_of::<T>())
+}
+
+#[inline(always)]
 pub unsafe fn store_advance<T>(val: &T, ptr: &mut *mut u8) {
-    unsafe {
-        std::ptr::copy_nonoverlapping(val as *const T as *const u8, *ptr, std::mem::size_of::<T>());
-        *ptr = ptr.add(std::mem::size_of::<T>())
-    }
+    store(val, *ptr);
+    *ptr = ptr.add(std::mem::size_of::<T>())
 }
 
 /// # Safety
@@ -31,11 +34,14 @@ pub unsafe fn store_advance<T>(val: &T, ptr: &mut *mut u8) {
 /// * `ptr` must be [valid] for writes.
 /// * `ptr` must be properly aligned.
 #[inline(always)]
-pub unsafe fn store_advance_aligned<T>(val: T, ptr: &mut *mut T) {
-    unsafe {
-        std::ptr::write(*ptr, val);
-        *ptr = ptr.add(1)
-    }
+pub unsafe fn store_aligned<T>(val: T, ptr: *mut T) {
+    std::ptr::write(ptr, val);
+}
+
+#[inline(always)]
+pub unsafe fn store_aligned_advance<T>(val: T, ptr: &mut *mut T) {
+    store_aligned(val, *ptr);
+    *ptr = ptr.add(1)
 }
 
 /// # Safety
@@ -47,11 +53,14 @@ pub unsafe fn store_advance_aligned<T>(val: T, ptr: &mut *mut T) {
 ///   bytes must *not* overlap with the region of memory beginning at `ptr` with the
 ///   same size.
 #[inline(always)]
-pub unsafe fn copy_advance_aligned<T>(src: *const T, ptr: &mut *mut T, count: usize) {
-    unsafe {
-        std::ptr::copy_nonoverlapping(src, *ptr, count);
-        *ptr = ptr.add(count);
-    }
+pub unsafe fn copy_aligned<T>(src: *const T, ptr: *mut T, count: usize) {
+    std::ptr::copy_nonoverlapping(src, ptr, count);
+}
+
+#[inline(always)]
+pub unsafe fn copy_aligned_advance<T>(src: *const T, ptr: &mut *mut T, count: usize) {
+    copy_aligned(src, *ptr, count);
+    *ptr = ptr.add(count);
 }
 
 /// # Safety
@@ -60,7 +69,5 @@ pub unsafe fn copy_advance_aligned<T>(src: *const T, ptr: &mut *mut T, count: us
 ///    less than or equal to the capacity of Vec.
 #[inline(always)]
 pub unsafe fn set_vec_len_by_ptr<T>(vec: &mut Vec<T>, ptr: *const T) {
-    unsafe {
-        vec.set_len((ptr as usize - vec.as_ptr() as usize) / std::mem::size_of::<T>());
-    }
+    vec.set_len((ptr as usize - vec.as_ptr() as usize) / std::mem::size_of::<T>());
 }

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -1861,7 +1861,7 @@ impl Column {
                 col.iter().map(|c| c.len()).max().unwrap_or_default().add(8)
             }
             Column::Array(col) | Column::Map(col) => {
-                // Serialization of this types will degrade to the non-batch version,
+                // Vectorized serialization of these types will degrade to the non-vectorized version,
                 // so we only need the maximum of the serialize size of the inner columns.
                 // 8 bytes for serializing the length.
                 col.iter()

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_cell.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_cell.rs
@@ -17,11 +17,11 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use common_functions::aggregates::StateAddr;
+use common_hashtable::Area;
+use common_hashtable::ArenaHolder;
 use common_hashtable::HashtableEntryRefLike;
 use common_hashtable::HashtableLike;
 
-use crate::pipelines::processors::transforms::group_by::Area;
-use crate::pipelines::processors::transforms::group_by::ArenaHolder;
 use crate::pipelines::processors::transforms::group_by::HashMethodBounds;
 use crate::pipelines::processors::transforms::group_by::PartitionedHashMethod;
 use crate::pipelines::processors::transforms::group_by::PolymorphicKeysHelper;

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_injector.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_injector.rs
@@ -21,6 +21,8 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::BlockMetaInfoDowncast;
 use common_expression::DataBlock;
+use common_hashtable::Area;
+use common_hashtable::ArenaHolder;
 use common_hashtable::FastHash;
 use common_hashtable::HashtableEntryMutRefLike;
 use common_hashtable::HashtableEntryRefLike;
@@ -42,8 +44,6 @@ use crate::pipelines::processors::transforms::aggregator::aggregate_meta::HashTa
 use crate::pipelines::processors::transforms::aggregator::serde::TransformExchangeAggregateSerializer;
 use crate::pipelines::processors::transforms::aggregator::serde::TransformExchangeAsyncBarrier;
 use crate::pipelines::processors::transforms::aggregator::serde::TransformExchangeGroupBySerializer;
-use crate::pipelines::processors::transforms::group_by::Area;
-use crate::pipelines::processors::transforms::group_by::ArenaHolder;
 use crate::pipelines::processors::transforms::group_by::HashMethodBounds;
 use crate::pipelines::processors::transforms::group_by::PartitionedHashMethod;
 use crate::pipelines::processors::transforms::HashTableCell;

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_params.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_params.rs
@@ -21,9 +21,8 @@ use common_expression::DataSchemaRef;
 use common_functions::aggregates::get_layout_offsets;
 use common_functions::aggregates::AggregateFunctionRef;
 use common_functions::aggregates::StateAddr;
+use common_hashtable::Area;
 use common_sql::IndexType;
-
-use crate::pipelines::processors::transforms::group_by::Area;
 
 pub struct AggregatorParams {
     pub input_schema: DataSchemaRef,

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
@@ -244,7 +244,9 @@ impl<Method: HashMethodBounds> TransformPartialAggregate<Method> {
 
         unsafe {
             let rows_num = block.num_rows();
-            let state = self.method.build_keys_state(&group_columns, rows_num)?;
+            let state = self
+                .method
+                .mutable_build_keys_state(&group_columns, rows_num)?;
 
             match &mut self.hash_table {
                 HashTable::MovedOut => unreachable!(),

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_partial.rs
@@ -147,7 +147,9 @@ impl<Method: HashMethodBounds> AccumulatingTransform for TransformPartialGroupBy
 
         unsafe {
             let rows_num = block.num_rows();
-            let state = self.method.build_keys_state(&group_columns, rows_num)?;
+            let state = self
+                .method
+                .mutable_build_keys_state(&group_columns, rows_num)?;
 
             match &mut self.hash_table {
                 HashTable::MovedOut => unreachable!(),

--- a/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_polymorphic_keys.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_polymorphic_keys.rs
@@ -31,6 +31,8 @@ use common_expression::HashMethodKeysU256;
 use common_expression::HashMethodSerializer;
 use common_expression::HashMethodSingleString;
 use common_expression::KeysState;
+use common_hashtable::Area;
+use common_hashtable::ArenaHolder;
 use common_hashtable::DictionaryKeys;
 use common_hashtable::DictionaryStringHashMap;
 use common_hashtable::FastHash;
@@ -60,8 +62,6 @@ use crate::pipelines::processors::transforms::group_by::aggregator_keys_iter::Di
 use crate::pipelines::processors::transforms::group_by::aggregator_keys_iter::FixedKeysColumnIter;
 use crate::pipelines::processors::transforms::group_by::aggregator_keys_iter::KeysColumnIter;
 use crate::pipelines::processors::transforms::group_by::aggregator_keys_iter::SerializedKeysColumnIter;
-use crate::pipelines::processors::transforms::group_by::Area;
-use crate::pipelines::processors::transforms::group_by::ArenaHolder;
 use crate::pipelines::processors::transforms::HashTableCell;
 use crate::pipelines::processors::transforms::PartitionedHashTableDropper;
 use crate::pipelines::processors::AggregatorParams;

--- a/src/query/service/src/pipelines/processors/transforms/group_by/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/mod.rs
@@ -16,7 +16,6 @@ mod aggregator_groups_builder;
 mod aggregator_keys_builder;
 mod aggregator_keys_iter;
 mod aggregator_polymorphic_keys;
-mod aggregator_state;
 mod aggregator_state_entity;
 mod large_number;
 
@@ -26,8 +25,6 @@ pub use aggregator_keys_iter::KeysColumnIter;
 pub use aggregator_polymorphic_keys::HashMethodBounds;
 pub use aggregator_polymorphic_keys::PartitionedHashMethod;
 pub use aggregator_polymorphic_keys::PolymorphicKeysHelper;
-pub use aggregator_state::Area;
-pub use aggregator_state::ArenaHolder;
 pub use aggregator_state_entity::StateEntityMutRef;
 pub use aggregator_state_entity::StateEntityRef;
 

--- a/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/window_function.rs
@@ -25,10 +25,9 @@ use common_functions::aggregates::get_layout_offsets;
 use common_functions::aggregates::AggregateFunction;
 use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::aggregates::StateAddr;
+use common_hashtable::Area;
 use common_sql::executor::LagLeadDefault;
 use common_sql::executor::WindowFunction;
-
-use crate::pipelines::processors::transforms::group_by::Area;
 
 #[derive(Clone)]
 pub enum WindowFunctionInfo {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Serialize each column in batch to leverage SIMD.

We should preallocate the whole memory space for the serializing target, and it could be a huge consumption. 
Therefore, I add a threshold for the memory usage. If it exceed the limit, degrade the serialization to the original non-batch one (not use the memory buffer).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13254)
<!-- Reviewable:end -->
