### PR TITLE
refactor: Remove the depends on settings from license check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,6 @@ version = "0.1.0"
 dependencies = [
  "common-base",
  "common-exception",
- "common-settings",
  "jwt-simple",
  "serde",
 ]

--- a/src/bendpy/src/lib.rs
+++ b/src/bendpy/src/lib.rs
@@ -57,7 +57,7 @@ fn databend(_py: Python, m: &PyModule) -> PyResult<()> {
         GlobalServices::init(conf.clone()).await.unwrap();
 
         // init oss license manager
-        OssLicenseManager::init().unwrap();
+        OssLicenseManager::init(conf.query.tenant_id.clone()).unwrap();
         ClusterDiscovery::instance()
             .register_to_metastore(&conf)
             .await

--- a/src/binaries/query/oss_main.rs
+++ b/src/binaries/query/oss_main.rs
@@ -53,6 +53,6 @@ async fn main_entrypoint() -> Result<()> {
     }
     init_services(&conf).await?;
     // init oss license manager
-    OssLicenseManager::init()?;
+    OssLicenseManager::init(conf.query.tenant_id.clone())?;
     start_services(&conf).await
 }

--- a/src/common/license/Cargo.toml
+++ b/src/common/license/Cargo.toml
@@ -14,6 +14,5 @@ test = false
 # Workspace dependencies
 common-base = { path = "../base" }
 common-exception = { path = "../exception" }
-common-settings = { path = "../../query/settings" }
 jwt-simple = "0.11.0"
 serde = { workspace = true }

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -214,4 +214,7 @@ pub trait TableContext: Send + Sync {
     fn add_file_status(&self, file_path: &str, file_status: FileStatus) -> Result<()>;
 
     fn get_copy_status(&self) -> Arc<CopyStatus>;
+
+    /// Get license key from context, return empty if license is not found or error happened.
+    fn get_license_key(&self) -> String;
 }

--- a/src/query/ee-features/table-lock/src/table_lock_handler.rs
+++ b/src/query/ee-features/table-lock/src/table_lock_handler.rs
@@ -70,19 +70,21 @@ impl TableLockHandlerWrapper {
 
         info!("Table lock enabled : [{}]", enabled_table_lock);
 
+        let dummy = Arc::new(TableLockHandlerWrapper::new(Box::new(DummyTableLock {})));
+
         if !enabled_table_lock {
             // dummy lock does nothing
-            return Arc::new(TableLockHandlerWrapper::new(Box::new(DummyTableLock {})));
+            return dummy;
         }
 
         let enterprise_enabled = get_license_manager()
             .manager
-            .check_enterprise_enabled(&ctx.get_settings(), ctx.get_tenant(), Feature::TableLock)
+            .check_enterprise_enabled(ctx.get_license_key(), Feature::TableLock)
             .is_ok();
         if enterprise_enabled {
             GlobalInstance::get()
         } else {
-            Arc::new(TableLockHandlerWrapper::new(Box::new(DummyTableLock {})))
+            dummy
         }
     }
 }

--- a/src/query/ee/Cargo.toml
+++ b/src/query/ee/Cargo.toml
@@ -29,7 +29,6 @@ common-meta-app = { path = "../../meta/app" }
 common-meta-kvapi = { path = "../../meta/kvapi" }
 common-meta-store = { path = "../../meta/store" }
 common-meta-types = { path = "../../meta/types" }
-common-settings = { path = "../../query/settings" }
 common-storages-fuse = { path = "../storages/fuse" }
 common-tracing = { path = "../../common/tracing" }
 common-users = { path = "../users" }

--- a/src/query/ee/src/background_service/background_service_handler.rs
+++ b/src/query/ee/src/background_service/background_service_handler.rs
@@ -267,8 +267,7 @@ impl RealBackgroundService {
             .get_settings();
         // check for valid license
         get_license_manager().manager.check_enterprise_enabled(
-            &settings,
-            self.conf.query.tenant_id.clone(),
+            settings.get_enterprise_license().unwrap_or_default(),
             Feature::BackgroundService,
         )
     }

