### PR TITLE
chore: refactor meta grpc service

### DIFF
--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -48,6 +48,7 @@ use minitrace::prelude::*;
 use prost::Message;
 use tokio_stream;
 use tokio_stream::Stream;
+use tonic::codegen::BoxStream;
 use tonic::metadata::MetadataMap;
 use tonic::transport::NamedService;
 use tonic::Request;
@@ -55,7 +56,6 @@ use tonic::Response;
 use tonic::Status;
 use tonic::Streaming;
 
-use crate::meta_service::meta_service_impl::GrpcStream;
 use crate::meta_service::MetaNode;
 use crate::metrics::network_metrics;
 use crate::metrics::RequestInFlight;
@@ -158,8 +158,7 @@ impl NamedService for MetaServiceImpl {
 
 #[async_trait::async_trait]
 impl MetaService for MetaServiceImpl {
-    // rpc handshake related type
-    type HandshakeStream = GrpcStream<HandshakeResponse>;
+    type HandshakeStream = BoxStream<HandshakeResponse>;
 
     // rpc handshake first
     #[minitrace::trace]

--- a/src/meta/service/src/meta_service/meta_service_impl.rs
+++ b/src/meta/service/src/meta_service/meta_service_impl.rs
@@ -15,7 +15,6 @@
 //! Meta service impl a grpc server that serves both raft protocol: append_entries, vote and install_snapshot.
 //! It also serves RPC for user-data access.
 
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -24,16 +23,12 @@ use common_meta_types::protobuf::RaftReply;
 use common_meta_types::protobuf::RaftRequest;
 use common_tracing::func_name;
 use minitrace::prelude::*;
-use tokio_stream::Stream;
 
 use crate::grpc_helper::GrpcHelper;
 use crate::message::ForwardRequest;
 use crate::message::ForwardRequestBody;
 use crate::meta_service::MetaNode;
 use crate::metrics::raft_metrics;
-
-pub type GrpcStream<T> =
-    Pin<Box<dyn Stream<Item = Result<T, tonic::Status>> + Send + Sync + 'static>>;
 
 pub struct RaftServiceImpl {
     pub meta_node: Arc<MetaNode>,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore: refactor meta grpc service

chore: remove unused type param Resp from grpc_client::ClientHandle::request()

chore: remove duplicated stream definition GrpcStream

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13278)
<!-- Reviewable:end -->
