### PR TITLE
chore(planner): fix probe to build

### DIFF
--- a/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
@@ -293,8 +293,8 @@ impl PhysicalPlanBuilder {
                 }
                 if !is_tail {
                     build_fields.push(field.clone());
+                    merged_fields.push(field.clone());
                 }
-                merged_fields.push(field.clone());
             }
         }
         build_fields.extend(tail_fields.clone());

--- a/tests/sqllogictests/suites/query/join.test
+++ b/tests/sqllogictests/suites/query/join.test
@@ -710,6 +710,30 @@ select t1.a, t2.b, t1.b from t1 inner join t2 on t1.a = t2.a order by t1.a, t2.b
 2 8 2
 2 8 4
 
+# test probe to build with other condition
+statement ok
+drop table if exists t1;
+
+statement ok
+drop table if exists t2;
+
+statement ok
+create table t1 (id int, val bigint unsigned DEFAULT 0);
+
+statement ok
+create table t2 (id int, val bigint unsigned DEFAULT 0);
+
+statement ok
+insert into t1 values(1, 1696549154011), (2, 1696549154013);
+
+statement ok
+insert into t2 values(1, 1697650260000), (3, 1696549154009), (2, 1696549154010);
+
+query I
+select t1.id from t1 left join t2 on t1.id = t2.id where t1.val >= t2.val;
+----
+2
+
 statement ok
 drop table t1;
 

--- a/tests/sqllogictests/suites/query/join.test
+++ b/tests/sqllogictests/suites/query/join.test
@@ -727,10 +727,15 @@ statement ok
 insert into t1 values(1, 1696549154011), (2, 1696549154013);
 
 statement ok
-insert into t2 values(1, 1697650260000), (3, 1696549154009), (2, 1696549154010);
+insert into t2 values(1, 1697650260000), (3, 1696549154009), (2, 1696549154010), (2, 1696549154013);
 
 query I
 select t1.id from t1 left join t2 on t1.id = t2.id where t1.val >= t2.val;
+----
+2
+
+query I
+select t1.id, t1.val from t1 left join t2 on t1.id = t2.id and t1.val = t2.val where t1.val >= t2.val;
 ----
 2
 

--- a/tests/sqllogictests/suites/query/join.test
+++ b/tests/sqllogictests/suites/query/join.test
@@ -733,6 +733,7 @@ query I
 select t1.id from t1 left join t2 on t1.id = t2.id where t1.val >= t2.val;
 ----
 2
+2
 
 query I
 select t1.id, t1.val from t1 left join t2 on t1.id = t2.id and t1.val = t2.val where t1.val >= t2.val;

--- a/tests/sqllogictests/suites/query/join.test
+++ b/tests/sqllogictests/suites/query/join.test
@@ -738,7 +738,7 @@ select t1.id from t1 left join t2 on t1.id = t2.id where t1.val >= t2.val;
 query I
 select t1.id, t1.val from t1 left join t2 on t1.id = t2.id and t1.val = t2.val where t1.val >= t2.val;
 ----
-2
+2 1696549154013
 
 statement ok
 drop table t1;

--- a/tests/sqllogictests/suites/query/join.test
+++ b/tests/sqllogictests/suites/query/join.test
@@ -718,10 +718,10 @@ statement ok
 drop table if exists t2;
 
 statement ok
-create table t1 (id int, val bigint unsigned DEFAULT 0);
+create table t1 (id int, val bigint unsigned default 0);
 
 statement ok
-create table t2 (id int, val bigint unsigned DEFAULT 0);
+create table t2 (id int, val bigint unsigned default 0);
 
 statement ok
 insert into t1 values(1, 1696549154011), (2, 1696549154013);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

The result block schema is: id1, val1, val2, id2(tail), the merged schema: id1, val1, id2, val2, id2(tail), for `t1.val >= t2.val`, the indexes of (val1, val2) are (1, 2) and (1, 3) respectively, but they should be the same.

- Closes #13443

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13446)
<!-- Reviewable:end -->
