### PR TITLE
feat: add stream api for get, mget and list

### DIFF
--- a/src/meta/client/src/grpc_action.rs
+++ b/src/meta/client/src/grpc_action.rs
@@ -26,6 +26,7 @@ use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use common_meta_types::protobuf::ClientInfo;
 use common_meta_types::protobuf::RaftRequest;
+use common_meta_types::protobuf::StreamItem;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
 use common_meta_types::InvalidArgument;
@@ -36,12 +37,14 @@ use log::debug;
 use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 use tonic::Request;
+use tonic::Streaming;
 
 use crate::grpc_client::AuthInterceptor;
 use crate::message::ExportReq;
 use crate::message::GetClientInfo;
 use crate::message::GetEndpoints;
 use crate::message::MakeClient;
+use crate::message::Streamed;
 
 /// Bind a request type to its corresponding response type.
 pub trait RequestFor {
@@ -86,16 +89,60 @@ impl MetaGrpcReq {
     }
 }
 
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    derive_more::From,
+    derive_more::TryInto,
+)]
+pub enum MetaGrpcReadReq {
+    GetKV(GetKVReq),
+    MGetKV(MGetKVReq),
+    ListKV(ListKVReq),
+}
+
+impl MetaGrpcReadReq {
+    pub fn to_raft_request(&self) -> Result<RaftRequest, InvalidArgument> {
+        let raft_request = RaftRequest {
+            data: serde_json::to_string(self)
+                .map_err(|e| InvalidArgument::new(e, "fail to encode request"))?,
+        };
+
+        debug!(
+            req = as_debug!(&raft_request);
+            "build raft_request"
+        );
+
+        Ok(raft_request)
+    }
+}
+
 impl RequestFor for GetKVReq {
     type Reply = GetKVReply;
+}
+
+impl RequestFor for Streamed<GetKVReq> {
+    type Reply = Streaming<StreamItem>;
 }
 
 impl RequestFor for MGetKVReq {
     type Reply = MGetKVReply;
 }
 
