### PR TITLE
feat(planner): improve outer join elimination

### DIFF
--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -150,7 +150,7 @@ pub struct QueryConfig {
     /// ID for construct the cluster.
     pub cluster_id: String,
     // ID for the query node.
-    // This only initialized when InnerConfig.load().
+    // This only initialized when InnerConfig::load().
     pub node_id: String,
     pub num_cpus: u64,
     pub mysql_handler_host: String,

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -1412,7 +1412,7 @@ impl Binder {
         let mut cluster_keys = Vec::with_capacity(cluster_by.len());
         for cluster_by in cluster_by.iter() {
             let (cluster_key, _) = scalar_binder.bind(cluster_by).await?;
-            if cluster_key.used_columns().len() != 1 || !cluster_key.valid_for_clustering() {
+            if cluster_key.used_columns().len() != 1 || !cluster_key.evaluable() {
                 return Err(ErrorCode::InvalidClusterKeys(format!(
                     "Cluster by expression `{:#}` is invalid",
                     cluster_by

--- a/src/query/sql/src/planner/optimizer/property/constraint.rs
+++ b/src/query/sql/src/planner/optimizer/property/constraint.rs
@@ -154,6 +154,7 @@ pub fn as_mir(scalar: &ScalarExpr) -> Option<MirExpr> {
                 }
                 Scalar::Boolean(value) => MirConstant::Bool(*value),
                 Scalar::Null => MirConstant::Null,
+                Scalar::Timestamp(value) => MirConstant::Int(*value),
                 _ => return None,
             };
             Some(MirExpr::Constant(value))
@@ -163,6 +164,7 @@ pub fn as_mir(scalar: &ScalarExpr) -> Option<MirExpr> {
             let data_type = match column_ref.column.data_type.remove_nullable() {
                 DataType::Boolean => MirDataType::Bool,
                 DataType::Number(num_ty) if num_ty.is_integer() => MirDataType::Int,
+                DataType::Timestamp => MirDataType::Int,
                 _ => return None,
             };
             Some(MirExpr::Variable { name, data_type })

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -167,20 +167,17 @@ impl ScalarExpr {
         }
     }
 
-    pub fn valid_for_clustering(&self) -> bool {
+    /// Returns true if the expression can be evaluated from a row of data.
+    pub fn evaluable(&self) -> bool {
         match self {
             ScalarExpr::BoundColumnRef(_) | ScalarExpr::ConstantExpr(_) => true,
             ScalarExpr::WindowFunction(_)
             | ScalarExpr::AggregateFunction(_)
             | ScalarExpr::SubqueryExpr(_)
             | ScalarExpr::UDFServerCall(_) => false,
-            ScalarExpr::FunctionCall(func) => {
-                func.arguments.iter().all(|arg| arg.valid_for_clustering())
-            }
-            ScalarExpr::LambdaFunction(func) => {
-                func.args.iter().all(|arg| arg.valid_for_clustering())
-            }
-            ScalarExpr::CastExpr(expr) => expr.argument.valid_for_clustering(),
+            ScalarExpr::FunctionCall(func) => func.arguments.iter().all(|arg| arg.evaluable()),
+            ScalarExpr::LambdaFunction(func) => func.args.iter().all(|arg| arg.evaluable()),
+            ScalarExpr::CastExpr(expr) => expr.argument.evaluable(),
         }
     }
 }

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1817,6 +1817,30 @@ impl<'a> TypeChecker<'a> {
         };
         let expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS)?;
 
+        // Run constant folding for arguments of the scalar function.
+        // This will be helpful to simplify some constant expressions, especially
+        // the implicitly casted literal values, e.g. `timestamp > '2001-01-01'`
+        // will be folded from `timestamp > to_timestamp('2001-01-01')` to `timestamp > 978307200000000`
+        let folded_args = match &expr {
+            common_expression::Expr::FunctionCall {
+                args: checked_args, ..
+            } => {
+                let mut folded_args = Vec::with_capacity(args.len());
+                for (checked_arg, arg) in checked_args.iter().zip(args.iter()) {
+                    match self.try_fold_constant(checked_arg) {
+                        Some(constant) if arg.evaluable() => {
+                            folded_args.push(constant.0);
+                        }
+                        _ => {
+                            folded_args.push(arg.clone());
+                        }
+                    }
+                }
+                folded_args
+            }
+            _ => args,
+        };
+
         if !expr.is_deterministic(&BUILTIN_FUNCTIONS) {
             self.ctx.set_cacheable(false);
         }
@@ -1829,7 +1853,7 @@ impl<'a> TypeChecker<'a> {
             FunctionCall {
                 span,
                 params,
-                arguments: args,
+                arguments: folded_args,
                 func_name: func_name.to_string(),
             }
             .into(),

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -639,4 +639,46 @@ Filter
         └── estimated rows: 10.00
 
 statement ok
+create table time_table(a timestamp)
+
+query T
+explain select * from time_table t left join time_table t1 on t.a = t1.a where t1.a > '2001-01-01'
+----
+HashJoin
+├── output columns: [t.a (#0), t1.a (#1)]
+├── join type: INNER
+├── build keys: [t1.a (#1)]
+├── probe keys: [t.a (#0)]
+├── filters: []
+├── estimated rows: 0.00
+├── Filter(Build)
+│   ├── output columns: [t1.a (#1)]
+│   ├── filters: [is_true(t1.a (#1) > '2001-01-01 00:00:00.000000')]
+│   ├── estimated rows: 0.00
+│   └── TableScan
+│       ├── table: default.eliminate_outer_join.time_table
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 0
+│       ├── read bytes: 0
+│       ├── partitions total: 0
+│       ├── partitions scanned: 0
+│       ├── push downs: [filters: [is_true(t1.a (#1) > '2001-01-01 00:00:00.000000')], limit: NONE]
+│       └── estimated rows: 0.00
+└── Filter(Probe)
+    ├── output columns: [t.a (#0)]
+    ├── filters: [is_true(t.a (#0) > '2001-01-01 00:00:00.000000')]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.eliminate_outer_join.time_table
+        ├── output columns: [a (#0)]
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [is_true(t.a (#0) > '2001-01-01 00:00:00.000000')], limit: NONE]
+        └── estimated rows: 0.00
+
+
+
+statement ok
 drop database eliminate_outer_join


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support eliminating outer join with filter using timestamp comparison, e.g. `updated_at > '2023-01-01'`.

Part of #13236

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13397)
<!-- Reviewable:end -->
