### PR TITLE
fix(docs): scroll bar flickering with search modal input(#13395)

### DIFF
--- a/website/src/components/BaseComponents/CommonModal/index.tsx
+++ b/website/src/components/BaseComponents/CommonModal/index.tsx
@@ -12,12 +12,7 @@ interface IProps {
 const CommonModal = ({ visible, width, children, className, onClose }: IProps) => {
   useEffect(() => {
     if (visible) {
-      const id = setTimeout(()=> {
-        document.body.style.overflow = 'hidden';
-        clearTimeout(id);
-      });
-    } else {
-      document.body.style.overflow = 'visible';
+      document.body.style.overflow = 'hidden';
     }
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

When the search modal opened, hide webpage scroll bar.
When the search modal closed, show the webpage scroll bar.

- Closes #13395

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13396)
<!-- Reviewable:end -->
