### PR TITLE
fix: do not reuse expr when function are if

### DIFF
--- a/src/query/sql/src/evaluator/cse.rs
+++ b/src/query/sql/src/evaluator/cse.rs
@@ -124,8 +124,7 @@ pub fn apply_cse(
 /// and stores the count in a HashMap.
 fn count_expressions(expr: &Expr, counter: &mut HashMap<Expr, usize>) {
     match expr {
-        Expr::FunctionCall { function, .. }
-            if function.signature.name == "if" || function.signature.name == "and_filters" => {}
+        Expr::FunctionCall { function, .. } if function.signature.name == "if" => {}
         Expr::FunctionCall { args, .. } => {
             let entry = counter.entry(expr.clone()).or_insert(0);
             *entry += 1;

--- a/src/query/sql/src/evaluator/cse.rs
+++ b/src/query/sql/src/evaluator/cse.rs
@@ -124,6 +124,8 @@ pub fn apply_cse(
 /// and stores the count in a HashMap.
 fn count_expressions(expr: &Expr, counter: &mut HashMap<Expr, usize>) {
     match expr {
+        Expr::FunctionCall { function, .. }
+            if function.signature.name == "if" || function.signature.name == "and_filters" => {}
         Expr::FunctionCall { args, .. } => {
             let entry = counter.entry(expr.clone()).or_insert(0);
             *entry += 1;

--- a/tests/sqllogictests/suites/base/issues/issue_13269.test
+++ b/tests/sqllogictests/suites/base/issues/issue_13269.test
@@ -1,0 +1,25 @@
+# issue 13269
+
+statement ok
+DROP DATABASE IF EXISTS issue_13296
+
+statement ok
+CREATE DATABASE issue_13269
+
+statement ok
+USE issue_13269
+
+statement ok
+create table test(a int)
+
+statement ok
+insert into test select * from numbers(3)
+
+query F rowsort
+select coalesce((case when a = 0 then NULL else 6/a end) ,0,1) aaa from ( select 0 a union all select 3 a ) test
+----
+0.0
+2.0
+
+statement ok
+DROP DATABASE issue_13269


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`if` is not same as normal function, they eval with validity, we not reuse expr in these two special functions to avoid bug.

- Closes #13269

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13271)
<!-- Reviewable:end -->
