### PR TITLE
ci: add build_linux_sanitizer

### DIFF
--- a/.github/actions/build_linux_sanitizer/action.yml
+++ b/.github/actions/build_linux_sanitizer/action.yml
@@ -1,0 +1,73 @@
+name: "Build Linux with AddressSanitizer"
+description: "Build with AddressSanitizer"
+inputs:
+  sha:
+    description: "Git commit sha"
+    required: true
+  target:
+    description: ""
+    required: true
+  upload:
+    description: "Upload artifact"
+    required: false
+    default: "false"
+  artifacts:
+    description: "Artifacts to build"
+    required: false
+    default: "meta,query"
+  features:
+    description: "Features to build"
+    required: false
+    default: "default"
+  category:
+    description: "Category to upload"
+    required: false
+    default: "false"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Build Tool
+      uses: ./.github/actions/setup_build_tool
+      with:
+        target: ${{ inputs.target }}
+        bypass_env_vars: RUSTFLAGS,RUST_LOG
+
+    - name: Cross setup
+      if: startsWith(inputs.target, 'aarch64-')
+      shell: bash
+      run: |
+        echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
+
+    - name: Set Build Flags
+      shell: bash
+      run: |
+        case ${{ inputs.target }} in
+          x86_64-unknown-linux-gnu)
+            flags="-Z sanitizer=address"
+            ;;
+          aarch64-unknown-linux-gnu)
+            flags="-Z sanitizer=address"
+            ;;
+          *)
+            flags=""
+            ;;
+        esac
+        echo "RUSTFLAGS=${flags} -C link-arg=-Wl,--compress-debug-sections=zlib" >> $GITHUB_ENV
+        target=${{ inputs.target }}
+        echo "BUILD_ARCH=${target/-unknown-linux-*}" >> $GITHUB_ENV
+
+    # build all binaries for debug
+    - name: Build Debug
+      if: env.BUILD_PROFILE == 'debug' && endsWith(inputs.target, '-gnu')
+      shell: bash
+      run: |
+        artifacts="meta,metactl,query"
+        for artifact in ${artifacts//,/ }; do
+          echo "==> building databend-$artifact with sanitizer ..."
+          cargo -Zbuild-std -Zgitoxide=fetch,shallow-index,shallow-deps build --target ${{ inputs.target }} --features ${{ inputs.features }} --bin databend-$artifact
+        done
+        cargo -Zbuild-std -Zgitoxide=fetch,shallow-index,shallow-deps build --target ${{ inputs.target }} --features ${{ inputs.features }} --bin open-sharing
+        ls -lh ./target/${{ inputs.target }}/${{ env.BUILD_PROFILE }}/databend-*
+
+    - shell: bash
+      run: readelf -p .comment ./target/${{ inputs.target }}/${{ env.BUILD_PROFILE }}/databend-query

--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           sha: ${{ github.sha }}
           target: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
-          artifacts: all
+          artifacts: query
 
   build_other:
     name: build_${{ matrix.arch }}_${{ matrix.libc }}

--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -72,6 +72,26 @@ jobs:
           target: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
           artifacts: all
 
+  build_address_sanitizer:
+    name: build_${{ matrix.arch }}_${{ matrix.libc }}_asan
+    runs-on: [ self-hosted, X64, Linux, 16c32g, "${{ inputs.runner_provider }}" ]
+    strategy:
+      matrix:
+        include:
+          - { arch: x86_64, libc: gnu }
+          - { arch: aarch64, libc: gnu }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # fetch all tags, metasrv and metaclient need tag as its version.
+          fetch-depth: 0
+      - uses: ./.github/actions/build_linux_sanitizer
+        timeout-minutes: 60
+        with:
+          sha: ${{ github.sha }}
+          target: ${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}
+          artifacts: all
+
   build_other:
     name: build_${{ matrix.arch }}_${{ matrix.libc }}
     runs-on: [self-hosted, X64, Linux, 8c16g, "${{ inputs.runner_provider }}"]

--- a/src/common/arrow/src/lib.rs
+++ b/src/common/arrow/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(unused_crate_dependencies)]
-
 mod parquet_read;
 mod parquet_write;
 pub mod schema_projection;

--- a/src/common/compress/src/lib.rs
+++ b/src/common/compress/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(unused_crate_dependencies)]
-
 //! This mod provides compress support for BytesWrite and decompress support for BytesRead.
 
 mod compress_algorithms;

--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -14,7 +14,6 @@
 
 #![feature(try_blocks)]
 #![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
 
 mod config;
 mod minitrace;

--- a/src/meta/api/src/lib.rs
+++ b/src/meta/api/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
 #![allow(clippy::diverging_sub_expression)]
 extern crate common_meta_types;
 

--- a/src/meta/app/src/lib.rs
+++ b/src/meta/app/src/lib.rs
@@ -19,7 +19,6 @@
 //! But instead, they are used by the caller of meta-client, e.g, databend-query.
 
 #![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
 #![feature(no_sanitize)]
 
 pub mod app_error;

--- a/src/meta/kvapi/src/lib.rs
+++ b/src/meta/kvapi/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
 
 #[macro_export]
 macro_rules! func_name {

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(unused_crate_dependencies)]
-
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;

--- a/src/query/pipeline/sources/src/lib.rs
+++ b/src/query/pipeline/sources/src/lib.rs
@@ -14,7 +14,6 @@
 
 #![feature(type_alias_impl_trait)]
 #![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(cursor_remaining)]
 #![allow(clippy::diverging_sub_expression)]

--- a/src/query/pipeline/transforms/src/lib.rs
+++ b/src/query/pipeline/transforms/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(unused_crate_dependencies)]
 #![feature(core_intrinsics)]
 #![feature(int_roundings)]
 #![feature(binary_heap_as_slice)]

--- a/src/query/storages/common/cache-manager/src/lib.rs
+++ b/src/query/storages/common/cache-manager/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
 
 mod cache_manager;
 mod caches;

--- a/src/query/storages/common/pruner/src/lib.rs
+++ b/src/query/storages/common/pruner/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
 
 mod block_meta;
 mod internal_column_pruner;

--- a/src/query/storages/hive/hive/src/lib.rs
+++ b/src/query/storages/hive/hive/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![allow(clippy::uninlined_format_args)]
-#![deny(unused_crate_dependencies)]
 #![allow(clippy::diverging_sub_expression)]
 
 mod converters;

--- a/src/query/storages/result_cache/src/lib.rs
+++ b/src/query/storages/result_cache/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![feature(type_alias_impl_trait)]
-#![deny(unused_crate_dependencies)]
 #![feature(impl_trait_in_assoc_type)]
 
 mod common;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add build_linux_sanitizer with AddressSanitizer to check memory safety.

**NOTE:** compile with sanitizer will inject crates to codes, so we need delete `#![deny(unused_crate_dependencies)]` in some codes.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13416)
<!-- Reviewable:end -->