+impl RequestFor for Streamed<MGetKVReq> {
+    type Reply = Streaming<StreamItem>;
+}
+
 impl RequestFor for ListKVReq {
     type Reply = ListKVReply;
+}
+
+impl RequestFor for Streamed<ListKVReq> {
+    type Reply = Streaming<StreamItem>;
 }
 
 impl RequestFor for UpsertKVReq {

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -43,6 +43,7 @@ use common_grpc::RpcClientConf;
 use common_grpc::RpcClientTlsConfig;
 use common_meta_api::reply::reply_to_api_result;
 use common_meta_types::anyerror::AnyError;
+use common_meta_types::protobuf as pb;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use common_meta_types::protobuf::ClientInfo;
 use common_meta_types::protobuf::Empty;
@@ -81,16 +82,19 @@ use tonic::transport::Channel;
 use tonic::Code;
 use tonic::Request;
 use tonic::Status;
+use tonic::Streaming;
 
 use crate::from_digit_ver;
 use crate::grpc_action::RequestFor;
 use crate::grpc_metrics;
 use crate::message;
 use crate::to_digit_ver;
+use crate::MetaGrpcReadReq;
 use crate::MetaGrpcReq;
 use crate::METACLI_COMMIT_SEMVER;
 use crate::MIN_METASRV_SEMVER;
 
+const RPC_RETRIES: usize = 2;
 const AUTH_TOKEN_KEY: &str = "auth-token-bin";
 
 #[derive(Debug)]
@@ -403,6 +407,13 @@ impl MetaGrpcClient {
                         .await;
                     message::Response::Get(resp)
                 }
+                message::Request::StreamGet(r) => {
+                    let strm = self
+                        .kv_read_v1(MetaGrpcReadReq::GetKV(r.into_inner()))
+                        .timed_ge(threshold(), info_spent("MetaGrpcClient::kv_read_v1(GetKV)"))
+                        .await;
+                    message::Response::StreamGet(strm)
+                }
                 message::Request::MGet(r) => {
                     let resp = self
                         .kv_api(r)
@@ -410,12 +421,32 @@ impl MetaGrpcClient {
                         .await;
                     message::Response::MGet(resp)
                 }
-                message::Request::PrefixList(r) => {
+                message::Request::StreamMGet(r) => {
+                    let strm = self
+                        .kv_read_v1(MetaGrpcReadReq::MGetKV(r.into_inner()))
+                        .timed_ge(
+                            threshold(),
+                            info_spent("MetaGrpcClient::kv_read_v1(MGetKV)"),
+                        )
+                        .await;
+                    message::Response::StreamMGet(strm)
+                }
+                message::Request::List(r) => {
                     let resp = self
                         .kv_api(r)
                         .timed_ge(threshold(), info_spent("MetaGrpcClient::kv_api"))
                         .await;
-                    message::Response::PrefixList(resp)
+                    message::Response::List(resp)
+                }
+                message::Request::StreamList(r) => {
+                    let strm = self
+                        .kv_read_v1(MetaGrpcReadReq::ListKV(r.into_inner()))
+                        .timed_ge(
+                            threshold(),
+                            info_spent("MetaGrpcClient::kv_read_v1(ListKV)"),
+                        )
+                        .await;
+                    message::Response::StreamMGet(strm)
                 }
                 message::Request::Upsert(r) => {
                     let resp = self
@@ -898,7 +929,7 @@ impl MetaGrpcClient {
             .to_raft_request()
             .map_err(MetaNetworkError::InvalidArgument)?;
 
-        for i in 0..2 {
+        for i in 0..RPC_RETRIES {
             let req = common_tracing::inject_span_to_tonic_request(Request::new(raft_req.clone()));
 
             let mut client = self
@@ -929,7 +960,54 @@ impl MetaGrpcClient {
             return Ok(resp);
         }
 
-        unreachable!("impossible to reach here");
+        unreachable!("impossible to quit loop without error or success");
+    }
+
+    #[minitrace::trace]
+    pub(crate) async fn kv_read_v1(
+        &self,
+        grpc_req: MetaGrpcReadReq,
+    ) -> Result<Streaming<pb::StreamItem>, MetaError> {
+        debug!(
+            req = as_debug!(&grpc_req);
+            "MetaGrpcClient::kv_api request"
+        );
+
+        let raft_req: RaftRequest = grpc_req
+            .to_raft_request()
+            .map_err(MetaNetworkError::InvalidArgument)?;
+
+        for i in 0..RPC_RETRIES {
+            let req = common_tracing::inject_span_to_tonic_request(Request::new(raft_req.clone()));
+
+            let mut client = self
+                .make_client()
+                .timed_ge(threshold(), info_spent("MetaGrpcClient::make_client"))
+                .await?;
+
+            let result = client
+                .kv_read_v1(req)
+                .timed_ge(threshold(), info_spent("client::kv_read_v1"))
+                .await;
+
+            debug!(
+                result = as_debug!(&result);
+                "MetaGrpcClient::kv_read_v1 result, {}-th try", i
+            );
+
+            if let Err(ref e) = result {
+                if status_is_retryable(e) {
+                    self.mark_as_unhealthy();
+                    continue;
+                }
+            }
+
+            let strm = result?.into_inner();
+
+            return Ok(strm);
+        }
+
+        unreachable!("impossible to quit loop without error or success");
     }
 
     #[minitrace::trace]

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -22,11 +22,13 @@ mod message;
 
 pub use common_meta_api::reply::reply_to_api_result;
 pub use common_meta_api::reply::reply_to_meta_result;
+pub use grpc_action::MetaGrpcReadReq;
 pub use grpc_action::MetaGrpcReq;
 pub use grpc_action::RequestFor;
 pub use grpc_client::ClientHandle;
 pub use grpc_client::MetaGrpcClient;
 pub use message::ClientWorkerRequest;
+pub use message::Streamed;
 use once_cell::sync::Lazy;
 use semver::BuildMetadata;
 use semver::Prerelease;
@@ -67,6 +69,9 @@ pub static METACLI_COMMIT_SEMVER: Lazy<Version> = Lazy::new(|| {
 ///
 /// - 2023-10-11: since 1.2.153:
 ///   Meta service: add: pb::SeqV.meta field to support record expiration.
+///
+/// - 2023-10-17: since TODO(fill in when merged):
+///   Meta service: add: stream api: kv_read_v1().
 pub static MIN_METASRV_SEMVER: Version = Version {
     major: 1,
     minor: 1,

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -26,6 +26,7 @@ use common_meta_kvapi::kvapi::UpsertKVReq;
 use common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use common_meta_types::protobuf::ClientInfo;
 use common_meta_types::protobuf::ExportedChunk;
+use common_meta_types::protobuf::StreamItem;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
 use common_meta_types::MetaClientError;
@@ -34,6 +35,7 @@ use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
 use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
+use tonic::Streaming;
 
 use crate::grpc_client::AuthInterceptor;
 
@@ -57,6 +59,16 @@ impl fmt::Debug for ClientWorkerRequest {
     }
 }
 
+/// Mark an RPC to return a stream.
+#[derive(Debug, Clone)]
+pub struct Streamed<T>(pub T);
+
+impl<T> Streamed<T> {
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
 /// Meta-client handle-to-worker request body
 #[derive(Debug, Clone, derive_more::From)]
 pub enum Request {
@@ -67,7 +79,16 @@ pub enum Request {
     MGet(MGetKVReq),
 
     /// List KVs by key prefix
-    PrefixList(ListKVReq),
+    List(ListKVReq),
+
+    /// Get KV, returning a stream
+    StreamGet(Streamed<GetKVReq>),
+
+    /// Get multiple KV, returning a stream.
+    StreamMGet(Streamed<MGetKVReq>),
+
+    /// List KVs by key prefix, returning a stream.
+    StreamList(Streamed<ListKVReq>),
 
     /// Update or insert KV
     Upsert(UpsertKVReq),
@@ -96,7 +117,10 @@ impl Request {
         match self {
             Request::Get(_) => "Get",
             Request::MGet(_) => "MGet",
-            Request::PrefixList(_) => "PrefixList",
+            Request::List(_) => "PrefixList",
+            Request::StreamGet(_) => "StreamGet",
+            Request::StreamMGet(_) => "StreamMGet",
+            Request::StreamList(_) => "StreamPrefixList",
             Request::Upsert(_) => "Upsert",
             Request::Txn(_) => "Txn",
             Request::Watch(_) => "Watch",
@@ -113,7 +137,10 @@ impl Request {
 pub enum Response {
     Get(Result<GetKVReply, MetaError>),
     MGet(Result<MGetKVReply, MetaError>),
-    PrefixList(Result<ListKVReply, MetaError>),
+    List(Result<ListKVReply, MetaError>),
+    StreamGet(Result<Streaming<StreamItem>, MetaError>),
+    StreamMGet(Result<Streaming<StreamItem>, MetaError>),
+    StreamList(Result<Streaming<StreamItem>, MetaError>),
     Upsert(Result<UpsertKVReply, MetaError>),
     Txn(Result<TxnReply, MetaError>),
     Watch(Result<tonic::codec::Streaming<WatchResponse>, MetaError>),
@@ -126,21 +153,6 @@ pub enum Response {
 }
 
 impl Response {
-    pub fn is_err(&self) -> bool {
-        match self {
-            Response::Get(res) => res.is_err(),
-            Response::MGet(res) => res.is_err(),
-            Response::PrefixList(res) => res.is_err(),
-            Response::Upsert(res) => res.is_err(),
-            Response::Txn(res) => res.is_err(),
-            Response::Watch(res) => res.is_err(),
-            Response::Export(res) => res.is_err(),
-            Response::MakeClient(res) => res.is_err(),
-            Response::GetEndpoints(res) => res.is_err(),
-            Response::GetClientInfo(res) => res.is_err(),
-        }
-    }
-
     pub fn err(&self) -> Option<&(dyn std::error::Error + 'static)> {
         let e = match self {
             Response::Get(res) => res
@@ -151,7 +163,19 @@ impl Response {
                 .as_ref()
                 .err()
                 .map(|x| x as &(dyn std::error::Error + 'static)),
-            Response::PrefixList(res) => res
+            Response::List(res) => res
+                .as_ref()
+                .err()
+                .map(|x| x as &(dyn std::error::Error + 'static)),
+            Response::StreamGet(res) => res
+                .as_ref()
+                .err()
+                .map(|x| x as &(dyn std::error::Error + 'static)),
+            Response::StreamMGet(res) => res
+                .as_ref()
+                .err()
+                .map(|x| x as &(dyn std::error::Error + 'static)),
+            Response::StreamList(res) => res
                 .as_ref()
                 .err()
                 .map(|x| x as &(dyn std::error::Error + 'static)),

--- a/src/meta/client/tests/it/grpc_server.rs
+++ b/src/meta/client/tests/it/grpc_server.rs
@@ -29,18 +29,21 @@ use common_meta_types::protobuf::MemberListReply;
 use common_meta_types::protobuf::MemberListRequest;
 use common_meta_types::protobuf::RaftReply;
 use common_meta_types::protobuf::RaftRequest;
+use common_meta_types::protobuf::StreamItem;
 use common_meta_types::protobuf::TxnReply;
 use common_meta_types::protobuf::TxnRequest;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
 use futures::Stream;
 use rand::Rng;
+use tonic::codegen::BoxStream;
 use tonic::transport::Server;
 use tonic::Request;
 use tonic::Response;
 use tonic::Status;
 use tonic::Streaming;
 
+/// A service that times out a kv_api() call, without impl other API.
 pub struct GrpcServiceForTestImpl {}
 
 #[tonic::async_trait]
@@ -66,6 +69,15 @@ impl MetaService for GrpcServiceForTestImpl {
         // for timeout test
         tokio::time::sleep(Duration::from_secs(60)).await;
         Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    type KvReadV1Stream = BoxStream<StreamItem>;
+
+    async fn kv_read_v1(
+        &self,
+        _request: Request<RaftRequest>,
+    ) -> Result<Response<Self::KvReadV1Stream>, Status> {
+        todo!()
     }
 
     type ExportStream =

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -21,6 +21,7 @@ use common_base::base::tokio::sync::mpsc;
 use common_base::base::tokio::time::Instant;
 use common_grpc::GrpcClaim;
 use common_grpc::GrpcToken;
+use common_meta_client::MetaGrpcReadReq;
 use common_meta_client::MetaGrpcReq;
 use common_meta_kvapi::kvapi::KVApi;
 use common_meta_types::protobuf::meta_service_server::MetaService;
@@ -33,6 +34,7 @@ use common_meta_types::protobuf::MemberListReply;
 use common_meta_types::protobuf::MemberListRequest;
 use common_meta_types::protobuf::RaftReply;
 use common_meta_types::protobuf::RaftRequest;
+use common_meta_types::protobuf::StreamItem;
 use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::protobuf::WatchResponse;
 use common_meta_types::TxnReply;
@@ -56,6 +58,8 @@ use tonic::Response;
 use tonic::Status;
 use tonic::Streaming;
 
+use crate::grpc_helper::GrpcHelper;
+use crate::message::ForwardRequest;
 use crate::meta_service::MetaNode;
 use crate::metrics::network_metrics;
 use crate::metrics::RequestInFlight;
@@ -123,6 +127,35 @@ impl MetaServiceImpl {
         network_metrics::incr_request_result(reply.error.is_empty());
 
         Ok(reply)
+    }
+
+    #[minitrace::trace]
+    async fn handle_kv_read_v1(
+        &self,
+        request: Request<RaftRequest>,
+    ) -> Result<BoxStream<StreamItem>, Status> {
+        let req: MetaGrpcReadReq = GrpcHelper::parse_req(request)?;
+
+        info!("{}: Received ReadRequest: {:?}", func_name!(), req);
+
+        let req = ForwardRequest {
+            forward_to_leader: 1,
+            body: req,
+        };
+
+        let t0 = Instant::now();
+
+        let res = self
+            .meta_node
+            .handle_forwardable_request::<MetaGrpcReadReq>(req.clone())
+            .await
+            .map_err(GrpcHelper::internal_err);
+
+        let elapsed = t0.elapsed();
+        info!("Handled(elapsed: {:?}) ReadRequest: {:?}", elapsed, req);
+
+        network_metrics::incr_request_result(res.is_ok());
+        res
     }
 
     #[minitrace::trace]
@@ -230,6 +263,22 @@ impl MetaService for MetaServiceImpl {
         network_metrics::incr_sent_bytes(reply.encoded_len() as u64);
 
         Ok(Response::new(reply))
+    }
+
+    type KvReadV1Stream = BoxStream<StreamItem>;
+
+    async fn kv_read_v1(
+        &self,
+        request: Request<RaftRequest>,
+    ) -> Result<Response<Self::KvReadV1Stream>, Status> {
+        self.check_token(request.metadata())?;
+
+        network_metrics::incr_recv_bytes(request.get_ref().encoded_len() as u64);
+        let root = common_tracing::start_trace_for_remote_request(func_name!(), &request);
+
+        let strm = self.handle_kv_read_v1(request).in_span(root).await?;
+
+        Ok(Response::new(strm))
     }
 
     async fn transaction(

--- a/src/meta/service/src/message.rs
+++ b/src/meta/service/src/message.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use anyerror::AnyError;
+use common_meta_client::MetaGrpcReadReq;
 use common_meta_kvapi::kvapi::GetKVReply;
 use common_meta_kvapi::kvapi::GetKVReq;
 use common_meta_kvapi::kvapi::ListKVReply;
@@ -141,6 +142,15 @@ pub enum ForwardResponse {
 }
 
 impl tonic::IntoRequest<RaftRequest> for ForwardRequest<ForwardRequestBody> {
+    fn into_request(self) -> tonic::Request<RaftRequest> {
+        let mes = RaftRequest {
+            data: serde_json::to_string(&self).expect("fail to serialize"),
+        };
+        tonic::Request::new(mes)
+    }
+}
+
+impl tonic::IntoRequest<RaftRequest> for ForwardRequest<MetaGrpcReadReq> {
     fn into_request(self) -> tonic::Request<RaftRequest> {
         let mes = RaftRequest {
             data: serde_json::to_string(&self).expect("fail to serialize"),

--- a/src/meta/service/src/meta_service/forwarder.rs
+++ b/src/meta/service/src/meta_service/forwarder.rs
@@ -60,7 +60,7 @@ impl<'a> MetaForwarder<'a> {
 
         let endpoint = self
             .sto
-            .get_node_endpoint(&target)
+            .get_node_endpoint(target)
             .await
             .map_err(|e| MetaNetworkError::GetNodeAddrError(e.to_string()))?;
 

--- a/src/meta/service/src/meta_service/forwarder.rs
+++ b/src/meta/service/src/meta_service/forwarder.rs
@@ -15,14 +15,19 @@
 //! Forward request to another node
 
 use common_meta_api::reply::reply_to_api_result;
+use common_meta_client::MetaGrpcReadReq;
 use common_meta_types::protobuf::raft_service_client::RaftServiceClient;
+use common_meta_types::protobuf::StreamItem;
 use common_meta_types::ConnectionError;
+use common_meta_types::Endpoint;
 use common_meta_types::ForwardRPCError;
 use common_meta_types::GrpcConfig;
 use common_meta_types::MetaAPIError;
 use common_meta_types::MetaNetworkError;
 use common_meta_types::NodeId;
 use log::debug;
+use tonic::codegen::BoxStream;
+use tonic::transport::Channel;
 
 use crate::message::ForwardRequest;
 use crate::message::ForwardRequestBody;
@@ -46,17 +51,12 @@ impl<'a> MetaForwarder<'a> {
             raft: &meta_node.raft,
         }
     }
-}
 
-#[async_trait::async_trait]
-impl<'a> Forwarder<ForwardRequestBody> for MetaForwarder<'a> {
-    #[minitrace::trace]
-    async fn forward(
+    async fn new_raft_client(
         &self,
-        target: NodeId,
-        req: ForwardRequest<ForwardRequestBody>,
-    ) -> Result<ForwardResponse, ForwardRPCError> {
-        debug!("forward to: {} {:?}", target, req);
+        target: &NodeId,
+    ) -> Result<(Endpoint, RaftServiceClient<Channel>), MetaNetworkError> {
+        debug!("new RaftServiceClient to: {}", target);
 
         let endpoint = self
             .sto
@@ -71,9 +71,25 @@ impl<'a> Forwarder<ForwardRequestBody> for MetaForwarder<'a> {
                 MetaNetworkError::ConnectionError(conn_err)
             })?;
 
-        let mut client = client
+        let client = client
             .max_decoding_message_size(GrpcConfig::MAX_DECODING_SIZE)
             .max_encoding_message_size(GrpcConfig::MAX_ENCODING_SIZE);
+
+        Ok((endpoint, client))
+    }
+}
+
+#[async_trait::async_trait]
+impl<'a> Forwarder<ForwardRequestBody> for MetaForwarder<'a> {
+    #[minitrace::trace]
+    async fn forward(
+        &self,
+        target: NodeId,
+        req: ForwardRequest<ForwardRequestBody>,
+    ) -> Result<ForwardResponse, ForwardRPCError> {
+        debug!("forward ForwardRequest to: {} {:?}", target, req);
+
+        let (endpoint, mut client) = self.new_raft_client(&target).await?;
 
         let resp = client.forward(req).await.map_err(|e| {
             MetaNetworkError::from(e)
@@ -84,5 +100,27 @@ impl<'a> Forwarder<ForwardRequestBody> for MetaForwarder<'a> {
         let res: Result<ForwardResponse, MetaAPIError> = reply_to_api_result(raft_mes);
         let resp = res?;
         Ok(resp)
+    }
+}
+
+#[async_trait::async_trait]
+impl<'a> Forwarder<MetaGrpcReadReq> for MetaForwarder<'a> {
+    #[minitrace::trace]
+    async fn forward(
+        &self,
+        target: NodeId,
+        req: ForwardRequest<MetaGrpcReadReq>,
+    ) -> Result<BoxStream<StreamItem>, ForwardRPCError> {
+        debug!("forward ReadRequest to: {} {:?}", target, req);
+
+        let (endpoint, mut client) = self.new_raft_client(&target).await?;
+
+        let strm = client.kv_read_v1(req).await.map_err(|e| {
+            MetaNetworkError::from(e)
+                .add_context(format!("target: {}, endpoint: {}", target, endpoint))
+        })?;
+
+        let strm = strm.into_inner();
+        Ok(Box::pin(strm))
     }
 }

--- a/src/meta/service/src/request_handling.rs
+++ b/src/meta/service/src/request_handling.rs
@@ -14,9 +14,12 @@
 
 use std::fmt;
 
+use common_meta_client::MetaGrpcReadReq;
+use common_meta_types::protobuf::StreamItem;
 use common_meta_types::ForwardRPCError;
 use common_meta_types::MetaOperationError;
 use common_meta_types::NodeId;
+use tonic::codegen::BoxStream;
 
 use crate::message::ForwardRequest;
 use crate::message::ForwardRequestBody;
@@ -45,4 +48,8 @@ pub trait Forwarder<Req: MetaRequest> {
 
 impl MetaRequest for ForwardRequestBody {
     type Resp = ForwardResponse;
+}
+
+impl MetaRequest for MetaGrpcReadReq {
+    type Resp = BoxStream<StreamItem>;
 }

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
@@ -1,0 +1,177 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test kv_read_v1() API, which handles kv-read request and return result in a stream.
+
+use std::sync::Arc;
+
+use common_meta_client::ClientHandle;
+use common_meta_client::Streamed;
+use common_meta_kvapi::kvapi::GetKVReq;
+use common_meta_kvapi::kvapi::KVApi;
+use common_meta_kvapi::kvapi::ListKVReq;
+use common_meta_kvapi::kvapi::MGetKVReq;
+use common_meta_kvapi::kvapi::UpsertKVReq;
+use common_meta_types::protobuf as pb;
+use common_meta_types::protobuf::KvMeta;
+use common_meta_types::KVMeta;
+use common_meta_types::SeqV;
+use common_meta_types::With;
+use futures::stream::StreamExt;
+use futures::TryStreamExt;
+use log::info;
+use pretty_assertions::assert_eq;
+use test_harness::test;
+
+use crate::testing::meta_service_test_harness;
+
+#[test(harness = meta_service_test_harness)]
+#[minitrace::trace]
+async fn test_kv_read_v1_on_leader() -> anyhow::Result<()> {
+    let now_sec = SeqV::<()>::now_sec();
+
+    let (tc, _addr) = crate::tests::start_metasrv().await?;
+
+    let client = tc.grpc_client().await?;
+
+    initialize_kvs(&client, now_sec).await?;
+    test_streamed_get(&client, now_sec).await?;
+    test_streamed_mget(&client, now_sec).await?;
+    test_streamed_list(&client, now_sec).await?;
+
+    Ok(())
+}
+
+#[test(harness = meta_service_test_harness)]
+#[minitrace::trace]
+async fn test_kv_read_v1_on_follower() -> anyhow::Result<()> {
+    let now_sec = SeqV::<()>::now_sec();
+
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let client = tcs[0].grpc_client().await?;
+
+    initialize_kvs(&client, now_sec).await?;
+
+    let client = tcs[1].grpc_client().await?;
+    test_streamed_get(&client, now_sec).await?;
+    test_streamed_mget(&client, now_sec).await?;
+    test_streamed_list(&client, now_sec).await?;
+
+    Ok(())
+}
+
+/// Initialize kv store for test.
+///
+/// Insert keys:
+/// a(meta), c, c1, c2
+async fn initialize_kvs(client: &Arc<ClientHandle>, now_sec: u64) -> anyhow::Result<()> {
+    info!("--- prepare keys: a(meta),c,c1,c2");
+
+    let updates = vec![
+        UpsertKVReq::insert("a", &b("a")).with(KVMeta::new_expire(now_sec + 10)),
+        UpsertKVReq::insert("c", &b("c")),
+        UpsertKVReq::insert("c1", &b("c1")),
+        UpsertKVReq::insert("c2", &b("c2")),
+    ];
+
+    for update in updates {
+        client.upsert_kv(update).await?;
+    }
+
+    Ok(())
+}
+
+/// Test streamed mget on a grpc meta-service client
+async fn test_streamed_get(client: &Arc<ClientHandle>, now_sec: u64) -> anyhow::Result<()> {
+    info!("--- test streamed get");
+
+    let strm = client.request(Streamed(GetKVReq { key: s("a") })).await?;
+
+    let got = strm.map_err(|e| e.to_string()).collect::<Vec<_>>().await;
+    assert_eq!(
+        vec![Ok(pb::StreamItem::new(
+            s("a"),
+            Some(pb::SeqV::with_meta(
+                1,
+                Some(KvMeta::new_expire(now_sec + 10)),
+                b("a")
+            ))
+        )),],
+        got
+    );
+    Ok(())
+}
+
+/// Test streamed mget on a grpc meta-service client
+async fn test_streamed_mget(client: &Arc<ClientHandle>, now_sec: u64) -> anyhow::Result<()> {
+    info!("--- test streamed mget");
+
+    let strm = client
+        .request(Streamed(MGetKVReq {
+            keys: vec![s("a"), s("b")],
+        }))
+        .await?;
+
+    let got = strm.map_err(|e| e.to_string()).collect::<Vec<_>>().await;
+    assert_eq!(
+        vec![
+            Ok(pb::StreamItem::new(
+                s("a"),
+                Some(pb::SeqV::with_meta(
+                    1,
+                    Some(KvMeta::new_expire(now_sec + 10)),
+                    b("a")
+                ))
+            )),
+            Ok(pb::StreamItem::new(s("b"), None)),
+        ],
+        got
+    );
+    Ok(())
+}
+
+/// Test streamed list on a grpc meta-service client
+async fn test_streamed_list(client: &Arc<ClientHandle>, _now_sec: u64) -> anyhow::Result<()> {
+    info!("--- test streamed list");
+
+    let strm = client
+        .request(Streamed(ListKVReq { prefix: s("c") }))
+        .await?;
+
+    let got = strm.map_err(|e| e.to_string()).collect::<Vec<_>>().await;
+    assert_eq!(
+        vec![
+            Ok(pb::StreamItem::new(s("c"), Some(pb::SeqV::new(2, b("c"))))),
+            Ok(pb::StreamItem::new(
+                s("c1"),
+                Some(pb::SeqV::new(3, b("c1")))
+            )),
+            Ok(pb::StreamItem::new(
+                s("c2"),
+                Some(pb::SeqV::new(4, b("c2")))
+            )),
+        ],
+        got
+    );
+    Ok(())
+}
+
+fn s(x: &str) -> String {
+    x.to_string()
+}
+
+fn b(x: &str) -> Vec<u8> {
+    x.as_bytes().to_vec()
+}

--- a/src/meta/service/tests/it/grpc/mod.rs
+++ b/src/meta/service/tests/it/grpc/mod.rs
@@ -19,6 +19,7 @@ pub mod metasrv_grpc_get_client_info;
 pub mod metasrv_grpc_handshake;
 pub mod metasrv_grpc_kv_api;
 pub mod metasrv_grpc_kv_api_restart_cluster;
+pub mod metasrv_grpc_kv_read_v1;
 pub mod metasrv_grpc_schema_api;
 pub mod metasrv_grpc_schema_api_follower_follower;
 pub mod metasrv_grpc_schema_api_leader_follower;

--- a/src/meta/service/tests/it/tests/mod.rs
+++ b/src/meta/service/tests/it/tests/mod.rs
@@ -19,4 +19,5 @@ pub mod service;
 pub mod tls_constants;
 
 pub use service::start_metasrv;
+pub use service::start_metasrv_cluster;
 pub use service::start_metasrv_with_context;

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -20,7 +20,9 @@ import "request.proto";
 
 message Empty {}
 
-message RaftRequest { string data = 1; }
+message RaftRequest {
+  string data = 1;
+}
 
 message RaftReply {
   string data = 1;
@@ -148,10 +150,21 @@ message ClientInfo {
   string client_addr = 10;
 }
 
+// Item for a Streaming read reply, e.g., for `Mget` and `List`.
+message StreamItem {
+  string key = 1;
+  optional SeqV value = 2;
+}
+
+
 service RaftService {
 
-  /// Forward a request to other
-  rpc Forward(RaftRequest) returns (RaftReply) {}
+  // Forward a request to another node.
+  rpc Forward(RaftRequest) returns (RaftReply);
+
+  // Handling internally redirected KvReadV1 request.
+  // Without checking token.
+  rpc KvReadV1(RaftRequest) returns (stream StreamItem);
 
   // raft RPC
 
@@ -169,6 +182,15 @@ service MetaService {
   //
   // Since: 0.8.35; 2022-09-14
   rpc KvApi(RaftRequest) returns (RaftReply);
+
+  // Handle application read request.
+  //
+  // This API is not exposed to client directly, but is only used for internal request forwarding.
+  // The request will be forwarded to leader if current node is not leader.
+  // It returns a stream of `StreamItem`.
+  // - For single-reply request, the stream contains only one item, e.g. `Get`.
+  // - For multi-reply request, the stream contains multiple items, e.g. `MGet` and `List`.
+  rpc KvReadV1(RaftRequest) returns (stream StreamItem);
 
   // Export all meta data.
   //

--- a/src/meta/types/src/proto_ext/mod.rs
+++ b/src/meta/types/src/proto_ext/mod.rs
@@ -15,4 +15,5 @@
 //! Extend protobuf generated code with some useful methods.
 
 mod seq_v_ext;
+mod stream_item_ext;
 mod txn_ext;

--- a/src/meta/types/src/proto_ext/stream_item_ext.rs
+++ b/src/meta/types/src/proto_ext/stream_item_ext.rs
@@ -1,0 +1,41 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::protobuf as pb;
+use crate::protobuf::StreamItem;
+use crate::SeqV;
+
+impl StreamItem {
+    pub fn new(key: String, value: Option<pb::SeqV>) -> Self {
+        StreamItem { key, value }
+    }
+}
+
+impl From<(String, Option<pb::SeqV>)> for StreamItem {
+    fn from(kv: (String, Option<pb::SeqV>)) -> Self {
+        StreamItem::new(kv.0, kv.1)
+    }
+}
+
+impl From<(String, Option<SeqV>)> for StreamItem {
+    fn from(kv: (String, Option<SeqV>)) -> Self {
+        StreamItem::new(kv.0, kv.1.map(pb::SeqV::from))
+    }
+}
+
+impl From<(String, SeqV)> for StreamItem {
+    fn from(kv: (String, SeqV)) -> Self {
+        StreamItem::new(kv.0, Some(pb::SeqV::from(kv.1)))
+    }
+}

--- a/src/meta/types/src/seq_value.rs
+++ b/src/meta/types/src/seq_value.rs
@@ -53,6 +53,14 @@ pub struct KVMeta {
     pub expire_at: Option<u64>,
 }
 
+impl KVMeta {
+    pub fn new_expire(expire_at: u64) -> Self {
+        Self {
+            expire_at: Some(expire_at),
+        }
+    }
+}
+
 /// Some value bound with a seq number
 #[derive(Serialize, Deserialize, Default, Clone, Eq, PartialEq)]
 pub struct SeqV<T = Vec<u8>> {
@@ -136,6 +144,14 @@ impl<T> SeqV<T> {
             meta: None,
             data,
         }
+    }
+
+    /// Create a timestamp in second for expiration control used in SeqV
+    pub fn now_sec() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
     }
 
     /// Create a timestamp in millisecond for expiration control used in SeqV


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat: add stream api for get, mget and list

In this commit, meta grpc service provides new api
`kv_read_v1() -> Stream<StreamItem>`. Service and client are both ready
but not yet used by databend-query yet.

This new API support `get` single kv, `mget` multiple kv and `list` kv
by a prefix. The result is returned in a stream.

Raft service also provides a `kv_read_v1()` API for internal forwarding
such a request to the leader.

Other changes: rename internal term `PrefixList -> List`.

- Fix: #13160

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13299)
<!-- Reviewable:end -->
