### PR TITLE
chore: aws_* to access_key_id/secret_access_key

### DIFF
--- a/scripts/benchmark/query/load/hits.sh
+++ b/scripts/benchmark/query/load/hits.sh
@@ -121,7 +121,7 @@ cat <<SQL | bendsql
 SQL
 
 cat <<SQL | bendsql
-COPY INTO hits FROM 's3://repo.databend.rs/hits_p/' credentials=(aws_key_id='$REPO_ACCESS_KEY_ID' aws_secret_key='$REPO_SECRET_ACCESS_KEY') pattern ='.*[.]tsv' file_format=(type='TSV' field_delimiter='\\t' record_delimiter='\\n' skip_header=1);
+COPY INTO hits FROM 's3://repo.databend.rs/hits_p/' credentials=(access_key_id ='$REPO_ACCESS_KEY_ID' secret_access_key ='$REPO_SECRET_ACCESS_KEY') pattern ='.*[.]tsv' file_format=(type='TSV' field_delimiter='\\t' record_delimiter='\\n' skip_header=1);
 SQL
 
 cat <<SQL | bendsql

--- a/scripts/benchmark/query/load/tpch10.sh
+++ b/scripts/benchmark/query/load/tpch10.sh
@@ -116,7 +116,7 @@ for t in customer lineitem nation orders partsupp part region supplier; do
 	echo "loading into $t ..."
 	cat <<SQL | bendsql
 COPY INTO $t FROM 's3://repo.databend.rs/datasets/tpch10/${t}/'
-credentials=(aws_key_id='$REPO_ACCESS_KEY_ID' aws_secret_key='$REPO_SECRET_ACCESS_KEY') pattern ='${t}.*'
+credentials=(access_key_id ='$REPO_ACCESS_KEY_ID' secret_access_key ='$REPO_SECRET_ACCESS_KEY') pattern ='${t}.*'
 file_format=(type='CSV' field_delimiter='|' record_delimiter='\\n' skip_header=0);
 ANALYZE TABLE "${t}";
 SELECT count(*) as count_${t} FROM "${t}";

--- a/scripts/benchmark/query/load/tpch100.sh
+++ b/scripts/benchmark/query/load/tpch100.sh
@@ -116,7 +116,7 @@ for t in nation region; do
 	echo "loading into $t ..."
 	cat <<SQL | bendsql
 COPY INTO $t FROM 's3://repo.databend.rs/tpch100/${t}.tbl'
-credentials=(aws_key_id='$REPO_ACCESS_KEY_ID' aws_secret_key='$REPO_SECRET_ACCESS_KEY')
+credentials=(access_key_id ='$REPO_ACCESS_KEY_ID' secret_access_key ='$REPO_SECRET_ACCESS_KEY')
 file_format=(type='CSV' field_delimiter='|' record_delimiter='\\n' skip_header=1);
 ANALYZE TABLE "${t}";
 SELECT count(*) as count_${t} FROM "${t}";
@@ -127,7 +127,7 @@ for t in customer lineitem orders partsupp part supplier; do
 	echo "loading into $t ..."
 	cat <<SQL | bendsql
 COPY INTO $t FROM 's3://repo.databend.rs/tpch100/${t}/'
-credentials=(aws_key_id='$REPO_ACCESS_KEY_ID' aws_secret_key='$REPO_SECRET_ACCESS_KEY') pattern ='${t}.tbl.*'
+credentials=(access_key_id ='$REPO_ACCESS_KEY_ID' secret_access_key ='$REPO_SECRET_ACCESS_KEY') pattern ='${t}.tbl.*'
 file_format=(type='CSV' field_delimiter='|' record_delimiter='\\n' skip_header=1);
 ANALYZE TABLE "${t}";
 SELECT count(*) as count_${t} FROM "${t}";

--- a/tests/sqllogictests/scripts/prepare_stage.sh
+++ b/tests/sqllogictests/scripts/prepare_stage.sh
@@ -11,7 +11,7 @@ if [ -z "$TEST_STAGE_STORAGE" ] || [ "$TEST_STAGE_STORAGE" == "fs" ]; then
 	DATADIR="fs://${PWD}/tests/data/"
 	echo "create stage data url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);" | $MYSQL_CLIENT_CONNECT
 elif [ "$TEST_STAGE_STORAGE" == "s3" ]; then
