### PR TITLE
docs: fix example selecting from URI

### DIFF
--- a/docs/doc/12-load-data/00-transform/05-querying-stage.md
+++ b/docs/doc/12-load-data/00-transform/05-querying-stage.md
@@ -180,25 +180,35 @@ databend-toronto/
 To query data from all Parquet files in the folder, you can use the PATTERN option:
 
 ```sql
-SELECT * FROM 's3://databend-toronto' 
-connection => (
- access_key_id = '<your-access-key-id>', 
- secret_access_key = '<your-secret-access-key>',
- endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
- region = 'us-east-2'
-)
- pattern => '.*parquet'; 
+SELECT
+  *
+FROM
+  's3://databend-toronto' (
+    connection => (
+      access_key_id = '<your-access-key-id>',
+      secret_access_key = '<your-secret_access_key>',
+      endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
+      region = 'us-east-2'
+    ) pattern => '.*parquet'
+  );
 ```
 
 To query data from the Parquet files "books-2023.parquet", "books-2022.parquet", and "books-2021.parquet" in the folder, you can use the FILES option:
 
 ```sql
-SELECT * FROM 's3://databend-toronto' 
-connection => (
- access_key_id = '<your-access-key-id>', 
- secret_access_key = '<your-secret-access-key>',
- endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
- region = 'us-east-2'
-)
- files => ('books-2023.parquet','books-2022.parquet','books-2021.parquet'); 
+SELECT
+  *
+FROM
+  's3://databend-toronto' (
+    connection => (
+      access_key_id = '<your-access-key-id>',
+      secret_access_key = '<your-secret_access_key>',
+      endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
+      region = 'us-east-2'
+    ) files => (
+      'books-2023.parquet',
+      'books-2022.parquet',
+      'books-2021.parquet'
+    )
+  );
 ```

--- a/docs/doc/12-load-data/00-transform/05-querying-stage.md
+++ b/docs/doc/12-load-data/00-transform/05-querying-stage.md
@@ -153,7 +153,8 @@ FROM
       secret_access_key = '<your-secret-access-key>',
       endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
       region = 'us-east-2'
-    ) files => ('books.parquet')
+    ) 
+    files => ('books.parquet')
   );  
 ```
 </TabItem>
@@ -209,7 +210,8 @@ FROM
       secret_access_key = '<your-secret_access_key>',
       endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
       region = 'us-east-2'
-    ) files => (
+    ) 
+    files => (
       'books-2023.parquet',
       'books-2022.parquet',
       'books-2021.parquet'

--- a/docs/doc/12-load-data/00-transform/05-querying-stage.md
+++ b/docs/doc/12-load-data/00-transform/05-querying-stage.md
@@ -144,14 +144,17 @@ SELECT * FROM @my_external_stage/books.parquet;
 Let's assume you have a sample file named [books.parquet](https://datafuse-1253727613.cos.ap-hongkong.myqcloud.com/data/books.parquet) stored in a bucket named *databend-toronto* on Amazon S3 in the region *us-east-2*. You can query the data by specifying the connection parameters:
 
 ```sql
-SELECT *  FROM 's3://databend-toronto' 
-connection => (
- access_key_id = '<your-access-key-id>', 
- secret_access_key = '<your-secret-access-key>',
- endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
- region = 'us-east-2'
-),
- files => ('books.parquet');  
+SELECT
+  *
+FROM
+  's3://databend-toronto' (
+    connection => (
+      access_key_id = '<your-access-key-id>',
+      secret_access_key = '<your-secret-access-key>',
+      endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
+      region = 'us-east-2'
+    ) files => ('books.parquet')
+  );  
 ```
 </TabItem>
 <TabItem value="Remote" label="Remote">
@@ -189,7 +192,8 @@ FROM
       secret_access_key = '<your-secret_access_key>',
       endpoint_url = 'https://databend-toronto.s3.us-east-2.amazonaws.com',
       region = 'us-east-2'
-    ) pattern => '.*parquet'
+    ) 
+    pattern => '.*parquet'
   );
 ```
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fixed https://databend.rs/doc/load-data/transform/querying-stage#example-2-filtering-files as the syntax was changed by https://github.com/datafuselabs/databend/pull/13427

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13488)
<!-- Reviewable:end -->
