### PR TITLE
docs: connection parameter format in sql

### DIFF
--- a/docs/doc/13-sql-reference/51-connect-parameters.md
+++ b/docs/doc/13-sql-reference/51-connect-parameters.md
@@ -9,11 +9,7 @@ The connection parameters refer to a set of essential connection details require
 
 ### Syntax and Examples
 
-The connection parameters are specified using a CONNECTION clause and are separated by comma. 
-
-- The CONNECTION keyword is followed by either '=' or '=>', depending on the context: '=' is used with the [COPY INTO](../14-sql-commands/10-dml/dml-copy-into-table.md) or [CREATE STAGE](../14-sql-commands/00-ddl/40-stage/01-ddl-create-stage.md) commands, whereas '=>' is employed when [Querying Staged Files](../12-load-data/00-transform/05-querying-stage.md).
-
-- When [Querying Staged Files](../12-load-data/00-transform/05-querying-stage.md), the CONNECTION clause is enclosed in an additional set of parentheses.
+The connection parameters are specified using a CONNECTION clause and are separated by comma. When [Querying Staged Files](../12-load-data/00-transform/05-querying-stage.md), the CONNECTION clause is enclosed in an additional set of parentheses.
 
 ```sql title='Examples:'
 -- This example illustrates a 'CREATE STAGE' command where 'CONNECTION' is followed by '=', establishing a Minio stage with specific connection parameters.
@@ -25,7 +21,6 @@ CREATE STAGE my_minio_stage
     SECRET_ACCESS_KEY = 'CHANGEME123',
     REGION = 'us-west-2'
   );
-
 
 -- This example showcases a 'COPY INTO' command, employing '=' after 'CONNECTION' to copy data, while also specifying file format details.
 COPY INTO mytable

--- a/docs/doc/13-sql-reference/51-connect-parameters.md
+++ b/docs/doc/13-sql-reference/51-connect-parameters.md
@@ -38,7 +38,7 @@ COPY INTO mytable
     SIZE_LIMIT = 10;
 
 -- This example uses a 'SELECT' statement to query staged files. 
--- 'CONNECTION' is followed by '=>' to access Minio data, and the  connection clause is enclosed in an additional set of parentheses.
+-- 'CONNECTION' is followed by '=>' to access Minio data, and the connection clause is enclosed in an additional set of parentheses.
 SELECT * FROM 's3://testbucket/admin/data/parquet/tuple.parquet' 
     (CONNECTION => (
         ACCESS_KEY_ID = 'minioadmin', 

--- a/docs/doc/13-sql-reference/51-connect-parameters.md
+++ b/docs/doc/13-sql-reference/51-connect-parameters.md
@@ -17,9 +17,15 @@ The connection parameters are specified using a CONNECTION clause and are separa
 
 ```sql title='Examples:'
 -- This example illustrates a 'CREATE STAGE' command where 'CONNECTION' is followed by '=', establishing a Minio stage with specific connection parameters.
-CREATE STAGE my_minio_stage 
-URL = 's3://databend' 
-CONNECTION = (ENDPOINT_URL = 'http://localhost:9000', ACCESS_KEY_ID = 'ROOTUSER', SECRET_ACCESS_KEY = 'CHANGEME123', region = 'us-west-2');
+CREATE STAGE my_minio_stage
+  URL = 's3://databend'
+  CONNECTION = (
+    ENDPOINT_URL = 'http://localhost:9000',
+    ACCESS_KEY_ID = 'ROOTUSER',
+    SECRET_ACCESS_KEY = 'CHANGEME123',
+    REGION = 'us-west-2'
+  );
+
 
 -- This example showcases a 'COPY INTO' command, employing '=' after 'CONNECTION' to copy data, while also specifying file format details.
 COPY INTO mytable

--- a/docs/doc/13-sql-reference/51-connect-parameters.md
+++ b/docs/doc/13-sql-reference/51-connect-parameters.md
@@ -7,10 +7,39 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 The connection parameters refer to a set of essential connection details required for establishing a secure link to supported external storage services, like Amazon S3. These parameters are enclosed within parentheses and consists of key-value pairs separated by commas. It is commonly utilized in operations such as creating a stage, copying data into Databend, and querying staged files from external sources. The provided key-value pairs offer the necessary authentication and configuration information for the connection.
 
