### PR TITLE
chore: remove useless type param from kv_api

### DIFF
--- a/src/meta/client/src/grpc_action.rs
+++ b/src/meta/client/src/grpc_action.rs
@@ -28,8 +28,11 @@ use common_meta_types::protobuf::ClientInfo;
 use common_meta_types::protobuf::RaftRequest;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
+use common_meta_types::InvalidArgument;
 use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
+use log::as_debug;
+use log::debug;
 use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 use tonic::Request;
@@ -67,16 +70,19 @@ impl TryInto<MetaGrpcReq> for Request<RaftRequest> {
     }
 }
 
-impl TryInto<Request<RaftRequest>> for MetaGrpcReq {
-    type Error = serde_json::Error;
-
-    fn try_into(self) -> Result<Request<RaftRequest>, Self::Error> {
+impl MetaGrpcReq {
+    pub fn to_raft_request(&self) -> Result<RaftRequest, InvalidArgument> {
         let raft_request = RaftRequest {
-            data: serde_json::to_string(&self)?,
+            data: serde_json::to_string(self)
+                .map_err(|e| InvalidArgument::new(e, "fail to encode request"))?,
         };
 
-        let request = tonic::Request::new(raft_request);
-        Ok(request)
+        debug!(
+            req = as_debug!(&raft_request);
+            "build raft_request"
+        );
+
+        Ok(raft_request)
     }
 }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore: remove useless type param from kv_api

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13265)
<!-- Reviewable:end -->
