### PR TITLE
chore: improve memory accuracy for hash join spill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3861,6 +3861,7 @@ dependencies = [
  "base64 0.21.0",
  "bincode 1.3.3",
  "bumpalo",
+ "byte-unit",
  "byteorder",
  "chrono",
  "chrono-tz",

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -42,9 +42,6 @@ enable_udf_server = true
 udf_server_allow_list = ['http://0.0.0.0:8815']
 # cloud_control_grpc_server_address = "http://0.0.0.0:50051"
 
-max_memory_limit_enabled=true
-max_server_memory_usage = 3221225472
-
 [[query.users]]
 name = "root"
 auth_type = "no_password"

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -42,6 +42,9 @@ enable_udf_server = true
 udf_server_allow_list = ['http://0.0.0.0:8815']
 # cloud_control_grpc_server_address = "http://0.0.0.0:50051"
 
+max_memory_limit_enabled=true
+max_server_memory_usage = 3221225472
+
 [[query.users]]
 name = "root"
 auth_type = "no_password"

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -116,6 +116,7 @@ async-trait = { version = "0.1.57", package = "async-trait-fn" }
 base64 = "0.21.0"
 bincode = "1.3.3"
 bumpalo = { workspace = true }
+byte-unit = "4.0.19"
 byteorder = "1.4.3"
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
@@ -169,7 +170,6 @@ typetag = "0.2.3"
 unicode-segmentation = "1.10.1"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 walkdir = "2.3.2"
-byte-unit = "4.0.19"
 
 [dev-dependencies]
 arrow-cast = { workspace = true }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -169,6 +169,7 @@ typetag = "0.2.3"
 unicode-segmentation = "1.10.1"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 walkdir = "2.3.2"
+byte-unit = "4.0.19"
 
 [dev-dependencies]
 arrow-cast = { workspace = true }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/build_spill/build_spill_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/build_spill/build_spill_state.rs
@@ -171,9 +171,6 @@ impl BuildSpillState {
             total_bytes += block.memory_size();
         }
 
-        let byte = Byte::from_unit(total_bytes as f64, ByteUnit::B).unwrap();
-        let total_gb = byte.get_appropriate_unit(false).format(3);
-
         if total_bytes * 3 > spill_threshold {
             return Ok(true);
         }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
@@ -185,7 +185,7 @@ impl Processor for TransformHashJoinBuild {
                     self.build_state.row_space_build_done()?;
                     return Ok(Event::Async);
                 }
-
+                // Before pulling data, check if need spill.
                 if let Some(spill_state) = self.spill_state.as_ref() {
                     if spill_state.check_need_spill()? {
                         spill_state.spill_coordinator.need_spill()?;
@@ -199,7 +199,6 @@ impl Processor for TransformHashJoinBuild {
                         return Ok(Event::Async);
                     }
                 }
-
                 match self.input_port.has_data() {
                     true => {
                         self.input_data = Some(self.input_port.pull_data().unwrap()?);
@@ -251,6 +250,20 @@ impl Processor for TransformHashJoinBuild {
                         self.step = HashJoinBuildStep::FollowSpill;
                         self.spill_data = Some(data_block);
                     } else {
+                        // Before write data to `RowSpace` and `Chunks`, check if need spill.
+                        if let Some(spill_state) = self.spill_state.as_ref() {
+                            if spill_state.check_need_spill()? {
+                                spill_state.spill_coordinator.need_spill()?;
+                                self.wait_spill()?;
+                                // WaitProbe or FirstSpill, so set Event to Async
+                                return Ok(());
+                            } else if spill_state.spill_coordinator.get_need_spill() {
+                                // even if input can fit into memory, but there exists one processor need to spill,
+                                // then it needs to wait spill.
+                                self.wait_spill()?;
+                                return Ok(());
+                            }
+                        }
                         self.build_state.build(data_block)?;
                     }
                 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
@@ -94,7 +94,6 @@ impl TransformHashJoinBuild {
             // Before notify all processors to spill, we need to collect all buffered data in `RowSpace` and `Chunks`
             // Partition all rows and stat how many partitions and rows in each partition.
             // Then choose the largest partitions(which contain rows that can avoid oom exactly) to spill.
-            // For each partition, we should equally divide the rows into each processor.
             // Then all processors will spill same partitions.
             let mut spill_tasks = spill_state.spill_coordinator.spill_tasks.lock();
             spill_state.split_spill_tasks(
@@ -309,7 +308,6 @@ impl Processor for TransformHashJoinBuild {
                 let spill_state = self.spill_state.as_mut().unwrap();
                 spill_state.spill(self.processor_id).await?;
                 // After spill, the processor should continue to run, and process incoming data.
-                // FIXME: We should wait all processors finish spill, and then continue to run.
                 self.step = HashJoinBuildStep::Running;
             }
             HashJoinBuildStep::FollowSpill => {

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -159,10 +159,9 @@ impl Spiller {
             self.ctx.get_join_spill_progress().incr(&progress_val);
         }
         info!(
-            "{:?} spilled {:?} rows data into {:?}, partition id is {:?}, worker id is {:?}",
+            "{:?} spilled {:?} rows data, partition id is {:?}, worker id is {:?}",
             self.spiller_type,
             data.num_rows(),
-            location,
             p_id,
             worker_id
         );

--- a/src/query/service/tests/it/spillers/spiller.rs
+++ b/src/query/service/tests/it/spillers/spiller.rs
@@ -47,7 +47,7 @@ async fn test_spill_with_partition() -> Result<()> {
         Int32Type::from_data((1..101).collect::<Vec<_>>()),
     ]);
 
-    let res = spiller.spill_with_partition(&(0_u8), &data, 0).await;
+    let res = spiller.spill_with_partition(0_u8, data, 0).await;
 
     assert!(res.is_ok());
     assert!(spiller.partition_location.get(&0).unwrap()[0].starts_with("_query_spill"));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
Adjusting the memory check, currently the lineitem and partsupp tables for 15G tpch data can complete the join in 3G memory

```
select l.l_orderkey from partsupp as p join lineitem as l on p.ps_partkey = l.l_partkey ;
```

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13507)
<!-- Reviewable:end -->
