### PR TITLE
refactor: adjust syntax of select from uri.

### DIFF
--- a/src/query/ast/src/ast/ast.rs
+++ b/src/query/ast/src/ast/ast.rs
@@ -136,21 +136,7 @@ pub(crate) fn write_comma_separated_map(
         if i > 0 {
             write!(f, ", ")?;
         }
-        write!(f, "{k}='{v}'")?;
-    }
-    Ok(())
-}
-
-/// Write input map items into `field_a=>x, field_b=>y`
-pub(crate) fn write_comma_separated_arrow_map(
-    f: &mut Formatter<'_>,
-    items: impl IntoIterator<Item = (impl Display, impl Display)>,
-) -> std::fmt::Result {
-    for (i, (k, v)) in items.into_iter().enumerate() {
-        if i > 0 {
-            write!(f, ", ")?;
-        }
-        write!(f, "{k}=>'{v}'")?;
+        write!(f, "{k} = '{v}'")?;
     }
     Ok(())
 }

--- a/src/query/ast/src/ast/statements/stage.rs
+++ b/src/query/ast/src/ast/statements/stage.rs
@@ -17,7 +17,6 @@ use std::default::Default;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
-use crate::ast::write_comma_separated_arrow_map;
 use crate::ast::write_comma_separated_map;
 use crate::ast::write_comma_separated_quoted_list;
 use crate::ast::UriLocation;
