### PR TITLE
chore: max the OTLP reporter to 2 threads

### DIFF
--- a/src/common/tracing/src/minitrace.rs
+++ b/src/common/tracing/src/minitrace.rs
@@ -81,7 +81,11 @@ pub fn init_logging(name: &str, cfg: &Config) -> Vec<Box<dyn Drop + Send + Sync 
         let otlp_endpoint = cfg.tracing.otlp_endpoint.clone();
 
         let (reporter_rt, otlp_reporter) = std::thread::spawn(|| {
-            let rt = tokio::runtime::Runtime::new().unwrap();
+            // Init runtime with 2 threads.
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .build()
+                .unwrap();
             let reporter = rt.block_on(async {
                 minitrace_opentelemetry::OpenTelemetryReporter::new(
                     opentelemetry_otlp::SpanExporter::new_tonic(

--- a/src/query/service/src/global_services.rs
+++ b/src/query/service/src/global_services.rs
@@ -52,9 +52,15 @@ impl GlobalServices {
 
     #[async_backtrace::framed]
     pub async fn init_with(config: InnerConfig) -> Result<()> {
+        // app name format: node_id[0..7]@cluster_id
         let app_name_shuffle = format!(
-            "databend-query@{}-{}",
-            config.query.node_id, config.query.cluster_id
+            "databend-query-{}@{}",
+            if config.query.node_id.len() >= 7 {
+                &config.query.node_id[0..7]
+            } else {
+                &config.query.node_id
+            },
+            config.query.cluster_id
         );
 
         // The order of initialization is very important


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* make the otlp worker threads max to 2
* `databend-query@CoI7y371WDDNFwrCCY4JN5-default` to `databend-query-CoI7y37@default` for short

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13402)
<!-- Reviewable:end -->
