### PR TITLE
refactor: state machine API MapApi::range() returns static lifetime stream

### DIFF
--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map.rs
@@ -18,11 +18,11 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use common_meta_types::KVMeta;
-use futures_util::stream::BoxStream;
 
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::compacted_get;
 use crate::sm_v002::leveled_store::map_api::compacted_range;
+use crate::sm_v002::leveled_store::map_api::EntryStream;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
@@ -116,7 +116,7 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<'f, Q, R>(&'f self, range: R) -> BoxStream<'f, (K, Marked<K::V>)>
+    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,

--- a/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
@@ -46,6 +46,9 @@ pub(in crate::sm_v002) trait MapValue:
 {
 }
 
+/// A stream of key-value entry returned by `range()`.
+pub(in crate::sm_v002) type EntryStream<K> = BoxStream<'static, (K, Marked<<K as MapKey>::V>)>;
+
 // Auto implement MapValue for all types that satisfy the constraints.
 impl<V> MapValue for V where V: Clone + Send + Sync + Unpin + 'static {}
 
@@ -73,7 +76,7 @@ where K: MapKey
     /// Iterate over a range of entries by keys.
     ///
     /// The returned iterator contains tombstone entries: [`Marked::TombStone`].
-    async fn range<'f, Q, R>(&'f self, range: R) -> BoxStream<'f, (K, Marked<K::V>)>
+    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
@@ -209,7 +212,7 @@ where
 pub(in crate::sm_v002) async fn compacted_range<'d, K, Q, R, L>(
     range: R,
     levels: impl IntoIterator<Item = &'d L>,
-) -> BoxStream<'d, (K, Marked<K::V>)>
+) -> EntryStream<K>
 where
     K: MapKey,
     K: Borrow<Q>,
@@ -227,7 +230,7 @@ where
     // Merge entries with the same key, keep the one with larger internal-seq
     let m = kmerge.coalesce(util::choose_greater);
 
-    let strm: BoxStream<'_, (K, Marked<K::V>)> = Box::pin(m);
+    let strm: EntryStream<K> = Box::pin(m);
     strm
 }
 

--- a/src/meta/raft-store/src/sm_v002/leveled_store/ref_.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/ref_.rs
@@ -16,11 +16,10 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::ops::RangeBounds;
 
-use futures_util::stream::BoxStream;
-
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::compacted_get;
 use crate::sm_v002::leveled_store::map_api::compacted_range;
+use crate::sm_v002::leveled_store::map_api::EntryStream;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
 use crate::sm_v002::leveled_store::static_levels::StaticLevels;
@@ -65,7 +64,7 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<'f, Q, R>(&'f self, range: R) -> BoxStream<'f, (K, Marked<K::V>)>
+    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
     where
         K: Borrow<Q>,
         R: RangeBounds<Q> + Clone + Send + Sync,

--- a/src/meta/raft-store/src/sm_v002/leveled_store/ref_mut.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/ref_mut.rs
@@ -16,11 +16,11 @@ use std::borrow::Borrow;
 use std::ops::RangeBounds;
 
 use common_meta_types::KVMeta;
-use futures_util::stream::BoxStream;
 
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::compacted_get;
 use crate::sm_v002::leveled_store::map_api::compacted_range;
+use crate::sm_v002::leveled_store::map_api::EntryStream;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
@@ -73,7 +73,7 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<'f, Q, R>(&'f self, range: R) -> BoxStream<'f, (K, Marked<K::V>)>
+    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,

--- a/src/meta/raft-store/src/sm_v002/leveled_store/static_levels.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/static_levels.rs
@@ -16,11 +16,10 @@ use std::borrow::Borrow;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
-use futures_util::stream::BoxStream;
-
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::compacted_get;
 use crate::sm_v002::leveled_store::map_api::compacted_range;
+use crate::sm_v002::leveled_store::map_api::EntryStream;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
 use crate::sm_v002::leveled_store::ref_::Ref;
@@ -78,7 +77,7 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<'f, Q, R>(&'f self, range: R) -> BoxStream<'f, (K, Marked<K::V>)>
+    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: state machine API MapApi::range() returns static lifetime stream

When querying the meta-service state machine with a stream oriented API,
such as `list_kv()`, the gRPC server respond to the client with a
`BoxStream<'static, ...>`. Therefore state machine has to return a
`'static` stream too.

In this commit, A new Stream `EntryStream<K>` is introduced as a type of
the output type for `MapApi::range()`

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13461)
<!-- Reviewable:end -->
