### PR TITLE
chore: adjust partition number for hash join spill

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
@@ -85,10 +85,9 @@ impl TransformHashJoinBuild {
         }))
     }
 
-    fn wait_spill(&mut self, data_block: DataBlock) -> Result<()> {
+    fn wait_spill(&mut self) -> Result<()> {
         let spill_state = self.spill_state.as_mut().unwrap();
         let wait = spill_state.spill_coordinator.wait_spill()?;
-        self.input_data = Some(data_block);
         if wait {
             self.step = HashJoinBuildStep::WaitSpill;
         } else {
@@ -188,6 +187,20 @@ impl Processor for TransformHashJoinBuild {
                     return Ok(Event::Async);
                 }
 
+                if let Some(spill_state) = self.spill_state.as_ref() {
+                    if spill_state.check_need_spill()? {
+                        spill_state.spill_coordinator.need_spill()?;
+                        self.wait_spill()?;
+                        // WaitProbe or FirstSpill, so set Event to Async
+                        return Ok(Event::Async);
+                    } else if spill_state.spill_coordinator.get_need_spill() {
+                        // even if input can fit into memory, but there exists one processor need to spill,
+                        // then it needs to wait spill.
+                        self.wait_spill()?;
+                        return Ok(Event::Async);
+                    }
+                }
+
                 match self.input_port.has_data() {
                     true => {
                         self.input_data = Some(self.input_port.pull_data().unwrap()?);
@@ -231,33 +244,11 @@ impl Processor for TransformHashJoinBuild {
                     if self.from_spill {
                         return self.build_state.build(data_block);
                     }
-                    if let Some(spill_state) = &mut self.spill_state && !spill_state.spiller.is_all_spilled() {
-                        // Check if need to spill
-                        let need_spill = spill_state.check_need_spill(&data_block)?;
-                        if need_spill {
-                            spill_state.spill_coordinator.need_spill()?;
-                            self.wait_spill(data_block)?;
-                        } else if spill_state.spill_coordinator.get_need_spill() {
-                                // even if input can fit into memory, but there exists one processor need to spill,
-                                // then it needs to wait spill.
-                                self.wait_spill(data_block)?;
-                            } else {
-                                // If the processor had spilled data, we should continue to spill
-                                if spill_state.spiller.is_any_spilled() {
-                                    self.step = HashJoinBuildStep::FollowSpill;
-                                    self.spill_data = Some(data_block);
-                                } else {
-                                    self.build_state.build(data_block)?;
-                                }
-                            }
+                    if let Some(spill_state) = &mut self.spill_state && spill_state.spiller.is_any_spilled() {
+                        // If the processor had spilled data, we should continue to spill
+                        self.step = HashJoinBuildStep::FollowSpill;
+                        self.spill_data = Some(data_block);
                     } else {
-                        if let Some(spill_state) = &mut self.spill_state {
-                            if spill_state.spiller.is_all_spilled() {
-                                self.step = HashJoinBuildStep::FollowSpill;
-                                self.spill_data = Some(data_block);
-                                return Ok(());
-                            }
-                        }
                         self.build_state.build(data_block)?;
                     }
                 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
@@ -233,7 +233,7 @@ impl Processor for TransformHashJoinBuild {
                     }
                     if let Some(spill_state) = &mut self.spill_state && !spill_state.spiller.is_all_spilled() {
                         // Check if need to spill
-                        let need_spill = spill_state.check_need_spill()?;
+                        let need_spill = spill_state.check_need_spill(&data_block)?;
                         if need_spill {
                             spill_state.spill_coordinator.need_spill()?;
                             self.wait_spill(data_block)?;
@@ -364,7 +364,7 @@ impl Processor for TransformHashJoinBuild {
                 {
                     let spilled_data = spill_state
                         .spiller
-                        .read_spilled_data(&(partition_id as u8))
+                        .read_spilled_data(&(partition_id as u8), self.processor_id)
                         .await?;
                     self.input_data = Some(DataBlock::concat(&spilled_data)?);
                 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_probe.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_probe.rs
@@ -502,7 +502,10 @@ impl Processor for TransformHashJoinProbe {
                     .spilled_partition_set
                     .contains(&(p_id as u8))
                 {
-                    let spilled_data = spill_state.spiller.read_spilled_data(&(p_id as u8)).await?;
+                    let spilled_data = spill_state
+                        .spiller
+                        .read_spilled_data(&(p_id as u8), self.processor_id)
+                        .await?;
                     if !spilled_data.is_empty() {
                         self.input_data.extend(spilled_data);
                     }

--- a/src/query/service/tests/it/spillers/spiller.rs
+++ b/src/query/service/tests/it/spillers/spiller.rs
@@ -53,7 +53,7 @@ async fn test_spill_with_partition() -> Result<()> {
     assert!(spiller.partition_location.get(&0).unwrap()[0].starts_with("_query_spill"));
 
     // Test read spilled data
-    let data_blocks = spiller.read_spilled_data(&(0_u8)).await?;
+    let data_blocks = spiller.read_spilled_data(&(0_u8), 0).await?;
     for block in data_blocks {
         assert_eq!(block.num_rows(), 100);
         assert_eq!(block.num_columns(), 2);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. Increase partition number to eight
2. put `check_spill()` to proper position
3. simplify log

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13475)
<!-- Reviewable:end -->