-	echo "create stage data url='s3://testbucket/data/' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='http://127.0.0.1:9900') FILE_FORMAT = (type = PARQUET);" | $MYSQL_CLIENT_CONNECT
+	echo "create stage data url='s3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900') FILE_FORMAT = (type = PARQUET);" | $MYSQL_CLIENT_CONNECT
 else
 	echo "unknown TEST_STAGE_STORAGE value: ${TEST_STAGE_STORAGE}"
 	exit 1

--- a/tests/suites/1_stateful/00_stage/00_0008_remove_external_stage.sh
+++ b/tests/suites/1_stateful/00_stage/00_0008_remove_external_stage.sh
@@ -17,7 +17,7 @@ aws --endpoint-url  ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/admin/data/
 aws --endpoint-url  ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/admin/data/ontime_200.csv.zst s3://testbucket/admin/tempdata/dir/ontime_200.csv.zst >/dev/null 2>&1
 
 ## Copy from named external stage
-echo "CREATE STAGE named_external_stage url = 's3://testbucket/admin/tempdata/' credentials=(aws_key_id='minioadmin' aws_secret_key='minioadmin'  endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
+echo "CREATE STAGE named_external_stage url = 's3://testbucket/admin/tempdata/' credentials=(access_key_id ='minioadmin' secret_access_key ='minioadmin'  endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
 
 ## List files in internal stage
 echo "=== List files in external stage ==="

--- a/tests/suites/1_stateful/02_query/02_0001_create_table_with_external_location.sh
+++ b/tests/suites/1_stateful/02_query/02_0001_create_table_with_external_location.sh
@@ -7,8 +7,8 @@ echo "drop table if exists table_external_location;" | $MYSQL_CLIENT_CONNECT
 echo "drop table if exists table_external_location_with_location_prefix;" | $MYSQL_CLIENT_CONNECT
 
 ## Create table
