### PR TITLE
refactor: extract request handling to Handler and Forwarder

### DIFF
--- a/src/common/grpc/src/client_conf.rs
+++ b/src/common/grpc/src/client_conf.rs
@@ -38,7 +38,7 @@ pub struct RpcClientConf {
     /// AutoSyncInterval is the interval to update endpoints with its latest members.
     /// None disables auto-sync.
     pub auto_sync_interval: Option<Duration>,
-    pub unhealth_endpoint_evict_time: Duration,
+    pub unhealthy_endpoint_evict_time: Duration,
 }
 
 impl RpcClientConf {

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -299,7 +299,7 @@ impl MetaGrpcClient {
             &conf.password,
             conf.timeout,
             conf.auto_sync_interval,
-            conf.unhealth_endpoint_evict_time,
+            conf.unhealthy_endpoint_evict_time,
             conf.tls_conf.clone(),
         )
     }
@@ -311,7 +311,7 @@ impl MetaGrpcClient {
         password: &str,
         timeout: Option<Duration>,
         auto_sync_interval: Option<Duration>,
-        unhealth_endpoint_evict_time: Duration,
+        unhealthy_endpoint_evict_time: Duration,
         conf: Option<RpcClientTlsConfig>,
     ) -> Result<Arc<ClientHandle>, MetaClientError> {
         Self::endpoints_non_empty(&endpoints)?;
@@ -340,7 +340,7 @@ impl MetaGrpcClient {
             conn_pool: Pool::new(mgr, Duration::from_millis(50)),
             endpoints: Mutex::new(endpoints),
             current_endpoint: Arc::new(Mutex::new(None)),
-            unhealthy_endpoints: Mutex::new(TtlHashMap::new(unhealth_endpoint_evict_time)),
+            unhealthy_endpoints: Mutex::new(TtlHashMap::new(unhealthy_endpoint_evict_time)),
             auto_sync_interval,
             username: username.to_string(),
             password: password.to_string(),

--- a/src/meta/service/src/lib.rs
+++ b/src/meta/service/src/lib.rs
@@ -24,6 +24,7 @@ pub mod meta_service;
 pub mod metrics;
 pub mod network;
 pub mod raft_client;
+pub(crate) mod request_handling;
 pub mod store;
 pub mod version;
 pub mod watcher;

--- a/src/meta/service/src/message.rs
+++ b/src/meta/service/src/message.rs
@@ -81,14 +81,14 @@ pub enum ForwardRequestBody {
 
 /// A request that is forwarded from one raft node to another
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct ForwardRequest {
+pub struct ForwardRequest<T> {
     /// Forward the request to leader if the node received this request is not leader.
     pub forward_to_leader: u64,
 
-    pub body: ForwardRequestBody,
+    pub body: T,
 }
 
-impl ForwardRequest {
+impl<T> ForwardRequest<T> {
     pub fn decr_forward(&mut self) {
         self.forward_to_leader -= 1;
     }
@@ -111,7 +111,7 @@ pub enum ForwardResponse {
     ListKV(ListKVReply),
 }
 
-impl tonic::IntoRequest<RaftRequest> for ForwardRequest {
+impl tonic::IntoRequest<RaftRequest> for ForwardRequest<ForwardRequestBody> {
     fn into_request(self) -> tonic::Request<RaftRequest> {
         let mes = RaftRequest {
             data: serde_json::to_string(&self).expect("fail to serialize"),
@@ -120,7 +120,7 @@ impl tonic::IntoRequest<RaftRequest> for ForwardRequest {
     }
 }
 
-impl TryFrom<RaftRequest> for ForwardRequest {
+impl TryFrom<RaftRequest> for ForwardRequest<ForwardRequestBody> {
     type Error = tonic::Status;
 
     fn try_from(mes: RaftRequest) -> Result<Self, Self::Error> {

--- a/src/meta/service/src/meta_service/forwarder.rs
+++ b/src/meta/service/src/meta_service/forwarder.rs
@@ -1,0 +1,88 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Forward request to another node
+
+use common_meta_api::reply::reply_to_api_result;
+use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
+use common_meta_types::ConnectionError;
+use common_meta_types::ForwardRPCError;
+use common_meta_types::GrpcConfig;
+use common_meta_types::MetaAPIError;
+use common_meta_types::MetaNetworkError;
+use common_meta_types::NodeId;
+use log::debug;
+
+use crate::message::ForwardRequest;
+use crate::message::ForwardRequestBody;
+use crate::message::ForwardResponse;
+use crate::meta_service::raftmeta::MetaRaft;
+use crate::meta_service::MetaNode;
+use crate::request_handling::Forwarder;
+use crate::store::RaftStore;
+
+/// Handle a request locally if it is leader. Otherwise, forward it to the leader.
+pub struct MetaForwarder<'a> {
+    sto: &'a RaftStore,
+    #[allow(dead_code)]
+    raft: &'a MetaRaft,
+}
+
+impl<'a> MetaForwarder<'a> {
+    pub fn new(meta_node: &'a MetaNode) -> Self {
+        Self {
+            sto: &meta_node.sto,
+            raft: &meta_node.raft,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<'a> Forwarder<ForwardRequestBody> for MetaForwarder<'a> {
+    #[minitrace::trace]
+    async fn forward(
+        &self,
+        target: NodeId,
+        req: ForwardRequest<ForwardRequestBody>,
+    ) -> Result<ForwardResponse, ForwardRPCError> {
+        debug!("forward to: {} {:?}", target, req);
+
+        let endpoint = self
+            .sto
+            .get_node_endpoint(&target)
+            .await
+            .map_err(|e| MetaNetworkError::GetNodeAddrError(e.to_string()))?;
+
+        let client = RaftServiceClient::connect(format!("http://{}", endpoint))
+            .await
+            .map_err(|e| {
+                let conn_err = ConnectionError::new(e, format!("address: {}", endpoint));
+                MetaNetworkError::ConnectionError(conn_err)
+            })?;
+
+        let mut client = client
+            .max_decoding_message_size(GrpcConfig::MAX_DECODING_SIZE)
+            .max_encoding_message_size(GrpcConfig::MAX_ENCODING_SIZE);
+
+        let resp = client.forward(req).await.map_err(|e| {
+            MetaNetworkError::from(e)
+                .add_context(format!("target: {}, endpoint: {}", target, endpoint))
+        })?;
+        let raft_mes = resp.into_inner();
+
+        let res: Result<ForwardResponse, MetaAPIError> = reply_to_api_result(raft_mes);
+        let resp = res?;
+        Ok(resp)
+    }
+}

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -69,7 +69,7 @@ impl<'a> MetaLeader<'a> {
     #[minitrace::trace]
     pub async fn handle_request(
         &self,
-        req: ForwardRequest,
+        req: ForwardRequest<ForwardRequestBody>,
     ) -> Result<ForwardResponse, MetaOperationError> {
         debug!(req = as_debug!(&req), target = req.forward_to_leader; "handle_forwardable_req");
 

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -47,6 +47,7 @@ use crate::meta_service::raftmeta::MetaRaft;
 use crate::meta_service::MetaNode;
 use crate::metrics::server_metrics;
 use crate::metrics::ProposalPending;
+use crate::request_handling::Handler;
 use crate::store::RaftStore;
 
 /// The container of APIs of the leader in a meta service cluster.
@@ -58,16 +59,10 @@ pub struct MetaLeader<'a> {
     raft: &'a MetaRaft,
 }
 
-impl<'a> MetaLeader<'a> {
-    pub fn new(meta_node: &'a MetaNode) -> MetaLeader {
-        MetaLeader {
-            sto: &meta_node.sto,
-            raft: &meta_node.raft,
-        }
-    }
-
+#[async_trait::async_trait]
+impl<'a> Handler<ForwardRequestBody> for MetaLeader<'a> {
     #[minitrace::trace]
-    pub async fn handle_request(
+    async fn handle(
         &self,
         req: ForwardRequest<ForwardRequestBody>,
     ) -> Result<ForwardResponse, MetaOperationError> {
@@ -104,6 +99,15 @@ impl<'a> MetaLeader<'a> {
                 let res = sm.kv_api().prefix_list_kv(&req.prefix).await.unwrap();
                 Ok(ForwardResponse::ListKV(res))
             }
+        }
+    }
+}
+
+impl<'a> MetaLeader<'a> {
+    pub fn new(meta_node: &'a MetaNode) -> MetaLeader {
+        MetaLeader {
+            sto: &meta_node.sto,
+            raft: &meta_node.raft,
         }
     }
 

--- a/src/meta/service/src/meta_service/meta_service_impl.rs
+++ b/src/meta/service/src/meta_service/meta_service_impl.rs
@@ -28,6 +28,7 @@ use tokio_stream::Stream;
 
 use crate::grpc_helper::GrpcHelper;
 use crate::message::ForwardRequest;
+use crate::message::ForwardRequestBody;
 use crate::meta_service::MetaNode;
 use crate::metrics::raft_metrics;
 
@@ -61,7 +62,7 @@ impl RaftService for RaftServiceImpl {
         let root = common_tracing::start_trace_for_remote_request(func_name!(), &request);
 
         async {
-            let forward_req: ForwardRequest = GrpcHelper::parse_req(request)?;
+            let forward_req: ForwardRequest<ForwardRequestBody> = GrpcHelper::parse_req(request)?;
 
             let res = self.meta_node.handle_forwardable_request(forward_req).await;
 

--- a/src/meta/service/src/meta_service/mod.rs
+++ b/src/meta/service/src/meta_service/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use forwarder::MetaForwarder;
 pub use meta_service_impl::RaftServiceImpl;
 pub use raftmeta::MetaNode;
 
@@ -21,6 +22,7 @@ pub use crate::message::JoinRequest;
 pub use crate::message::LeaveRequest;
 
 mod errors;
+mod forwarder;
 pub mod meta_leader;
 mod meta_node_kv_api_impl;
 pub mod meta_service_impl;

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -996,7 +996,7 @@ impl MetaNode {
     #[minitrace::trace]
     pub async fn handle_forwardable_request(
         &self,
-        req: ForwardRequest,
+        req: ForwardRequest<ForwardRequestBody>,
     ) -> Result<ForwardResponse, MetaAPIError> {
         debug!(target = as_display!(&req.forward_to_leader),
                req = as_debug!(&req);
@@ -1177,7 +1177,7 @@ impl MetaNode {
     pub async fn forward_to(
         &self,
         node_id: &NodeId,
-        req: ForwardRequest,
+        req: ForwardRequest<ForwardRequestBody>,
     ) -> Result<ForwardResponse, ForwardRPCError> {
         debug!("forward_to: {} {:?}", node_id, req);
 

--- a/src/meta/service/src/meta_service/raftmeta.rs
+++ b/src/meta/service/src/meta_service/raftmeta.rs
@@ -44,7 +44,6 @@ use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::AppliedState;
 use common_meta_types::Cmd;
 use common_meta_types::CommittedLeaderId;
-use common_meta_types::ConnectionError;
 use common_meta_types::Endpoint;
 use common_meta_types::ForwardRPCError;
 use common_meta_types::ForwardToLeader;
@@ -86,10 +85,14 @@ use crate::message::ForwardResponse;
 use crate::message::JoinRequest;
 use crate::message::LeaveRequest;
 use crate::meta_service::errors::grpc_error_to_network_err;
+use crate::meta_service::forwarder::MetaForwarder;
 use crate::meta_service::meta_leader::MetaLeader;
 use crate::meta_service::RaftServiceImpl;
 use crate::metrics::server_metrics;
 use crate::network::Network;
+use crate::request_handling::Forwarder;
+use crate::request_handling::Handler;
+use crate::request_handling::MetaRequest;
 use crate::store::RaftStore;
 use crate::version::METASRV_COMMIT_VERSION;
 use crate::watcher::DispatcherSender;
@@ -994,15 +997,18 @@ impl MetaNode {
     }
 
     #[minitrace::trace]
-    pub async fn handle_forwardable_request(
+    pub async fn handle_forwardable_request<Req>(
         &self,
-        req: ForwardRequest<ForwardRequestBody>,
-    ) -> Result<ForwardResponse, MetaAPIError> {
+        req: ForwardRequest<Req>,
+    ) -> Result<Req::Resp, MetaAPIError>
+    where
+        Req: MetaRequest,
+        for<'a> MetaLeader<'a>: Handler<Req>,
+        for<'a> MetaForwarder<'a>: Forwarder<Req>,
+    {
         debug!(target = as_display!(&req.forward_to_leader),
                req = as_debug!(&req);
                "handle_forwardable_request");
-
-        let forward = req.forward_to_leader;
 
         let mut n_retry = 20;
         let mut slp = Duration::from_millis(200);
@@ -1014,7 +1020,7 @@ impl MetaNode {
             // Handle the request locally or return a ForwardToLeader error
             let op_err = match assume_leader_res {
                 Ok(leader) => {
-                    let res = leader.handle_request(req.clone()).await;
+                    let res = leader.handle(req.clone()).await;
                     match res {
                         Ok(x) => return Ok(x),
                         Err(e) => e,
@@ -1031,21 +1037,15 @@ impl MetaNode {
                 }
             };
 
-            if forward == 0 {
-                return Err(MetaAPIError::CanNotForward(AnyError::error(
-                    "max number of forward reached",
-                )));
-            }
-
             let leader_id = to_leader.leader_id.ok_or_else(|| {
                 MetaAPIError::CanNotForward(AnyError::error("need to forward but no known leader"))
             })?;
 
-            let mut req_cloned = req.clone();
-            // Avoid infinite forward
-            req_cloned.decr_forward();
+            let req_cloned = req.next()?;
 
-            let res = self.forward_to(&leader_id, req_cloned).await;
+            let f = MetaForwarder::new(self);
+            let res = f.forward(leader_id, req_cloned).await;
+
             let forward_err = match res {
                 Ok(x) => {
                     return Ok(x);
@@ -1171,44 +1171,6 @@ impl MetaNode {
             // Note that when it returns, `changed()` will mark the most recent value as **seen**.
             rx.changed().await?;
         }
-    }
-
-    #[minitrace::trace]
-    pub async fn forward_to(
-        &self,
-        node_id: &NodeId,
-        req: ForwardRequest<ForwardRequestBody>,
-    ) -> Result<ForwardResponse, ForwardRPCError> {
-        debug!("forward_to: {} {:?}", node_id, req);
-
-        let endpoint = self
-            .sto
-            .get_node_endpoint(node_id)
-            .await
-            .map_err(|e| MetaNetworkError::GetNodeAddrError(e.to_string()))?;
-
-        let client = RaftServiceClient::connect(format!("http://{}", endpoint))
-            .await
-            .map_err(|e| {
-                MetaNetworkError::ConnectionError(ConnectionError::new(
-                    e,
-                    format!("address: {}", endpoint),
-                ))
-            })?;
-
-        let mut client = client
-            .max_decoding_message_size(GrpcConfig::MAX_DECODING_SIZE)
-            .max_encoding_message_size(GrpcConfig::MAX_ENCODING_SIZE);
-
-        let resp = client.forward(req).await.map_err(|e| {
-            MetaNetworkError::from(e)
-                .add_context(format!("target: {}, endpoint: {}", node_id, endpoint))
-        })?;
-        let raft_mes = resp.into_inner();
-
-        let res: Result<ForwardResponse, MetaAPIError> = reply_to_api_result(raft_mes);
-        let resp = res?;
-        Ok(resp)
     }
 
     pub(crate) async fn add_watcher(

--- a/src/meta/service/src/request_handling.rs
+++ b/src/meta/service/src/request_handling.rs
@@ -1,0 +1,48 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use common_meta_types::ForwardRPCError;
+use common_meta_types::MetaOperationError;
+use common_meta_types::NodeId;
+
+use crate::message::ForwardRequest;
+use crate::message::ForwardRequestBody;
+use crate::message::ForwardResponse;
+
+/// A request that can be handled by meta node
+pub trait MetaRequest: Clone + fmt::Debug {
+    type Resp;
+}
+
+/// A handler that handles meta node request locally
+#[async_trait::async_trait]
+pub trait Handler<Req: MetaRequest> {
+    async fn handle(&self, req: ForwardRequest<Req>) -> Result<Req::Resp, MetaOperationError>;
+}
+
+/// A handler that forward meta node request locally
+#[async_trait::async_trait]
+pub trait Forwarder<Req: MetaRequest> {
+    async fn forward(
+        &self,
+        target: NodeId,
+        req: ForwardRequest<Req>,
+    ) -> Result<Req::Resp, ForwardRPCError>;
+}
+
+impl MetaRequest for ForwardRequestBody {
+    type Resp = ForwardResponse;
+}

--- a/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -752,7 +752,7 @@ fn join_req(
     endpoint: Endpoint,
     grpc_api_advertise_address: Option<String>,
     forward: u64,
-) -> ForwardRequest {
+) -> ForwardRequest<ForwardRequestBody> {
     ForwardRequest {
         forward_to_leader: forward,
         body: ForwardRequestBody::Join(JoinRequest::new(

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -391,7 +391,7 @@ impl MetaConfig {
             } else {
                 None
             },
-            unhealth_endpoint_evict_time: Duration::from_secs(self.unhealth_endpoint_evict_time),
+            unhealthy_endpoint_evict_time: Duration::from_secs(self.unhealth_endpoint_evict_time),
         }
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: extract request handling to Handler and Forwarder

Introduce `Forwarder` as a container of various request forwarding
functions.

And treat `MetaLeader` as a container of various request handling
functions.

We also introduce trait `Handler` and `Forwarder` to define behavior of
these two containers.


##### chore: fix typo


##### make forward request generic

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13257)
<!-- Reviewable:end -->
