### PR TITLE
chore: Add soyeric128 as code owner of docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,3 +47,7 @@
 /docker/               @datafuselabs/databend-tool-reviewer
 /scripts/              @datafuselabs/databend-tool-reviewer
 /.github/              @datafuselabs/databend-tool-reviewer
+
+# Docs
+
+**/*.md @soyeric128


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: Add soyeric128 as code owner of docs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13465)
<!-- Reviewable:end -->
