### PR TITLE
fix(query): check port used for rpc and flightsql servers

### DIFF
--- a/src/query/service/tests/it/api/rpc_service.rs
+++ b/src/query/service/tests/it/api/rpc_service.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::net::TcpListener;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -101,5 +102,21 @@ async fn test_tls_rpc_server_invalid_client_config() -> Result<()> {
         }
         _ => unimplemented!("expect TLSConfigError"),
     }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_rpc_server_port_used() -> Result<()> {
+    let listener = TcpListener::bind("0.0.0.0:0").unwrap();
+    let local_socket = listener.local_addr().unwrap();
+
+    let mut srv = RpcService {
+        config: ConfigBuilder::create().build(),
+        abort_notify: Arc::new(Default::default()),
+    };
+
+    let r = srv.start_with_incoming(local_socket).await;
+
+    assert!(r.is_err());
     Ok(())
 }

--- a/src/query/service/tests/it/servers/flight_sql/flight_sql_server.rs
+++ b/src/query/service/tests/it/servers/flight_sql/flight_sql_server.rs
@@ -1,0 +1,37 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::TcpListener;
+use std::sync::Arc;
+
+use common_base::base::tokio;
+use common_exception::Result;
+use databend_query::servers::FlightSQLServer;
+use databend_query::test_kits::ConfigBuilder;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_flight_sql_server_port_used() -> Result<()> {
+    let listener = TcpListener::bind("0.0.0.0:0").unwrap();
+    let local_socket = listener.local_addr().unwrap();
+
+    let mut srv = FlightSQLServer {
+        config: ConfigBuilder::create().build(),
+        abort_notify: Arc::new(Default::default()),
+    };
+
+    let r = srv.start_with_incoming(local_socket).await;
+
+    assert!(r.is_err());
+    Ok(())
+}

--- a/src/query/service/tests/it/servers/flight_sql/mod.rs
+++ b/src/query/service/tests/it/servers/flight_sql/mod.rs
@@ -15,3 +15,4 @@
 // The servers module used for external communication with user, such as MySQL wired protocol, etc.
 
 mod flight_sql_handler;
+mod flight_sql_server;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(query): check port used for rpc and flightsql servers

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13398)
<!-- Reviewable:end -->