-For example, the following statement creates an external stage on MinIO with the connection parameters:
+### Syntax and Examples
 
-```sql
-CREATE STAGE my_minio_stage URL = 's3://databend' CONNECTION = (ENDPOINT_URL = 'http://localhost:9000', ACCESS_KEY_ID = 'ROOTUSER', SECRET_ACCESS_KEY = 'CHANGEME123', region = 'us-west-2');
+The connection parameters are specified using a CONNECTION clause and are separated by comma. 
+
+- The CONNECTION keyword is followed by either '=' or '=>', depending on the context: '=' is used with the [COPY INTO](../14-sql-commands/10-dml/dml-copy-into-table.md) or [CREATE STAGE](../14-sql-commands/00-ddl/40-stage/01-ddl-create-stage.md) commands, whereas '=>' is employed when [Querying Staged Files](../12-load-data/00-transform/05-querying-stage.md).
+
+- When [Querying Staged Files](../12-load-data/00-transform/05-querying-stage.md), the CONNECTION clause is enclosed in an additional set of parentheses.
+
+```sql title='Examples:'
+-- This example illustrates a 'CREATE STAGE' command where 'CONNECTION' is followed by '=', establishing a Minio stage with specific connection parameters.
+CREATE STAGE my_minio_stage 
+URL = 's3://databend' 
+CONNECTION = (ENDPOINT_URL = 'http://localhost:9000', ACCESS_KEY_ID = 'ROOTUSER', SECRET_ACCESS_KEY = 'CHANGEME123', region = 'us-west-2');
+
+-- This example showcases a 'COPY INTO' command, employing '=' after 'CONNECTION' to copy data, while also specifying file format details.
+COPY INTO mytable
+    FROM 's3://mybucket/data.csv'
+    CONNECTION = (
+        ACCESS_KEY_ID = '<your-access-key-ID>',
+        SECRET_ACCESS_KEY = '<your-secret-access-key>'
+    )
+    FILE_FORMAT = (
+        TYPE = CSV,
+        FIELD_DELIMITER = ',',
+        RECORD_DELIMITER = '\n',
+        SKIP_HEADER = 1
+    )
+    SIZE_LIMIT = 10;
+
+-- This example uses a 'SELECT' statement to query staged files. 
+-- 'CONNECTION' is followed by '=>' to access Minio data, and the  connection clause is enclosed in an additional set of parentheses.
+SELECT * FROM 's3://testbucket/admin/data/parquet/tuple.parquet' 
+(CONNECTION => (ACCESS_KEY_ID = 'minioadmin', SECRET_ACCESS_KEY = 'minioadmin', ENDPOINT_URL = 'http://127.0.0.1:9900/'));
 ```
 
 The connection parameters vary for different storage services based on their specific requirements and authentication mechanisms. For more information, please refer to the tables below.

--- a/docs/doc/13-sql-reference/51-connect-parameters.md
+++ b/docs/doc/13-sql-reference/51-connect-parameters.md
@@ -45,7 +45,12 @@ COPY INTO mytable
 -- This example uses a 'SELECT' statement to query staged files. 
 -- 'CONNECTION' is followed by '=>' to access Minio data, and the  connection clause is enclosed in an additional set of parentheses.
 SELECT * FROM 's3://testbucket/admin/data/parquet/tuple.parquet' 
-(CONNECTION => (ACCESS_KEY_ID = 'minioadmin', SECRET_ACCESS_KEY = 'minioadmin', ENDPOINT_URL = 'http://127.0.0.1:9900/'));
+    (CONNECTION => (
+        ACCESS_KEY_ID = 'minioadmin', 
+        SECRET_ACCESS_KEY = 'minioadmin', 
+        ENDPOINT_URL = 'http://127.0.0.1:9900/'
+        )
+    );
 ```
 
 The connection parameters vary for different storage services based on their specific requirements and authentication mechanisms. For more information, please refer to the tables below.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- Summarized the connection parameter format (for example, = or =>) in SQLs (CREATE STAGE, COPY INTO, SELECT)
- Highlighted the differences that might confuse the users.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13470)
<!-- Reviewable:end -->
