### PR TITLE
chore: fix filter offset

### DIFF
--- a/src/query/expression/src/kernels/filter.rs
+++ b/src/query/expression/src/kernels/filter.rs
@@ -202,7 +202,7 @@ impl Column {
                     }
                 });
             slice = &slice[1..];
-            length -= n;
+            length = if length >= n { length - n } else { 0 };
         }
 
         let mut mask_chunks = BitChunksExact::<u64>::new(slice, length);
@@ -258,9 +258,14 @@ impl Column {
                     }
                     mask = mask & (mask - 1);
                 }
-                length -= 8 - offset;
+                let bits_to_align = 8 - offset;
+                length = if length >= bits_to_align {
+                    length - bits_to_align
+                } else {
+                    0
+                };
                 slice = &slice[1..];
-                values_ptr = values_ptr.add(8 - offset);
+                values_ptr = values_ptr.add(bits_to_align);
             }
 
             const CHUNK_SIZE: usize = 64;
@@ -342,9 +347,14 @@ impl Column {
                     }
                     mask = mask & (mask - 1);
                 }
-                length -= 8 - offset;
+                let bits_to_align = 8 - offset;
+                length = if length >= bits_to_align {
+                    length - bits_to_align
+                } else {
+                    0
+                };
                 slice = &slice[1..];
-                idx += 8 - offset;
+                idx += bits_to_align;
             }
 
             const CHUNK_SIZE: usize = 64;
@@ -507,9 +517,14 @@ impl Column {
                     }
                     mask = mask & (mask - 1);
                 }
-                filter_length -= 8 - filter_offset;
+                let bits_to_align = 8 - filter_offset;
+                filter_length = if filter_length >= bits_to_align {
+                    filter_length - bits_to_align
+                } else {
+                    0
+                };
                 filter_slice = &filter_slice[1..];
-                bitmap_idx += 8 - filter_offset;
+                bitmap_idx += bits_to_align;
             }
 
             const CHUNK_SIZE: usize = 64;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This bug has existed before https://github.com/datafuselabs/databend/pull/13497, we found it via `test_filter_boolean`, the reason for the error is that the `length`(usize) becomes a negative number during subtraction.

- Closes #13527 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13529)
<!-- Reviewable:end -->
