### PR TITLE
feat: allow restricting a current role on starting a query

### DIFF
--- a/src/query/service/src/interpreters/interpreter_role_set.rs
+++ b/src/query/service/src/interpreters/interpreter_role_set.rs
@@ -63,7 +63,7 @@ impl Interpreter for SetRoleInterpreter {
                 .await?;
         } else {
             session
-                .set_current_role_checked(&self.plan.role_name)
+                .set_current_role_checked(&self.plan.role_name, false)
                 .await?;
         }
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -134,6 +134,8 @@ pub struct HttpSessionConf {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_server_session_secs: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<BTreeMap<String, String>>,
@@ -251,10 +253,14 @@ impl HttpQuery {
         // Read the session variables in the request, and set them to the current session.
         // the session variables includes:
         // - the current database
+        // - the current role
         // - the session-level settings, like max_threads
         if let Some(session_conf) = &request.session {
             if let Some(db) = &session_conf.database {
                 session.set_current_database(db.clone());
+            }
+            if let Some(role) = &session_conf.role {
+                session.set_current_role_checked(role).await?;
             }
             if let Some(conf_settings) = &session_conf.settings {
                 let settings = session.get_settings();

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -260,7 +260,7 @@ impl HttpQuery {
                 session.set_current_database(db.clone());
             }
             if let Some(role) = &session_conf.role {
-                session.set_current_role_checked(role).await?;
+                session.set_current_role_checked(role, true).await?;
             }
             if let Some(conf_settings) = &session_conf.settings {
                 let settings = session.get_settings();

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -203,11 +203,13 @@ impl Session {
     }
 
     // Only the available role can be set as current role. The current role can be set by the SET
-    // ROLE statement, or by the X-DATABEND-ROLE header in HTTP protocol (not implemented yet).
+    // ROLE statement, or by the `session.role` field in the HTTP query request body.
+    // When the `restricted` is true, this role will become the only role of the current session,
+    // only this role and its sub roles take effect.
     #[async_backtrace::framed]
-    pub async fn set_current_role_checked(self: &Arc<Self>, role_name: &str) -> Result<()> {
+    pub async fn set_current_role_checked(self: &Arc<Self>, role_name: &str, restricted: bool) -> Result<()> {
         self.privilege_mgr
-            .set_current_role(Some(role_name.to_string()))
+            .set_current_role(Some(role_name.to_string()), restricted)
             .await
     }
 
@@ -217,7 +219,7 @@ impl Session {
 
     #[async_backtrace::framed]
     pub async fn unset_current_role(self: &Arc<Self>) -> Result<()> {
-        self.privilege_mgr.set_current_role(None).await
+        self.privilege_mgr.set_current_role(None, false).await
     }
 
     // Returns all the roles the current session has. If the user have been granted restricted_role,

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -185,16 +185,16 @@ impl Session {
     }
 
     // set_authed_user() is called after authentication is passed in various protocol handlers, like
-    // HTTP handler, clickhouse query handler, mysql query handler. auth_role represents the role
+    // HTTP handler, clickhouse query handler, mysql query handler. restricted_role represents the role
     // granted by external authenticator, it will over write the current user's granted roles, and
     // becomes the CURRENT ROLE if not set X-DATABEND-ROLE.
     #[async_backtrace::framed]
     pub async fn set_authed_user(
         self: &Arc<Self>,
         user: UserInfo,
-        auth_role: Option<String>,
+        restricted_role: Option<String>,
     ) -> Result<()> {
-        self.privilege_mgr.set_authed_user(user, auth_role).await
+        self.privilege_mgr.set_authed_user(user, restricted_role).await
     }
 
     #[async_backtrace::framed]
@@ -220,7 +220,7 @@ impl Session {
         self.privilege_mgr.set_current_role(None).await
     }
 
-    // Returns all the roles the current session has. If the user have been granted auth_role,
+    // Returns all the roles the current session has. If the user have been granted restricted_role,
     // the other roles will be ignored.
     // On executing SET ROLE, the role have to be one of the available roles.
     #[async_backtrace::framed]

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -194,7 +194,9 @@ impl Session {
         user: UserInfo,
         restricted_role: Option<String>,
     ) -> Result<()> {
-        self.privilege_mgr.set_authed_user(user, restricted_role).await
+        self.privilege_mgr
+            .set_authed_user(user, restricted_role)
+            .await
     }
 
     #[async_backtrace::framed]
@@ -207,7 +209,11 @@ impl Session {
     // When the `restricted` is true, this role will become the only role of the current session,
     // only this role and its sub roles take effect.
     #[async_backtrace::framed]
-    pub async fn set_current_role_checked(self: &Arc<Self>, role_name: &str, restricted: bool) -> Result<()> {
+    pub async fn set_current_role_checked(
+        self: &Arc<Self>,
+        role_name: &str,
+        restricted: bool,
+    ) -> Result<()> {
         self.privilege_mgr
             .set_current_role(Some(role_name.to_string()), restricted)
             .await

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -47,9 +47,14 @@ pub struct SessionContext {
     // roles will not take effect. The user can switch to another available role by `SET ROLE`.
     // If the current_role is not set, it takes the user's default role.
     current_role: RwLock<Option<RoleInfo>>,
-    // The role granted to user by external auth provider, when auth_role is provided, the current
-    // user's all other roles are overridden by this role.
-    auth_role: RwLock<Option<String>>,
+    // The role restricted by external auth provider or sql client. When restricted_role is 
+    // provided, the current user's all other roles are overridden by this role, all the other
+    // roles' privileges will not take effect.
+    // The difference between current_role and restricted_role is that current_role could be set
+    // by `SET ROLE`, user's DEFAULT ROLE or `restricted_role`, the other roles' privileges will
+    // still take effect, what the current_role does is to act as the owner on CREATE DATABASE/
+    // TABLE etc.
+    restricted_role: RwLock<Option<String>>,
     // The client IP from the client.
     client_host: RwLock<Option<SocketAddr>>,
     io_shutdown_tx: RwLock<Option<Box<dyn FnOnce() + Send + Sync + 'static>>>,
@@ -67,7 +72,7 @@ impl SessionContext {
             abort: Default::default(),
             current_user: Default::default(),
             current_role: Default::default(),
-            auth_role: Default::default(),
+            restricted_role: Default::default(),
             current_tenant: Default::default(),
             client_host: Default::default(),
             current_catalog: RwLock::new("default".to_string()),
@@ -177,14 +182,15 @@ impl SessionContext {
         *lock = Some(user);
     }
 
-    // Get auth role. Auth role is the role granted by authenticator.
-    pub fn get_auth_role(&self) -> Option<String> {
-        let lock = self.auth_role.read();
+    // Get restricted role. Restricted role is the role granted by authenticator, or set
+    // by sql client to restrict its privilege.
+    pub fn get_restricted_role(&self) -> Option<String> {
+        let lock = self.restricted_role.read();
         lock.clone()
     }
 
-    pub fn set_auth_role(&self, role: Option<String>) {
-        let mut lock = self.auth_role.write();
+    pub fn set_restricted_role(&self, role: Option<String>) {
+        let mut lock = self.restricted_role.write();
         *lock = role;
     }
 

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -47,7 +47,7 @@ pub struct SessionContext {
     // roles will not take effect. The user can switch to another available role by `SET ROLE`.
     // If the current_role is not set, it takes the user's default role.
     current_role: RwLock<Option<RoleInfo>>,
-    // The role restricted by external auth provider or sql client. When restricted_role is 
+    // The role restricted by external auth provider or sql client. When restricted_role is
     // provided, the current user's all other roles are overridden by this role, all the other
     // roles' privileges will not take effect.
     // The difference between current_role and restricted_role is that current_role could be set

--- a/src/query/service/src/sessions/session_privilege_mgr.rs
+++ b/src/query/service/src/sessions/session_privilege_mgr.rs
@@ -161,7 +161,11 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl {
             Some(auth_role) => vec![auth_role],
             None => {
                 let current_user = self.get_current_user()?;
-                current_user.grants.roles()
+                let mut roles = current_user.grants.roles();
+                if let Some(current_role) = self.get_current_role() {
+                    roles.push(current_role.name);
+                }
+                roles
             }
         };
 

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -928,6 +928,41 @@ async fn assert_auth_current_role(
     Ok(())
 }
 
+async fn assert_auth_current_role_with_restricted_role(
+    ep: &EndpointType,
+    role_name: &str,
+    restricted_role: &str,
+    header: impl Header,
+) -> Result<()> {
+    let sql = "select current_role()";
+
+    let json = serde_json::json!({"sql": sql.to_string(), "session": {"role": restricted_role.to_string()}});
+
+    let path = "/v1/query";
+    let uri = format!("{}?wait_time_secs={}", path, 3);
+    let content_type = "application/json";
+    let body = serde_json::to_vec(&json)?;
+
+    let response = ep
+        .call(
+            Request::builder()
+                .uri(uri.parse().unwrap())
+                .method(Method::POST)
+                .header(header::CONTENT_TYPE, content_type)
+                .typed_header(header)
+                .body(body),
+        )
+        .await
+        .unwrap();
+
+    let (_, resp) = check_response(response).await?;
+    let v = resp.data;
+    assert_eq!(v.len(), 1);
+    assert_eq!(v[0].len(), 1);
+    assert_eq!(v[0][0], serde_json::Value::String(role_name.to_string()));
+    Ok(())
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn test_auth_jwt_with_create_user() -> Result<()> {
     let user_name = "user1";
@@ -984,7 +1019,8 @@ async fn test_auth_jwt_with_create_user() -> Result<()> {
     let token = key_pair.sign(claims)?;
     let bearer = headers::Authorization::bearer(&token).unwrap();
     assert_auth_current_user(&ep, user_name, bearer.clone(), "%").await?;
-    assert_auth_current_role(&ep, "account_admin", bearer).await?;
+    assert_auth_current_role(&ep, "account_admin", bearer.clone()).await?;
+    assert_auth_current_role_with_restricted_role(&ep, "public", "public", bearer).await?;
     Ok(())
 }
 
@@ -1217,6 +1253,7 @@ async fn test_affect() -> Result<()> {
             }),
             Some(HttpSessionConf {
                 database: None,
+                role: None,
                 keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([
                     ("max_threads".to_string(), "1".to_string()),
@@ -1229,6 +1266,7 @@ async fn test_affect() -> Result<()> {
             None,
             Some(HttpSessionConf {
                 database: None,
+                role: None,
                 keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "max_threads".to_string(),
@@ -1243,6 +1281,7 @@ async fn test_affect() -> Result<()> {
             }),
             Some(HttpSessionConf {
                 database: Some("db2".to_string()),
+                role: None,
                 keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "max_threads".to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

An user may have multiple roles, sometimes we hope to restrict the role to limit the privilege we have. It'd be useful when you have a scheduler which hopes to execute multiple tasks in arbitary roles.

- [x] rename auth_role to restricted_role
- [x] add restricted to set_current_role_checked
- [x] add test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13537)
<!-- Reviewable:end -->
