### PR TITLE
chore: rename: SMV002::get_kv() to get_maybe_expired_kv()

### DIFF
--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -36,6 +36,7 @@ use common_meta_raft_store::ondisk::DataVersion;
 use common_meta_raft_store::ondisk::OnDisk;
 use common_meta_raft_store::ondisk::DATA_VERSION;
 use common_meta_raft_store::ondisk::TREE_HEADER;
+use common_meta_raft_store::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use common_meta_raft_store::sm_v002::SnapshotStoreV002;
 use common_meta_raft_store::state::RaftState;
 use common_meta_sled_store::get_sled_db;
@@ -369,7 +370,7 @@ async fn init_new_cluster(
 
     let last_applied = {
         let sm2 = sto.get_state_machine().await;
-        *sm2.last_applied_ref()
+        *sm2.sys_data_ref().last_applied_ref()
     };
 
     let last_log_id = std::cmp::max(last_applied, max_log_id);
@@ -382,12 +383,13 @@ async fn init_new_cluster(
     {
         let mut sm2 = sto.get_state_machine().await;
 
-        *sm2.nodes_mut() = nodes.clone();
+        *sm2.sys_data_mut().nodes_mut() = nodes.clone();
 
         // It must set membership to state machine because
         // the snapshot may contain more logs than the last_log_id.
         // In which case, logs will be purged upon startup.
-        *sm2.last_membership_mut() = StoredMembership::new(last_applied, membership.clone());
+        *sm2.sys_data_mut().last_membership_mut() =
+            StoredMembership::new(last_applied, membership.clone());
     }
 
     // Build snapshot to persist state machine.

--- a/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
@@ -64,6 +64,10 @@ impl Level {
         }
     }
 
+    pub(in crate::sm_v002) fn sys_data_ref(&self) -> &SysData {
+        &self.sys_data
+    }
+
     pub(in crate::sm_v002) fn sys_data_mut(&mut self) -> &mut SysData {
         &mut self.sys_data
     }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/sys_data.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/sys_data.rs
@@ -94,15 +94,15 @@ impl SysData {
         self.sequence
     }
 
-    pub(crate) fn last_applied_mut(&mut self) -> &mut Option<LogId> {
+    pub fn last_applied_mut(&mut self) -> &mut Option<LogId> {
         &mut self.last_applied
     }
 
-    pub(crate) fn last_membership_mut(&mut self) -> &mut StoredMembership {
+    pub fn last_membership_mut(&mut self) -> &mut StoredMembership {
         &mut self.last_membership
     }
 
-    pub(crate) fn nodes_mut(&mut self) -> &mut BTreeMap<NodeId, Node> {
+    pub fn nodes_mut(&mut self) -> &mut BTreeMap<NodeId, Node> {
         &mut self.nodes
     }
 }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/sys_data_api.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/sys_data_api.rs
@@ -20,7 +20,7 @@ use common_meta_types::NodeId;
 use common_meta_types::StoredMembership;
 
 /// APIs to access the non-user-data of the state machine(leveled map).
-pub(in crate::sm_v002) trait SysDataApiRO {
+pub trait SysDataApiRO {
     fn curr_seq(&self) -> u64;
 
     fn last_applied_ref(&self) -> &Option<LogId>;

--- a/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
@@ -33,31 +33,31 @@ async fn test_one_level_upsert_get_range() -> anyhow::Result<()> {
     assert_eq!(prev, None);
     assert_eq!(result, Some(SeqV::new(1, b("a0"))));
 
-    let got = sm.get_kv("a").await;
+    let got = sm.get_maybe_expired_kv("a").await;
     assert_eq!(got, Some(SeqV::new(1, b("a0"))));
 
     let mut a = sm.new_applier();
     let (prev, result) = a.upsert_kv(&UpsertKV::update("b", b"b0")).await;
     assert_eq!(prev, None);
     assert_eq!(result, Some(SeqV::new(2, b("b0"))));
-    let got = sm.get_kv("b").await;
+    let got = sm.get_maybe_expired_kv("b").await;
     assert_eq!(got, Some(SeqV::new(2, b("b0"))));
 
     let mut a = sm.new_applier();
     let (prev, result) = a.upsert_kv(&UpsertKV::update("a", b"a00")).await;
     assert_eq!(prev, Some(SeqV::new(1, b("a0"))));
     assert_eq!(result, Some(SeqV::new(3, b("a00"))));
-    let got = sm.get_kv("a").await;
+    let got = sm.get_maybe_expired_kv("a").await;
     assert_eq!(got, Some(SeqV::new(3, b("a00"))));
 
     // get_kv_ref()
 
-    let got = sm.get_kv("a").await;
+    let got = sm.get_maybe_expired_kv("a").await;
     assert_eq!(got.seq(), 3);
     assert_eq!(got.meta(), None);
     assert_eq!(got.value(), Some(&b("a00")));
 
-    let got = sm.get_kv("x").await;
+    let got = sm.get_maybe_expired_kv("x").await;
     assert_eq!(got.seq(), 0);
     assert_eq!(got.meta(), None);
     assert_eq!(got.value(), None);
@@ -93,24 +93,33 @@ async fn test_two_level_upsert_get_range() -> anyhow::Result<()> {
 
     // get_kv_ref()
 
-    let got = sm.get_kv("a").await;
+    let got = sm.get_maybe_expired_kv("a").await;
     assert_eq!((got.seq(), got.value()), (1u64, Some(&b("a0"))));
 
-    let got = sm.get_kv("b").await;
+    let got = sm.get_maybe_expired_kv("b").await;
     assert_eq!((got.seq(), got.value()), (0, None));
 
-    let got = sm.get_kv("c").await;
+    let got = sm.get_maybe_expired_kv("c").await;
     assert_eq!((got.seq(), got.value()), (4, Some(&b("c1"))));
 
-    let got = sm.get_kv("d").await;
+    let got = sm.get_maybe_expired_kv("d").await;
     assert_eq!((got.seq(), got.value()), (5, Some(&b("d1"))));
 
     // get_kv()
 
-    assert_eq!(sm.get_kv("a").await, Some(SeqV::new(1, b("a0"))));
-    assert_eq!(sm.get_kv("b").await, None);
-    assert_eq!(sm.get_kv("c").await, Some(SeqV::new(4, b("c1"))));
-    assert_eq!(sm.get_kv("d").await, Some(SeqV::new(5, b("d1"))));
+    assert_eq!(
+        sm.get_maybe_expired_kv("a").await,
+        Some(SeqV::new(1, b("a0")))
+    );
+    assert_eq!(sm.get_maybe_expired_kv("b").await, None);
+    assert_eq!(
+        sm.get_maybe_expired_kv("c").await,
+        Some(SeqV::new(4, b("c1")))
+    );
+    assert_eq!(
+        sm.get_maybe_expired_kv("d").await,
+        Some(SeqV::new(5, b("d1")))
+    );
 
     // prefix_list_kv()
 
@@ -241,7 +250,7 @@ async fn test_inserting_expired_becomes_deleting() -> anyhow::Result<()> {
     a.upsert_kv(&UpsertKV::update("a", b"a1").with_expire_sec(10))
         .await;
 
-    assert_eq!(sm.get_kv("a").await, None, "a is expired");
+    assert_eq!(sm.get_maybe_expired_kv("a").await, None, "a is expired");
 
     let got = sm.list_expire_index().await.collect::<Vec<_>>().await;
     assert_eq!(got, vec![

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -17,6 +17,7 @@ use std::collections::BTreeSet;
 use common_base::base::tokio::sync::RwLockReadGuard;
 use common_meta_client::MetaGrpcReadReq;
 use common_meta_kvapi::kvapi::KVApi;
+use common_meta_raft_store::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use common_meta_raft_store::sm_v002::SMV002;
 use common_meta_sled_store::openraft::ChangeMembers;
 use common_meta_stoerr::MetaStorageError;
@@ -284,7 +285,7 @@ impl<'a> MetaLeader<'a> {
     async fn can_leave(&self, id: NodeId) -> Result<Result<(), String>, MetaStorageError> {
         let membership = {
             let sm = self.get_state_machine().await;
-            sm.last_membership_ref().membership().clone()
+            sm.sys_data_ref().last_membership_ref().membership().clone()
         };
         info!("check can_leave: id: {}, membership: {:?}", id, membership);
 

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -35,6 +35,7 @@ use common_meta_client::RequestFor;
 use common_meta_raft_store::config::RaftConfig;
 use common_meta_raft_store::ondisk::DataVersion;
 use common_meta_raft_store::ondisk::DATA_VERSION;
+use common_meta_raft_store::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use common_meta_sled_store::openraft;
 use common_meta_sled_store::openraft::storage::Adaptor;
 use common_meta_sled_store::openraft::ChangeMembers;
@@ -786,7 +787,7 @@ impl MetaNode {
     async fn is_in_cluster(&self) -> Result<Result<String, String>, MetaStorageError> {
         let membership = {
             let sm = self.sto.get_state_machine().await;
-            sm.last_membership_ref().membership().clone()
+            sm.sys_data_ref().last_membership_ref().membership().clone()
         };
         info!("is_in_cluster: membership: {:?}", membership);
 
@@ -870,7 +871,7 @@ impl MetaNode {
         // inconsistent get: from local state machine
 
         let sm = self.sto.state_machine.read().await;
-        let n = sm.nodes_ref().get(node_id).cloned();
+        let n = sm.sys_data_ref().nodes_ref().get(node_id).cloned();
         n
     }
 
@@ -879,7 +880,12 @@ impl MetaNode {
         // inconsistent get: from local state machine
 
         let sm = self.sto.state_machine.read().await;
-        let nodes = sm.nodes_ref().values().cloned().collect::<Vec<_>>();
+        let nodes = sm
+            .sys_data_ref()
+            .nodes_ref()
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
         nodes
     }
 
@@ -945,7 +951,11 @@ impl MetaNode {
 
         let nodes = {
             let sm = self.sto.state_machine.read().await;
-            sm.nodes_ref().values().cloned().collect::<Vec<_>>()
+            sm.sys_data_ref()
+                .nodes_ref()
+                .values()
+                .cloned()
+                .collect::<Vec<_>>()
         };
 
         let endpoints: Vec<String> = nodes

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -942,7 +942,7 @@ impl MetaNode {
 
     pub(crate) async fn get_last_seq(&self) -> u64 {
         let sm = self.sto.state_machine.read().await;
-        sm.curr_seq()
+        sm.sys_data_ref().curr_seq()
     }
 
     #[minitrace::trace]

--- a/src/meta/service/src/store/store.rs
+++ b/src/meta/service/src/store/store.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_meta_raft_store::config::RaftConfig;
 use common_meta_raft_store::ondisk::DATA_VERSION;
+use common_meta_raft_store::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use common_meta_raft_store::sm_v002::SnapshotStoreV002;
 use common_meta_raft_store::state_machine::StoredSnapshot;
 use common_meta_sled_store::openraft::ErrorSubject;
@@ -437,8 +438,8 @@ impl RaftStorage<TypeConfig> for RaftStore {
         &mut self,
     ) -> Result<(Option<LogId>, StoredMembership), StorageError> {
         let sm = self.state_machine.read().await;
-        let last_applied = *sm.last_applied_ref();
-        let last_membership = sm.last_membership_ref().clone();
+        let last_applied = *sm.sys_data_ref().last_applied_ref();
+        let last_membership = sm.sys_data_ref().last_membership_ref().clone();
 
         debug!(
             "last_applied_state: applied: {:?}, membership: {:?}",

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -29,6 +29,7 @@ use common_meta_raft_store::key_spaces::RaftStoreEntry;
 use common_meta_raft_store::log::RaftLog;
 use common_meta_raft_store::ondisk::DATA_VERSION;
 use common_meta_raft_store::ondisk::TREE_HEADER;
+use common_meta_raft_store::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use common_meta_raft_store::sm_v002::SnapshotStoreError;
 use common_meta_raft_store::sm_v002::SnapshotStoreV002;
 use common_meta_raft_store::sm_v002::SnapshotViewV002;
@@ -194,8 +195,8 @@ impl StoreInner {
 
         let (last_applied, last_membership) = {
             let sm = sm.read().await;
-            let last_applied = *sm.last_applied_ref();
-            let last_membership = sm.last_membership_ref().clone();
+            let last_applied = *sm.sys_data_ref().last_applied_ref();
+            let last_membership = sm.sys_data_ref().last_membership_ref().clone();
 
             (last_applied, last_membership)
         };
@@ -335,7 +336,7 @@ impl StoreInner {
         // State machine ensures no modification to `base` during snapshotting.
         {
             let mut s = self.state_machine.write().await;
-            s.replace_base(&snapshot_view);
+            s.replace_frozen(&snapshot_view);
         }
 
         snapshot_view
@@ -507,7 +508,7 @@ impl StoreInner {
 
     pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
         let sm = self.state_machine.read().await;
-        let n = sm.nodes_ref().get(node_id).cloned();
+        let n = sm.sys_data_ref().nodes_ref().get(node_id).cloned();
         n
     }
 
@@ -517,7 +518,7 @@ impl StoreInner {
         list_ids: impl Fn(&Membership) -> Vec<NodeId>,
     ) -> Vec<Node> {
         let sm = self.state_machine.read().await;
-        let membership = sm.last_membership_ref().membership();
+        let membership = sm.sys_data_ref().last_membership_ref().membership();
 
         debug!("in-statemachine membership: {:?}", membership);
 
@@ -526,7 +527,7 @@ impl StoreInner {
         let mut ns = vec![];
 
         for id in ids {
-            let node = sm.nodes_ref().get(&id).cloned();
+            let node = sm.sys_data_ref().nodes_ref().get(&id).cloned();
             if let Some(x) = node {
                 ns.push(x);
             }

--- a/src/meta/service/tests/it/meta_node/meta_node_replication.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_replication.rs
@@ -122,7 +122,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     for i in 0..n_req {
         let key = format!("test_meta_node_snapshot_replication-key-{}", i);
         let sm = mn1.sto.get_state_machine().await;
-        let got = sm.get_kv(&key).await;
+        let got = sm.get_maybe_expired_kv(&key).await;
         match got {
             None => {
                 panic!("expect get some value for {}", key)

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_meta_raft_store::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use common_meta_raft_store::state_machine::testing::snapshot_logs;
 use common_meta_sled_store::openraft::async_trait::async_trait;
 use common_meta_sled_store::openraft::entry::RaftEntry;
@@ -251,6 +252,7 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
                 .state_machine
                 .write()
                 .await
+                .sys_data_ref()
                 .last_membership_ref()
                 .clone();
 
@@ -262,7 +264,12 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
                 mem
             );
 
-            let last_applied = *sto.state_machine.write().await.last_applied_ref();
+            let last_applied = *sto
+                .state_machine
+                .write()
+                .await
+                .sys_data_ref()
+                .last_applied_ref();
             assert_eq!(Some(log_id(1, 0, 9)), last_applied);
         }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### chore: rename: SMV002::get_kv() to get_maybe_expired_kv()

Because its return value may be an expired record and should be considered as None


##### chore: collect sys data API into SysData, reduce state machine API set

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13466)
<!-- Reviewable:end -->