--- a/src/query/ee/src/enterprise_services.rs
+++ b/src/query/ee/src/enterprise_services.rs
@@ -27,13 +27,13 @@ use crate::virtual_column::RealVirtualColumnHandler;
 pub struct EnterpriseServices;
 impl EnterpriseServices {
     #[async_backtrace::framed]
-    pub async fn init(_config: InnerConfig) -> Result<()> {
-        RealLicenseManager::init()?;
+    pub async fn init(cfg: InnerConfig) -> Result<()> {
+        RealLicenseManager::init(cfg.query.tenant_id.clone())?;
         RealVacuumHandler::init()?;
         RealAggregatingIndexHandler::init()?;
         RealTableLockHandler::init()?;
         RealDatamaskHandler::init()?;
-        RealBackgroundService::init(&_config).await?;
+        RealBackgroundService::init(&cfg).await?;
         RealVirtualColumnHandler::init()?;
         Ok(())
     }

--- a/src/query/ee/src/test_kits/mock_services.rs
+++ b/src/query/ee/src/test_kits/mock_services.rs
@@ -29,8 +29,8 @@ use crate::virtual_column::RealVirtualColumnHandler;
 pub struct MockServices;
 impl MockServices {
     #[async_backtrace::framed]
-    pub async fn init(_config: InnerConfig, public_key: String) -> Result<()> {
-        let rm = RealLicenseManager::new(public_key);
+    pub async fn init(cfg: InnerConfig, public_key: String) -> Result<()> {
+        let rm = RealLicenseManager::new(cfg.query.tenant_id.clone(), public_key);
         let wrapper = LicenseManagerWrapper {
             manager: Box::new(rm),
         };

--- a/src/query/ee/tests/it/license/license_mgr.rs
+++ b/src/query/ee/tests/it/license/license_mgr.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use common_base::base::tokio;
-use common_catalog::table_context::TableContext;
 use common_license::license::Feature;
 use common_license::license::LicenseInfo;
 use common_license::license_manager::LicenseManager;
@@ -41,10 +40,12 @@ fn build_custom_claims(
 #[tokio::test(flavor = "multi_thread")]
 async fn test_parse_license() -> common_exception::Result<()> {
     let fixture = TestFixture::new().await;
-    let ctx = fixture.ctx();
 
     let key_pair = ES256KeyPair::generate();
-    let license_mgr = RealLicenseManager::new(key_pair.public_key().to_pem().unwrap());
+    let license_mgr = RealLicenseManager::new(
+        fixture.default_tenant(),
+        key_pair.public_key().to_pem().unwrap(),
+    );
     let claims = Claims::with_custom_claims(
         build_custom_claims("trial".to_string(), "databend".to_string(), None),
         Duration::from_hours(2),
@@ -54,17 +55,15 @@ async fn test_parse_license() -> common_exception::Result<()> {
     let parsed = license_mgr.parse_license(token.as_str());
     assert!(parsed.is_ok());
 
-    let settings = ctx.get_settings();
-    settings.set_enterprise_license(token)?;
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::Test)
+            .check_enterprise_enabled(token.clone(), Feature::Test)
             .is_ok()
     );
     // test cache hit
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::Test)
+            .check_enterprise_enabled(token, Feature::Test)
             .is_ok()
     );
 
@@ -77,10 +76,9 @@ async fn test_parse_license() -> common_exception::Result<()> {
     let token = key_pair.sign(claims)?;
     let parsed = license_mgr.parse_license(token.as_str());
     assert!(parsed.is_err());
-    settings.set_enterprise_license(token)?;
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::Test)
+            .check_enterprise_enabled(token, Feature::Test)
             .is_err()
     );
 
@@ -90,10 +88,12 @@ async fn test_parse_license() -> common_exception::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_license_features() -> common_exception::Result<()> {
     let fixture = TestFixture::new().await;
-    let ctx = fixture.ctx();
 
     let key_pair = ES256KeyPair::generate();
-    let license_mgr = RealLicenseManager::new(key_pair.public_key().to_pem().unwrap());
+    let license_mgr = RealLicenseManager::new(
+        fixture.default_tenant(),
+        key_pair.public_key().to_pem().unwrap(),
+    );
     let claims = Claims::with_custom_claims(
         build_custom_claims(
             "trial".to_string(),
@@ -111,35 +111,32 @@ async fn test_license_features() -> common_exception::Result<()> {
     let parsed = license_mgr.parse_license(token.as_str());
     assert!(parsed.is_ok());
 
-    let settings = ctx.get_settings();
-    settings.set_enterprise_license(token)?;
-
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::ComputedColumn)
+            .check_enterprise_enabled(token.clone(), Feature::ComputedColumn)
             .is_err()
     );
 
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::LicenseInfo)
+            .check_enterprise_enabled(token.clone(), Feature::LicenseInfo)
             .is_ok()
     );
 
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::VirtualColumn)
+            .check_enterprise_enabled(token.clone(), Feature::VirtualColumn)
             .is_err()
     );
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::Test)
+            .check_enterprise_enabled(token.clone(), Feature::Test)
             .is_ok()
     );
 
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::Vacuum)
+            .check_enterprise_enabled(token, Feature::Vacuum)
             .is_ok()
     );
 