@@ -80,7 +79,7 @@ pub enum SelectStageOption {
     Files(Vec<String>),
     Pattern(String),
     FileFormat(String),
-    Connection((String, String)),
+    Connection(BTreeMap<String, String>),
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -133,7 +132,11 @@ impl Display for SelectStageOptions {
             write!(f, " PATTERN => '{}',", pattern)?;
         }
 
-        write_comma_separated_arrow_map(f, &self.connection)?;
+        if !self.connection.is_empty() {
+            write!(f, " CONNECTION => (")?;
+            write_comma_separated_map(f, &self.connection)?;
+            write!(f, " )")?;
+        }
 
         write!(f, " )")?;
 
@@ -149,9 +152,7 @@ impl SelectStageOptions {
                 SelectStageOption::Files(v) => options.files = Some(v),
                 SelectStageOption::Pattern(v) => options.pattern = Some(v),
                 SelectStageOption::FileFormat(v) => options.file_format = Some(v),
-                SelectStageOption::Connection((k, v)) => {
-                    options.connection.insert(k, v);
-                }
+                SelectStageOption::Connection(v) => options.connection = v,
             }
         }
         options

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -226,6 +226,9 @@ pub fn select_stage_option(i: Input) -> IResult<SelectStageOption> {
             rule! { FILE_FORMAT ~ ^"=>" ~ ^#literal_string },
             |(_, _, file_format)| SelectStageOption::FileFormat(file_format),
         ),
-        map(connection_opt("=>"), SelectStageOption::Connection),
+        map(
+            rule! { CONNECTION ~ ^"=>" ~ ^#connection_options },
+            |(_, _, file_format)| SelectStageOption::Connection(file_format),
+        ),
     ))(i)
 }

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -445,7 +445,7 @@ fn test_statement() {
         r#"select table0.c1, table1.c2 from
             @stage1/dir/file ( FILE_FORMAT => 'parquet', FILES => ('file1', 'file2')) table0
             left join table1;"#,
-        r#"SELECT c1 FROM 's3://test/bucket' (ENDPOINT_URL => 'xxx', PATTERN => '*.parquet') t;"#,
+        r#"SELECT c1 FROM 's3://test/bucket' (PATTERN => '*.parquet', connection => (ENDPOINT_URL = 'xxx')) t;"#,
         r#"CREATE FILE FORMAT my_csv
             type = CSV field_delimiter = ',' record_delimiter = '\n' skip_header = 1;"#,
         r#"SHOW FILE FORMATS"#,
@@ -550,6 +550,7 @@ fn test_statement_error() {
         r#"select * from aa.bb limit 10,2,3;"#,
         r#"with a as (select 1) with b as (select 2) select * from aa.bb;"#,
         r#"copy into t1 from "" FILE"#,
+        r#"select $1 from @data/csv/books.csv (file_format => 'aa' bad_arg => 'x', pattern => 'bb')"#,
         r#"copy into t1 from "" FILE_FORMAT"#,
         r#"copy into t1 from "" FILE_FORMAT = "#,
         r#"copy into t1 from "" FILE_FORMAT = ("#,

--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -516,6 +516,18 @@ error:
 
 
 ---------- Input ----------
+select $1 from @data/csv/books.csv (file_format => 'aa' bad_arg => 'x', pattern => 'bb')
+---------- Output ---------
+error: 
+  --> SQL:1:57
+  |
+1 | select $1 from @data/csv/books.csv (file_format => 'aa' bad_arg => 'x', pattern => 'bb')
+  | ------                                                  ^^^^^^^ expected `PATTERN`, `FILE_FORMAT`, `)`, `,`, `FILES`, or `CONNECTION`
+  | |                                                        
+  | while parsing `SELECT ...`
+
+
+---------- Input ----------
 copy into t1 from "" FILE_FORMAT
 ---------- Output ---------
 error: 

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -1571,7 +1571,7 @@ UseDatabase {
 ---------- Input ----------
 create catalog ctl type=hive connection=(url='<hive-meta-store>' thrift_protocol='binary');
 ---------- Output ---------
-CREATE CATALOG ctl TYPE='HIVE' CONNECTION = ( thrift_protocol='binary', url='<hive-meta-store>' )
+CREATE CATALOG ctl TYPE='HIVE' CONNECTION = ( thrift_protocol = 'binary', url = '<hive-meta-store>' )
 ---------- AST ------------
 CreateCatalog(
     CreateCatalogStmt {
@@ -7018,7 +7018,7 @@ CreateStage(
 ---------- Input ----------
 CREATE STAGE IF NOT EXISTS test_stage url='s3://load/files/' credentials=(aws_key_id='1a2b3c', aws_secret_key='4x5y6z') file_format=(type = CSV, compression = GZIP record_delimiter=',')
 ---------- Output ---------
-CREATE STAGE IF NOT EXISTS test_stage URL = 's3://load/files/' CONNECTION = ( aws_key_id='1a2b3c', aws_secret_key='4x5y6z' ) FILE_FORMAT = (compression='GZIP', record_delimiter=',', type='CSV' )
+CREATE STAGE IF NOT EXISTS test_stage URL = 's3://load/files/' CONNECTION = ( aws_key_id = '1a2b3c', aws_secret_key = '4x5y6z' ) FILE_FORMAT = (compression = 'GZIP', record_delimiter = ',', type = 'CSV' )
 ---------- AST ------------
 CreateStage(
     CreateStageStmt {
@@ -7055,7 +7055,7 @@ CreateStage(
 ---------- Input ----------
 CREATE STAGE IF NOT EXISTS test_stage url='azblob://load/files/' connection=(account_name='1a2b3c' account_key='4x5y6z') file_format=(type = CSV compression = GZIP record_delimiter=',')
 ---------- Output ---------
-CREATE STAGE IF NOT EXISTS test_stage URL = 'azblob://load/files/' CONNECTION = ( account_key='4x5y6z', account_name='1a2b3c' ) FILE_FORMAT = (compression='GZIP', record_delimiter=',', type='CSV' )
+CREATE STAGE IF NOT EXISTS test_stage URL = 'azblob://load/files/' CONNECTION = ( account_key = '4x5y6z', account_name = '1a2b3c' ) FILE_FORMAT = (compression = 'GZIP', record_delimiter = ',', type = 'CSV' )
 ---------- AST ------------
 CreateStage(
     CreateStageStmt {
@@ -8102,7 +8102,7 @@ AlterTable(
 ---------- Input ----------
 ALTER TABLE t SET OPTIONS(SNAPSHOT_LOCATION='1/7/_ss/101fd790dbbe4238a31a8f2e2f856179_v4.mpk',block_per_segment = 500);
 ---------- Output ---------
-ALTER TABLE t SET OPTIONS (block_per_segment='500', snapshot_location='1/7/_ss/101fd790dbbe4238a31a8f2e2f856179_v4.mpk')
+ALTER TABLE t SET OPTIONS (block_per_segment = '500', snapshot_location = '1/7/_ss/101fd790dbbe4238a31a8f2e2f856179_v4.mpk')
 ---------- AST ------------
 AlterTable(
     AlterTableStmt {
@@ -8421,7 +8421,7 @@ VacuumDropTable(
 ---------- Input ----------
 CREATE TABLE t (a INT COMMENT 'col comment') COMMENT='table comment';
 ---------- Output ---------
-CREATE TABLE t (a Int32 COMMENT 'col comment')comment='table comment'
+CREATE TABLE t (a Int32 COMMENT 'col comment')comment = 'table comment'
 ---------- AST ------------
 CreateTable(
     CreateTableStmt {
@@ -9232,8 +9232,8 @@ COPY INTO mytable
                 )
                 size_limit=10;
 ---------- Output ---------
-COPY INTO mytable FROM @~/mybucket/data.csv FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM @~/mybucket/data.csv FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9288,8 +9288,8 @@ COPY INTO mytable
                 size_limit=10
                 max_files=10;
 ---------- Output ---------
-COPY INTO mytable FROM 's3://mybucket/data.csv' FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 MAX_FILES = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM 's3://mybucket/data.csv' FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 MAX_FILES = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9353,8 +9353,8 @@ COPY INTO mytable
                 size_limit=10
                 max_files=3000;
 ---------- Output ---------
-COPY INTO mytable FROM 's3://mybucket/data.csv' FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 MAX_FILES = 2000 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM 's3://mybucket/data.csv' FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 MAX_FILES = 2000 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9420,8 +9420,8 @@ COPY INTO mytable
                 )
                 size_limit=10;
 ---------- Output ---------
-COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( endpoint_url='http://127.0.0.1:9900' ) FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( endpoint_url = 'http://127.0.0.1:9900' ) FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9489,8 +9489,8 @@ COPY INTO mytable
                     skip_header = 1
                 );
 ---------- Output ---------
-COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( endpoint_url='http://127.0.0.1:9900' ) FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( endpoint_url = 'http://127.0.0.1:9900' ) FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9658,8 +9658,8 @@ COPY INTO mytable
                 )
                 size_limit=10;
 ---------- Output ---------
-COPY INTO mytable FROM @my_stage FILE_FORMAT = (error_on_column_count_mismatch='false', field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM @my_stage FILE_FORMAT = (error_on_column_count_mismatch = 'false', field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9713,8 +9713,8 @@ COPY INTO 's3://mybucket/data.csv'
                     skip_header = 1
                 )
 ---------- Output ---------
-COPY INTO 's3://mybucket/data.csv' FROM mytable FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SINGLE = false MAX_FILE_SIZE= 0
+COPY INTO 's3://mybucket/data.csv' FROM mytable FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SINGLE = false MAX_FILE_SIZE= 0
 ---------- AST ------------
 CopyIntoLocation(
     CopyIntoLocationStmt {
@@ -9798,8 +9798,8 @@ COPY INTO @my_stage
                     skip_header = 1
                 );
 ---------- Output ---------
-COPY INTO @my_stage FROM mytable FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SINGLE = false MAX_FILE_SIZE= 0
+COPY INTO @my_stage FROM mytable FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SINGLE = false MAX_FILE_SIZE= 0
 ---------- AST ------------
 CopyIntoLocation(
     CopyIntoLocationStmt {
@@ -9847,8 +9847,8 @@ COPY INTO mytable
                 )
                 size_limit=10;
 ---------- Output ---------
-COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( aws_key_id='access_key', aws_secret_key='secret_key' ) FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM 's3://mybucket/data.csv' CONNECTION = ( aws_key_id = 'access_key', aws_secret_key = 'secret_key' ) FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9914,8 +9914,8 @@ COPY INTO mytable
                 )
                 size_limit=10;
 ---------- Output ---------
-COPY INTO mytable FROM @external_stage/path/to/file.csv FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM @external_stage/path/to/file.csv FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9969,8 +9969,8 @@ COPY INTO mytable
                 )
                 size_limit=10;
 ---------- Output ---------
-COPY INTO mytable FROM @external_stage/path/to/dir/ FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM @external_stage/path/to/dir/ FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -10024,8 +10024,8 @@ COPY INTO mytable
                 )
                 force=true;
 ---------- Output ---------
-COPY INTO mytable FROM @external_stage/path/to/file.csv FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') PURGE = false FORCE = true DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO mytable FROM @external_stage/path/to/file.csv FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') PURGE = false FORCE = true DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -10080,8 +10080,8 @@ COPY INTO mytable
                 size_limit=10
                 disable_variant_check=true;
 ---------- Output ---------
-COPY INTO mytable FROM 'fs:///path/to/data.csv' FILE_FORMAT = (field_delimiter=',', record_delimiter='
-', skip_header='1', type='CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = true ON_ERROR = 'abort'
+COPY INTO mytable FROM 'fs:///path/to/data.csv' FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = true ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -10143,7 +10143,7 @@ COPY INTO books FROM 's3://databend/books.csv'
                 )
                 FILE_FORMAT = (type = CSV);
 ---------- Output ---------
-COPY INTO books FROM 's3://databend/books.csv' CONNECTION = ( access_key_id='ROOTUSER', endpoint_url='http://localhost:9000/', region='us-west-2', secret_access_key='CHANGEME123' ) FILE_FORMAT = (type='CSV') PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+COPY INTO books FROM 's3://databend/books.csv' CONNECTION = ( access_key_id = 'ROOTUSER', endpoint_url = 'http://localhost:9000/', region = 'us-west-2', secret_access_key = 'CHANGEME123' ) FILE_FORMAT = (type = 'CSV') PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -11399,20 +11399,20 @@ Query(
 
 
 ---------- Input ----------
-SELECT c1 FROM 's3://test/bucket' (ENDPOINT_URL => 'xxx', PATTERN => '*.parquet') t;
+SELECT c1 FROM 's3://test/bucket' (PATTERN => '*.parquet', connection => (ENDPOINT_URL = 'xxx')) t;
 ---------- Output ---------
-SELECT c1 FROM 's3://test/bucket' ( PATTERN => '*.parquet',endpoint_url=>'xxx' ) AS t
+SELECT c1 FROM 's3://test/bucket' ( PATTERN => '*.parquet', CONNECTION => (endpoint_url = 'xxx' ) ) AS t
 ---------- AST ------------
 Query(
     Query {
         span: Some(
-            0..83,
+            0..98,
         ),
         with: None,
         body: Select(
             SelectStmt {
                 span: Some(
-                    0..83,
+                    0..98,
                 ),
                 hints: None,
                 distinct: false,
@@ -11440,7 +11440,7 @@ Query(
                 from: [
                     Location {
                         span: Some(
-                            15..83,
+                            15..98,
                         ),
                         location: Uri(
                             UriLocation {
@@ -11470,7 +11470,7 @@ Query(
                                     name: "t",
                                     quote: None,
                                     span: Some(
-                                        82..83,
+                                        97..98,
                                     ),
                                 },
                                 columns: [],

--- a/tests/sqllogictests/suites/base/05_ddl/05_0019_ddl_create_view
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0019_ddl_create_view
@@ -104,13 +104,13 @@ statement ok
 drop view if exists tmp_view
 
 query T
-explain syntax create view test as SELECT * FROM 's3://testbucket/admin/data/tuple.parquet'(files => ('tuple.parquet', 'test.parquet'), pattern => '.*.parquet', FILE_FORMAT => 'parquet',  aws_key_id => 'minioadmin',  aws_secret_key => 'minioadmin',  endpoint_url => 'http://127.0.0.1:9900/')
+explain syntax create view test as SELECT * FROM 's3://testbucket/admin/data/tuple.parquet'(files => ('tuple.parquet', 'test.parquet'), pattern => '.*.parquet', FILE_FORMAT => 'parquet',  CONNECTION => (aws_key_id = 'minioadmin',  aws_secret_key = 'minioadmin',  endpoint_url = 'http://127.0.0.1:9900/'))
 ----
 CREATE VIEW test
 AS
     SELECT *
     FROM
-        's3://testbucket/admin/data/tuple.parquet' ( FILES => ('tuple.parquet', 'test.parquet'), FILE_FORMAT => 'parquet', PATTERN => '.*.parquet',aws_key_id=>'minioadmin', aws_secret_key=>'minioadmin', endpoint_url=>'http://127.0.0.1:9900/' )
+        's3://testbucket/admin/data/tuple.parquet' ( FILES => ('tuple.parquet', 'test.parquet'), FILE_FORMAT => 'parquet', PATTERN => '.*.parquet', CONNECTION => (aws_key_id = 'minioadmin', aws_secret_key = 'minioadmin', endpoint_url = 'http://127.0.0.1:9900/' ) )
 
 statement ok
 drop view if exists loop_view1;

--- a/tests/sqllogictests/suites/stage_parquet/options/select_options
+++ b/tests/sqllogictests/suites/stage_parquet/options/select_options
@@ -1,5 +1,5 @@
 query 
-select $1 from @data/parquet/alltypes_plain.parquet () a;
+select $1 from @data/parquet/alltypes_plain.parquet a;
 ----
 4
 5

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_05_query_uri.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_05_query_uri.sh
@@ -3,4 +3,4 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../../shell_env.sh
 
-echo  "select * from 's3://testbucket/admin/data/parquet/tuple.parquet' (aws_key_id => 'minioadmin', aws_secret_key => 'minioadmin', endpoint_url => 'http://127.0.0.1:9900/', file_format => 'parquet')"  | $MYSQL_CLIENT_CONNECT
+echo  "select * from 's3://testbucket/admin/data/parquet/tuple.parquet' (connection => (aws_key_id = 'minioadmin', aws_secret_key = 'minioadmin', endpoint_url = 'http://127.0.0.1:9900/'), file_format => 'parquet')"  | $MYSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

change 

```
`select * from 's3://testbucket/admin/data/parquet/tuple.parquet' (aws_key_id => 'minioadmin', aws_secret_key => 'minioadmin', endpoint_url => 'http://127.0.0.1:9900/', file_format => 'parquet')"`
```

to 

```
select * from 's3://testbucket/admin/data/parquet/tuple.parquet' (connection => (aws_key_id = 'minioadmin', aws_secret_key = 'minioadmin', endpoint_url = 'http://127.0.0.1:9900/')
```


also Closes https://github.com/datafuselabs/databend/issues/13419

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13427)
<!-- Reviewable:end -->
