### PR TITLE
chore(query): using Bitmap::new_constant to replace constant_bitmap and extend_constant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.4"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=6a4b531#6a4b53169a48cbd234cecde6ab6a98f84146fca2"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=3c61372#3c61372d7ac76bba149316b1fbad6e981752e502"
 dependencies = [
  "ahash 0.8.3",
  "arrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.4"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=dd80c89#dd80c891850213104c8c0d11b76b56401cb1ce52"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=6a4b531#6a4b53169a48cbd234cecde6ab6a98f84146fca2"
 dependencies = [
  "ahash 0.8.3",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ rpath = false
 [patch.crates-io]
 # If there are dependencies that need patching, they can be listed below.
 
-arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", rev = "6a4b531" }
+arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", rev = "3c61372" }
 arrow-format = { git = "https://github.com/everpcpc/arrow-format", rev = "588d371" }
 parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "b0e6545" }
 metrics = { git = "https://github.com/datafuse-extras/metrics.git", rev = "fc2ecd1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ rpath = false
 [patch.crates-io]
 # If there are dependencies that need patching, they can be listed below.
 
-arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", rev = "dd80c89" }
+arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", rev = "6a4b531" }
 arrow-format = { git = "https://github.com/everpcpc/arrow-format", rev = "588d371" }
 parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "b0e6545" }
 metrics = { git = "https://github.com/datafuse-extras/metrics.git", rev = "fc2ecd1" }

--- a/src/query/expression/src/utils/arrow.rs
+++ b/src/query/expression/src/utils/arrow.rs
@@ -53,12 +53,6 @@ pub fn append_bitmap(bitmap: &mut MutableBitmap, other: &Bitmap) {
     bitmap.extend_from_bitmap(other)
 }
 
-pub fn constant_bitmap(value: bool, len: usize) -> MutableBitmap {
-    let mut builder = MutableBitmap::new();
-    builder.extend_constant(len, value);
-    builder
-}
-
 pub fn buffer_into_mut<T: Clone>(mut buffer: Buffer<T>) -> Vec<T> {
     unsafe {
         buffer

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -75,7 +75,6 @@ use crate::types::*;
 use crate::utils::arrow::append_bitmap;
 use crate::utils::arrow::bitmap_into_mut;
 use crate::utils::arrow::buffer_into_mut;
-use crate::utils::arrow::constant_bitmap;
 use crate::utils::arrow::deserialize_column;
 use crate::utils::arrow::serialize_column;
 use crate::utils::FromData;
@@ -1626,11 +1625,10 @@ impl Column {
         };
 
         if is_nullable {
-            let validity = arrow_col.validity().cloned().unwrap_or_else(|| {
-                let mut validity = MutableBitmap::with_capacity(arrow_col.len());
-                validity.extend_constant(arrow_col.len(), true);
-                validity.into()
-            });
+            let validity = arrow_col
+                .validity()
+                .cloned()
+                .unwrap_or_else(|| Bitmap::new_constant(true, arrow_col.len()));
             Column::Nullable(Box::new(NullableColumn { column, validity }))
         } else {
             column
@@ -1774,11 +1772,7 @@ impl Column {
                 }))
             }
             _ => {
-                let validity = validity.unwrap_or_else(|| {
-                    let mut validity = MutableBitmap::with_capacity(self.len());
-                    validity.extend_constant(self.len(), true);
-                    validity.into()
-                });
+                let validity = validity.unwrap_or_else(|| Bitmap::new_constant(true, self.len()));
                 Column::Nullable(Box::new(NullableColumn {
                     column: self.clone(),
                     validity,
@@ -1935,7 +1929,7 @@ impl ColumnBuilder {
                 }
                 return ColumnBuilder::Nullable(Box::new(NullableColumnBuilder {
                     builder,
-                    validity: constant_bitmap(true, n),
+                    validity: Bitmap::new_constant(true, n).make_mut(),
                 }));
             }
         }
@@ -1950,7 +1944,7 @@ impl ColumnBuilder {
                     }
                     ColumnBuilder::Nullable(Box::new(NullableColumnBuilder {
                         builder,
-                        validity: constant_bitmap(false, n),
+                        validity: Bitmap::new_constant(false, n).make_mut(),
                     }))
                 }
                 _ => unreachable!(),
@@ -1961,7 +1955,7 @@ impl ColumnBuilder {
             ScalarRef::Decimal(dec) => {
                 ColumnBuilder::Decimal(DecimalColumnBuilder::repeat(*dec, n))
             }
-            ScalarRef::Boolean(b) => ColumnBuilder::Boolean(constant_bitmap(*b, n)),
+            ScalarRef::Boolean(b) => ColumnBuilder::Boolean(Bitmap::new_constant(*b, n).make_mut()),
             ScalarRef::String(s) => ColumnBuilder::String(StringColumnBuilder::repeat(s, n)),
             ScalarRef::Timestamp(d) => ColumnBuilder::Timestamp(vec![*d; n]),
             ScalarRef::Date(d) => ColumnBuilder::Date(vec![*d; n]),

--- a/src/query/formats/tests/it/output_format_utils.rs
+++ b/src/query/formats/tests/it/output_format_utils.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_arrow::arrow::bitmap::MutableBitmap;
+use common_arrow::arrow::bitmap::Bitmap;
 use common_expression::types::nullable::NullableColumn;
 use common_expression::types::number::Float64Type;
 use common_expression::types::number::Int32Type;
@@ -72,12 +72,11 @@ pub fn get_simple_block(is_nullable: bool) -> (TableSchemaRef, DataBlock) {
             .into_iter()
             .enumerate()
             .map(|(idx, (data_type, c))| {
-                let mut validity = MutableBitmap::new();
-                validity.extend_constant(c.len(), true);
+                let validity = Bitmap::new_constant(true, c.len());
                 (
                     Column::Nullable(Box::new(NullableColumn {
                         column: c,
-                        validity: validity.into(),
+                        validity,
                     })),
                     TableField::new(&format!("c{}", idx + 1), data_type.wrap_nullable()),
                 )

--- a/src/query/functions/src/scalars/arithmetic.rs
+++ b/src/query/functions/src/scalars/arithmetic.rs
@@ -19,6 +19,7 @@ use std::ops::BitOr;
 use std::ops::BitXor;
 use std::sync::Arc;
 
+use common_arrow::arrow::bitmap::Bitmap;
 use common_expression::types::decimal::Decimal;
 use common_expression::types::decimal::DecimalColumn;
 use common_expression::types::decimal::DecimalDomain;
@@ -44,7 +45,6 @@ use common_expression::types::ALL_NUMERICS_TYPES;
 use common_expression::types::ALL_UNSIGNED_INTEGER_TYPES;
 use common_expression::utils::arithmetics_type::ResultTypeOfBinary;
 use common_expression::utils::arithmetics_type::ResultTypeOfUnary;
-use common_expression::utils::arrow::constant_bitmap;
 use common_expression::values::Value;
 use common_expression::values::ValueRef;
 use common_expression::vectorize_1_arg;
@@ -885,7 +885,7 @@ pub fn register_number_to_string(registry: &mut FunctionRegistry) {
                             let result = builder.build();
                             Value::Column(NullableColumn {
                                 column: result,
-                                validity: constant_bitmap(true, from.len()).into(),
+                                validity: Bitmap::new_constant(true, from.len()),
                             })
                         }
                     },

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -18,6 +18,7 @@ use chrono::prelude::*;
 use chrono::Datelike;
 use chrono::Utc;
 use chrono_tz::Tz;
+use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::temporal_conversions::EPOCH_DAYS_FROM_CE;
 use common_expression::error_to_null;
 use common_expression::types::date::check_date;
@@ -45,7 +46,6 @@ use common_expression::types::NullableType;
 use common_expression::types::NumberType;
 use common_expression::types::StringType;
 use common_expression::types::TimestampType;
-use common_expression::utils::arrow::constant_bitmap;
 use common_expression::utils::date_helper::*;
 use common_expression::vectorize_1_arg;
 use common_expression::vectorize_2_arg;
@@ -531,7 +531,7 @@ fn register_to_number(registry: &mut FunctionRegistry) {
         |val, _| match val {
             ValueRef::Scalar(scalar) => Value::Scalar(Some(scalar as i64)),
             ValueRef::Column(col) => Value::Column(NullableColumn {
-                validity: constant_bitmap(true, col.len()).into(),
+                validity: Bitmap::new_constant(true, col.len()),
                 column: col.iter().map(|val| *val as i64).collect(),
             }),
         },
@@ -548,7 +548,7 @@ fn register_to_number(registry: &mut FunctionRegistry) {
         |val, _| match val {
             ValueRef::Scalar(scalar) => Value::Scalar(Some(scalar)),
             ValueRef::Column(col) => Value::Column(NullableColumn {
-                validity: constant_bitmap(true, col.len()).into(),
+                validity: Bitmap::new_constant(true, col.len()),
                 column: col,
             }),
         },

--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use bstr::ByteSlice;
 use chrono::Datelike;
+use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::temporal_conversions::EPOCH_DAYS_FROM_CE;
 use common_expression::types::date::string_to_date;
 use common_expression::types::nullable::NullableColumn;
@@ -38,7 +39,6 @@ use common_expression::types::StringType;
 use common_expression::types::TimestampType;
 use common_expression::types::VariantType;
 use common_expression::types::ALL_NUMERICS_TYPES;
-use common_expression::utils::arrow::constant_bitmap;
 use common_expression::vectorize_1_arg;
 use common_expression::vectorize_with_builder_1_arg;
 use common_expression::vectorize_with_builder_2_arg;
@@ -649,7 +649,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             ValueRef::Column(col) => {
                 let new_col = cast_scalars_to_variants(col.iter(), ctx.func_ctx.tz);
                 Value::Column(NullableColumn {
-                    validity: constant_bitmap(true, new_col.len()).into(),
+                    validity: Bitmap::new_constant(true, new_col.len()),
                     column: new_col,
                 })
             }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use common_arrow::arrow::bitmap::Bitmap;
-use common_arrow::arrow::bitmap::MutableBitmap;
 use common_base::base::tokio::sync::Barrier;
 use common_catalog::table_context::TableContext;
 use common_exception::ErrorCode;
@@ -168,9 +167,7 @@ impl HashJoinBuildState {
             self.hash_join_state.hash_join_desc.join_type,
             JoinType::Left | JoinType::LeftSingle | JoinType::Full
         ) {
-            let mut validity = MutableBitmap::new();
-            validity.extend_constant(data_block.num_rows(), true);
-            let validity: Bitmap = validity.into();
+            let validity = Bitmap::new_constant(true, data_block.num_rows());
             let nullable_columns = data_block
                 .columns()
                 .iter()

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::bitmap::MutableBitmap;
 use common_base::base::tokio::sync::Barrier;
 use common_catalog::table_context::TableContext;
@@ -216,9 +217,7 @@ impl HashJoinProbeState {
             for (col, _) in probe_keys.iter() {
                 let (is_all_null, tmp_valids) = col.validity();
                 if is_all_null {
-                    let mut m = MutableBitmap::with_capacity(input.num_rows());
-                    m.extend_constant(input.num_rows(), false);
-                    valids = Some(m.into());
+                    valids = Some(Bitmap::new_constant(false, input.num_rows()));
                     break;
                 } else {
                     valids = and_validities(valids, tmp_valids.cloned());

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use common_arrow::arrow::bitmap::Bitmap;
-use common_arrow::arrow::bitmap::MutableBitmap;
 use common_expression::FunctionContext;
 use common_hashtable::RowPtr;
 
@@ -52,9 +51,7 @@ impl ProbeState {
         has_string_column: bool,
         func_ctx: FunctionContext,
     ) -> Self {
-        let mut true_validity = MutableBitmap::new();
-        true_validity.extend_constant(max_block_size, true);
-        let true_validity: Bitmap = true_validity.into();
+        let true_validity = Bitmap::new_constant(true, max_block_size);
         let (row_state, row_state_indexes, probe_unmatched_indexes) = match &join_type {
             JoinType::Left | JoinType::LeftSingle | JoinType::Full => {
                 if with_conjunct {

--- a/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_arrow::arrow::bitmap::Bitmap;
 use common_arrow::arrow::bitmap::MutableBitmap;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -265,8 +266,7 @@ impl RangeJoinState {
             }
         }
         // Initialize bit_array
-        let mut bit_array = MutableBitmap::with_capacity(p_array.len());
-        bit_array.extend_constant(p_array.len(), false);
+        let bit_array = Bitmap::new_constant(false, p_array.len()).make_mut();
 
         let l2 = &merged_blocks.columns()[1].value.convert_to_full_column(
             self.conditions[0]

--- a/src/query/service/tests/it/servers/http/json_block.rs
+++ b/src/query/service/tests/it/servers/http/json_block.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_arrow::arrow::bitmap::MutableBitmap;
+use common_arrow::arrow::bitmap::Bitmap;
 use common_exception::Result;
 use common_expression::types::nullable::NullableColumn;
 use common_expression::types::number::Float64Type;
@@ -69,12 +69,9 @@ fn test_data_block(is_nullable: bool) -> Result<()> {
         columns = columns
             .iter()
             .map(|c| {
-                let mut validity = MutableBitmap::new();
-                validity.extend_constant(c.len(), true);
-
                 Column::Nullable(Box::new(NullableColumn {
                     column: c.clone(),
-                    validity: validity.into(),
+                    validity: Bitmap::new_constant(true, c.len()),
                 }))
             })
             .collect();

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/topk.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/topk.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 
 use common_arrow::arrow::bitmap::Bitmap;
-use common_arrow::arrow::bitmap::MutableBitmap;
 use common_catalog::plan::TopK;
 use common_exception::Result;
 use common_expression::Column;
@@ -63,8 +62,8 @@ impl ParquetTopK {
 
     pub fn evaluate_column(&self, column: &Column, sorter: &mut TopKSorter) -> Bitmap {
         let num_rows = column.len();
-        let mut bitmap = MutableBitmap::with_capacity(num_rows);
-        bitmap.extend_constant(num_rows, true);
+        let bitmap = Bitmap::new_constant(true, num_rows);
+        let mut bitmap = bitmap.make_mut();
         sorter.push_column(column, &mut bitmap);
         bitmap.into()
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

After adding `Bitmap::new_constant` in https://github.com/jorgecarleitao/arrow2/pull/1579, we can use it to replace `constant_bitmap` and `extend_constant`, which can avoid doing a bitcount when converting `MutableBitmap` to `Bitmap`.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13309)
<!-- Reviewable:end -->
