### PR TITLE
chore: add a global node_id to config

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1563,6 +1563,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
         Ok(InnerQueryConfig {
             tenant_id: self.tenant_id,
             cluster_id: self.cluster_id,
+            node_id: "".to_string(),
             num_cpus: self.num_cpus,
             mysql_handler_host: self.mysql_handler_host,
             mysql_handler_port: self.mysql_handler_port,
@@ -2375,7 +2376,6 @@ pub struct DiskCacheConfig {
 }
 
 mod cache_config_converters {
-    use common_base::base::GlobalUniqName;
     use log::warn;
 
     use super::*;
@@ -2431,7 +2431,6 @@ mod cache_config_converters {
                 catalogs,
                 cache: self.cache.try_into()?,
                 background: self.background.try_into()?,
-                node_id: GlobalUniqName::unique(),
             })
         }
     }

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -2375,6 +2375,7 @@ pub struct DiskCacheConfig {
 }
 
 mod cache_config_converters {
+    use common_base::base::GlobalUniqName;
     use log::warn;
 
     use super::*;
@@ -2430,6 +2431,7 @@ mod cache_config_converters {
                 catalogs,
                 cache: self.cache.try_into()?,
                 background: self.background.try_into()?,
+                node_id: GlobalUniqName::unique(),
             })
         }
     }

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -64,9 +64,6 @@ pub struct InnerConfig {
 
     // Background Config
     pub background: InnerBackgroundConfig,
-
-    // UUID node id, this is not configurable.
-    pub node_id: String,
 }
 
 impl InnerConfig {
@@ -76,6 +73,9 @@ impl InnerConfig {
     pub async fn load() -> Result<Self> {
         let mut cfg: Self = Config::load(true)?.try_into()?;
 
+        // Handle the node_id for query node.
+        cfg.query.node_id = GlobalUniqName::unique();
+
         // Handle auto detect for storage params.
         cfg.storage.params = cfg.storage.params.auto_detect().await;
 
@@ -83,9 +83,6 @@ impl InnerConfig {
         if cfg.subcommand.is_none() {
             cfg.meta.check_valid()?;
         }
-
-        // UUID.
-        cfg.node_id = GlobalUniqName::unique();
         Ok(cfg)
     }
 
@@ -152,6 +149,9 @@ pub struct QueryConfig {
     pub tenant_id: String,
     /// ID for construct the cluster.
     pub cluster_id: String,
+    // ID for the query node.
+    // This only initialized when InnerConfig.load().
+    pub node_id: String,
     pub num_cpus: u64,
     pub mysql_handler_host: String,
     pub mysql_handler_port: u16,
@@ -228,6 +228,7 @@ impl Default for QueryConfig {
         Self {
             tenant_id: "admin".to_string(),
             cluster_id: "".to_string(),
+            node_id: "".to_string(),
             num_cpus: 0,
             mysql_handler_host: "127.0.0.1".to_string(),
             mysql_handler_port: 3307,

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use common_base::base::mask_string;
+use common_base::base::GlobalUniqName;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_grpc::RpcClientConf;
@@ -63,6 +64,9 @@ pub struct InnerConfig {
 
     // Background Config
     pub background: InnerBackgroundConfig,
+
+    // UUID node id, this is not configurable.
+    pub node_id: String,
 }
 
 impl InnerConfig {
@@ -79,6 +83,9 @@ impl InnerConfig {
         if cfg.subcommand.is_none() {
             cfg.meta.check_valid()?;
         }
+
+        // UUID.
+        cfg.node_id = GlobalUniqName::unique();
         Ok(cfg)
     }
 

--- a/src/query/service/src/clusters/cluster.rs
+++ b/src/query/service/src/clusters/cluster.rs
@@ -29,7 +29,6 @@ use common_base::base::tokio::task::JoinHandle;
 use common_base::base::tokio::time::sleep as tokio_async_sleep;
 use common_base::base::DummySignalStream;
 use common_base::base::GlobalInstance;
-use common_base::base::GlobalUniqName;
 use common_base::base::SignalStream;
 use common_base::base::SignalType;
 pub use common_catalog::cluster_info::Cluster;
@@ -165,7 +164,7 @@ impl ClusterDiscovery {
         let (lift_time, provider) = Self::create_provider(cfg, metastore)?;
 
         Ok(Arc::new(ClusterDiscovery {
-            local_id: GlobalUniqName::unique(),
+            local_id: cfg.node_id.clone(),
             api_provider: provider.clone(),
             heartbeat: Mutex::new(ClusterHeartbeat::create(
                 lift_time,

--- a/src/query/service/src/clusters/cluster.rs
+++ b/src/query/service/src/clusters/cluster.rs
@@ -164,7 +164,7 @@ impl ClusterDiscovery {
         let (lift_time, provider) = Self::create_provider(cfg, metastore)?;
 
         Ok(Arc::new(ClusterDiscovery {
-            local_id: cfg.node_id.clone(),
+            local_id: cfg.query.node_id.clone(),
             api_provider: provider.clone(),
             heartbeat: Mutex::new(ClusterHeartbeat::create(
                 lift_time,

--- a/src/query/service/src/global_services.rs
+++ b/src/query/service/src/global_services.rs
@@ -54,7 +54,7 @@ impl GlobalServices {
     pub async fn init_with(config: InnerConfig) -> Result<()> {
         let app_name_shuffle = format!(
             "databend-query@{}-{}",
-            config.node_id, config.query.cluster_id
+            config.query.node_id, config.query.cluster_id
         );
 
         // The order of initialization is very important

--- a/src/query/service/src/global_services.rs
+++ b/src/query/service/src/global_services.rs
@@ -52,16 +52,23 @@ impl GlobalServices {
 
     #[async_backtrace::framed]
     pub async fn init_with(config: InnerConfig) -> Result<()> {
+        let app_name_shuffle = format!(
+            "databend-query@{}-{}",
+            config.node_id, config.query.cluster_id
+        );
+
         // The order of initialization is very important
+        // 1. global config init.
         GlobalConfig::init(config.clone())?;
 
-        let app_name_shuffle = format!("{}-{}", config.query.tenant_id, config.query.cluster_id);
-
+        // 2. log init.
         GlobalLogger::init(&app_name_shuffle, &config.log);
+
+        // 3. runtime init.
         GlobalIORuntime::init(config.storage.num_cpus as usize)?;
         GlobalQueryRuntime::init(config.storage.num_cpus as usize)?;
 
-        // Cluster discovery.
+        // 4. cluster discovery init.
         ClusterDiscovery::init(config.clone()).await?;
 
         // TODO(xuanwo):

--- a/src/query/service/src/test_kits/config.rs
+++ b/src/query/service/src/test_kits/config.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use common_base::base::GlobalUniqName;
 use common_config::InnerConfig;
 use common_meta_app::principal::AuthInfo;
 use common_users::idm_config::IDMConfig;
@@ -31,6 +32,9 @@ impl ConfigBuilder {
         let mut users = HashMap::new();
         users.insert("root".to_string(), AuthInfo::None);
         conf.query.idm = IDMConfig { users };
+
+        // set node_id to a unique value
+        conf.query.node_id = GlobalUniqName::unique();
 
         ConfigBuilder { conf }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* add a `node_id` to `InnerConfig.Query` for global using, now only cluster use the node_id
* prepare for https://github.com/datafuselabs/databend/pull/13381, tracing name will use node_id

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13391)
<!-- Reviewable:end -->
