### PR TITLE
refactor: MapApi should return Result<T, io::Error>

### DIFF
--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -224,7 +224,7 @@ async fn import_v002(
         if tree_name.starts_with("state_machine/") {
             // Write to snapshot
             writer
-                .write_entries::<io::Error>(futures::stream::iter([kv_entry]))
+                .write_entry_results::<io::Error>(futures::stream::iter([Ok(kv_entry)]))
                 .await?;
         } else {
             // Write to sled tree

--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
 use std::time::Duration;
 use std::time::SystemTime;
 
@@ -46,7 +47,7 @@ use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
 use common_meta_types::UpsertKV;
 use common_meta_types::With;
-use futures_util::StreamExt;
+use futures::stream::TryStreamExt;
 use log::as_debug;
 use log::as_display;
 use log::debug;
@@ -76,13 +77,13 @@ impl<'a> Applier<'a> {
     ///
     /// And publish kv change events to subscriber.
     #[minitrace::trace]
-    pub async fn apply(&mut self, entry: &Entry) -> AppliedState {
+    pub async fn apply(&mut self, entry: &Entry) -> Result<AppliedState, io::Error> {
         info!("apply: entry: {}", entry,);
 
         let log_id = &entry.log_id;
         let log_time_ms = Self::get_log_time(entry);
 
-        self.clean_expired_kvs(log_time_ms).await;
+        self.clean_expired_kvs(log_time_ms).await?;
 
         *self.sm.sys_data_mut().last_applied_mut() = Some(*log_id);
 
@@ -96,7 +97,7 @@ impl<'a> Applier<'a> {
                 info!("apply: normal: {}", data);
                 assert!(data.txid.is_none(), "txid is disabled");
 
-                self.apply_cmd(&data.cmd).await
+                self.apply_cmd(&data.cmd).await?
             }
             EntryPayload::Membership(ref mem) => {
                 info!("apply: membership: {:?}", mem);
@@ -114,7 +115,7 @@ impl<'a> Applier<'a> {
             }
         }
 
-        applied_state
+        Ok(applied_state)
     }
 
     /// Apply a `Cmd` to state machine.
@@ -123,7 +124,7 @@ impl<'a> Applier<'a> {
     /// This is the only entry to modify state machine.
     /// The `cmd` is always committed by raft before applying.
     #[minitrace::trace]
-    pub async fn apply_cmd(&mut self, cmd: &Cmd) -> AppliedState {
+    pub async fn apply_cmd(&mut self, cmd: &Cmd) -> Result<AppliedState, io::Error> {
         info!("apply_cmd: {}", cmd);
 
         let res = match cmd {
@@ -135,14 +136,14 @@ impl<'a> Applier<'a> {
 
             Cmd::RemoveNode { ref node_id } => self.apply_remove_node(node_id),
 
-            Cmd::UpsertKV(ref upsert_kv) => self.apply_upsert_kv(upsert_kv).await,
+            Cmd::UpsertKV(ref upsert_kv) => self.apply_upsert_kv(upsert_kv).await?,
 
-            Cmd::Transaction(txn) => self.apply_txn(txn).await,
+            Cmd::Transaction(txn) => self.apply_txn(txn).await?,
         };
 
         info!("apply_result: cmd: {}; res: {}", cmd, res);
 
-        res
+        Ok(res)
     }
 
     /// Insert a node only when it does not exist or `overriding` is true.
@@ -188,12 +189,13 @@ impl<'a> Applier<'a> {
     /// Thus upsert a kv entry is done in two steps:
     /// update the primary index and optionally update the secondary index.
     #[minitrace::trace]
-    async fn apply_upsert_kv(&mut self, upsert_kv: &UpsertKV) -> AppliedState {
+    async fn apply_upsert_kv(&mut self, upsert_kv: &UpsertKV) -> Result<AppliedState, io::Error> {
         debug!(upsert_kv = as_debug!(upsert_kv); "apply_update_kv_cmd");
 
-        let (prev, result) = self.upsert_kv(upsert_kv).await;
+        let (prev, result) = self.upsert_kv(upsert_kv).await?;
 
-        Change::new(prev, result).into()
+        let st = Change::new(prev, result).into();
+        Ok(st)
     }
 
     // TODO(1): when get an applier, pass in a now_ms to ensure all expired are cleaned.
@@ -201,14 +203,17 @@ impl<'a> Applier<'a> {
     ///
     /// If the input entry has expired, it performs a delete operation.
     #[minitrace::trace]
-    pub(crate) async fn upsert_kv(&mut self, upsert_kv: &UpsertKV) -> (Option<SeqV>, Option<SeqV>) {
+    pub(crate) async fn upsert_kv(
+        &mut self,
+        upsert_kv: &UpsertKV,
+    ) -> Result<(Option<SeqV>, Option<SeqV>), io::Error> {
         debug!(upsert_kv = as_debug!(upsert_kv); "upsert_kv");
 
-        let (prev, result) = self.sm.upsert_kv_primary_index(upsert_kv).await;
+        let (prev, result) = self.sm.upsert_kv_primary_index(upsert_kv).await?;
 
         self.sm
             .update_expire_index(&upsert_kv.key, &prev, &result)
-            .await;
+            .await?;
 
         let prev = Into::<Option<SeqV>>::into(prev);
         let result = Into::<Option<SeqV>>::into(result);
@@ -220,14 +225,14 @@ impl<'a> Applier<'a> {
 
         self.push_change(&upsert_kv.key, prev.clone(), result.clone());
 
-        (prev, result)
+        Ok((prev, result))
     }
 
     #[minitrace::trace]
-    async fn apply_txn(&mut self, req: &TxnRequest) -> AppliedState {
+    async fn apply_txn(&mut self, req: &TxnRequest) -> Result<AppliedState, io::Error> {
         debug!(txn = as_display!(req); "apply txn cmd");
 
-        let success = self.eval_txn_conditions(&req.condition).await;
+        let success = self.eval_txn_conditions(&req.condition).await?;
 
         let ops = if success {
             &req.if_then
@@ -242,27 +247,30 @@ impl<'a> Applier<'a> {
         };
 
         for op in ops {
-            self.txn_execute_operation(op, &mut resp).await;
+            self.txn_execute_operation(op, &mut resp).await?;
         }
 
-        AppliedState::TxnReply(resp)
+        Ok(AppliedState::TxnReply(resp))
     }
 
     #[minitrace::trace]
-    async fn eval_txn_conditions(&mut self, condition: &Vec<TxnCondition>) -> bool {
+    async fn eval_txn_conditions(
+        &mut self,
+        condition: &Vec<TxnCondition>,
+    ) -> Result<bool, io::Error> {
         for cond in condition {
             debug!(condition = as_display!(cond); "txn_execute_condition");
 
-            if !self.eval_one_condition(cond).await {
-                return false;
+            if !self.eval_one_condition(cond).await? {
+                return Ok(false);
             }
         }
 
-        true
+        Ok(true)
     }
 
     #[minitrace::trace]
-    async fn eval_one_condition(&self, cond: &TxnCondition) -> bool {
+    async fn eval_one_condition(&self, cond: &TxnCondition) -> Result<bool, io::Error> {
         debug!(cond = as_display!(cond); "txn_execute_one_condition");
 
         let key = &cond.key;
@@ -270,7 +278,7 @@ impl<'a> Applier<'a> {
         // If the key expired, it should be treated as `None` value.
         // sm.get_kv() does not check expiration.
         // Expired keys are cleaned before applying a log, see: `clean_expired_kvs()`.
-        let seqv = self.sm.get_maybe_expired_kv(key).await;
+        let seqv = self.sm.get_maybe_expired_kv(key).await?;
 
         debug!(
             "txn_execute_one_condition: key: {} curr: seq:{} value:{:?}",
@@ -282,10 +290,10 @@ impl<'a> Applier<'a> {
         let target = if let Some(target) = &cond.target {
             target
         } else {
-            return false;
+            return Ok(false);
         };
 
-        match target {
+        let positive = match target {
             txn_condition::Target::Seq(right) => {
                 Self::eval_seq_condition(seqv.seq(), cond.expected, right)
             }
@@ -296,7 +304,8 @@ impl<'a> Applier<'a> {
                     false
                 }
             }
-        }
+        };
+        Ok(positive)
     }
 
     fn eval_seq_condition(left: u64, op: i32, right: &u64) -> bool {
@@ -324,28 +333,37 @@ impl<'a> Applier<'a> {
     }
 
     #[minitrace::trace]
-    async fn txn_execute_operation(&mut self, op: &TxnOp, resp: &mut TxnReply) {
+    async fn txn_execute_operation(
+        &mut self,
+        op: &TxnOp,
+        resp: &mut TxnReply,
+    ) -> Result<(), io::Error> {
         debug!(op = as_display!(op); "txn execute TxnOp");
         match &op.request {
             Some(txn_op::Request::Get(get)) => {
-                self.txn_execute_get(get, resp).await;
+                self.txn_execute_get(get, resp).await?;
             }
             Some(txn_op::Request::Put(put)) => {
-                self.txn_execute_put(put, resp).await;
+                self.txn_execute_put(put, resp).await?;
             }
             Some(txn_op::Request::Delete(delete)) => {
-                self.txn_execute_delete(delete, resp).await;
+                self.txn_execute_delete(delete, resp).await?;
             }
             Some(txn_op::Request::DeleteByPrefix(delete_by_prefix)) => {
                 self.txn_execute_delete_by_prefix(delete_by_prefix, resp)
-                    .await;
+                    .await?;
             }
             None => {}
         }
+        Ok(())
     }
 
-    async fn txn_execute_get(&self, get: &TxnGetRequest, resp: &mut TxnReply) {
-        let sv = self.sm.get_maybe_expired_kv(&get.key).await;
+    async fn txn_execute_get(
+        &self,
+        get: &TxnGetRequest,
+        resp: &mut TxnReply,
+    ) -> Result<(), io::Error> {
+        let sv = self.sm.get_maybe_expired_kv(&get.key).await?;
         let value = sv.map(pb::SeqV::from);
         let get_resp = TxnGetResponse {
             key: get.key.clone(),
@@ -355,14 +373,20 @@ impl<'a> Applier<'a> {
         resp.responses.push(TxnOpResponse {
             response: Some(txn_op_response::Response::Get(get_resp)),
         });
+
+        Ok(())
     }
 
-    async fn txn_execute_put(&mut self, put: &TxnPutRequest, resp: &mut TxnReply) {
+    async fn txn_execute_put(
+        &mut self,
+        put: &TxnPutRequest,
+        resp: &mut TxnReply,
+    ) -> Result<(), io::Error> {
         let upsert = UpsertKV::update(&put.key, &put.value).with(KVMeta {
             expire_at: put.expire_at,
         });
 
-        let (prev, _result) = self.upsert_kv(&upsert).await;
+        let (prev, _result) = self.upsert_kv(&upsert).await?;
 
         let put_resp = TxnPutResponse {
             key: put.key.clone(),
@@ -376,9 +400,15 @@ impl<'a> Applier<'a> {
         resp.responses.push(TxnOpResponse {
             response: Some(txn_op_response::Response::Put(put_resp)),
         });
+
+        Ok(())
     }
 
-    async fn txn_execute_delete(&mut self, delete: &TxnDeleteRequest, resp: &mut TxnReply) {
+    async fn txn_execute_delete(
+        &mut self,
+        delete: &TxnDeleteRequest,
+        resp: &mut TxnReply,
+    ) -> Result<(), io::Error> {
         let upsert = UpsertKV::delete(&delete.key);
 
         // If `delete.match_seq` is `Some`, only delete the entry with the exact `seq`.
@@ -388,7 +418,7 @@ impl<'a> Applier<'a> {
             upsert
         };
 
-        let (prev, result) = self.upsert_kv(&upsert).await;
+        let (prev, result) = self.upsert_kv(&upsert).await?;
         let is_deleted = prev.is_some() && result.is_none();
 
         let del_resp = TxnDeleteResponse {
@@ -404,18 +434,19 @@ impl<'a> Applier<'a> {
         resp.responses.push(TxnOpResponse {
             response: Some(txn_op_response::Response::Delete(del_resp)),
         });
+        Ok(())
     }
 
     async fn txn_execute_delete_by_prefix(
         &mut self,
         delete_by_prefix: &TxnDeleteByPrefixRequest,
         resp: &mut TxnReply,
-    ) {
-        let mut strm = self.sm.list_kv(&delete_by_prefix.prefix).await;
+    ) -> Result<(), io::Error> {
+        let mut strm = self.sm.list_kv(&delete_by_prefix.prefix).await?;
         let mut count = 0;
 
-        while let Some((key, _seq_v)) = strm.next().await {
-            let (prev, res) = self.upsert_kv(&UpsertKV::delete(&key)).await;
+        while let Some((key, _seq_v)) = strm.try_next().await? {
+            let (prev, res) = self.upsert_kv(&UpsertKV::delete(&key)).await?;
             self.push_change(key, prev, res);
             count += 1;
         }
@@ -428,6 +459,7 @@ impl<'a> Applier<'a> {
         resp.responses.push(TxnOpResponse {
             response: Some(txn_op_response::Response::DeleteByPrefix(del_resp)),
         });
+        Ok(())
     }
 
     /// Before applying, list expired keys to clean.
@@ -435,19 +467,19 @@ impl<'a> Applier<'a> {
     /// All expired keys will be removed before applying a log.
     /// This is different from the sled based implementation.
     #[minitrace::trace]
-    async fn clean_expired_kvs(&mut self, log_time_ms: u64) {
+    async fn clean_expired_kvs(&mut self, log_time_ms: u64) -> Result<(), io::Error> {
         if log_time_ms == 0 {
-            return;
+            return Ok(());
         }
 
         info!("to clean expired kvs, log_time_ts: {}", log_time_ms);
 
         let mut to_clean = vec![];
-        let mut strm = self.sm.list_expire_index().await;
+        let mut strm = self.sm.list_expire_index().await?;
 
         {
             let mut strm = std::pin::pin!(strm);
-            while let Some((expire_key, key)) = strm.next().await {
+            while let Some((expire_key, key)) = strm.try_next().await? {
                 if !expire_key.is_expired(log_time_ms) {
                     break;
                 }
@@ -457,12 +489,12 @@ impl<'a> Applier<'a> {
         }
 
         for (expire_key, key) in to_clean {
-            let curr = self.sm.get_maybe_expired_kv(&key).await;
+            let curr = self.sm.get_maybe_expired_kv(&key).await?;
             if let Some(seq_v) = &curr {
                 assert_eq!(expire_key.seq, seq_v.seq);
                 info!("clean expired: {}, {}", key, expire_key);
 
-                self.upsert_kv(&UpsertKV::delete(key.clone())).await;
+                self.upsert_kv(&UpsertKV::delete(key.clone())).await?;
             } else {
                 unreachable!(
                     "trying to remove un-cleanable: {}, {}, kv-entry: {:?}",
@@ -472,6 +504,8 @@ impl<'a> Applier<'a> {
         }
 
         self.sm.update_expire_cursor(log_time_ms);
+
+        Ok(())
     }
 
     /// Push a **change** that is applied to `key`.

--- a/src/meta/raft-store/src/ondisk/mod.rs
+++ b/src/meta/raft-store/src/ondisk/mod.rs
@@ -358,7 +358,7 @@ impl OnDisk {
             }
 
             writer
-                .write_entries::<io::Error>(futures::stream::iter([kv_entry]))
+                .write_entry_results::<io::Error>(futures::stream::iter([Ok(kv_entry)]))
                 .await
                 .map_err(|e| {
                     let ae = AnyError::new(&e).add_context(|| "write snapshot entry");

--- a/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
@@ -14,16 +14,19 @@
 
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
+use std::io;
 use std::ops::RangeBounds;
 
 use common_meta_types::KVMeta;
 use futures_util::StreamExt;
 
 use crate::sm_v002::leveled_store::map_api::AsMap;
-use crate::sm_v002::leveled_store::map_api::EntryStream;
+use crate::sm_v002::leveled_store::map_api::KVResultStream;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
+use crate::sm_v002::leveled_store::map_api::MarkedOf;
+use crate::sm_v002::leveled_store::map_api::Transition;
 use crate::sm_v002::leveled_store::sys_data::SysData;
 use crate::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use crate::sm_v002::marked::Marked;
@@ -88,15 +91,16 @@ impl Level {
 
 #[async_trait::async_trait]
 impl MapApiRO<String> for Level {
-    async fn get<Q>(&self, key: &Q) -> Marked<<String as MapKey>::V>
+    async fn get<Q>(&self, key: &Q) -> Result<Marked<<String as MapKey>::V>, io::Error>
     where
         String: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
     {
-        self.kv.get(key).cloned().unwrap_or(Marked::empty())
+        let got = self.kv.get(key).cloned().unwrap_or(Marked::empty());
+        Ok(got)
     }
 
-    async fn range<Q, R>(&self, range: R) -> EntryStream<String>
+    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<String>, io::Error>
     where
         String: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
@@ -108,7 +112,8 @@ impl MapApiRO<String> for Level {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect::<Vec<_>>();
 
-        futures::stream::iter(vec.into_iter()).boxed()
+        let strm = futures::stream::iter(vec.into_iter()).map(Ok).boxed();
+        Ok(strm)
     }
 }
 
@@ -118,7 +123,7 @@ impl MapApi<String> for Level {
         &mut self,
         key: String,
         value: Option<(<String as MapKey>::V, Option<KVMeta>)>,
-    ) -> (Marked<<String as MapKey>::V>, Marked<<String as MapKey>::V>) {
+    ) -> Result<Transition<MarkedOf<String>>, io::Error> {
         // The chance it is the bottom level is very low in a loaded system.
         // Thus we always tombstone the key if it is None.
 
@@ -131,23 +136,24 @@ impl MapApi<String> for Level {
             Marked::new_tomb_stone(seq)
         };
 
-        let prev = (*self).str_map().get(&key).await;
+        let prev = (*self).str_map().get(&key).await?;
         self.kv.insert(key, marked.clone());
-        (prev, marked)
+        Ok((prev, marked))
     }
 }
 
 #[async_trait::async_trait]
 impl MapApiRO<ExpireKey> for Level {
-    async fn get<Q>(&self, key: &Q) -> Marked<<ExpireKey as MapKey>::V>
+    async fn get<Q>(&self, key: &Q) -> Result<MarkedOf<ExpireKey>, io::Error>
     where
         ExpireKey: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
     {
-        self.expire.get(key).cloned().unwrap_or(Marked::empty())
+        let got = self.expire.get(key).cloned().unwrap_or(Marked::empty());
+        Ok(got)
     }
 
-    async fn range<Q, R>(&self, range: R) -> EntryStream<ExpireKey>
+    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<ExpireKey>, io::Error>
     where
         ExpireKey: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
@@ -159,7 +165,8 @@ impl MapApiRO<ExpireKey> for Level {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect::<Vec<_>>();
 
-        futures::stream::iter(vec.into_iter()).boxed()
+        let strm = futures::stream::iter(vec.into_iter()).map(Ok).boxed();
+        Ok(strm)
     }
 }
 
@@ -169,12 +176,7 @@ impl MapApi<ExpireKey> for Level {
         &mut self,
         key: ExpireKey,
         value: Option<(<ExpireKey as MapKey>::V, Option<KVMeta>)>,
-    ) -> (
-        Marked<<ExpireKey as MapKey>::V>,
-        Marked<<ExpireKey as MapKey>::V>,
-    ) {
-        // dbg!("set expire", &key, &value);
-
+    ) -> Result<Transition<MarkedOf<ExpireKey>>, io::Error> {
         let seq = self.curr_seq();
 
         let marked = if let Some((v, meta)) = value {
@@ -183,9 +185,9 @@ impl MapApi<ExpireKey> for Level {
             Marked::TombStone { internal_seq: seq }
         };
 
-        let prev = (*self).expire_map().get(&key).await;
+        let prev = (*self).expire_map().get(&key).await?;
         self.expire.insert(key, marked.clone());
-        (prev, marked)
+        Ok((prev, marked))
     }
 }
 

--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_meta_types::KVMeta;
-use futures_util::StreamExt;
+use futures_util::TryStreamExt;
 
 use crate::sm_v002::leveled_store::leveled_map::LeveledMap;
 use crate::sm_v002::leveled_store::map_api::AsMap;
@@ -27,19 +27,24 @@ async fn test_freeze() -> anyhow::Result<()> {
     let mut l = LeveledMap::default();
 
     // Insert an entry at level 0
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b0"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b0"), None))).await?;
     assert_eq!(prev, Marked::new_tomb_stone(0));
     assert_eq!(result, Marked::new_with_meta(1, b("b0"), None));
 
     // Insert the same entry at level 1
     l.freeze_writable();
 
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
     assert_eq!(prev, Marked::new_with_meta(1, b("b0"), None));
     assert_eq!(result, Marked::new_with_meta(2, b("b1"), None));
 
     // Listing entries from all levels see the latest
-    let got = l.str_map().range(s("")..).await.collect::<Vec<_>>().await;
+    let got = l
+        .str_map()
+        .range(s("")..)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (s("a1"), Marked::new_with_meta(2, b("b1"), None)),
@@ -51,9 +56,9 @@ async fn test_freeze() -> anyhow::Result<()> {
     let got = frozen
         .str_map()
         .range(s("")..)
-        .await
-        .collect::<Vec<_>>()
-        .await;
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (s("a1"), Marked::new_with_meta(1, b("b0"), None)),
@@ -67,30 +72,30 @@ async fn test_single_level() -> anyhow::Result<()> {
     let mut l = LeveledMap::default();
 
     // Write a1
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
     assert_eq!(prev, Marked::new_tomb_stone(0));
     assert_eq!(result, Marked::new_with_meta(1, b("b1"), None));
 
     // Write more
-    let (_prev, result) = l.str_map_mut().set(s("a2"), Some((b("b2"), None))).await;
+    let (_prev, result) = l.str_map_mut().set(s("a2"), Some((b("b2"), None))).await?;
     assert_eq!(result, Marked::new_with_meta(2, b("b2"), None));
 
-    let (_prev, result) = l.str_map_mut().set(s("a3"), Some((b("b3"), None))).await;
+    let (_prev, result) = l.str_map_mut().set(s("a3"), Some((b("b3"), None))).await?;
     assert_eq!(result, Marked::new_with_meta(3, b("b3"), None));
 
-    let (_prev, result) = l.str_map_mut().set(s("x1"), Some((b("y1"), None))).await;
+    let (_prev, result) = l.str_map_mut().set(s("x1"), Some((b("y1"), None))).await?;
     assert_eq!(result, Marked::new_with_meta(4, b("y1"), None));
 
-    let (_prev, result) = l.str_map_mut().set(s("x2"), Some((b("y2"), None))).await;
+    let (_prev, result) = l.str_map_mut().set(s("x2"), Some((b("y2"), None))).await?;
     assert_eq!(result, Marked::new_with_meta(5, b("y2"), None));
 
     // Override a1
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
     assert_eq!(prev, Marked::new_with_meta(1, b("b1"), None));
     assert_eq!(result, Marked::new_with_meta(6, b("b1"), None));
 
     // Delete a3
-    let (prev, result) = l.str_map_mut().set(s("a3"), None).await;
+    let (prev, result) = l.str_map_mut().set(s("a3"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(3, b("b3"), None));
     assert_eq!(
         result,
@@ -99,8 +104,8 @@ async fn test_single_level() -> anyhow::Result<()> {
     );
 
     // Range
-    let it = l.str_map().range(s("")..).await;
-    let got = it.collect::<Vec<_>>().await;
+    let strm = l.str_map().range(s("")..).await?;
+    let got = strm.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
         (s("a1"), Marked::new_with_meta(6, b("b1"), None)),
@@ -111,10 +116,10 @@ async fn test_single_level() -> anyhow::Result<()> {
     ]);
 
     // Get
-    let got = l.str_map().get("a2").await;
+    let got = l.str_map().get("a2").await?;
     assert_eq!(got, Marked::new_with_meta(2, b("b2"), None));
 
-    let got = l.str_map().get("a3").await;
+    let got = l.str_map().get("a3").await?;
     assert_eq!(got, Marked::new_tomb_stone(6));
     Ok(())
 }
@@ -125,13 +130,13 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     let mut l = LeveledMap::default();
 
-    l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await;
-    l.str_map_mut().set(s("a2"), Some((b("b2"), None))).await;
-    l.str_map_mut().set(s("x1"), Some((b("y1"), None))).await;
-    l.str_map_mut().set(s("x2"), Some((b("y2"), None))).await;
+    l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
+    l.str_map_mut().set(s("a2"), Some((b("b2"), None))).await?;
+    l.str_map_mut().set(s("x1"), Some((b("y1"), None))).await?;
+    l.str_map_mut().set(s("x2"), Some((b("y2"), None))).await?;
 
-    let it = l.str_map().range(s("")..).await;
-    let got = it.collect::<Vec<_>>().await;
+    let it = l.str_map().range(s("")..).await?;
+    let got = it.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
         (s("a1"), Marked::new_with_meta(1, b("b1"), None)),
@@ -145,28 +150,28 @@ async fn test_two_levels() -> anyhow::Result<()> {
     l.freeze_writable();
 
     // Override
-    let (prev, result) = l.str_map_mut().set(s("a2"), Some((b("b3"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("a2"), Some((b("b3"), None))).await?;
     assert_eq!(prev, Marked::new_with_meta(2, b("b2"), None));
     assert_eq!(result, Marked::new_with_meta(5, b("b3"), None));
 
     // Override again
-    let (prev, result) = l.str_map_mut().set(s("a2"), Some((b("b4"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("a2"), Some((b("b4"), None))).await?;
     assert_eq!(prev, Marked::new_with_meta(5, b("b3"), None));
     assert_eq!(result, Marked::new_with_meta(6, b("b4"), None));
 
     // Delete by adding a tombstone
-    let (prev, result) = l.str_map_mut().set(s("a1"), None).await;
+    let (prev, result) = l.str_map_mut().set(s("a1"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(1, b("b1"), None));
     assert_eq!(result, Marked::new_tomb_stone(6));
 
     // Override tombstone
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b5"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b5"), None))).await?;
     assert_eq!(prev, Marked::new_tomb_stone(6));
     assert_eq!(result, Marked::new_with_meta(7, b("b5"), None));
 
     // Range
-    let it = l.str_map().range(s("")..).await;
-    let got = it.collect::<Vec<_>>().await;
+    let it = l.str_map().range(s("")..).await?;
+    let got = it.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
         (s("a1"), Marked::new_with_meta(7, b("b5"), None)),
@@ -177,21 +182,21 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     // Get
 
-    let got = l.str_map().get("a1").await;
+    let got = l.str_map().get("a1").await?;
     assert_eq!(got, Marked::new_with_meta(7, b("b5"), None));
 
-    let got = l.str_map().get("a2").await;
+    let got = l.str_map().get("a2").await?;
     assert_eq!(got, Marked::new_with_meta(6, b("b4"), None));
 
-    let got = l.str_map().get("w1").await;
+    let got = l.str_map().get("w1").await?;
     assert_eq!(got, Marked::new_tomb_stone(0));
 
     // Check base level
 
     let frozen = l.frozen_ref();
 
-    let it = frozen.str_map().range(s("")..).await;
-    let got = it.collect::<Vec<_>>().await;
+    let strm = frozen.str_map().range(s("")..).await?;
+    let got = strm.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
         (s("a1"), Marked::new_with_meta(1, b("b1"), None)),
@@ -210,51 +215,56 @@ async fn test_two_levels() -> anyhow::Result<()> {
 /// l1 |    b(D) c        e
 /// l0 | a  b    c    d
 /// ```
-async fn build_3_levels() -> LeveledMap {
+async fn build_3_levels() -> anyhow::Result<LeveledMap> {
     let mut l = LeveledMap::default();
     // internal_seq: 0
-    l.str_map_mut().set(s("a"), Some((b("a0"), None))).await;
-    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await;
-    l.str_map_mut().set(s("c"), Some((b("c0"), None))).await;
-    l.str_map_mut().set(s("d"), Some((b("d0"), None))).await;
+    l.str_map_mut().set(s("a"), Some((b("a0"), None))).await?;
+    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
+    l.str_map_mut().set(s("c"), Some((b("c0"), None))).await?;
+    l.str_map_mut().set(s("d"), Some((b("d0"), None))).await?;
 
     l.freeze_writable();
     // internal_seq: 4
-    l.str_map_mut().set(s("b"), None).await;
-    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await;
-    l.str_map_mut().set(s("e"), Some((b("e1"), None))).await;
+    l.str_map_mut().set(s("b"), None).await?;
+    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
+    l.str_map_mut().set(s("e"), Some((b("e1"), None))).await?;
 
     l.freeze_writable();
     // internal_seq: 6
-    l.str_map_mut().set(s("c"), None).await;
-    l.str_map_mut().set(s("d"), Some((b("d2"), None))).await;
+    l.str_map_mut().set(s("c"), None).await?;
+    l.str_map_mut().set(s("d"), Some((b("d2"), None))).await?;
 
-    l
+    Ok(l)
 }
 
 #[tokio::test]
 async fn test_three_levels_get_range() -> anyhow::Result<()> {
-    let l = build_3_levels().await;
+    let l = build_3_levels().await?;
 
-    let got = l.str_map().get("a").await;
+    let got = l.str_map().get("a").await?;
     assert_eq!(got, Marked::new_with_meta(1, b("a0"), None));
 
-    let got = l.str_map().get("b").await;
+    let got = l.str_map().get("b").await?;
     assert_eq!(got, Marked::new_tomb_stone(4));
 
-    let got = l.str_map().get("c").await;
+    let got = l.str_map().get("c").await?;
     assert_eq!(got, Marked::new_tomb_stone(6));
 
-    let got = l.str_map().get("d").await;
+    let got = l.str_map().get("d").await?;
     assert_eq!(got, Marked::new_with_meta(7, b("d2"), None));
 
-    let got = l.str_map().get("e").await;
+    let got = l.str_map().get("e").await?;
     assert_eq!(got, Marked::new_with_meta(6, b("e1"), None));
 
-    let got = l.str_map().get("f").await;
+    let got = l.str_map().get("f").await?;
     assert_eq!(got, Marked::new_tomb_stone(0));
 
-    let got = l.str_map().range(s("")..).await.collect::<Vec<_>>().await;
+    let got = l
+        .str_map()
+        .range(s("")..)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (s("a"), Marked::new_with_meta(1, b("a0"), None)),
@@ -269,33 +279,38 @@ async fn test_three_levels_get_range() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_three_levels_override() -> anyhow::Result<()> {
-    let mut l = build_3_levels().await;
+    let mut l = build_3_levels().await?;
 
-    let (prev, result) = l.str_map_mut().set(s("a"), Some((b("x"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("a"), Some((b("x"), None))).await?;
     assert_eq!(prev, Marked::new_with_meta(1, b("a0"), None));
     assert_eq!(result, Marked::new_with_meta(8, b("x"), None));
 
-    let (prev, result) = l.str_map_mut().set(s("b"), Some((b("y"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("b"), Some((b("y"), None))).await?;
     assert_eq!(prev, Marked::new_tomb_stone(4));
     assert_eq!(result, Marked::new_with_meta(9, b("y"), None));
 
-    let (prev, result) = l.str_map_mut().set(s("c"), Some((b("z"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("c"), Some((b("z"), None))).await?;
     assert_eq!(prev, Marked::new_tomb_stone(6));
     assert_eq!(result, Marked::new_with_meta(10, b("z"), None));
 
-    let (prev, result) = l.str_map_mut().set(s("d"), Some((b("u"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("d"), Some((b("u"), None))).await?;
     assert_eq!(prev, Marked::new_with_meta(7, b("d2"), None));
     assert_eq!(result, Marked::new_with_meta(11, b("u"), None));
 
-    let (prev, result) = l.str_map_mut().set(s("e"), Some((b("v"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("e"), Some((b("v"), None))).await?;
     assert_eq!(prev, Marked::new_with_meta(6, b("e1"), None));
     assert_eq!(result, Marked::new_with_meta(12, b("v"), None));
 
-    let (prev, result) = l.str_map_mut().set(s("f"), Some((b("w"), None))).await;
+    let (prev, result) = l.str_map_mut().set(s("f"), Some((b("w"), None))).await?;
     assert_eq!(prev, Marked::new_tomb_stone(0));
     assert_eq!(result, Marked::new_with_meta(13, b("w"), None));
 
-    let got = l.str_map().range(s("")..).await.collect::<Vec<_>>().await;
+    let got = l
+        .str_map()
+        .range(s("")..)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (s("a"), Marked::new_with_meta(8, b("x"), None)),
@@ -311,33 +326,38 @@ async fn test_three_levels_override() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_three_levels_delete() -> anyhow::Result<()> {
-    let mut l = build_3_levels().await;
+    let mut l = build_3_levels().await?;
 
-    let (prev, result) = l.str_map_mut().set(s("a"), None).await;
+    let (prev, result) = l.str_map_mut().set(s("a"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(1, b("a0"), None));
     assert_eq!(result, Marked::new_tomb_stone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("b"), None).await;
+    let (prev, result) = l.str_map_mut().set(s("b"), None).await?;
     assert_eq!(prev, Marked::new_tomb_stone(4));
     assert_eq!(result, Marked::new_tomb_stone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("c"), None).await;
+    let (prev, result) = l.str_map_mut().set(s("c"), None).await?;
     assert_eq!(prev, Marked::new_tomb_stone(6));
     assert_eq!(result, Marked::new_tomb_stone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("d"), None).await;
+    let (prev, result) = l.str_map_mut().set(s("d"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(7, b("d2"), None));
     assert_eq!(result, Marked::new_tomb_stone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("e"), None).await;
+    let (prev, result) = l.str_map_mut().set(s("e"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(6, b("e1"), None));
     assert_eq!(result, Marked::new_tomb_stone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("f"), None).await;
+    let (prev, result) = l.str_map_mut().set(s("f"), None).await?;
     assert_eq!(prev, Marked::new_tomb_stone(0));
     assert_eq!(result, Marked::new_tomb_stone(0));
 
-    let got = l.str_map().range(s("")..).await.collect::<Vec<_>>().await;
+    let got = l
+        .str_map()
+        .range(s("")..)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (s("a"), Marked::new_tomb_stone(7)),
@@ -354,17 +374,17 @@ async fn test_three_levels_delete() -> anyhow::Result<()> {
 /// |      b(m) c
 /// | a(m) b    c(m)
 /// ```
-async fn build_2_level_with_meta() -> LeveledMap {
+async fn build_2_level_with_meta() -> anyhow::Result<LeveledMap> {
     let mut l = LeveledMap::default();
 
     // internal_seq: 0
     l.str_map_mut()
         .set(s("a"), Some((b("a0"), Some(KVMeta { expire_at: Some(1) }))))
-        .await;
-    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await;
+        .await?;
+    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
     l.str_map_mut()
         .set(s("c"), Some((b("c0"), Some(KVMeta { expire_at: Some(2) }))))
-        .await;
+        .await?;
 
     l.freeze_writable();
 
@@ -379,19 +399,19 @@ async fn build_2_level_with_meta() -> LeveledMap {
                 }),
             )),
         )
-        .await;
-    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await;
+        .await?;
+    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
 
-    l
+    Ok(l)
 }
 
 #[tokio::test]
 async fn test_two_level_update_value() -> anyhow::Result<()> {
     // Update value for a.
     {
-        let mut l = build_2_level_with_meta().await;
+        let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::upsert_value(&mut l, s("a"), b("a1")).await;
+        let (prev, result) = MapApiExt::upsert_value(&mut l, s("a"), b("a1")).await?;
         assert_eq!(
             prev,
             Marked::new_with_meta(1, b("a0"), Some(KVMeta { expire_at: Some(1) }))
@@ -401,7 +421,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
             Marked::new_with_meta(6, b("a1"), Some(KVMeta { expire_at: Some(1) }))
         );
 
-        let got = l.str_map().get("a").await;
+        let got = l.str_map().get("a").await?;
         assert_eq!(
             got,
             Marked::new_with_meta(6, b("a1"), Some(KVMeta { expire_at: Some(1) }))
@@ -410,9 +430,9 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
 
     // Update value for b.
     {
-        let mut l = build_2_level_with_meta().await;
+        let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::upsert_value(&mut l, s("b"), b("x1")).await;
+        let (prev, result) = MapApiExt::upsert_value(&mut l, s("b"), b("x1")).await?;
         assert_eq!(
             prev,
             Marked::new_normal(4, b("b1")).with_meta(Some(KVMeta {
@@ -426,7 +446,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
             }))
         );
 
-        let got = l.str_map().get("b").await;
+        let got = l.str_map().get("b").await?;
         assert_eq!(
             got,
             Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta {
@@ -437,13 +457,13 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
 
     // Update nonexistent.
     {
-        let mut l = build_2_level_with_meta().await;
+        let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::upsert_value(&mut l, s("d"), b("d1")).await;
+        let (prev, result) = MapApiExt::upsert_value(&mut l, s("d"), b("d1")).await?;
         assert_eq!(prev, Marked::new_tomb_stone(0));
         assert_eq!(result, Marked::new_with_meta(6, b("d1"), None));
 
-        let got = l.str_map().get("d").await;
+        let got = l.str_map().get("d").await?;
         assert_eq!(got, Marked::new_with_meta(6, b("d1"), None));
     }
 
@@ -454,10 +474,10 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
 async fn test_two_level_update_meta() -> anyhow::Result<()> {
     // Update meta for a.
     {
-        let mut l = build_2_level_with_meta().await;
+        let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("a"), Some(KVMeta { expire_at: Some(2) })).await;
+            MapApiExt::update_meta(&mut l, s("a"), Some(KVMeta { expire_at: Some(2) })).await?;
         assert_eq!(
             prev,
             Marked::new_with_meta(1, b("a0"), Some(KVMeta { expire_at: Some(1) }))
@@ -467,7 +487,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
             Marked::new_with_meta(6, b("a0"), Some(KVMeta { expire_at: Some(2) }))
         );
 
-        let got = l.str_map().get("a").await;
+        let got = l.str_map().get("a").await?;
         assert_eq!(
             got,
             Marked::new_with_meta(6, b("a0"), Some(KVMeta { expire_at: Some(2) }))
@@ -476,9 +496,9 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
 
     // Delete meta for a.
     {
-        let mut l = build_2_level_with_meta().await;
+        let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::update_meta(&mut l, s("b"), None).await;
+        let (prev, result) = MapApiExt::update_meta(&mut l, s("b"), None).await?;
         assert_eq!(
             prev,
             Marked::new_with_meta(
@@ -491,13 +511,13 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         );
         assert_eq!(result, Marked::new_with_meta(6, b("b1"), None));
 
-        let got = l.str_map().get("b").await;
+        let got = l.str_map().get("b").await?;
         assert_eq!(got, Marked::new_with_meta(6, b("b1"), None));
     }
 
     // Update meta for c.
     {
-        let mut l = build_2_level_with_meta().await;
+        let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) = MapApiExt::update_meta(
             &mut l,
@@ -506,7 +526,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
                 expire_at: Some(20),
             }),
         )
-        .await;
+        .await?;
         assert_eq!(prev, Marked::new_with_meta(5, b("c1"), None));
         assert_eq!(
             result,
@@ -515,7 +535,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
             }))
         );
 
-        let got = l.str_map().get("c").await;
+        let got = l.str_map().get("c").await?;
         assert_eq!(
             got,
             Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta {
@@ -526,14 +546,14 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
 
     // Update nonexistent.
     {
-        let mut l = build_2_level_with_meta().await;
+        let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("d"), Some(KVMeta { expire_at: Some(2) })).await;
+            MapApiExt::update_meta(&mut l, s("d"), Some(KVMeta { expire_at: Some(2) })).await?;
         assert_eq!(prev, Marked::new_tomb_stone(0));
         assert_eq!(result, Marked::new_tomb_stone(0));
 
-        let got = l.str_map().get("d").await;
+        let got = l.str_map().get("d").await?;
         assert_eq!(got, Marked::new_tomb_stone(0));
     }
 

--- a/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
@@ -14,6 +14,7 @@
 
 use std::borrow::Borrow;
 use std::fmt;
+use std::io;
 use std::ops::RangeBounds;
 
 use common_meta_types::KVMeta;
@@ -47,11 +48,20 @@ pub(in crate::sm_v002) trait MapValue:
 {
 }
 
-/// A key-value pair used in a map.
-pub(in crate::sm_v002) type MapKV<K> = (K, Marked<<K as MapKey>::V>);
+/// A Marked value type of a key type.
+pub(in crate::sm_v002) type MarkedOf<K> = Marked<<K as MapKey>::V>;
 
-/// A stream of key-value entry returned by `range()`.
-pub(in crate::sm_v002) type EntryStream<K> = BoxStream<'static, (K, Marked<<K as MapKey>::V>)>;
+/// A key-value pair used in a map.
+pub(in crate::sm_v002) type MapKV<K> = (K, MarkedOf<K>);
+
+/// Transition from one state to another.
+pub(in crate::sm_v002) type Transition<T> = (T, T);
+
+/// A boxed stream of io results of key-value pair.
+pub(in crate::sm_v002) type ResultStream<T> = BoxStream<'static, Result<T, io::Error>>;
+
+/// A stream of result of key-value returned by `range()`.
+pub(in crate::sm_v002) type KVResultStream<K> = ResultStream<MapKV<K>>;
 
 // Auto implement MapValue for all types that satisfy the constraints.
 impl<V> MapValue for V where V: Clone + Send + Sync + Unpin + 'static {}
@@ -72,7 +82,7 @@ pub(in crate::sm_v002) trait MapApiRO<K>: Send + Sync
 where K: MapKey
 {
     /// Get an entry by key.
-    async fn get<Q>(&self, key: &Q) -> Marked<K::V>
+    async fn get<Q>(&self, key: &Q) -> Result<MarkedOf<K>, io::Error>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized;
@@ -80,7 +90,7 @@ where K: MapKey
     /// Iterate over a range of entries by keys.
     ///
     /// The returned iterator contains tombstone entries: [`Marked::TombStone`].
-    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
+    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
@@ -134,7 +144,7 @@ where K: MapKey
         &mut self,
         key: K,
         value: Option<(K::V, Option<KVMeta>)>,
-    ) -> (Marked<K::V>, Marked<K::V>);
+    ) -> Result<Transition<MarkedOf<K>>, io::Error>;
 }
 
 pub(in crate::sm_v002) struct MapApiExt;
@@ -146,15 +156,15 @@ impl MapApiExt {
         s: &mut T,
         key: K,
         meta: Option<KVMeta>,
-    ) -> (Marked<K::V>, Marked<K::V>)
+    ) -> Result<Transition<MarkedOf<K>>, io::Error>
     where
         K: MapKey,
         T: MapApi<K>,
     {
         //
-        let got = s.get(&key).await;
+        let got = s.get(&key).await?;
         if got.is_tomb_stone() {
-            return (got.clone(), got.clone());
+            return Ok((got.clone(), got.clone()));
         }
 
         // Safe unwrap(), got is Normal
@@ -170,12 +180,12 @@ impl MapApiExt {
         s: &mut T,
         key: K,
         value: K::V,
-    ) -> (Marked<K::V>, Marked<K::V>)
+    ) -> Result<Transition<MarkedOf<K>>, io::Error>
     where
         K: MapKey,
         T: MapApi<K>,
     {
-        let got = s.get(&key).await;
+        let got = s.get(&key).await?;
 
         let meta = if let Some((_, meta)) = got.unpack_ref() {
             meta
@@ -193,7 +203,7 @@ impl MapApiExt {
 pub(in crate::sm_v002) async fn compacted_get<'d, K, Q, L>(
     key: &Q,
     levels: impl IntoIterator<Item = &'d L>,
-) -> Marked<K::V>
+) -> Result<MarkedOf<K>, io::Error>
 where
     K: MapKey,
     K: Borrow<Q>,
@@ -201,12 +211,12 @@ where
     L: MapApiRO<K> + 'static,
 {
     for lvl in levels {
-        let got = lvl.get(key).await;
+        let got = lvl.get(key).await?;
         if !got.not_found() {
-            return got;
+            return Ok(got);
         }
     }
-    Marked::empty()
+    Ok(Marked::empty())
 }
 
 /// Iterate over a range of entries by keys from multi levels.
@@ -216,7 +226,7 @@ where
 pub(in crate::sm_v002) async fn compacted_range<'d, K, Q, R, L>(
     range: R,
     levels: impl IntoIterator<Item = &'d L>,
-) -> EntryStream<K>
+) -> Result<KVResultStream<K>, io::Error>
 where
     K: MapKey,
     K: Borrow<Q>,
@@ -224,22 +234,23 @@ where
     Q: Ord + Send + Sync + ?Sized,
     L: MapApiRO<K> + 'static,
 {
+    // TODO: handle Result
     let mut kmerge = KMerge::by(util::by_key_seq);
 
     for lvl in levels {
-        let strm = lvl.range(range.clone()).await;
+        let strm = lvl.range(range.clone()).await?;
         kmerge = kmerge.merge(strm);
     }
 
     // Merge entries with the same key, keep the one with larger internal-seq
     let coalesce = kmerge.coalesce(util::choose_greater);
 
-    coalesce.boxed()
+    Ok(coalesce.boxed())
 }
 
 #[cfg(test)]
 mod tests {
-    use futures_util::StreamExt;
+    use futures_util::TryStreamExt;
 
     use crate::sm_v002::leveled_store::level::Level;
     use crate::sm_v002::leveled_store::map_api::compacted_get;
@@ -250,23 +261,23 @@ mod tests {
     #[tokio::test]
     async fn test_compacted_get() -> anyhow::Result<()> {
         let mut l0 = Level::default();
-        l0.set(s("a"), Some((b("a"), None))).await;
+        l0.set(s("a"), Some((b("a"), None))).await?;
 
         let mut l1 = l0.new_level();
-        l1.set(s("a"), None).await;
+        l1.set(s("a"), None).await?;
 
         let l2 = l1.new_level();
 
-        let got = compacted_get::<String, _, _>(&s("a"), [&l0, &l1, &l2]).await;
+        let got = compacted_get::<String, _, _>(&s("a"), [&l0, &l1, &l2]).await?;
         assert_eq!(got, Marked::new_normal(1, b("a")));
 
-        let got = compacted_get::<String, _, _>(&s("a"), [&l2, &l1, &l0]).await;
+        let got = compacted_get::<String, _, _>(&s("a"), [&l2, &l1, &l0]).await?;
         assert_eq!(got, Marked::new_tomb_stone(1));
 
-        let got = compacted_get::<String, _, _>(&s("a"), [&l1, &l0]).await;
+        let got = compacted_get::<String, _, _>(&s("a"), [&l1, &l0]).await?;
         assert_eq!(got, Marked::new_tomb_stone(1));
 
-        let got = compacted_get::<String, _, _>(&s("a"), [&l2, &l0]).await;
+        let got = compacted_get::<String, _, _>(&s("a"), [&l2, &l0]).await?;
         assert_eq!(got, Marked::new_normal(1, b("a")));
         Ok(())
     }
@@ -279,18 +290,18 @@ mod tests {
         // l0 | a  b
         // ```
         let mut l0 = Level::default();
-        l0.set(s("a"), Some((b("a"), None))).await;
-        l0.set(s("b"), Some((b("b"), None))).await;
+        l0.set(s("a"), Some((b("a"), None))).await?;
+        l0.set(s("b"), Some((b("b"), None))).await?;
 
         let mut l1 = l0.new_level();
-        l1.set(s("a"), None).await;
-        l1.set(s("c"), None).await;
+        l1.set(s("a"), None).await?;
+        l1.set(s("c"), None).await?;
 
         let mut l2 = l1.new_level();
-        l2.set(s("b"), Some((b("b2"), None))).await;
+        l2.set(s("b"), Some((b("b2"), None))).await?;
 
-        let got = compacted_range::<String, String, _, _>(&s("").., [&l2, &l1, &l0]).await;
-        let got = got.collect::<Vec<_>>().await;
+        let got = compacted_range::<String, String, _, _>(&s("").., [&l2, &l1, &l0]).await?;
+        let got = got.try_collect::<Vec<_>>().await?;
         assert_eq!(got, vec![
             //
             (s("a"), Marked::new_tomb_stone(2)),
@@ -298,8 +309,8 @@ mod tests {
             (s("c"), Marked::new_tomb_stone(2)),
         ]);
 
-        let got = compacted_range::<String, String, _, _>(&s("b").., [&l2, &l1, &l0]).await;
-        let got = got.collect::<Vec<_>>().await;
+        let got = compacted_range::<String, String, _, _>(&s("b").., [&l2, &l1, &l0]).await?;
+        let got = got.try_collect::<Vec<_>>().await?;
         assert_eq!(got, vec![
             //
             (s("b"), Marked::new_normal(3, b("b2"))),

--- a/src/meta/raft-store/src/sm_v002/leveled_store/ref_.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/ref_.rs
@@ -14,12 +14,13 @@
 
 use std::borrow::Borrow;
 use std::fmt;
+use std::io;
 use std::ops::RangeBounds;
 
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::compacted_get;
 use crate::sm_v002::leveled_store::map_api::compacted_range;
-use crate::sm_v002::leveled_store::map_api::EntryStream;
+use crate::sm_v002::leveled_store::map_api::KVResultStream;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
 use crate::sm_v002::leveled_store::static_levels::StaticLevels;
@@ -55,7 +56,7 @@ where
     K: MapKey + fmt::Debug,
     Level: MapApiRO<K>,
 {
-    async fn get<Q>(&self, key: &Q) -> Marked<K::V>
+    async fn get<Q>(&self, key: &Q) -> Result<Marked<K::V>, io::Error>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
@@ -64,7 +65,7 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
+    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
     where
         K: Borrow<Q>,
         R: RangeBounds<Q> + Clone + Send + Sync,

--- a/src/meta/raft-store/src/sm_v002/leveled_store/ref_mut.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/ref_mut.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Borrow;
+use std::io;
 use std::ops::RangeBounds;
 
 use common_meta_types::KVMeta;
@@ -20,10 +21,12 @@ use common_meta_types::KVMeta;
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::compacted_get;
 use crate::sm_v002::leveled_store::map_api::compacted_range;
-use crate::sm_v002::leveled_store::map_api::EntryStream;
+use crate::sm_v002::leveled_store::map_api::KVResultStream;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
+use crate::sm_v002::leveled_store::map_api::MarkedOf;
+use crate::sm_v002::leveled_store::map_api::Transition;
 use crate::sm_v002::leveled_store::ref_::Ref;
 use crate::sm_v002::leveled_store::static_levels::StaticLevels;
 use crate::sm_v002::marked::Marked;
@@ -64,7 +67,7 @@ where
     K: MapKey,
     Level: MapApiRO<K>,
 {
-    async fn get<Q>(&self, key: &Q) -> Marked<K::V>
+    async fn get<Q>(&self, key: &Q) -> Result<Marked<K::V>, io::Error>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
@@ -73,7 +76,7 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
+    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
@@ -94,21 +97,21 @@ where
         &mut self,
         key: K,
         value: Option<(K::V, Option<KVMeta>)>,
-    ) -> (Marked<K::V>, Marked<K::V>)
+    ) -> Result<Transition<MarkedOf<K>>, io::Error>
     where
         K: Ord,
     {
         // Get from the newest level where there is a tombstone or normal record of this key.
-        let prev = self.get(&key).await.clone();
+        let prev = self.get(&key).await?.clone();
 
         // No such entry at all, no need to create a tombstone for delete
         if prev.not_found() && value.is_none() {
-            return (prev, Marked::new_tomb_stone(0));
+            return Ok((prev, Marked::new_tomb_stone(0)));
         }
 
         // `writeable` is a single level map and the returned `_prev` is only from that level.
         // Therefore it should be ignored and we use the `prev` from the multi-level map.
-        let (_prev, inserted) = self.writable.set(key, value).await;
-        (prev, inserted)
+        let (_prev, inserted) = self.writable.set(key, value).await?;
+        Ok((prev, inserted))
     }
 }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/static_levels.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/static_levels.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 use std::borrow::Borrow;
+use std::io;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::compacted_get;
 use crate::sm_v002::leveled_store::map_api::compacted_range;
-use crate::sm_v002::leveled_store::map_api::EntryStream;
+use crate::sm_v002::leveled_store::map_api::KVResultStream;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::MapKey;
 use crate::sm_v002::leveled_store::ref_::Ref;
@@ -68,7 +69,7 @@ where
     K: MapKey,
     Level: MapApiRO<K>,
 {
-    async fn get<Q>(&self, key: &Q) -> Marked<K::V>
+    async fn get<Q>(&self, key: &Q) -> Result<Marked<K::V>, io::Error>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
@@ -77,7 +78,7 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> EntryStream<K>
+    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,

--- a/src/meta/raft-store/src/sm_v002/leveled_store/util.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/util.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::fmt;
+use std::io;
 
 use crate::sm_v002::leveled_store::map_api::MapKV;
 use crate::sm_v002::leveled_store::map_api::MapKey;
@@ -20,27 +21,47 @@ use crate::sm_v002::marked::Marked;
 
 /// Sort by key and internal_seq.
 /// Return `true` if `a` should be placed before `b`, e.g., `a` is smaller.
-pub(in crate::sm_v002) fn by_key_seq<K>((k1, v1): &MapKV<K>, (k2, v2): &MapKV<K>) -> bool
-where K: MapKey + Ord + fmt::Debug {
-    assert_ne!((k1, v1.internal_seq()), (k2, v2.internal_seq()));
+pub(in crate::sm_v002) fn by_key_seq<K>(
+    r1: &Result<MapKV<K>, io::Error>,
+    r2: &Result<MapKV<K>, io::Error>,
+) -> bool
+where
+    K: MapKey + Ord + fmt::Debug,
+{
+    // TODO test Result
+    match (r1, r2) {
+        (Ok((k1, v1)), Ok((k2, v2))) => {
+            assert_ne!((k1, v1.internal_seq()), (k2, v2.internal_seq()));
 
-    // Put entries with the same key together, smaller internal-seq first
-    // Tombstone is always greater.
-    (k1, v1.internal_seq()) <= (k2, v2.internal_seq())
+            // Put entries with the same key together, smaller internal-seq first
+            // Tombstone is always greater.
+            (k1, v1.internal_seq()) <= (k2, v2.internal_seq())
+        }
+        // If there is an error, just yield them in order.
+        // It's the caller's responsibility to handle the error.
+        _ => true,
+    }
 }
 
-/// Return `true` if `a` should be placed before `b`, e.g., `a` is smaller.
+/// Result type of a key-value pair and io Error used in a map.
+type KVResult<K> = Result<MapKV<K>, io::Error>;
+
+/// Return a Ok(combined) to merge two consecutive values,
+/// otherwise return Err((x,y)) to not to merge.
 #[allow(clippy::type_complexity)]
 pub(in crate::sm_v002) fn choose_greater<K>(
-    (k1, v1): MapKV<K>,
-    (k2, v2): MapKV<K>,
-) -> Result<MapKV<K>, (MapKV<K>, MapKV<K>)>
+    r1: KVResult<K>,
+    r2: KVResult<K>,
+) -> Result<KVResult<K>, (KVResult<K>, KVResult<K>)>
 where
     K: MapKey + Ord,
 {
-    if k1 == k2 {
-        Ok((k1, Marked::max(v1, v2)))
-    } else {
-        Err(((k1, v1), (k2, v2)))
+    // TODO test Result
+    match (r1, r2) {
+        (Ok((k1, v1)), Ok((k2, v2))) if k1 == k2 => Ok(Ok((k1, Marked::max(v1, v2)))),
+        // If there is an error,
+        // or k1 != k2
+        // just yield them without change.
+        (r1, r2) => Err((r1, r2)),
     }
 }

--- a/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
@@ -15,7 +15,7 @@
 use common_meta_types::SeqV;
 use common_meta_types::SeqValue;
 use common_meta_types::UpsertKV;
-use futures_util::StreamExt;
+use futures_util::TryStreamExt;
 use pretty_assertions::assert_eq;
 
 use crate::sm_v002::leveled_store::map_api::AsMap;
@@ -29,40 +29,40 @@ async fn test_one_level_upsert_get_range() -> anyhow::Result<()> {
     let mut sm = SMV002::default();
 
     let mut a = sm.new_applier();
-    let (prev, result) = a.upsert_kv(&UpsertKV::update("a", b"a0")).await;
+    let (prev, result) = a.upsert_kv(&UpsertKV::update("a", b"a0")).await?;
     assert_eq!(prev, None);
     assert_eq!(result, Some(SeqV::new(1, b("a0"))));
 
-    let got = sm.get_maybe_expired_kv("a").await;
+    let got = sm.get_maybe_expired_kv("a").await?;
     assert_eq!(got, Some(SeqV::new(1, b("a0"))));
 
     let mut a = sm.new_applier();
-    let (prev, result) = a.upsert_kv(&UpsertKV::update("b", b"b0")).await;
+    let (prev, result) = a.upsert_kv(&UpsertKV::update("b", b"b0")).await?;
     assert_eq!(prev, None);
     assert_eq!(result, Some(SeqV::new(2, b("b0"))));
-    let got = sm.get_maybe_expired_kv("b").await;
+    let got = sm.get_maybe_expired_kv("b").await?;
     assert_eq!(got, Some(SeqV::new(2, b("b0"))));
 
     let mut a = sm.new_applier();
-    let (prev, result) = a.upsert_kv(&UpsertKV::update("a", b"a00")).await;
+    let (prev, result) = a.upsert_kv(&UpsertKV::update("a", b"a00")).await?;
     assert_eq!(prev, Some(SeqV::new(1, b("a0"))));
     assert_eq!(result, Some(SeqV::new(3, b("a00"))));
-    let got = sm.get_maybe_expired_kv("a").await;
+    let got = sm.get_maybe_expired_kv("a").await?;
     assert_eq!(got, Some(SeqV::new(3, b("a00"))));
 
     // get_kv_ref()
 
-    let got = sm.get_maybe_expired_kv("a").await;
+    let got = sm.get_maybe_expired_kv("a").await?;
     assert_eq!(got.seq(), 3);
     assert_eq!(got.meta(), None);
     assert_eq!(got.value(), Some(&b("a00")));
 
-    let got = sm.get_maybe_expired_kv("x").await;
+    let got = sm.get_maybe_expired_kv("x").await?;
     assert_eq!(got.seq(), 0);
     assert_eq!(got.meta(), None);
     assert_eq!(got.value(), None);
 
-    let got = sm.list_kv("").await.collect::<Vec<_>>().await;
+    let got = sm.list_kv("").await?.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         (s("a"), SeqV::new(3, b("a00"))),
         (s("b"), SeqV::new(2, b("b0")))
@@ -79,58 +79,58 @@ async fn test_two_level_upsert_get_range() -> anyhow::Result<()> {
     let mut a = sm.new_applier();
 
     // internal_seq = 0
-    a.upsert_kv(&UpsertKV::update("a", b"a0")).await;
-    a.upsert_kv(&UpsertKV::update("a/b", b"b0")).await;
-    a.upsert_kv(&UpsertKV::update("c", b"c0")).await;
+    a.upsert_kv(&UpsertKV::update("a", b"a0")).await?;
+    a.upsert_kv(&UpsertKV::update("a/b", b"b0")).await?;
+    a.upsert_kv(&UpsertKV::update("c", b"c0")).await?;
 
     sm.levels.freeze_writable();
     let mut a = sm.new_applier();
 
     // internal_seq = 3
-    a.upsert_kv(&UpsertKV::delete("a/b")).await;
-    a.upsert_kv(&UpsertKV::update("c", b"c1")).await;
-    a.upsert_kv(&UpsertKV::update("d", b"d1")).await;
+    a.upsert_kv(&UpsertKV::delete("a/b")).await?;
+    a.upsert_kv(&UpsertKV::update("c", b"c1")).await?;
+    a.upsert_kv(&UpsertKV::update("d", b"d1")).await?;
 
     // get_kv_ref()
 
-    let got = sm.get_maybe_expired_kv("a").await;
+    let got = sm.get_maybe_expired_kv("a").await?;
     assert_eq!((got.seq(), got.value()), (1u64, Some(&b("a0"))));
 
-    let got = sm.get_maybe_expired_kv("b").await;
+    let got = sm.get_maybe_expired_kv("b").await?;
     assert_eq!((got.seq(), got.value()), (0, None));
 
-    let got = sm.get_maybe_expired_kv("c").await;
+    let got = sm.get_maybe_expired_kv("c").await?;
     assert_eq!((got.seq(), got.value()), (4, Some(&b("c1"))));
 
-    let got = sm.get_maybe_expired_kv("d").await;
+    let got = sm.get_maybe_expired_kv("d").await?;
     assert_eq!((got.seq(), got.value()), (5, Some(&b("d1"))));
 
     // get_kv()
 
     assert_eq!(
-        sm.get_maybe_expired_kv("a").await,
+        sm.get_maybe_expired_kv("a").await?,
         Some(SeqV::new(1, b("a0")))
     );
-    assert_eq!(sm.get_maybe_expired_kv("b").await, None);
+    assert_eq!(sm.get_maybe_expired_kv("b").await?, None);
     assert_eq!(
-        sm.get_maybe_expired_kv("c").await,
+        sm.get_maybe_expired_kv("c").await?,
         Some(SeqV::new(4, b("c1")))
     );
     assert_eq!(
-        sm.get_maybe_expired_kv("d").await,
+        sm.get_maybe_expired_kv("d").await?,
         Some(SeqV::new(5, b("d1")))
     );
 
     // prefix_list_kv()
 
-    let got = sm.list_kv("").await.collect::<Vec<_>>().await;
+    let got = sm.list_kv("").await?.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         (s("a"), SeqV::new(1, b("a0"))),
         (s("c"), SeqV::new(4, b("c1"))),
         (s("d"), SeqV::new(5, b("d1"))),
     ]);
 
-    let got = sm.list_kv("a").await.collect::<Vec<_>>().await;
+    let got = sm.list_kv("a").await?.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![(s("a"), SeqV::new(1, b("a0"))),]);
     Ok(())
 }
@@ -162,42 +162,42 @@ async fn test_update_expire_index() -> anyhow::Result<()> {
 /// l1 | a₄       c₃    |               10,1₄ -> ø    15,4₄ -> a  20,3₃ -> c          
 /// ------------------------------------------------------------
 /// l0 | a₁  b₂         |  5,2₂ -> b    10,1₁ -> a
-async fn build_sm_with_expire() -> SMV002 {
+async fn build_sm_with_expire() -> anyhow::Result<SMV002> {
     let mut sm = SMV002::default();
     let mut a = sm.new_applier();
 
     a.upsert_kv(&UpsertKV::update("a", b"a0").with_expire_sec(10))
-        .await;
+        .await?;
     a.upsert_kv(&UpsertKV::update("b", b"b0").with_expire_sec(5))
-        .await;
+        .await?;
 
     sm.levels.freeze_writable();
     let mut a = sm.new_applier();
 
     a.upsert_kv(&UpsertKV::update("c", b"c0").with_expire_sec(20))
-        .await;
+        .await?;
     a.upsert_kv(&UpsertKV::update("a", b"a1").with_expire_sec(15))
-        .await;
+        .await?;
 
     // let x: Vec<(&ExpireKey, &Marked<String>)> =
     //     sm.top.range::<ExpireKey, _>(..).collect::<Vec<_>>();
     // dbg!(x);
 
-    sm
+    Ok(sm)
 }
 
 #[tokio::test]
 async fn test_internal_expire_index() -> anyhow::Result<()> {
-    let sm = build_sm_with_expire().await;
+    let sm = build_sm_with_expire().await?;
 
     // Check internal expire index
     let got = sm
         .levels
         .expire_map()
         .range(..)
-        .await
-        .collect::<Vec<_>>()
-        .await;
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         (
             ExpireKey::new(5_000, 2),
@@ -219,9 +219,13 @@ async fn test_internal_expire_index() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_list_expire_index() -> anyhow::Result<()> {
-    let mut sm = build_sm_with_expire().await;
+    let mut sm = build_sm_with_expire().await?;
 
-    let got = sm.list_expire_index().await.collect::<Vec<_>>().await;
+    let got = sm
+        .list_expire_index()
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         (ExpireKey::new(5000, 2), s("b")),
         (ExpireKey::new(15000, 4), s("a")),
@@ -230,7 +234,11 @@ async fn test_list_expire_index() -> anyhow::Result<()> {
 
     sm.update_expire_cursor(15000);
 
-    let got = sm.list_expire_index().await.collect::<Vec<_>>().await;
+    let got = sm
+        .list_expire_index()
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         (ExpireKey::new(15000, 4), s("a")),
         (ExpireKey::new(20000, 3), s("c")),
@@ -240,7 +248,7 @@ async fn test_list_expire_index() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_inserting_expired_becomes_deleting() -> anyhow::Result<()> {
-    let mut sm = build_sm_with_expire().await;
+    let mut sm = build_sm_with_expire().await?;
 
     sm.update_expire_cursor(15_000);
 
@@ -248,11 +256,15 @@ async fn test_inserting_expired_becomes_deleting() -> anyhow::Result<()> {
 
     // Inserting an expired entry will delete it.
     a.upsert_kv(&UpsertKV::update("a", b"a1").with_expire_sec(10))
-        .await;
+        .await?;
 
-    assert_eq!(sm.get_maybe_expired_kv("a").await, None, "a is expired");
+    assert_eq!(sm.get_maybe_expired_kv("a").await?, None, "a is expired");
 
-    let got = sm.list_expire_index().await.collect::<Vec<_>>().await;
+    let got = sm
+        .list_expire_index()
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (ExpireKey::new(20_000, 3), s("c")),
@@ -263,9 +275,9 @@ async fn test_inserting_expired_becomes_deleting() -> anyhow::Result<()> {
         .levels
         .expire_map()
         .range(..)
-        .await
-        .collect::<Vec<_>>()
-        .await;
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
@@ -13,19 +13,21 @@
 // limitations under the License.
 
 use std::future;
+use std::io;
 use std::sync::Arc;
 
 use common_meta_types::SeqNum;
 use common_meta_types::SeqV;
 use common_meta_types::SnapshotMeta;
-use futures::Stream;
 use futures_util::StreamExt;
+use futures_util::TryStreamExt;
 
 use crate::key_spaces::RaftStoreEntry;
 use crate::ondisk::Header;
 use crate::ondisk::OnDisk;
 use crate::sm_v002::leveled_store::map_api::AsMap;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
+use crate::sm_v002::leveled_store::map_api::ResultStream;
 use crate::sm_v002::leveled_store::static_levels::StaticLevels;
 use crate::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use crate::state_machine::ExpireValue;
@@ -84,35 +86,37 @@ impl SnapshotViewV002 {
     }
 
     /// Compact into one level and remove all tombstone record.
-    pub async fn compact_mem_levels(&mut self) {
+    pub async fn compact_mem_levels(&mut self) -> Result<(), io::Error> {
         if self.compacted.len() <= 1 {
-            return;
+            return Ok(());
         }
 
         // TODO: use a explicit method to return a compaction base
         let mut data = self.compacted.newest().unwrap().new_level();
 
         // `range()` will compact tombstone internally
-        let strm = self.compacted.str_map().range::<String, _>(..).await;
-        let strm = strm.filter(|(_k, v)| future::ready(v.is_normal()));
+        let strm = self.compacted.str_map().range::<String, _>(..).await?;
+        let strm = strm.try_filter(|(_k, v)| future::ready(v.is_normal()));
 
-        let bt = strm.collect().await;
+        let bt = strm.try_collect().await?;
 
         data.replace_kv(bt);
 
         // `range()` will compact tombstone internally
-        let strm = self.compacted.expire_map().range(..).await;
-        let strm = strm.filter(|(_k, v)| future::ready(v.is_normal()));
+        let strm = self.compacted.expire_map().range(..).await?;
+        let strm = strm.try_filter(|(_k, v)| future::ready(v.is_normal()));
 
-        let bt = strm.collect().await;
+        let bt = strm.try_collect().await?;
 
         data.replace_expire(bt);
 
         self.compacted = StaticLevels::new([Arc::new(data)]);
+        Ok(())
     }
 
     /// Export all its data in RaftStoreEntry format.
-    pub async fn export(&self) -> impl Stream<Item = RaftStoreEntry> + '_ {
+    // pub async fn export(&self) -> Result<impl Stream<Item = RaftStoreEntry> + '_, io::Error> {
+    pub async fn export(&self) -> Result<ResultStream<RaftStoreEntry>, io::Error> {
         let d = self.compacted.newest().unwrap();
 
         let mut sm_meta = vec![];
@@ -163,25 +167,28 @@ impl SnapshotViewV002 {
 
         // kv
 
-        let strm = self.compacted.str_map().range::<String, _>(..).await;
-        let kv_iter = strm.filter_map(|(k, v)| {
+        let strm = self.compacted.str_map().range::<String, _>(..).await?;
+        let kv_iter = strm.try_filter_map(|(k, v)| {
             let seqv: Option<SeqV<_>> = v.into();
             let ent = seqv.map(|value| RaftStoreEntry::GenericKV { key: k, value });
-            future::ready(ent)
+            future::ready(Ok(ent))
         });
 
         // expire index
 
-        let strm = self.compacted.expire_map().range(..).await;
-        let expire_iter = strm.filter_map(|(k, v)| {
+        let strm = self.compacted.expire_map().range(..).await?;
+        let expire_iter = strm.try_filter_map(|(k, v)| {
             let exp_val: Option<ExpireValue> = v.into();
             let ent = exp_val.map(|value| RaftStoreEntry::Expire { key: k, value });
-            future::ready(ent)
+            future::ready(Ok(ent))
         });
 
-        futures::stream::iter(sm_meta)
+        let strm = futures::stream::iter(sm_meta)
+            .map(Ok)
             .chain(kv_iter)
-            .chain(expire_iter)
+            .chain(expire_iter);
+
+        Ok(strm.boxed())
     }
 }
 

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
@@ -20,7 +20,7 @@ use common_meta_types::Membership;
 use common_meta_types::Node;
 use common_meta_types::StoredMembership;
 use common_meta_types::UpsertKV;
-use futures_util::StreamExt;
+use futures_util::TryStreamExt;
 use maplit::btreemap;
 use openraft::testing::log_id;
 use pretty_assertions::assert_eq;
@@ -39,13 +39,13 @@ use crate::state_machine::ExpireKey;
 
 #[tokio::test]
 async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
-    let mut l = build_3_levels().await;
+    let mut l = build_3_levels().await?;
 
     let frozen = l.freeze_writable().clone();
 
     let mut snapshot = SnapshotViewV002::new(frozen);
 
-    snapshot.compact_mem_levels().await;
+    snapshot.compact_mem_levels().await?;
 
     let top_level = snapshot.compacted();
 
@@ -65,9 +65,9 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
     let got = d
         .str_map()
         .range::<str, _>(..)
-        .await
-        .collect::<Vec<_>>()
-        .await;
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (s("a"), Marked::new_with_meta(1, b("a0"), None)),
@@ -75,7 +75,12 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
         (s("e"), Marked::new_with_meta(6, b("e1"), None)),
     ]);
 
-    let got = d.expire_map().range(..).await.collect::<Vec<_>>().await;
+    let got = d
+        .expire_map()
+        .range(..)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![]);
 
     Ok(())
@@ -83,11 +88,11 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_compact_expire_index() -> anyhow::Result<()> {
-    let mut sm = build_sm_with_expire().await;
+    let mut sm = build_sm_with_expire().await?;
 
     let mut snapshot = sm.full_snapshot_view();
 
-    snapshot.compact_mem_levels().await;
+    snapshot.compact_mem_levels().await?;
 
     let compacted = snapshot.compacted();
 
@@ -96,9 +101,9 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
     let got = d
         .str_map()
         .range::<String, _>(..)
-        .await
-        .collect::<Vec<_>>()
-        .await;
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (
@@ -127,7 +132,12 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
         ),
     ]);
 
-    let got = d.expire_map().range(..).await.collect::<Vec<_>>().await;
+    let got = d
+        .expire_map()
+        .range(..)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (
@@ -149,17 +159,17 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_export_3_level() -> anyhow::Result<()> {
-    let mut l = build_3_levels().await;
+    let mut l = build_3_levels().await?;
 
     let frozen = l.freeze_writable().clone();
 
     let snapshot = SnapshotViewV002::new(frozen);
     let got = snapshot
         .export()
-        .await
-        .map(|x| serde_json::to_string(&x).unwrap())
-        .collect::<Vec<_>>()
-        .await;
+        .await?
+        .map_ok(|x| serde_json::to_string(&x).unwrap())
+        .try_collect::<Vec<_>>()
+        .await?;
 
     // TODO(1): add tree name: ["state_machine/0",{"Sequences":{"key":"generic-kv","value":159}}]
 
@@ -179,16 +189,16 @@ async fn test_export_3_level() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_export_2_level_with_meta() -> anyhow::Result<()> {
-    let mut sm = build_sm_with_expire().await;
+    let mut sm = build_sm_with_expire().await?;
 
     let snapshot = sm.full_snapshot_view();
 
     let got = snapshot
         .export()
-        .await
-        .map(|x| serde_json::to_string(&x).unwrap())
-        .collect::<Vec<_>>()
-        .await;
+        .await?
+        .map_ok(|x| serde_json::to_string(&x).unwrap())
+        .try_collect::<Vec<_>>()
+        .await?;
 
     assert_eq!(got, vec![
         r#"{"DataHeader":{"key":"header","value":{"version":"V002","upgrading":null}}}"#,
@@ -230,10 +240,10 @@ async fn test_import() -> anyhow::Result<()> {
 
     let got = snapshot
         .export()
-        .await
-        .map(|x| serde_json::to_string(&x).unwrap())
-        .collect::<Vec<_>>()
-        .await;
+        .await?
+        .map_ok(|x| serde_json::to_string(&x).unwrap())
+        .try_collect::<Vec<_>>()
+        .await?;
 
     assert_eq!(got, exported);
 
@@ -245,7 +255,7 @@ async fn test_import() -> anyhow::Result<()> {
 /// l2 |         c(D) d
 /// l1 |    b(D) c        e
 /// l0 | a  b    c    d
-async fn build_3_levels() -> LeveledMap {
+async fn build_3_levels() -> anyhow::Result<LeveledMap> {
     let mut l = LeveledMap::default();
     let sd = l.writable_mut().sys_data_mut();
 
@@ -255,10 +265,10 @@ async fn build_3_levels() -> LeveledMap {
     *sd.nodes_mut() = btreemap! {1=>Node::new("1", Endpoint::new("1", 1))};
 
     // internal_seq: 0
-    l.str_map_mut().set(s("a"), Some((b("a0"), None))).await;
-    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await;
-    l.str_map_mut().set(s("c"), Some((b("c0"), None))).await;
-    l.str_map_mut().set(s("d"), Some((b("d0"), None))).await;
+    l.str_map_mut().set(s("a"), Some((b("a0"), None))).await?;
+    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
+    l.str_map_mut().set(s("c"), Some((b("c0"), None))).await?;
+    l.str_map_mut().set(s("d"), Some((b("d0"), None))).await?;
 
     l.freeze_writable();
     let sd = l.writable_mut().sys_data_mut();
@@ -269,9 +279,9 @@ async fn build_3_levels() -> LeveledMap {
     *sd.nodes_mut() = btreemap! {2=>Node::new("2", Endpoint::new("2", 2))};
 
     // internal_seq: 4
-    l.str_map_mut().set(s("b"), None).await;
-    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await;
-    l.str_map_mut().set(s("e"), Some((b("e1"), None))).await;
+    l.str_map_mut().set(s("b"), None).await?;
+    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
+    l.str_map_mut().set(s("e"), Some((b("e1"), None))).await?;
 
     l.freeze_writable();
     let sd = l.writable_mut().sys_data_mut();
@@ -282,10 +292,10 @@ async fn build_3_levels() -> LeveledMap {
     *sd.nodes_mut() = btreemap! {3=>Node::new("3", Endpoint::new("3", 3))};
 
     // internal_seq: 6
-    l.str_map_mut().set(s("c"), None).await;
-    l.str_map_mut().set(s("d"), Some((b("d2"), None))).await;
+    l.str_map_mut().set(s("c"), None).await?;
+    l.str_map_mut().set(s("d"), Some((b("d2"), None))).await?;
 
-    l
+    Ok(l)
 }
 
 /// The subscript is internal_seq:
@@ -295,24 +305,24 @@ async fn build_3_levels() -> LeveledMap {
 /// l1 | a₄       c₃    |               10,1₄ -> ø    15,4₄ -> a  20,3₃ -> c          
 /// ------------------------------------------------------------
 /// l0 | a₁  b₂         |  5,2₂ -> b    10,1₁ -> a
-async fn build_sm_with_expire() -> SMV002 {
+async fn build_sm_with_expire() -> anyhow::Result<SMV002> {
     let mut sm = SMV002::default();
 
     let mut a = sm.new_applier();
     a.upsert_kv(&UpsertKV::update("a", b"a0").with_expire_sec(10))
-        .await;
+        .await?;
     a.upsert_kv(&UpsertKV::update("b", b"b0").with_expire_sec(5))
-        .await;
+        .await?;
 
     sm.levels.freeze_writable();
 
     let mut a = sm.new_applier();
     a.upsert_kv(&UpsertKV::update("c", b"c0").with_expire_sec(20))
-        .await;
+        .await?;
     a.upsert_kv(&UpsertKV::update("a", b"a1").with_expire_sec(15))
-        .await;
+        .await?;
 
-    sm
+    Ok(sm)
 }
 
 fn s(x: impl ToString) -> String {

--- a/src/meta/raft-store/src/sm_v002/writer_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/writer_v002.rs
@@ -80,19 +80,6 @@ impl<'a> WriterV002<'a> {
         Ok(writer)
     }
 
-    /// Write entries to the snapshot, without flushing.
-    ///
-    /// Returns the count of entries
-    pub async fn write_entries<E>(
-        &mut self,
-        entries: impl Stream<Item = RaftStoreEntry>,
-    ) -> Result<usize, E>
-    where
-        E: std::error::Error + From<io::Error> + 'static,
-    {
-        self.write_entry_results(entries.map(Ok)).await
-    }
-
     /// Write `Result` of entries to the snapshot, without flushing.
     ///
     /// Returns the count of entries

--- a/src/meta/service/src/store/store.rs
+++ b/src/meta/service/src/store/store.rs
@@ -312,7 +312,7 @@ impl RaftStorage<TypeConfig> for RaftStore {
         }
 
         let mut sm = self.state_machine.write().await;
-        let res = sm.apply_entries(entries).await;
+        let res = sm.apply_entries(entries).await?;
 
         Ok(res)
     }

--- a/src/meta/service/tests/it/meta_node/meta_node_replication.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_replication.rs
@@ -122,7 +122,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     for i in 0..n_req {
         let key = format!("test_meta_node_snapshot_replication-key-{}", i);
         let sm = mn1.sto.get_state_machine().await;
-        let got = sm.get_maybe_expired_kv(&key).await;
+        let got = sm.get_maybe_expired_kv(&key).await?;
         match got {
             None => {
                 panic!("expect get some value for {}", key)

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -136,7 +136,7 @@ async fn test_meta_store_build_snapshot() -> anyhow::Result<()> {
     let (logs, want) = snapshot_logs();
 
     sto.log.write().await.append(logs.clone()).await?;
-    sto.state_machine.write().await.apply_entries(&logs).await;
+    sto.state_machine.write().await.apply_entries(&logs).await?;
 
     let curr_snap = sto.build_snapshot().await?;
     assert_eq!(Some(new_log_id(1, 0, 9)), curr_snap.meta.last_log_id);
@@ -185,7 +185,7 @@ async fn test_meta_store_current_snapshot() -> anyhow::Result<()> {
     sto.log.write().await.append(logs.clone()).await?;
     {
         let mut sm = sto.state_machine.write().await;
-        sm.apply_entries(&logs).await;
+        sm.apply_entries(&logs).await?;
     }
 
     sto.build_snapshot().await?;
@@ -228,7 +228,7 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
         info!("--- feed logs and state machine");
 
         sto.log.write().await.append(logs.clone()).await?;
-        sto.state_machine.write().await.apply_entries(&logs).await;
+        sto.state_machine.write().await.apply_entries(&logs).await?;
 
         snap = sto.build_snapshot().await?;
     }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: MapApi should return Result<T, io::Error>

The `MapApi` serves as the API for the state machine, which will be
upgraded to support on-disk data storage. Consequently, to ensure
I/O errors are revealed to the calling function, `MapApi` should return
a `Result<T, io::Error>` instead of simply `T`.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13485)
<!-- Reviewable:end -->
