### PR TITLE
chore: remove obsolete non-stream API SMV002::prefix_list_kv()

### DIFF
--- a/src/meta/raft-store/src/sm_v002/sm_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002.rs
@@ -262,15 +262,6 @@ impl SMV002 {
     /// List kv entries by prefix.
     ///
     /// If a value is expired, it is not returned.
-    // TODO: #[deprecated]
-    pub async fn prefix_list_kv(&self, prefix: &str) -> Vec<(String, SeqV)> {
-        let strm = self.list_kv(prefix).await;
-        strm.collect::<Vec<_>>().await
-    }
-
-    /// List kv entries by prefix.
-    ///
-    /// If a value is expired, it is not returned.
     pub async fn list_kv(&self, prefix: &str) -> BoxStream<'static, (String, SeqV)> {
         let p = prefix.to_string();
 

--- a/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
@@ -62,7 +62,7 @@ async fn test_one_level_upsert_get_range() -> anyhow::Result<()> {
     assert_eq!(got.meta(), None);
     assert_eq!(got.value(), None);
 
-    let got = sm.prefix_list_kv("").await;
+    let got = sm.list_kv("").await.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         (s("a"), SeqV::new(3, b("a00"))),
         (s("b"), SeqV::new(2, b("b0")))
@@ -114,14 +114,14 @@ async fn test_two_level_upsert_get_range() -> anyhow::Result<()> {
 
     // prefix_list_kv()
 
-    let got = sm.prefix_list_kv("").await;
+    let got = sm.list_kv("").await.collect::<Vec<_>>().await;
     assert_eq!(got, vec![
         (s("a"), SeqV::new(1, b("a0"))),
         (s("c"), SeqV::new(4, b("c1"))),
         (s("d"), SeqV::new(5, b("d1"))),
     ]);
 
-    let got = sm.prefix_list_kv("a").await;
+    let got = sm.list_kv("a").await.collect::<Vec<_>>().await;
     assert_eq!(got, vec![(s("a"), SeqV::new(1, b("a0"))),]);
     Ok(())
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore: remove obsolete non-stream API SMV002::prefix_list_kv()

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13464)
<!-- Reviewable:end -->