@@ -160,10 +157,9 @@ async fn test_license_features() -> common_exception::Result<()> {
     let token = key_pair.sign(claims)?;
     let parsed = license_mgr.parse_license(token.as_str());
     assert!(parsed.is_err());
-    settings.set_enterprise_license(token)?;
     assert!(
         license_mgr
-            .check_enterprise_enabled(&settings, ctx.get_tenant(), Feature::Test)
+            .check_enterprise_enabled(token, Feature::Test)
             .is_err()
     );
 

--- a/src/query/service/src/interpreters/interpreter_data_mask_create.rs
+++ b/src/query/service/src/interpreters/interpreter_data_mask_create.rs
@@ -46,11 +46,9 @@ impl Interpreter for CreateDataMaskInterpreter {
     #[async_backtrace::framed]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            Feature::DataMask,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), Feature::DataMask)?;
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let handler = get_datamask_handler();
         handler

--- a/src/query/service/src/interpreters/interpreter_data_mask_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_data_mask_desc.rs
@@ -51,11 +51,9 @@ impl Interpreter for DescDataMaskInterpreter {
     #[async_backtrace::framed]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            Feature::DataMask,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), Feature::DataMask)?;
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let handler = get_datamask_handler();
         let policy = handler

--- a/src/query/service/src/interpreters/interpreter_data_mask_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_data_mask_drop.rs
@@ -46,11 +46,9 @@ impl Interpreter for DropDataMaskInterpreter {
     #[async_backtrace::framed]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            Feature::DataMask,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), Feature::DataMask)?;
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let handler = get_datamask_handler();
         handler

--- a/src/query/service/src/interpreters/interpreter_index_create.rs
+++ b/src/query/service/src/interpreters/interpreter_index_create.rs
@@ -52,11 +52,9 @@ impl Interpreter for CreateIndexInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.ctx.get_tenant();
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            tenant.clone(),
-            Feature::AggregateIndex,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), Feature::AggregateIndex)?;
 
         let index_name = self.plan.index_name.clone();
         let catalog = self.ctx.get_current_catalog();

--- a/src/query/service/src/interpreters/interpreter_index_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_index_drop.rs
@@ -48,11 +48,9 @@ impl Interpreter for DropIndexInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.ctx.get_tenant();
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            tenant.clone(),
-            Feature::AggregateIndex,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), Feature::AggregateIndex)?;
 
         let index_name = self.plan.index.clone();
         let catalog = self

--- a/src/query/service/src/interpreters/interpreter_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_index_refresh.rs
@@ -218,11 +218,9 @@ impl Interpreter for RefreshIndexInterpreter {
     #[async_backtrace::framed]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            Feature::AggregateIndex,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), Feature::AggregateIndex)?;
         let (mut query_plan, output_schema, select_columns) = match self.plan.query_plan.as_ref() {
             Plan::Query {
                 s_expr,

--- a/src/query/service/src/interpreters/interpreter_table_add_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_add_column.rs
@@ -84,11 +84,9 @@ impl Interpreter for AddTableColumnInterpreter {
             let field = self.plan.field.clone();
             if field.computed_expr().is_some() {
                 let license_manager = get_license_manager();
-                license_manager.manager.check_enterprise_enabled(
-                    &self.ctx.get_settings(),
-                    self.plan.tenant.clone(),
-                    ComputedColumn,
-                )?;
+                license_manager
+                    .manager
+                    .check_enterprise_enabled(self.ctx.get_license_key(), ComputedColumn)?;
             }
 
             if field.default_expr().is_some() {

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -100,11 +100,9 @@ impl Interpreter for CreateTableInterpreter {
             .any(|f| f.computed_expr().is_some());
         if has_computed_column {
             let license_manager = get_license_manager();
-            license_manager.manager.check_enterprise_enabled(
-                &self.ctx.get_settings(),
-                tenant.clone(),
-                ComputedColumn,
-            )?;
+            license_manager
+                .manager
+                .check_enterprise_enabled(self.ctx.get_license_key(), ComputedColumn)?;
         }
 
         let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -76,11 +76,9 @@ impl ModifyTableColumnInterpreter {
         mask_name: String,
     ) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            DataMask,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), DataMask)?;
 
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let handler = get_datamask_handler();
@@ -145,11 +143,9 @@ impl ModifyTableColumnInterpreter {
         column: String,
     ) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            DataMask,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), DataMask)?;
 
         let table_info = table.get_table_info();
         let table_id = table_info.ident.table_id;
@@ -372,11 +368,9 @@ impl ModifyTableColumnInterpreter {
         column: String,
     ) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            ComputedColumn,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), ComputedColumn)?;
 
         let table_info = table.get_table_info();
         let schema = table.schema();

