### PR TITLE
fix: readelf only on debug mode when do asan build

### DIFF
--- a/.github/actions/build_linux_sanitizer/action.yml
+++ b/.github/actions/build_linux_sanitizer/action.yml
@@ -69,5 +69,8 @@ runs:
         cargo -Zbuild-std -Zgitoxide=fetch,shallow-index,shallow-deps build --target ${{ inputs.target }} --features ${{ inputs.features }} --bin open-sharing
         ls -lh ./target/${{ inputs.target }}/${{ env.BUILD_PROFILE }}/databend-*
 
-    - shell: bash
-      run: readelf -p .comment ./target/${{ inputs.target }}/${{ env.BUILD_PROFILE }}/databend-query
+    - name: Read elf
+      if: env.BUILD_PROFILE == 'debug' && endsWith(inputs.target, '-gnu')
+      shell: bash
+      run: |
+        readelf -p .comment ./target/${{ inputs.target }}/${{ env.BUILD_PROFILE }}/databend-query


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

readelf only on debug mode when do asan build

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13450)
<!-- Reviewable:end -->