-echo "create table table_external_location(a int) 's3://testbucket/admin/data/' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
-echo "create table table_external_location_with_location_prefix(a int) 's3://testbucket/admin/data/' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}') location_prefix = 'lulu_';" | $MYSQL_CLIENT_CONNECT
+echo "create table table_external_location(a int) 's3://testbucket/admin/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
+echo "create table table_external_location_with_location_prefix(a int) 's3://testbucket/admin/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}') location_prefix = 'lulu_';" | $MYSQL_CLIENT_CONNECT
 
 table_inserts=(
   "insert into table_external_location(a) values(888)"

--- a/tests/suites/1_stateful/02_query/02_0004_attach_table.result
+++ b/tests/suites/1_stateful/02_query/02_0004_attach_table.result
@@ -41,4 +41,4 @@ drop table IS allowed
 undrop table should work
 0
 show create attach table
-table_read_only	ATTACH TABLE `default`.`table_read_only` 'sPLACE_HOLDER://testbucket/admin/data/PLACE_HOLDER/PLACE_HOLDER/' CONNECTION = ( aws_key_id = '********', aws_secret_key = '********', endpoint_url = '********' ) READ_ONLY
+table_read_only	ATTACH TABLE `default`.`table_read_only` 'sPLACE_HOLDER://testbucket/admin/data/PLACE_HOLDER/PLACE_HOLDER/' CONNECTION = ( access_key_id = '********', endpoint_url = '********', secret_access_key = '********' ) READ_ONLY

--- a/tests/suites/1_stateful/02_query/02_0004_attach_table.sh
+++ b/tests/suites/1_stateful/02_query/02_0004_attach_table.sh
@@ -7,7 +7,7 @@ echo "drop table if exists table_from;" | $MYSQL_CLIENT_CONNECT
 echo "drop table if exists table_to;" | $MYSQL_CLIENT_CONNECT
 
 ## Create table
-echo "create table table_from(a int) 's3://testbucket/admin/data/' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
+echo "create table table_from(a int) 's3://testbucket/admin/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
 
 table_inserts=(
   "insert into table_from(a) values(0)"
@@ -21,7 +21,7 @@ done
 
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table table_from" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
 
-echo "attach table table_to 's3://testbucket/admin/data/$storage_prefix' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
+echo "attach table table_to 's3://testbucket/admin/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
 
 
 # ## Select table
@@ -40,7 +40,7 @@ echo "Attach READ_ONLY"
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table table_from" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
 
 # 1. READ_ONLY attach table
-echo "attach table table_read_only 's3://testbucket/admin/data/$storage_prefix' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}') READ_ONLY;" | $MYSQL_CLIENT_CONNECT
+echo "attach table table_read_only 's3://testbucket/admin/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}') READ_ONLY;" | $MYSQL_CLIENT_CONNECT
 
 echo "check content of attach table"
 # ## check table content

--- a/tests/suites/1_stateful/05_formats/05_01_compact/05_01_00_load_compact_copy.sh
+++ b/tests/suites/1_stateful/05_formats/05_01_compact/05_01_00_load_compact_copy.sh
@@ -22,7 +22,7 @@ aws --endpoint-url http://127.0.0.1:9900/ s3 cp $DATA s3://testbucket/$DATA > /d
 echo "---copy into"
 # let input data dispatch to multi threads
 echo "set global input_read_buffer_size = 100" | $MYSQL_CLIENT_CONNECT
-echo "copy into t1 from 's3://testbucket/${DATA}' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $MYSQL_CLIENT_CONNECT
+echo "copy into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $MYSQL_CLIENT_CONNECT
 echo "set global input_read_buffer_size = 1048576" | $MYSQL_CLIENT_CONNECT
 
 echo "---row_count"

--- a/tests/suites/1_stateful/05_formats/05_01_compact/05_01_02_load_compact_copy_max_size.sh
+++ b/tests/suites/1_stateful/05_formats/05_01_compact/05_01_02_load_compact_copy_max_size.sh
@@ -26,7 +26,7 @@ echo "---copy into"
 # let input data dispatch to multi threads
 # echo "set global max_threads = 1" | $MYSQL_CLIENT_CONNECT # for debug
 echo "set global input_read_buffer_size = 100" | $MYSQL_CLIENT_CONNECT
-echo "copy into t1 from 's3://testbucket/${DATA}' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $MYSQL_CLIENT_CONNECT
+echo "copy into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $MYSQL_CLIENT_CONNECT
 echo "set global input_read_buffer_size = 1048576" | $MYSQL_CLIENT_CONNECT
 
 echo "---row_count"

--- a/tests/suites/1_stateful/05_formats/05_01_compact/05_01_02_load_compact_copy_row_per_block.sh
+++ b/tests/suites/1_stateful/05_formats/05_01_compact/05_01_02_load_compact_copy_row_per_block.sh
@@ -26,7 +26,7 @@ echo "---copy into"
 # let input data dispatch to multi threads
 echo "set global max_threads = 1" | $MYSQL_CLIENT_CONNECT # for debug
 echo "set global input_read_buffer_size = 100" | $MYSQL_CLIENT_CONNECT
-echo "copy into t1 from 's3://testbucket/${DATA}' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $MYSQL_CLIENT_CONNECT
+echo "copy into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $MYSQL_CLIENT_CONNECT
 echo "set global input_read_buffer_size = 1048576" | $MYSQL_CLIENT_CONNECT
 
 echo "---row_count"

--- a/tests/suites/1_stateful/05_formats/05_04_tsv/05_04_01_tsv_multi_file.sh
+++ b/tests/suites/1_stateful/05_formats/05_04_tsv/05_04_01_tsv_multi_file.sh
@@ -32,7 +32,7 @@ echo "CREATE TABLE test_tsv
 
 # do copy
 echo "SET GLOBAL input_read_buffer_size = 111;" | $MYSQL_CLIENT_CONNECT
-COPY_SQL="copy into test_tsv from 's3://testbucket/tmp/multi_tsv/' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='http://127.0.0.1:9900/') PATTERN = '.*' FILE_FORMAT = (type = TSV) force=true"
+COPY_SQL="copy into test_tsv from 's3://testbucket/tmp/multi_tsv/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') PATTERN = '.*' FILE_FORMAT = (type = TSV) force=true"
 echo "${COPY_SQL}" |  $MYSQL_CLIENT_CONNECT
 echo "SET GLOBAL input_read_buffer_size = 1048576;" | $MYSQL_CLIENT_CONNECT
 

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_05_query_uri.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_05_query_uri.sh
@@ -3,4 +3,4 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../../shell_env.sh
 
-echo  "select * from 's3://testbucket/admin/data/parquet/tuple.parquet' (connection => (aws_key_id = 'minioadmin', aws_secret_key = 'minioadmin', endpoint_url = 'http://127.0.0.1:9900/'), file_format => 'parquet')"  | $MYSQL_CLIENT_CONNECT
+echo  "select * from 's3://testbucket/admin/data/parquet/tuple.parquet' (connection => (access_key_id  = 'minioadmin', secret_access_key  = 'minioadmin', endpoint_url = 'http://127.0.0.1:9900/'), file_format => 'parquet')"  | $MYSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/10_iceberg/10_0000_create_and_show.sh
+++ b/tests/suites/1_stateful/10_iceberg/10_0000_create_and_show.sh
@@ -11,8 +11,8 @@ CREATE CATALOG iceberg_ctl
 TYPE=ICEBERG
 CONNECTION=(
     URL='s3://testbucket/iceberg_ctl/'
-    AWS_KEY_ID='minioadmin'
-    AWS_SECRET_KEY='minioadmin'
+    access_key_id ='minioadmin'
+    secret_access_key ='minioadmin'
     ENDPOINT_URL='${STORAGE_S3_ENDPOINT_URL}'
 );
 EOF

--- a/tests/suites/1_stateful/10_iceberg/10_0001_read.sh
+++ b/tests/suites/1_stateful/10_iceberg/10_0001_read.sh
@@ -11,8 +11,8 @@ CREATE CATALOG iceberg_ctl
 TYPE=ICEBERG
 CONNECTION=(
     URL='s3://testbucket/iceberg_ctl/'
-    AWS_KEY_ID='minioadmin'
-    AWS_SECRET_KEY='minioadmin'
+    access_key_id ='minioadmin'
+    secret_access_key ='minioadmin'
     ENDPOINT_URL='${STORAGE_S3_ENDPOINT_URL}'
 );
 EOF

--- a/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
+++ b/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
@@ -61,7 +61,7 @@ echo "drop database if exists test_vacuum_drop_4" | $MYSQL_CLIENT_CONNECT
 echo "drop table if exists table_drop_external_location;" | $MYSQL_CLIENT_CONNECT
 
 ## Create table
-echo "create table table_drop_external_location(a int) 's3://testbucket/admin/data/' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
+echo "create table table_drop_external_location(a int) 's3://testbucket/admin/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
 
 table_inserts=(
   "insert into table_drop_external_location(a) values(888)"

--- a/tests/suites/5_ee/04_attach_read_only/04_0001_check_mutations.sh
+++ b/tests/suites/5_ee/04_attach_read_only/04_0001_check_mutations.sh
@@ -7,10 +7,10 @@ echo "create database if not exists test_attach_only;" | $MYSQL_CLIENT_CONNECT
 
 # mutation related enterprise features
 
-echo "create table test_attach_only.test_json(id int, val json) 's3://testbucket/admin/data/' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
+echo "create table test_attach_only.test_json(id int, val json) 's3://testbucket/admin/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $MYSQL_CLIENT_CONNECT
 echo "insert into test_attach_only.test_json values(1, '{\"a\":33,\"b\":44}'),(2, '{\"a\":55,\"b\":66}')" | $MYSQL_CLIENT_CONNECT
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table test_attach_only.test_json" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
-echo "attach table test_attach_only.test_json_read_only 's3://testbucket/admin/data/$storage_prefix' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}') READ_ONLY;" | $MYSQL_CLIENT_CONNECT
+echo "attach table test_attach_only.test_json_read_only 's3://testbucket/admin/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}') READ_ONLY;" | $MYSQL_CLIENT_CONNECT
 
 echo "create virtual column should fail"
 echo "CREATE VIRTUAL COLUMN (val['a'], val['b']) FOR test_attach_only.test_json_read_only" | $MYSQL_CLIENT_CONNECT
@@ -35,7 +35,7 @@ echo "vacuum drop table from db should not include the read_only attach table"
 echo "drop table test_attach_only.test_json_read_only" | $MYSQL_CLIENT_CONNECT
 echo "vacuum drop table from test_attach_only retain 0 hours" | $MYSQL_CLIENT_CONNECT
 # attach it back
-echo "attach table test_attach_only.test_json_read_only 's3://testbucket/admin/data/$storage_prefix' connection=(aws_key_id='minioadmin' aws_secret_key='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}') READ_ONLY" | $MYSQL_CLIENT_CONNECT
+echo "attach table test_attach_only.test_json_read_only 's3://testbucket/admin/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}') READ_ONLY" | $MYSQL_CLIENT_CONNECT
 echo "expect table data still there"
 echo "select * from test_attach_only.test_json_read_only order by id" | $MYSQL_CLIENT_CONNECT
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Change the test script:
* `aws_key_id` to `access_key_id`
* `aws_secret_key` to `secret_access_key`

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13473)
<!-- Reviewable:end -->