--- a/src/query/service/src/interpreters/interpreter_table_vacuum.rs
+++ b/src/query/service/src/interpreters/interpreter_table_vacuum.rs
@@ -49,11 +49,9 @@ impl Interpreter for VacuumTableInterpreter {
     #[async_backtrace::framed]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            Vacuum,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), Vacuum)?;
 
         let catalog_name = self.plan.catalog.clone();
         let db_name = self.plan.database.clone();

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -157,11 +157,9 @@ impl Interpreter for UpdateInterpreter {
 
         if !computed_list.is_empty() {
             let license_manager = get_license_manager();
-            license_manager.manager.check_enterprise_enabled(
-                &self.ctx.get_settings(),
-                self.ctx.get_tenant(),
-                ComputedColumn,
-            )?;
+            license_manager
+                .manager
+                .check_enterprise_enabled(self.ctx.get_license_key(), ComputedColumn)?;
         }
 
         // Add table lock heartbeat.

--- a/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
@@ -57,11 +57,9 @@ impl Interpreter for VacuumDropTablesInterpreter {
     #[async_backtrace::framed]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            self.ctx.get_tenant(),
-            Vacuum,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), Vacuum)?;
 
         let ctx = self.ctx.clone();
         let hours = match self.plan.option.retain_hours {

--- a/src/query/service/src/interpreters/interpreter_virtual_column_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_alter.rs
@@ -48,11 +48,9 @@ impl Interpreter for AlterVirtualColumnInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.ctx.get_tenant();
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            tenant.clone(),
-            VirtualColumn,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), VirtualColumn)?;
 
         let catalog_name = self.plan.catalog.clone();
         let db_name = self.plan.database.clone();

--- a/src/query/service/src/interpreters/interpreter_virtual_column_create.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_create.rs
@@ -48,11 +48,9 @@ impl Interpreter for CreateVirtualColumnInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.ctx.get_tenant();
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            tenant.clone(),
-            VirtualColumn,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), VirtualColumn)?;
 
         let catalog_name = self.plan.catalog.clone();
         let db_name = self.plan.database.clone();

--- a/src/query/service/src/interpreters/interpreter_virtual_column_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_drop.rs
@@ -48,11 +48,9 @@ impl Interpreter for DropVirtualColumnInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.ctx.get_tenant();
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            tenant.clone(),
-            VirtualColumn,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), VirtualColumn)?;
 
         let catalog_name = self.plan.catalog.clone();
         let db_name = self.plan.database.clone();

--- a/src/query/service/src/interpreters/interpreter_virtual_column_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_refresh.rs
@@ -48,11 +48,9 @@ impl Interpreter for RefreshVirtualColumnInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.ctx.get_tenant();
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &self.ctx.get_settings(),
-            tenant.clone(),
-            VirtualColumn,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), VirtualColumn)?;
 
         let catalog_name = self.plan.catalog.clone();
         let db_name = self.plan.database.clone();

--- a/src/query/service/src/local/mod.rs
+++ b/src/query/service/src/local/mod.rs
@@ -56,7 +56,7 @@ pub async fn query_local(query_sql: &str, output_format: &str) -> Result<()> {
 
     GlobalServices::init(conf.clone()).await?;
     // init oss license manager
-    OssLicenseManager::init().unwrap();
+    OssLicenseManager::init(conf.query.tenant_id.clone()).unwrap();
 
     // Cluster register.
     ClusterDiscovery::instance()

--- a/src/query/service/src/pipelines/processors/transforms/transform_add_computed_columns.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_add_computed_columns.rs
@@ -50,11 +50,9 @@ where Self: Transform
         output_schema: DataSchemaRef,
     ) -> Result<ProcessorPtr> {
         let license_manager = get_license_manager();
-        license_manager.manager.check_enterprise_enabled(
-            &ctx.get_settings(),
-            ctx.get_tenant(),
-            ComputedColumn,
-        )?;
+        license_manager
+            .manager
+            .check_enterprise_enabled(ctx.get_license_key(), ComputedColumn)?;
 
         let mut exprs = Vec::with_capacity(output_schema.fields().len());
         for f in output_schema.fields().iter() {

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -784,6 +784,12 @@ impl TableContext for QueryContext {
     fn get_copy_status(&self) -> Arc<CopyStatus> {
         self.shared.copy_status.clone()
     }
+
+    fn get_license_key(&self) -> String {
+        self.get_settings()
+            .get_enterprise_license()
+            .unwrap_or_default()
+    }
 }
 
 impl TrySpawn for QueryContext {

--- a/src/query/service/src/table_functions/others/license_info.rs
+++ b/src/query/service/src/table_functions/others/license_info.rs
@@ -234,11 +234,9 @@ impl AsyncSource for LicenseInfoSource {
                 format!("failed to get license for {}", self.ctx.get_tenant())
             })?;
 
-        get_license_manager().manager.check_enterprise_enabled(
-            &settings,
-            self.ctx.get_tenant(),
-            Feature::LicenseInfo,
-        )?;
+        get_license_manager()
+            .manager
+            .check_enterprise_enabled(license.clone(), Feature::LicenseInfo)?;
 
         let info = get_license_manager()
             .manager

--- a/src/query/service/src/table_functions/others/suggested_background_tasks.rs
+++ b/src/query/service/src/table_functions/others/suggested_background_tasks.rs
@@ -254,11 +254,9 @@ impl AsyncSource for SuggestedBackgroundTasksSource {
 
         let ctx = self.ctx.as_any().downcast_ref::<QueryContext>().unwrap();
         let license_mgr = get_license_manager();
-        license_mgr.manager.check_enterprise_enabled(
-            &ctx.get_settings(),
-            ctx.get_tenant(),
-            Feature::BackgroundService,
-        )?;
+        license_mgr
+            .manager
+            .check_enterprise_enabled(ctx.get_license_key(), Feature::BackgroundService)?;
 
         let suggestions = Self::all_suggestions(Arc::new(ctx.clone())).await?;
         Ok(Some(self.to_block(suggestions)?))

--- a/src/query/service/src/test_kits/sessions.rs
+++ b/src/query/service/src/test_kits/sessions.rs
@@ -42,7 +42,7 @@ impl TestGlobalServices {
         common_base::base::GlobalInstance::init_testing(&thread_name);
 
         GlobalServices::init_with(config.clone()).await?;
-        OssLicenseManager::init()?;
+        OssLicenseManager::init(config.query.tenant_id.clone())?;
 
         // Cluster register.
         {

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -642,6 +642,10 @@ impl TableContext for CtxDelegation {
     fn get_copy_status(&self) -> Arc<CopyStatus> {
         todo!()
     }
+
+    fn get_license_key(&self) -> String {
+        todo!()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/query/sql/src/executor/table_read_plan.rs
+++ b/src/query/sql/src/executor/table_read_plan.rs
@@ -170,11 +170,9 @@ impl ToReadDataSourcePlan for dyn Table {
 
             if let Some(column_mask_policy) = &table_meta.column_mask_policy {
                 let license_manager = get_license_manager();
-                let ret = license_manager.manager.check_enterprise_enabled(
-                    &ctx.get_settings(),
-                    tenant.clone(),
-                    DataMask,
-                );
+                let ret = license_manager
+                    .manager
+                    .check_enterprise_enabled(ctx.get_license_key(), DataMask);
                 if ret.is_err() {
                     None
                 } else {

--- a/src/query/sql/src/planner/binder/ddl/index.rs
+++ b/src/query/sql/src/planner/binder/ddl/index.rs
@@ -103,11 +103,7 @@ impl Binder {
                 let license_manager = get_license_manager();
                 if license_manager
                     .manager
-                    .check_enterprise_enabled(
-                        &self.ctx.get_settings(),
-                        self.ctx.get_tenant(),
-                        AggregateIndex,
-                    )
+                    .check_enterprise_enabled(self.ctx.get_license_key(), AggregateIndex)
                     .is_ok()
                 {
                     let indexes = self

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -3200,11 +3200,7 @@ impl<'a> TypeChecker<'a> {
         let license_manager = get_license_manager();
         if license_manager
             .manager
-            .check_enterprise_enabled(
-                &self.ctx.get_settings(),
-                self.ctx.get_tenant(),
-                VirtualColumn,
-            )
+            .check_enterprise_enabled(self.ctx.get_license_key(), VirtualColumn)
             .is_err()
         {
             return None;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR will remove the depends on settings from license check.

## Notews

`common-settings` heavily relies on `common-config` and `common-meta-app`. This dependency creates a cycle for `Settings`. This will block `common-storage` to depend on `common-license`.

This PR resolves this issue by directly passing the license key instead of accepting an `Arc<Settings>`. Additionally, since our license check doesn't utilize the `tenant` (it's only used for logging), I've removed it as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13343)
<!-- Reviewable:end -->
