### PR TITLE
chore: make pipeline builder more object [part-2]

### DIFF
--- a/src/query/service/src/pipelines/builders/builder_merge_into.rs
+++ b/src/query/service/src/pipelines/builders/builder_merge_into.rs
@@ -1,0 +1,640 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use common_base::base::tokio::sync::Semaphore;
+use common_catalog::table::Table;
+use common_catalog::table_context::TableContext;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_expression::DataSchema;
+use common_expression::DataSchemaRef;
+use common_expression::ROW_NUMBER_COL_NAME;
+use common_pipeline_core::pipe::Pipe;
+use common_pipeline_core::pipe::PipeItem;
+use common_pipeline_core::processors::port::InputPort;
+use common_pipeline_core::processors::port::OutputPort;
+use common_pipeline_core::processors::processor::ProcessorPtr;
+use common_pipeline_transforms::processors::transforms::create_dummy_item;
+use common_sql::evaluator::BlockOperator;
+use common_sql::evaluator::CompoundBlockOperator;
+use common_sql::executor::AddRowNumber;
+use common_sql::executor::MergeInto;
+use common_sql::executor::MergeIntoAppendNotMatched;
+use common_sql::executor::MergeIntoSource;
+use common_storages_fuse::operations::common::TransformSerializeSegment;
+use common_storages_fuse::operations::merge_into::MatchedSplitProcessor;
+use common_storages_fuse::operations::merge_into::MergeIntoNotMatchedProcessor;
+use common_storages_fuse::operations::merge_into::MergeIntoSplitProcessor;
+use common_storages_fuse::operations::merge_into::RowNumberAndLogSplitProcessor;
+use common_storages_fuse::operations::merge_into::TransformAddRowNumberColumnProcessor;
+use common_storages_fuse::operations::TransformSerializeBlock;
+use common_storages_fuse::FuseTable;
+
+use crate::pipelines::processors::transforms::ExtractHashTableByRowNumber;
+use crate::pipelines::processors::transforms::TransformAddComputedColumns;
+use crate::pipelines::processors::DeduplicateRowNumber;
+use crate::pipelines::processors::TransformResortAddOnWithoutSourceSchema;
+use crate::pipelines::PipelineBuilder;
+
+impl PipelineBuilder {
+    // Build and add row_number column
+    pub(crate) fn build_add_row_number(&mut self, add_row_number: &AddRowNumber) -> Result<()> {
+        // it must be distributed merge into execution
+        self.build_pipeline(&add_row_number.input)?;
+        let node_index = add_row_number
+            .cluster_index
+            .get(&self.ctx.get_cluster().local_id);
+        if node_index.is_none() {
+            return Err(ErrorCode::NotFoundClusterNode(format!(
+                "can't find out {} when build distributed merge into pipeline",
+                self.ctx.get_cluster().local_id
+            )));
+        }
+        let node_index = *node_index.unwrap() as u16;
+        let row_number = Arc::new(AtomicU64::new(0));
+        self.main_pipeline
+            .add_transform(|transform_input_port, transform_output_port| {
+                TransformAddRowNumberColumnProcessor::create(
+                    transform_input_port,
+                    transform_output_port,
+                    node_index,
+                    row_number.clone(),
+                )
+            })?;
+        Ok(())
+    }
+
+    // build merge into append not matched pipeline.
+    pub(crate) fn build_merge_into_append_not_matched(
+        &mut self,
+        merge_into_append_not_macted: &MergeIntoAppendNotMatched,
+    ) -> Result<()> {
+        let MergeIntoAppendNotMatched {
+            input,
+            table_info,
+            catalog_info,
+            unmatched,
+            input_schema,
+        } = merge_into_append_not_macted;
+        // receive row numbers and MutationLogs
+        self.build_pipeline(input)?;
+        self.main_pipeline.try_resize(1)?;
+
+        assert!(self.join_state.is_some());
+        assert!(self.probe_data_fields.is_some());
+
+        let join_state = self.join_state.clone().unwrap();
+        // split row_number and log
+        //      output_port_row_number
+        //      output_port_log
+        self.main_pipeline
+            .add_pipe(RowNumberAndLogSplitProcessor::create()?.into_pipe());
+
+        // accumulate source data which is not matched from hashstate
+        let pipe_items = vec![
+            DeduplicateRowNumber::create()?.into_pipe_item(),
+            create_dummy_item(),
+        ];
+        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
+
+        let pipe_items = vec![
+            ExtractHashTableByRowNumber::create(
+                join_state,
+                self.probe_data_fields.clone().unwrap(),
+            )?
+            .into_pipe_item(),
+            create_dummy_item(),
+        ];
+        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
+
+        // not macthed operation
+        let merge_into_not_matched_processor = MergeIntoNotMatchedProcessor::create(
+            unmatched.clone(),
+            input_schema.clone(),
+            self.func_ctx.clone(),
+        )?;
+        let pipe_items = vec![
+            merge_into_not_matched_processor.into_pipe_item(),
+            create_dummy_item(),
+        ];
+        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
+
+        // split row_number and log
+        //      output_port_not_matched_data
+        //      output_port_log
+        // start to append data
+        let tbl = self
+            .ctx
+            .build_table_by_table_info(catalog_info, table_info, None)?;
+        // 1.fill default columns
+        let table_default_schema = &tbl.schema().remove_computed_fields();
+        let mut builder = self.main_pipeline.add_transform_with_specified_len(
+            |transform_input_port, transform_output_port| {
+                TransformResortAddOnWithoutSourceSchema::try_create(
+                    self.ctx.clone(),
+                    transform_input_port,
+                    transform_output_port,
+                    Arc::new(DataSchema::from(table_default_schema)),
+                    tbl.clone(),
+                )
+            },
+            1,
+        )?;
+        builder.add_items(vec![create_dummy_item()]);
+        self.main_pipeline.add_pipe(builder.finalize());
+
+        // 2.fill computed columns
+        let table_computed_schema = &tbl.schema().remove_virtual_computed_fields();
+        let default_schema: DataSchemaRef = Arc::new(table_default_schema.into());
+        let computed_schema: DataSchemaRef = Arc::new(table_computed_schema.into());
+        if default_schema != computed_schema {
+            builder = self.main_pipeline.add_transform_with_specified_len(
+                |transform_input_port, transform_output_port| {
+                    TransformAddComputedColumns::try_create(
+                        self.ctx.clone(),
+                        transform_input_port,
+                        transform_output_port,
+                        default_schema.clone(),
+                        computed_schema.clone(),
+                    )
+                },
+                1,
+            )?;
+            builder.add_items(vec![create_dummy_item()]);
+            self.main_pipeline.add_pipe(builder.finalize());
+        }
+
+        // 3. cluster sort
+        let table = FuseTable::try_from_table(tbl.as_ref())?;
+        let block_thresholds = table.get_block_thresholds();
+        table.cluster_gen_for_append_with_specified_len(
+            self.ctx.clone(),
+            &mut self.main_pipeline,
+            block_thresholds,
+            1,
+            1,
+        )?;
+
+        // 4. serialize block
+        let cluster_stats_gen =
+            table.get_cluster_stats_gen(self.ctx.clone(), 0, block_thresholds, None)?;
+        let serialize_block_transform = TransformSerializeBlock::try_create(
+            self.ctx.clone(),
+            InputPort::create(),
+            OutputPort::create(),
+            table,
+            cluster_stats_gen,
+        )?;
+
+        let pipe_items = vec![
+            serialize_block_transform.into_pipe_item(),
+            create_dummy_item(),
+        ];
+        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
+
+        // 5. serialize segment
+        let serialize_segment_transform = TransformSerializeSegment::new(
+            self.ctx.clone(),
+            InputPort::create(),
+            OutputPort::create(),
+            table,
+            block_thresholds,
+        );
+        let pipe_items = vec![
+            serialize_segment_transform.into_pipe_item(),
+            create_dummy_item(),
+        ];
+        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
+
+        // resize to one, because they are all mutation logs now.
+        self.main_pipeline.try_resize(1)?;
+
+        Ok(())
+    }
+
+    pub(crate) fn build_merge_into_source(
+        &mut self,
+        merge_into_source: &MergeIntoSource,
+    ) -> Result<()> {
+        let MergeIntoSource { input, row_id_idx } = merge_into_source;
+
+        self.build_pipeline(input)?;
+        // merge into's parallism depends on the join probe number.
+        let mut items = Vec::with_capacity(self.main_pipeline.output_len());
+        let output_len = self.main_pipeline.output_len();
+        for _ in 0..output_len {
+            let merge_into_split_processor = MergeIntoSplitProcessor::create(*row_id_idx, false)?;
+            items.push(merge_into_split_processor.into_pipe_item());
+        }
+
+        self.main_pipeline
+            .add_pipe(Pipe::create(output_len, output_len * 2, items));
+
+        Ok(())
+    }
+
+    // build merge into pipeline.
+    pub(crate) fn build_merge_into(&mut self, merge_into: &MergeInto) -> Result<()> {
+        let MergeInto {
+            input,
+            table_info,
+            catalog_info,
+            unmatched,
+            matched,
+            field_index_of_input_schema,
+            row_id_idx,
+            segments,
+            distributed,
+            ..
+        } = merge_into;
+
+        self.build_pipeline(input)?;
+
+        let tbl = self
+            .ctx
+            .build_table_by_table_info(catalog_info, table_info, None)?;
+
+        let table = FuseTable::try_from_table(tbl.as_ref())?;
+        let block_thresholds = table.get_block_thresholds();
+
+        let cluster_stats_gen =
+            table.get_cluster_stats_gen(self.ctx.clone(), 0, block_thresholds, None)?;
+
+        // this TransformSerializeBlock is just used to get block_builder
+        let block_builder = TransformSerializeBlock::try_create(
+            self.ctx.clone(),
+            InputPort::create(),
+            OutputPort::create(),
+            table,
+            cluster_stats_gen.clone(),
+        )?
+        .get_block_builder();
+
+        let serialize_segment_transform = TransformSerializeSegment::new(
+            self.ctx.clone(),
+            InputPort::create(),
+            OutputPort::create(),
+            table,
+            block_thresholds,
+        );
+
+        let get_output_len = |pipe_items: &Vec<PipeItem>| -> usize {
+            let mut output_len = 0;
+            for item in pipe_items.iter() {
+                output_len += item.outputs_port.len();
+            }
+            output_len
+        };
+        // Handle matched and unmatched data separately.
+
+        //                                                                                 +-----------------------------+-+
+        //                                    +-----------------------+     Matched        |                             +-+
+        //                                    |                       +---+--------------->|    MatchedSplitProcessor    |
+        //                                    |                       |   |                |                             +-+
+        // +----------------------+           |                       +---+                +-----------------------------+-+
+        // |   MergeIntoSource    +---------->|MergeIntoSplitProcessor|
+        // +----------------------+           |                       +---+                +-----------------------------+
+        //                                    |                       |   | NotMatched     |                             +-+
+        //                                    |                       +---+--------------->| MergeIntoNotMatchedProcessor| |
+        //                                    +-----------------------+                    |                             +-+
+        //                                                                                 +-----------------------------+
+        // Note: here the output_port of MatchedSplitProcessor are arranged in the following order
+        // (0) -> output_port_row_id
+        // (1) -> output_port_updated
+
+        // Outputs from MatchedSplitProcessor's output_port_updated and MergeIntoNotMatchedProcessor's output_port are merged and processed uniformly by the subsequent ResizeProcessor
+
+        // receive matched data and not matched data parallelly.
+        let mut pipe_items = Vec::with_capacity(self.main_pipeline.output_len());
+        for _ in (0..self.main_pipeline.output_len()).step_by(2) {
+            // Todo(JackTan25): We should optimize pipeline. when only not matched, we should ignore this
+            let matched_split_processor = MatchedSplitProcessor::create(
+                self.ctx.clone(),
+                *row_id_idx,
+                matched.clone(),
+                field_index_of_input_schema.clone(),
+                input.output_schema()?,
+                Arc::new(DataSchema::from(tbl.schema())),
+            )?;
+
+            pipe_items.push(matched_split_processor.into_pipe_item());
+            if !*distributed {
+                // Todo(JackTan25): We should optimize pipeline. when only matched,we should ignore this
+                let merge_into_not_matched_processor = MergeIntoNotMatchedProcessor::create(
+                    unmatched.clone(),
+                    input.output_schema()?,
+                    self.func_ctx.clone(),
+                )?;
+
+                pipe_items.push(merge_into_not_matched_processor.into_pipe_item());
+            } else {
+                let input_num_columns = input.output_schema()?.num_fields();
+                assert_eq!(
+                    input.output_schema()?.field(input_num_columns - 1).name(),
+                    ROW_NUMBER_COL_NAME
+                );
+                let input_port = InputPort::create();
+                let output_port = OutputPort::create();
+                // project row number column
+                let proc = ProcessorPtr::create(CompoundBlockOperator::create(
+                    input_port.clone(),
+                    output_port.clone(),
+                    input_num_columns,
+                    self.func_ctx.clone(),
+                    vec![BlockOperator::Project {
+                        projection: vec![input_num_columns - 1],
+                    }],
+                ));
+                pipe_items.push(PipeItem {
+                    processor: proc,
+                    inputs_port: vec![input_port],
+                    outputs_port: vec![output_port],
+                })
+            };
+        }
+        self.main_pipeline.add_pipe(Pipe::create(
+            self.main_pipeline.output_len(),
+            get_output_len(&pipe_items),
+            pipe_items.clone(),
+        ));
+
+        // row_id port0_1
+        // matched update data port0_2
+        // not macthed insert data port0_3
+        // row_id port1_1
+        // matched update data port1_2
+        // not macthed insert data port1_3
+        // ......
+        assert_eq!(self.main_pipeline.output_len() % 3, 0);
+        let mut ranges = Vec::with_capacity(self.main_pipeline.output_len() / 3 * 2);
+        if !*distributed {
+            // merge rowid and serialize_blocks
+            for idx in (0..self.main_pipeline.output_len()).step_by(3) {
+                ranges.push(vec![idx]);
+                ranges.push(vec![idx + 1, idx + 2]);
+            }
+            self.main_pipeline.resize_partial_one(ranges.clone())?;
+            assert_eq!(self.main_pipeline.output_len() % 2, 0);
+
+            // shuffle outputs and resize row_id
+            // ----------------------------------------------------------------------
+            // row_id port0_1               row_id port0_1
+            // data port0_2                 row_id port1_1              row_id port
+            // row_id port1_1   ======>     ......           ======>
+            // data port1_2                 data port0_2                data port0
+            // ......                       data port1_2                data port1
+            // ......                       .....                       .....
+            // ----------------------------------------------------------------------
+            let mut rules = Vec::with_capacity(self.main_pipeline.output_len());
+            for idx in 0..(self.main_pipeline.output_len() / 2) {
+                rules.push(idx);
+                rules.push(idx + self.main_pipeline.output_len() / 2);
+            }
+            self.main_pipeline.reorder_inputs(rules);
+            // resize row_id
+            ranges.clear();
+            let mut vec = Vec::with_capacity(self.main_pipeline.output_len() / 2);
+            for idx in 0..(self.main_pipeline.output_len() / 2) {
+                vec.push(idx);
+            }
+            ranges.push(vec.clone());
+            for idx in 0..(self.main_pipeline.output_len() / 2) {
+                ranges.push(vec![idx + self.main_pipeline.output_len() / 2]);
+            }
+            self.main_pipeline.resize_partial_one(ranges.clone())?;
+        } else {
+            // shuffle outputs and resize row_id
+            // ----------------------------------------------------------------------
+            // row_id port0_1              row_id port0_1              row_id port
+            // matched data port0_2        row_id port1_1            matched data port0_2
+            // row_number port0_3          matched data port0_2      matched data port1_2
+            // row_id port1_1              matched data port1_2          ......
+            // matched data port1_2  ===>       .....           ====>    ......
+            // row_number port1_2               .....                    ......
+            // row_number port0_3        row_number port0_3          row_number port
+            // ......                    row_number port1_3
+            // ......                           .....
+            // ----------------------------------------------------------------------
+            // do shuffle
+            let mut rules = Vec::with_capacity(self.main_pipeline.output_len());
+            for idx in 0..(self.main_pipeline.output_len() / 3) {
+                rules.push(idx);
+                rules.push(idx + self.main_pipeline.output_len() / 3);
+                rules.push(idx + self.main_pipeline.output_len() / 3 * 2);
+            }
+            self.main_pipeline.reorder_inputs(rules);
+
+            // resize row_id
+            ranges.clear();
+            let mut vec = Vec::with_capacity(self.main_pipeline.output_len() / 3);
+            for idx in 0..(self.main_pipeline.output_len() / 3) {
+                vec.push(idx);
+            }
+            ranges.push(vec.clone());
+            for idx in 0..(self.main_pipeline.output_len() / 3) {
+                ranges.push(vec![idx + self.main_pipeline.output_len() / 3]);
+            }
+            vec.clear();
+            for idx in 0..(self.main_pipeline.output_len() / 3) {
+                vec.push(idx + self.main_pipeline.output_len() / 3 * 2);
+            }
+            ranges.push(vec);
+            self.main_pipeline.resize_partial_one(ranges.clone())?;
+        }
+
+        let fill_default_len = if !*distributed {
+            // remove first row_id port
+            self.main_pipeline.output_len() - 1
+        } else {
+            // remove first row_id port and last row_number_port
+            self.main_pipeline.output_len() - 2
+        };
+        // fill default columns
+        let table_default_schema = &table.schema().remove_computed_fields();
+        let mut builder = self.main_pipeline.add_transform_with_specified_len(
+            |transform_input_port, transform_output_port| {
+                TransformResortAddOnWithoutSourceSchema::try_create(
+                    self.ctx.clone(),
+                    transform_input_port,
+                    transform_output_port,
+                    Arc::new(DataSchema::from(table_default_schema)),
+                    tbl.clone(),
+                )
+            },
+            fill_default_len,
+        )?;
+
+        if !*distributed {
+            builder.add_items_prepend(vec![create_dummy_item()]);
+            self.main_pipeline.add_pipe(builder.finalize());
+        } else {
+            builder.add_items_prepend(vec![create_dummy_item()]);
+            // receive row_number
+            builder.add_items(vec![create_dummy_item()]);
+            self.main_pipeline.add_pipe(builder.finalize());
+        }
+
+        let fill_computed_len = if !*distributed {
+            // remove first row_id port
+            self.main_pipeline.output_len() - 1
+        } else {
+            // remove first row_id port and last row_number_port
+            self.main_pipeline.output_len() - 2
+        };
+
+        // fill computed columns
+        let table_computed_schema = &table.schema().remove_virtual_computed_fields();
+        let default_schema: DataSchemaRef = Arc::new(table_default_schema.into());
+        let computed_schema: DataSchemaRef = Arc::new(table_computed_schema.into());
+        if default_schema != computed_schema {
+            builder = self.main_pipeline.add_transform_with_specified_len(
+                |transform_input_port, transform_output_port| {
+                    TransformAddComputedColumns::try_create(
+                        self.ctx.clone(),
+                        transform_input_port,
+                        transform_output_port,
+                        default_schema.clone(),
+                        computed_schema.clone(),
+                    )
+                },
+                fill_computed_len,
+            )?;
+            if !*distributed {
+                builder.add_items_prepend(vec![create_dummy_item()]);
+                self.main_pipeline.add_pipe(builder.finalize());
+            } else {
+                builder.add_items_prepend(vec![create_dummy_item()]);
+                // receive row_number
+                builder.add_items(vec![create_dummy_item()]);
+                self.main_pipeline.add_pipe(builder.finalize());
+            }
+        }
+
+        let max_threads = self.settings.get_max_threads()?;
+        let io_request_semaphore = Arc::new(Semaphore::new(max_threads as usize));
+
+        // after filling default columns, we need to add cluster‘s blocksort if it's a cluster table
+        let output_lens = self.main_pipeline.output_len();
+        if !*distributed {
+            table.cluster_gen_for_append_with_specified_len(
+                self.ctx.clone(),
+                &mut self.main_pipeline,
+                block_thresholds,
+                output_lens - 1,
+                0,
+            )?;
+        } else {
+            table.cluster_gen_for_append_with_specified_len(
+                self.ctx.clone(),
+                &mut self.main_pipeline,
+                block_thresholds,
+                output_lens - 2,
+                1,
+            )?;
+        }
+
+        pipe_items.clear();
+
+        pipe_items.push(table.rowid_aggregate_mutator(
+            self.ctx.clone(),
+            block_builder,
+            io_request_semaphore,
+            segments.clone(),
+        )?);
+
+        let serialize_len = if !*distributed {
+            self.main_pipeline.output_len() - 1
+        } else {
+            self.main_pipeline.output_len() - 2
+        };
+
+        for _ in 0..serialize_len {
+            let serialize_block_transform = TransformSerializeBlock::try_create(
+                self.ctx.clone(),
+                InputPort::create(),
+                OutputPort::create(),
+                table,
+                cluster_stats_gen.clone(),
+            )?;
+            pipe_items.push(serialize_block_transform.into_pipe_item());
+        }
+
+        // receive row_number
+        if *distributed {
+            pipe_items.push(create_dummy_item());
+        }
+
+        self.main_pipeline.add_pipe(Pipe::create(
+            self.main_pipeline.output_len(),
+            get_output_len(&pipe_items),
+            pipe_items,
+        ));
+
+        // resize block ports
+        // aggregate_mutator port/dummy_item port               aggregate_mutator port/ dummy_item (this depends on apply_row_id)
+        // serialize_block port0                    ======>
+        // serialize_block port1                                serialize_block port
+        // .......
+        // row_number_port (distributed)                        row_number_port(distributed)
+        ranges.clear();
+        ranges.push(vec![0]);
+        let mut vec = Vec::with_capacity(self.main_pipeline.output_len());
+        let output_lens = if !*distributed {
+            self.main_pipeline.output_len() - 1
+        } else {
+            self.main_pipeline.output_len() - 2
+        };
+        for idx in 0..output_lens {
+            vec.push(idx + 1);
+        }
+        ranges.push(vec);
+        if *distributed {
+            ranges.push(vec![self.main_pipeline.output_len() - 1]);
+        }
+
+        self.main_pipeline.resize_partial_one(ranges)?;
+
+        let pipe_items = if !distributed {
+            vec![
+                create_dummy_item(),
+                serialize_segment_transform.into_pipe_item(),
+            ]
+        } else {
+            vec![
+                create_dummy_item(),
+                serialize_segment_transform.into_pipe_item(),
+                create_dummy_item(),
+            ]
+        };
+
+        // distributed: false
+        //      output_port0: MutationLogs
+        //      output_port1: MutationLogs
+        //
+        // distributed: true
+        //      output_port0: MutationLogs
+        //      output_port1: MutationLogs
+        //      output_port2: row_numbers
+        self.main_pipeline.add_pipe(Pipe::create(
+            self.main_pipeline.output_len(),
+            get_output_len(&pipe_items),
+            pipe_items,
+        ));
+
+        Ok(())
+    }
+}

--- a/src/query/service/src/pipelines/builders/builder_replace_into.rs
+++ b/src/query/service/src/pipelines/builders/builder_replace_into.rs
@@ -1,0 +1,365 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::base::tokio::sync::Semaphore;
+use common_catalog::table::Table;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_expression::DataSchema;
+use common_functions::BUILTIN_FUNCTIONS;
+use common_pipeline_core::pipe::Pipe;
+use common_pipeline_core::processors::port::InputPort;
+use common_pipeline_core::processors::port::OutputPort;
+use common_pipeline_sources::AsyncSourcer;
+use common_pipeline_transforms::processors::transforms::create_dummy_item;
+use common_sql::executor::AsyncSourcerPlan;
+use common_sql::executor::Deduplicate;
+use common_sql::executor::ReplaceInto;
+use common_sql::executor::SelectCtx;
+use common_sql::NameResolutionContext;
+use common_storages_fuse::operations::common::TransformSerializeSegment;
+use common_storages_fuse::operations::replace_into::BroadcastProcessor;
+use common_storages_fuse::operations::replace_into::ReplaceIntoProcessor;
+use common_storages_fuse::operations::replace_into::UnbranchedReplaceIntoProcessor;
+use common_storages_fuse::operations::TransformSerializeBlock;
+use common_storages_fuse::FuseTable;
+
+use crate::pipelines::processors::TransformCastSchema;
+use crate::pipelines::PipelineBuilder;
+use crate::pipelines::ValueSource;
+
+impl PipelineBuilder {
+    // check if cast needed
+    fn check_schema_cast(
+        select_schema: Arc<DataSchema>,
+        output_schema: Arc<DataSchema>,
+    ) -> Result<bool> {
+        let cast_needed = select_schema != output_schema;
+        Ok(cast_needed)
+    }
+
+    // build async sourcer pipeline.
+    pub(crate) fn build_async_sourcer(&mut self, async_sourcer: &AsyncSourcerPlan) -> Result<()> {
+        self.main_pipeline.add_source(
+            |output| {
+                let name_resolution_ctx = NameResolutionContext::try_from(self.settings.as_ref())?;
+                let inner = ValueSource::new(
+                    async_sourcer.value_data.clone(),
+                    self.ctx.clone(),
+                    name_resolution_ctx,
+                    async_sourcer.schema.clone(),
+                    async_sourcer.start,
+                );
+                AsyncSourcer::create(self.ctx.clone(), output, inner)
+            },
+            1,
+        )?;
+        Ok(())
+    }
+
+    // build replace into pipeline.
+    pub(crate) fn build_replace_into(&mut self, replace: &ReplaceInto) -> Result<()> {
+        let ReplaceInto {
+            input,
+            block_thresholds,
+            table_info,
+            on_conflicts,
+            bloom_filter_column_indexes,
+            catalog_info,
+            segments,
+            block_slots,
+            need_insert,
+        } = replace;
+        let max_threads = self.settings.get_max_threads()?;
+        let segment_partition_num = std::cmp::min(segments.len(), max_threads as usize);
+        let table = self
+            .ctx
+            .build_table_by_table_info(catalog_info, table_info, None)?;
+        let table = FuseTable::try_from_table(table.as_ref())?;
+        let cluster_stats_gen =
+            table.get_cluster_stats_gen(self.ctx.clone(), 0, *block_thresholds, None)?;
+        self.build_pipeline(input)?;
+        // connect to broadcast processor and append transform
+        let serialize_block_transform = TransformSerializeBlock::try_create(
+            self.ctx.clone(),
+            InputPort::create(),
+            OutputPort::create(),
+            table,
+            cluster_stats_gen,
+        )?;
+        let block_builder = serialize_block_transform.get_block_builder();
+
+        let serialize_segment_transform = TransformSerializeSegment::new(
+            self.ctx.clone(),
+            InputPort::create(),
+            OutputPort::create(),
+            table,
+            *block_thresholds,
+        );
+        if !*need_insert {
+            if segment_partition_num == 0 {
+                return Ok(());
+            }
+            let broadcast_processor = BroadcastProcessor::new(segment_partition_num);
+            self.main_pipeline
+                .add_pipe(Pipe::create(1, segment_partition_num, vec![
+                    broadcast_processor.into_pipe_item(),
+                ]));
+            let max_threads = self.settings.get_max_threads()?;
+            let io_request_semaphore = Arc::new(Semaphore::new(max_threads as usize));
+
+            let merge_into_operation_aggregators = table.merge_into_mutators(
+                self.ctx.clone(),
+                segment_partition_num,
+                block_builder,
+                on_conflicts.clone(),
+                bloom_filter_column_indexes.clone(),
+                segments,
+                block_slots.clone(),
+                io_request_semaphore,
+            )?;
+            self.main_pipeline.add_pipe(Pipe::create(
+                segment_partition_num,
+                segment_partition_num,
+                merge_into_operation_aggregators,
+            ));
+            return Ok(());
+        }
+
+        if segment_partition_num == 0 {
+            let dummy_item = create_dummy_item();
+            //                      ┌──────────────────────┐            ┌──────────────────┐
+            //                      │                      ├──┬────────►│  SerializeBlock  │
+            // ┌─────────────┐      │                      ├──┘         └──────────────────┘
+            // │ UpsertSource├─────►│ ReplaceIntoProcessor │
+            // └─────────────┘      │                      ├──┐         ┌──────────────────┐
+            //                      │                      ├──┴────────►│  DummyTransform  │
+            //                      └──────────────────────┘            └──────────────────┘
+            // wrap them into pipeline, order matters!
+            self.main_pipeline.add_pipe(Pipe::create(2, 2, vec![
+                serialize_block_transform.into_pipe_item(),
+                dummy_item,
+            ]));
+        } else {
+            //                      ┌──────────────────────┐            ┌──────────────────┐
+            //                      │                      ├──┬────────►│ SerializeBlock   │
+            // ┌─────────────┐      │                      ├──┘         └──────────────────┘
+            // │ UpsertSource├─────►│ ReplaceIntoProcessor │
+            // └─────────────┘      │                      ├──┐         ┌──────────────────┐
+            //                      │                      ├──┴────────►│BroadcastProcessor│
+            //                      └──────────────────────┘            └──────────────────┘
+            let broadcast_processor = BroadcastProcessor::new(segment_partition_num);
+            // wrap them into pipeline, order matters!
+            self.main_pipeline
+                .add_pipe(Pipe::create(2, segment_partition_num + 1, vec![
+                    serialize_block_transform.into_pipe_item(),
+                    broadcast_processor.into_pipe_item(),
+                ]));
+        };
+
+        // 4. connect with MergeIntoOperationAggregators
+        if segment_partition_num == 0 {
+            let dummy_item = create_dummy_item();
+            self.main_pipeline.add_pipe(Pipe::create(2, 2, vec![
+                serialize_segment_transform.into_pipe_item(),
+                dummy_item,
+            ]));
+        } else {
+            //      ┌──────────────────┐               ┌────────────────┐
+            // ────►│  SerializeBlock  ├──────────────►│SerializeSegment│
+            //      └──────────────────┘               └────────────────┘
+            //
+            //      ┌───────────────────┐              ┌──────────────────────┐
+            // ────►│                   ├──┬──────────►│MergeIntoOperationAggr│
+            //      │                   ├──┘           └──────────────────────┘
+            //      │ BroadcastProcessor│
+            //      │                   ├──┐           ┌──────────────────────┐
+            //      │                   ├──┴──────────►│MergeIntoOperationAggr│
+            //      │                   │              └──────────────────────┘
+            //      │                   ├──┐
+            //      │                   ├──┴──────────►┌──────────────────────┐
+            //      └───────────────────┘              │MergeIntoOperationAggr│
+            //                                         └──────────────────────┘
+
+            let item_size = segment_partition_num + 1;
+            let mut pipe_items = Vec::with_capacity(item_size);
+            // setup the dummy transform
+            pipe_items.push(serialize_segment_transform.into_pipe_item());
+
+            let max_threads = self.settings.get_max_threads()?;
+            let io_request_semaphore = Arc::new(Semaphore::new(max_threads as usize));
+
+            // setup the merge into operation aggregators
+            let mut merge_into_operation_aggregators = table.merge_into_mutators(
+                self.ctx.clone(),
+                segment_partition_num,
+                block_builder,
+                on_conflicts.clone(),
+                bloom_filter_column_indexes.clone(),
+                segments,
+                block_slots.clone(),
+                io_request_semaphore,
+            )?;
+            assert_eq!(
+                segment_partition_num,
+                merge_into_operation_aggregators.len()
+            );
+            pipe_items.append(&mut merge_into_operation_aggregators);
+
+            // extend the pipeline
+            assert_eq!(self.main_pipeline.output_len(), item_size);
+            assert_eq!(pipe_items.len(), item_size);
+            self.main_pipeline
+                .add_pipe(Pipe::create(item_size, item_size, pipe_items));
+        }
+        Ok(())
+    }
+
+    // build deduplicate pipeline.
+    pub(crate) fn build_deduplicate(&mut self, deduplicate: &Deduplicate) -> Result<()> {
+        let Deduplicate {
+            input,
+            on_conflicts,
+            bloom_filter_column_indexes,
+            table_is_empty,
+            table_info,
+            catalog_info,
+            select_ctx,
+            table_level_range_index,
+            table_schema,
+            need_insert,
+            delete_when,
+        } = deduplicate;
+
+        let tbl = self
+            .ctx
+            .build_table_by_table_info(catalog_info, table_info, None)?;
+        let table = FuseTable::try_from_table(tbl.as_ref())?;
+        self.build_pipeline(input)?;
+        let mut delete_column_idx = 0;
+        let mut opt_modified_schema = None;
+        if let Some(SelectCtx {
+            select_column_bindings,
+            select_schema,
+        }) = select_ctx
+        {
+            PipelineBuilder::render_result_set(
+                &self.func_ctx,
+                input.output_schema()?,
+                select_column_bindings,
+                &mut self.main_pipeline,
+                false,
+            )?;
+
+            let mut target_schema: DataSchema = table_schema.clone().into();
+            if let Some((_, delete_column)) = delete_when {
+                delete_column_idx = select_schema.index_of(delete_column.as_str())?;
+                let delete_column = select_schema.field(delete_column_idx).clone();
+                target_schema
+                    .fields
+                    .insert(delete_column_idx, delete_column);
+                opt_modified_schema = Some(Arc::new(target_schema.clone()));
+            }
+            let target_schema = Arc::new(target_schema.clone());
+            if target_schema.fields().len() != select_schema.fields().len() {
+                return Err(ErrorCode::BadArguments(
+                    "The number of columns in the target table is different from the number of columns in the SELECT clause",
+                ));
+            }
+            if Self::check_schema_cast(select_schema.clone(), target_schema.clone())? {
+                self.main_pipeline.add_transform(
+                    |transform_input_port, transform_output_port| {
+                        TransformCastSchema::try_create(
+                            transform_input_port,
+                            transform_output_port,
+                            select_schema.clone(),
+                            target_schema.clone(),
+                            self.func_ctx.clone(),
+                        )
+                    },
+                )?;
+            }
+        }
+
+        Self::build_fill_missing_columns_pipeline(
+            self.ctx.clone(),
+            &mut self.main_pipeline,
+            tbl.clone(),
+            Arc::new(table_schema.clone().into()),
+        )?;
+
+        let _ = table.cluster_gen_for_append(
+            self.ctx.clone(),
+            &mut self.main_pipeline,
+            table.get_block_thresholds(),
+            opt_modified_schema,
+        )?;
+        // 1. resize input to 1, since the UpsertTransform need to de-duplicate inputs "globally"
+        self.main_pipeline.try_resize(1)?;
+
+        // 2. connect with ReplaceIntoProcessor
+
+        //                      ┌──────────────────────┐
+        //                      │                      ├──┐
+        // ┌─────────────┐      │                      ├──┘
+        // │ UpsertSource├─────►│ ReplaceIntoProcessor │
+        // └─────────────┘      │                      ├──┐
+        //                      │                      ├──┘
+        //                      └──────────────────────┘
+        // NOTE: here the pipe items of last pipe are arranged in the following order
+        // (0) -> output_port_append_data
+        // (1) -> output_port_merge_into_action
+        //    the "downstream" is supposed to be connected with a processor which can process MergeIntoOperations
+        //    in our case, it is the broadcast processor
+        let delete_when = if let Some((remote_expr, delete_column)) = delete_when {
+            Some((
+                remote_expr.as_expr(&BUILTIN_FUNCTIONS),
+                delete_column.clone(),
+            ))
+        } else {
+            None
+        };
+        let cluster_keys = table.cluster_keys(self.ctx.clone());
+        if *need_insert {
+            let replace_into_processor = ReplaceIntoProcessor::create(
+                self.ctx.clone(),
+                on_conflicts.clone(),
+                cluster_keys,
+                bloom_filter_column_indexes.clone(),
+                table_schema.as_ref(),
+                *table_is_empty,
+                table_level_range_index.clone(),
+                delete_when.map(|(expr, _)| (expr, delete_column_idx)),
+            )?;
+            self.main_pipeline
+                .add_pipe(replace_into_processor.into_pipe());
+        } else {
+            let replace_into_processor = UnbranchedReplaceIntoProcessor::create(
+                self.ctx.as_ref(),
+                on_conflicts.clone(),
+                cluster_keys,
+                bloom_filter_column_indexes.clone(),
+                table_schema.as_ref(),
+                *table_is_empty,
+                table_level_range_index.clone(),
+                delete_when.map(|_| delete_column_idx),
+            )?;
+            self.main_pipeline
+                .add_pipe(replace_into_processor.into_pipe());
+        }
+        Ok(())
+    }
+}

--- a/src/query/service/src/pipelines/builders/mod.rs
+++ b/src/query/service/src/pipelines/builders/mod.rs
@@ -15,4 +15,6 @@
 mod builder_append_table;
 mod builder_copy_into;
 mod builder_fill_missing_columns;
+mod builder_merge_into;
 mod builder_on_finished;
+mod builder_replace_into;

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Instant;
@@ -23,7 +22,6 @@ use async_channel::Receiver;
 use common_ast::parser::parse_comma_separated_exprs;
 use common_ast::parser::tokenize_sql;
 use common_base::base::tokio::sync::Barrier;
-use common_base::base::tokio::sync::Semaphore;
 use common_base::runtime::Runtime;
 use common_catalog::plan::Projection;
 use common_catalog::table::AppendMode;
@@ -38,13 +36,11 @@ use common_expression::with_number_mapped_type;
 use common_expression::ColumnBuilder;
 use common_expression::DataBlock;
 use common_expression::DataField;
-use common_expression::DataSchema;
 use common_expression::DataSchemaRef;
 use common_expression::FunctionContext;
 use common_expression::HashMethodKind;
 use common_expression::Scalar;
 use common_expression::SortColumnDescription;
-use common_expression::ROW_NUMBER_COL_NAME;
 use common_formats::FastFieldDecoderValues;
 use common_formats::FastValuesDecodeFallback;
 use common_formats::FastValuesDecoder;
@@ -54,7 +50,6 @@ use common_functions::BUILTIN_FUNCTIONS;
 use common_pipeline_core::pipe::Pipe;
 use common_pipeline_core::pipe::PipeItem;
 use common_pipeline_core::processors::port::InputPort;
-use common_pipeline_core::processors::port::OutputPort;
 use common_pipeline_core::processors::processor::ProcessorPtr;
 use common_pipeline_core::processors::Processor;
 use common_pipeline_core::query_spill_prefix;
@@ -62,30 +57,25 @@ use common_pipeline_sinks::EmptySink;
 use common_pipeline_sinks::Sinker;
 use common_pipeline_sinks::UnionReceiveSink;
 use common_pipeline_sources::AsyncSource;
-use common_pipeline_sources::AsyncSourcer;
 use common_pipeline_sources::EmptySource;
 use common_pipeline_sources::OneBlockSource;
 use common_pipeline_transforms::processors::profile_wrapper::ProcessorProfileWrapper;
 use common_pipeline_transforms::processors::profile_wrapper::ProfileStub;
 use common_pipeline_transforms::processors::profile_wrapper::TransformProfileWrapper;
 use common_pipeline_transforms::processors::transforms::build_full_sort_pipeline;
-use common_pipeline_transforms::processors::transforms::create_dummy_item;
 use common_pipeline_transforms::processors::transforms::Transformer;
 use common_profile::SharedProcessorProfiles;
 use common_settings::Settings;
 use common_sql::evaluator::BlockOperator;
 use common_sql::evaluator::CompoundBlockOperator;
-use common_sql::executor::AddRowNumber;
 use common_sql::executor::AggregateExpand;
 use common_sql::executor::AggregateFinal;
 use common_sql::executor::AggregateFunctionDesc;
 use common_sql::executor::AggregatePartial;
-use common_sql::executor::AsyncSourcerPlan;
 use common_sql::executor::CommitSink;
 use common_sql::executor::CompactSource;
 use common_sql::executor::ConstantTableScan;
 use common_sql::executor::CteScan;
-use common_sql::executor::Deduplicate;
 use common_sql::executor::DeleteSource;
 use common_sql::executor::DistributedInsertSelect;
 use common_sql::executor::EvalScalar;
@@ -96,19 +86,14 @@ use common_sql::executor::HashJoin;
 use common_sql::executor::Lambda;
 use common_sql::executor::Limit;
 use common_sql::executor::MaterializedCte;
-use common_sql::executor::MergeInto;
-use common_sql::executor::MergeIntoAppendNotMatched;
-use common_sql::executor::MergeIntoSource;
 use common_sql::executor::PhysicalPlan;
 use common_sql::executor::Project;
 use common_sql::executor::ProjectSet;
 use common_sql::executor::RangeJoin;
 use common_sql::executor::ReclusterSink;
 use common_sql::executor::ReclusterSource;
-use common_sql::executor::ReplaceInto;
 use common_sql::executor::RowFetch;
 use common_sql::executor::RuntimeFilterSource;
-use common_sql::executor::SelectCtx;
 use common_sql::executor::Sort;
 use common_sql::executor::TableScan;
 use common_sql::executor::UnionAll;
@@ -122,15 +107,6 @@ use common_sql::NameResolutionContext;
 use common_storage::DataOperator;
 use common_storages_factory::Table;
 use common_storages_fuse::operations::build_row_fetcher_pipeline;
-use common_storages_fuse::operations::common::TransformSerializeSegment;
-use common_storages_fuse::operations::merge_into::MatchedSplitProcessor;
-use common_storages_fuse::operations::merge_into::MergeIntoNotMatchedProcessor;
-use common_storages_fuse::operations::merge_into::MergeIntoSplitProcessor;
-use common_storages_fuse::operations::merge_into::RowNumberAndLogSplitProcessor;
-use common_storages_fuse::operations::merge_into::TransformAddRowNumberColumnProcessor;
-use common_storages_fuse::operations::replace_into::BroadcastProcessor;
-use common_storages_fuse::operations::replace_into::ReplaceIntoProcessor;
-use common_storages_fuse::operations::replace_into::UnbranchedReplaceIntoProcessor;
 use common_storages_fuse::operations::FillInternalColumnProcessor;
 use common_storages_fuse::operations::MutationBlockPruningContext;
 use common_storages_fuse::operations::TransformSerializeBlock;
@@ -141,10 +117,8 @@ use log::info;
 use parking_lot::RwLock;
 
 use super::processors::transforms::FrameBound;
-use super::processors::transforms::TransformAddComputedColumns;
 use super::processors::transforms::WindowFunctionInfo;
 use super::processors::TransformExpandGroupingSets;
-use super::processors::TransformResortAddOnWithoutSourceSchema;
 use super::PipelineBuilderData;
 use crate::api::DefaultExchangeInjector;
 use crate::api::ExchangeInjector;
@@ -159,7 +133,6 @@ use crate::pipelines::processors::transforms::hash_join::TransformHashJoinProbe;
 use crate::pipelines::processors::transforms::range_join::TransformRangeJoinLeft;
 use crate::pipelines::processors::transforms::range_join::TransformRangeJoinRight;
 use crate::pipelines::processors::transforms::AggregateInjector;
-use crate::pipelines::processors::transforms::ExtractHashTableByRowNumber;
 use crate::pipelines::processors::transforms::FinalSingleStateAggregator;
 use crate::pipelines::processors::transforms::HashJoinDesc;
 use crate::pipelines::processors::transforms::MaterializedCteSink;
@@ -175,7 +148,6 @@ use crate::pipelines::processors::transforms::TransformPartialAggregate;
 use crate::pipelines::processors::transforms::TransformPartialGroupBy;
 use crate::pipelines::processors::transforms::TransformWindow;
 use crate::pipelines::processors::AggregatorParams;
-use crate::pipelines::processors::DeduplicateRowNumber;
 use crate::pipelines::processors::HashJoinState;
 use crate::pipelines::processors::SinkRuntimeFilterSource;
 use crate::pipelines::processors::TransformCastSchema;
@@ -191,8 +163,7 @@ pub struct PipelineBuilder {
     pub(crate) ctx: Arc<QueryContext>,
     pub(crate) func_ctx: FunctionContext,
     pub(crate) main_pipeline: Pipeline,
-
-    settings: Arc<Settings>,
+    pub(crate) settings: Arc<Settings>,
 
     pub pipelines: Vec<Pipeline>,
 
@@ -314,905 +285,6 @@ impl PipelineBuilder {
                 self.build_recluster_sink(recluster_sink)
             }
         }
-    }
-
-    fn check_schema_cast(
-        select_schema: Arc<DataSchema>,
-        output_schema: Arc<DataSchema>,
-    ) -> Result<bool> {
-        // check if cast needed
-        let cast_needed = select_schema != output_schema;
-        Ok(cast_needed)
-    }
-
-    fn build_add_row_number(&mut self, add_row_number: &AddRowNumber) -> Result<()> {
-        // it must be distributed merge into execution
-        self.build_pipeline(&add_row_number.input)?;
-        let node_index = add_row_number
-            .cluster_index
-            .get(&self.ctx.get_cluster().local_id);
-        if node_index.is_none() {
-            return Err(ErrorCode::NotFoundClusterNode(format!(
-                "can't find out {} when build distributed merge into pipeline",
-                self.ctx.get_cluster().local_id
-            )));
-        }
-        let node_index = *node_index.unwrap() as u16;
-        let row_number = Arc::new(AtomicU64::new(0));
-        self.main_pipeline
-            .add_transform(|transform_input_port, transform_output_port| {
-                TransformAddRowNumberColumnProcessor::create(
-                    transform_input_port,
-                    transform_output_port,
-                    node_index,
-                    row_number.clone(),
-                )
-            })?;
-        Ok(())
-    }
-
-    fn build_merge_into_append_not_matched(
-        &mut self,
-        merge_into_append_not_macted: &MergeIntoAppendNotMatched,
-    ) -> Result<()> {
-        let MergeIntoAppendNotMatched {
-            input,
-            table_info,
-            catalog_info,
-            unmatched,
-            input_schema,
-        } = merge_into_append_not_macted;
-        // receive row numbers and MutationLogs
-        self.build_pipeline(input)?;
-        self.main_pipeline.try_resize(1)?;
-
-        assert!(self.join_state.is_some());
-        assert!(self.probe_data_fields.is_some());
-
-        let join_state = self.join_state.clone().unwrap();
-        // split row_number and log
-        //      output_port_row_number
-        //      output_port_log
-        self.main_pipeline
-            .add_pipe(RowNumberAndLogSplitProcessor::create()?.into_pipe());
-
-        // accumulate source data which is not matched from hashstate
-        let pipe_items = vec![
-            DeduplicateRowNumber::create()?.into_pipe_item(),
-            create_dummy_item(),
-        ];
-        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
-
-        let pipe_items = vec![
-            ExtractHashTableByRowNumber::create(
-                join_state,
-                self.probe_data_fields.clone().unwrap(),
-            )?
-            .into_pipe_item(),
-            create_dummy_item(),
-        ];
-        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
-
-        // not macthed operation
-        let merge_into_not_matched_processor = MergeIntoNotMatchedProcessor::create(
-            unmatched.clone(),
-            input_schema.clone(),
-            self.func_ctx.clone(),
-        )?;
-        let pipe_items = vec![
-            merge_into_not_matched_processor.into_pipe_item(),
-            create_dummy_item(),
-        ];
-        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
-
-        // split row_number and log
-        //      output_port_not_matched_data
-        //      output_port_log
-        // start to append data
-        let tbl = self
-            .ctx
-            .build_table_by_table_info(catalog_info, table_info, None)?;
-        // 1.fill default columns
-        let table_default_schema = &tbl.schema().remove_computed_fields();
-        let mut builder = self.main_pipeline.add_transform_with_specified_len(
-            |transform_input_port, transform_output_port| {
-                TransformResortAddOnWithoutSourceSchema::try_create(
-                    self.ctx.clone(),
-                    transform_input_port,
-                    transform_output_port,
-                    Arc::new(DataSchema::from(table_default_schema)),
-                    tbl.clone(),
-                )
-            },
-            1,
-        )?;
-        builder.add_items(vec![create_dummy_item()]);
-        self.main_pipeline.add_pipe(builder.finalize());
-
-        // 2.fill computed columns
-        let table_computed_schema = &tbl.schema().remove_virtual_computed_fields();
-        let default_schema: DataSchemaRef = Arc::new(table_default_schema.into());
-        let computed_schema: DataSchemaRef = Arc::new(table_computed_schema.into());
-        if default_schema != computed_schema {
-            builder = self.main_pipeline.add_transform_with_specified_len(
-                |transform_input_port, transform_output_port| {
-                    TransformAddComputedColumns::try_create(
-                        self.ctx.clone(),
-                        transform_input_port,
-                        transform_output_port,
-                        default_schema.clone(),
-                        computed_schema.clone(),
-                    )
-                },
-                1,
-            )?;
-            builder.add_items(vec![create_dummy_item()]);
-            self.main_pipeline.add_pipe(builder.finalize());
-        }
-
-        // 3. cluster sort
-        let table = FuseTable::try_from_table(tbl.as_ref())?;
-        let block_thresholds = table.get_block_thresholds();
-        table.cluster_gen_for_append_with_specified_len(
-            self.ctx.clone(),
-            &mut self.main_pipeline,
-            block_thresholds,
-            1,
-            1,
-        )?;
-
-        // 4. serialize block
-        let cluster_stats_gen =
-            table.get_cluster_stats_gen(self.ctx.clone(), 0, block_thresholds, None)?;
-        let serialize_block_transform = TransformSerializeBlock::try_create(
-            self.ctx.clone(),
-            InputPort::create(),
-            OutputPort::create(),
-            table,
-            cluster_stats_gen,
-        )?;
-
-        let pipe_items = vec![
-            serialize_block_transform.into_pipe_item(),
-            create_dummy_item(),
-        ];
-        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
-
-        // 5. serialize segment
-        let serialize_segment_transform = TransformSerializeSegment::new(
-            self.ctx.clone(),
-            InputPort::create(),
-            OutputPort::create(),
-            table,
-            block_thresholds,
-        );
-        let pipe_items = vec![
-            serialize_segment_transform.into_pipe_item(),
-            create_dummy_item(),
-        ];
-        self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
-
-        // resize to one, because they are all mutation logs now.
-        self.main_pipeline.try_resize(1)?;
-
-        Ok(())
-    }
-
-    fn build_merge_into_source(&mut self, merge_into_source: &MergeIntoSource) -> Result<()> {
-        let MergeIntoSource { input, row_id_idx } = merge_into_source;
-
-        self.build_pipeline(input)?;
-        // merge into's parallism depends on the join probe number.
-        let mut items = Vec::with_capacity(self.main_pipeline.output_len());
-        let output_len = self.main_pipeline.output_len();
-        for _ in 0..output_len {
-            let merge_into_split_processor = MergeIntoSplitProcessor::create(*row_id_idx, false)?;
-            items.push(merge_into_split_processor.into_pipe_item());
-        }
-
-        self.main_pipeline
-            .add_pipe(Pipe::create(output_len, output_len * 2, items));
-
-        Ok(())
-    }
-
-    fn build_deduplicate(&mut self, deduplicate: &Deduplicate) -> Result<()> {
-        let Deduplicate {
-            input,
-            on_conflicts,
-            bloom_filter_column_indexes,
-            table_is_empty,
-            table_info,
-            catalog_info,
-            select_ctx,
-            table_level_range_index,
-            table_schema,
-            need_insert,
-            delete_when,
-        } = deduplicate;
-
-        let tbl = self
-            .ctx
-            .build_table_by_table_info(catalog_info, table_info, None)?;
-        let table = FuseTable::try_from_table(tbl.as_ref())?;
-        self.build_pipeline(input)?;
-        let mut delete_column_idx = 0;
-        let mut opt_modified_schema = None;
-        if let Some(SelectCtx {
-            select_column_bindings,
-            select_schema,
-        }) = select_ctx
-        {
-            PipelineBuilder::render_result_set(
-                &self.func_ctx,
-                input.output_schema()?,
-                select_column_bindings,
-                &mut self.main_pipeline,
-                false,
-            )?;
-
-            let mut target_schema: DataSchema = table_schema.clone().into();
-            if let Some((_, delete_column)) = delete_when {
-                delete_column_idx = select_schema.index_of(delete_column.as_str())?;
-                let delete_column = select_schema.field(delete_column_idx).clone();
-                target_schema
-                    .fields
-                    .insert(delete_column_idx, delete_column);
-                opt_modified_schema = Some(Arc::new(target_schema.clone()));
-            }
-            let target_schema = Arc::new(target_schema.clone());
-            if target_schema.fields().len() != select_schema.fields().len() {
-                return Err(ErrorCode::BadArguments(
-                    "The number of columns in the target table is different from the number of columns in the SELECT clause",
-                ));
-            }
-            if Self::check_schema_cast(select_schema.clone(), target_schema.clone())? {
-                self.main_pipeline.add_transform(
-                    |transform_input_port, transform_output_port| {
-                        TransformCastSchema::try_create(
-                            transform_input_port,
-                            transform_output_port,
-                            select_schema.clone(),
-                            target_schema.clone(),
-                            self.func_ctx.clone(),
-                        )
-                    },
-                )?;
-            }
-        }
-
-        Self::build_fill_missing_columns_pipeline(
-            self.ctx.clone(),
-            &mut self.main_pipeline,
-            tbl.clone(),
-            Arc::new(table_schema.clone().into()),
-        )?;
-
-        let _ = table.cluster_gen_for_append(
-            self.ctx.clone(),
-            &mut self.main_pipeline,
-            table.get_block_thresholds(),
-            opt_modified_schema,
-        )?;
-        // 1. resize input to 1, since the UpsertTransform need to de-duplicate inputs "globally"
-        self.main_pipeline.try_resize(1)?;
-
-        // 2. connect with ReplaceIntoProcessor
-
-        //                      ┌──────────────────────┐
-        //                      │                      ├──┐
-        // ┌─────────────┐      │                      ├──┘
-        // │ UpsertSource├─────►│ ReplaceIntoProcessor │
-        // └─────────────┘      │                      ├──┐
-        //                      │                      ├──┘
-        //                      └──────────────────────┘
-        // NOTE: here the pipe items of last pipe are arranged in the following order
-        // (0) -> output_port_append_data
-        // (1) -> output_port_merge_into_action
-        //    the "downstream" is supposed to be connected with a processor which can process MergeIntoOperations
-        //    in our case, it is the broadcast processor
-        let delete_when = if let Some((remote_expr, delete_column)) = delete_when {
-            Some((
-                remote_expr.as_expr(&BUILTIN_FUNCTIONS),
-                delete_column.clone(),
-            ))
-        } else {
-            None
-        };
-        let cluster_keys = table.cluster_keys(self.ctx.clone());
-        if *need_insert {
-            let replace_into_processor = ReplaceIntoProcessor::create(
-                self.ctx.clone(),
-                on_conflicts.clone(),
-                cluster_keys,
-                bloom_filter_column_indexes.clone(),
-                table_schema.as_ref(),
-                *table_is_empty,
-                table_level_range_index.clone(),
-                delete_when.map(|(expr, _)| (expr, delete_column_idx)),
-            )?;
-            self.main_pipeline
-                .add_pipe(replace_into_processor.into_pipe());
-        } else {
-            let replace_into_processor = UnbranchedReplaceIntoProcessor::create(
-                self.ctx.as_ref(),
-                on_conflicts.clone(),
-                cluster_keys,
-                bloom_filter_column_indexes.clone(),
-                table_schema.as_ref(),
-                *table_is_empty,
-                table_level_range_index.clone(),
-                delete_when.map(|_| delete_column_idx),
-            )?;
-            self.main_pipeline
-                .add_pipe(replace_into_processor.into_pipe());
-        }
-        Ok(())
-    }
-
-    fn build_merge_into(&mut self, merge_into: &MergeInto) -> Result<()> {
-        let MergeInto {
-            input,
-            table_info,
-            catalog_info,
-            unmatched,
-            matched,
-            field_index_of_input_schema,
-            row_id_idx,
-            segments,
-            distributed,
-            ..
-        } = merge_into;
-
-        self.build_pipeline(input)?;
-
-        let tbl = self
-            .ctx
-            .build_table_by_table_info(catalog_info, table_info, None)?;
-
-        let table = FuseTable::try_from_table(tbl.as_ref())?;
-        let block_thresholds = table.get_block_thresholds();
-
-        let cluster_stats_gen =
-            table.get_cluster_stats_gen(self.ctx.clone(), 0, block_thresholds, None)?;
-
-        // this TransformSerializeBlock is just used to get block_builder
-        let block_builder = TransformSerializeBlock::try_create(
-            self.ctx.clone(),
-            InputPort::create(),
-            OutputPort::create(),
-            table,
-            cluster_stats_gen.clone(),
-        )?
-        .get_block_builder();
-
-        let serialize_segment_transform = TransformSerializeSegment::new(
-            self.ctx.clone(),
-            InputPort::create(),
-            OutputPort::create(),
-            table,
-            block_thresholds,
-        );
-
-        let get_output_len = |pipe_items: &Vec<PipeItem>| -> usize {
-            let mut output_len = 0;
-            for item in pipe_items.iter() {
-                output_len += item.outputs_port.len();
-            }
-            output_len
-        };
-        // Handle matched and unmatched data separately.
-
-        //                                                                                 +-----------------------------+-+
-        //                                    +-----------------------+     Matched        |                             +-+
-        //                                    |                       +---+--------------->|    MatchedSplitProcessor    |
-        //                                    |                       |   |                |                             +-+
-        // +----------------------+           |                       +---+                +-----------------------------+-+
-        // |   MergeIntoSource    +---------->|MergeIntoSplitProcessor|
-        // +----------------------+           |                       +---+                +-----------------------------+
-        //                                    |                       |   | NotMatched     |                             +-+
-        //                                    |                       +---+--------------->| MergeIntoNotMatchedProcessor| |
-        //                                    +-----------------------+                    |                             +-+
-        //                                                                                 +-----------------------------+
-        // Note: here the output_port of MatchedSplitProcessor are arranged in the following order
-        // (0) -> output_port_row_id
-        // (1) -> output_port_updated
-
-        // Outputs from MatchedSplitProcessor's output_port_updated and MergeIntoNotMatchedProcessor's output_port are merged and processed uniformly by the subsequent ResizeProcessor
-
-        // receive matched data and not matched data parallelly.
-        let mut pipe_items = Vec::with_capacity(self.main_pipeline.output_len());
-        for _ in (0..self.main_pipeline.output_len()).step_by(2) {
-            // Todo(JackTan25): We should optimize pipeline. when only not matched, we should ignore this
-            let matched_split_processor = MatchedSplitProcessor::create(
-                self.ctx.clone(),
-                *row_id_idx,
-                matched.clone(),
-                field_index_of_input_schema.clone(),
-                input.output_schema()?,
-                Arc::new(DataSchema::from(tbl.schema())),
-            )?;
-
-            pipe_items.push(matched_split_processor.into_pipe_item());
-            if !*distributed {
-                // Todo(JackTan25): We should optimize pipeline. when only matched,we should ignore this
-                let merge_into_not_matched_processor = MergeIntoNotMatchedProcessor::create(
-                    unmatched.clone(),
-                    input.output_schema()?,
-                    self.func_ctx.clone(),
-                )?;
-
-                pipe_items.push(merge_into_not_matched_processor.into_pipe_item());
-            } else {
-                let input_num_columns = input.output_schema()?.num_fields();
-                assert_eq!(
-                    input.output_schema()?.field(input_num_columns - 1).name(),
-                    ROW_NUMBER_COL_NAME
-                );
-                let input_port = InputPort::create();
-                let output_port = OutputPort::create();
-                // project row number column
-                let proc = ProcessorPtr::create(CompoundBlockOperator::create(
-                    input_port.clone(),
-                    output_port.clone(),
-                    input_num_columns,
-                    self.func_ctx.clone(),
-                    vec![BlockOperator::Project {
-                        projection: vec![input_num_columns - 1],
-                    }],
-                ));
-                pipe_items.push(PipeItem {
-                    processor: proc,
-                    inputs_port: vec![input_port],
-                    outputs_port: vec![output_port],
-                })
-            };
-        }
-        self.main_pipeline.add_pipe(Pipe::create(
-            self.main_pipeline.output_len(),
-            get_output_len(&pipe_items),
-            pipe_items.clone(),
-        ));
-
-        // row_id port0_1
-        // matched update data port0_2
-        // not macthed insert data port0_3
-        // row_id port1_1
-        // matched update data port1_2
-        // not macthed insert data port1_3
-        // ......
-        assert_eq!(self.main_pipeline.output_len() % 3, 0);
-        let mut ranges = Vec::with_capacity(self.main_pipeline.output_len() / 3 * 2);
-        if !*distributed {
-            // merge rowid and serialize_blocks
-            for idx in (0..self.main_pipeline.output_len()).step_by(3) {
-                ranges.push(vec![idx]);
-                ranges.push(vec![idx + 1, idx + 2]);
-            }
-            self.main_pipeline.resize_partial_one(ranges.clone())?;
-            assert_eq!(self.main_pipeline.output_len() % 2, 0);
-
-            // shuffle outputs and resize row_id
-            // ----------------------------------------------------------------------
-            // row_id port0_1               row_id port0_1
-            // data port0_2                 row_id port1_1              row_id port
-            // row_id port1_1   ======>     ......           ======>
-            // data port1_2                 data port0_2                data port0
-            // ......                       data port1_2                data port1
-            // ......                       .....                       .....
-            // ----------------------------------------------------------------------
-            let mut rules = Vec::with_capacity(self.main_pipeline.output_len());
-            for idx in 0..(self.main_pipeline.output_len() / 2) {
-                rules.push(idx);
-                rules.push(idx + self.main_pipeline.output_len() / 2);
-            }
-            self.main_pipeline.reorder_inputs(rules);
-            // resize row_id
-            ranges.clear();
-            let mut vec = Vec::with_capacity(self.main_pipeline.output_len() / 2);
-            for idx in 0..(self.main_pipeline.output_len() / 2) {
-                vec.push(idx);
-            }
-            ranges.push(vec.clone());
-            for idx in 0..(self.main_pipeline.output_len() / 2) {
-                ranges.push(vec![idx + self.main_pipeline.output_len() / 2]);
-            }
-            self.main_pipeline.resize_partial_one(ranges.clone())?;
-        } else {
-            // shuffle outputs and resize row_id
-            // ----------------------------------------------------------------------
-            // row_id port0_1              row_id port0_1              row_id port
-            // matched data port0_2        row_id port1_1            matched data port0_2
-            // row_number port0_3          matched data port0_2      matched data port1_2
-            // row_id port1_1              matched data port1_2          ......
-            // matched data port1_2  ===>       .....           ====>    ......
-            // row_number port1_2               .....                    ......
-            // row_number port0_3        row_number port0_3          row_number port
-            // ......                    row_number port1_3
-            // ......                           .....
-            // ----------------------------------------------------------------------
-            // do shuffle
-            let mut rules = Vec::with_capacity(self.main_pipeline.output_len());
-            for idx in 0..(self.main_pipeline.output_len() / 3) {
-                rules.push(idx);
-                rules.push(idx + self.main_pipeline.output_len() / 3);
-                rules.push(idx + self.main_pipeline.output_len() / 3 * 2);
-            }
-            self.main_pipeline.reorder_inputs(rules);
-
-            // resize row_id
-            ranges.clear();
-            let mut vec = Vec::with_capacity(self.main_pipeline.output_len() / 3);
-            for idx in 0..(self.main_pipeline.output_len() / 3) {
-                vec.push(idx);
-            }
-            ranges.push(vec.clone());
-            for idx in 0..(self.main_pipeline.output_len() / 3) {
-                ranges.push(vec![idx + self.main_pipeline.output_len() / 3]);
-            }
-            vec.clear();
-            for idx in 0..(self.main_pipeline.output_len() / 3) {
-                vec.push(idx + self.main_pipeline.output_len() / 3 * 2);
-            }
-            ranges.push(vec);
-            self.main_pipeline.resize_partial_one(ranges.clone())?;
-        }
-
-        let fill_default_len = if !*distributed {
-            // remove first row_id port
-            self.main_pipeline.output_len() - 1
-        } else {
-            // remove first row_id port and last row_number_port
-            self.main_pipeline.output_len() - 2
-        };
-        // fill default columns
-        let table_default_schema = &table.schema().remove_computed_fields();
-        let mut builder = self.main_pipeline.add_transform_with_specified_len(
-            |transform_input_port, transform_output_port| {
-                TransformResortAddOnWithoutSourceSchema::try_create(
-                    self.ctx.clone(),
-                    transform_input_port,
-                    transform_output_port,
-                    Arc::new(DataSchema::from(table_default_schema)),
-                    tbl.clone(),
-                )
-            },
-            fill_default_len,
-        )?;
-
-        if !*distributed {
-            builder.add_items_prepend(vec![create_dummy_item()]);
-            self.main_pipeline.add_pipe(builder.finalize());
-        } else {
-            builder.add_items_prepend(vec![create_dummy_item()]);
-            // receive row_number
-            builder.add_items(vec![create_dummy_item()]);
-            self.main_pipeline.add_pipe(builder.finalize());
-        }
-
-        let fill_computed_len = if !*distributed {
-            // remove first row_id port
-            self.main_pipeline.output_len() - 1
-        } else {
-            // remove first row_id port and last row_number_port
-            self.main_pipeline.output_len() - 2
-        };
-
-        // fill computed columns
-        let table_computed_schema = &table.schema().remove_virtual_computed_fields();
-        let default_schema: DataSchemaRef = Arc::new(table_default_schema.into());
-        let computed_schema: DataSchemaRef = Arc::new(table_computed_schema.into());
-        if default_schema != computed_schema {
-            builder = self.main_pipeline.add_transform_with_specified_len(
-                |transform_input_port, transform_output_port| {
-                    TransformAddComputedColumns::try_create(
-                        self.ctx.clone(),
-                        transform_input_port,
-                        transform_output_port,
-                        default_schema.clone(),
-                        computed_schema.clone(),
-                    )
-                },
-                fill_computed_len,
-            )?;
-            if !*distributed {
-                builder.add_items_prepend(vec![create_dummy_item()]);
-                self.main_pipeline.add_pipe(builder.finalize());
-            } else {
-                builder.add_items_prepend(vec![create_dummy_item()]);
-                // receive row_number
-                builder.add_items(vec![create_dummy_item()]);
-                self.main_pipeline.add_pipe(builder.finalize());
-            }
-        }
-
-        let max_threads = self.settings.get_max_threads()?;
-        let io_request_semaphore = Arc::new(Semaphore::new(max_threads as usize));
-
-        // after filling default columns, we need to add cluster‘s blocksort if it's a cluster table
-        let output_lens = self.main_pipeline.output_len();
-        if !*distributed {
-            table.cluster_gen_for_append_with_specified_len(
-                self.ctx.clone(),
-                &mut self.main_pipeline,
-                block_thresholds,
-                output_lens - 1,
-                0,
-            )?;
-        } else {
-            table.cluster_gen_for_append_with_specified_len(
-                self.ctx.clone(),
-                &mut self.main_pipeline,
-                block_thresholds,
-                output_lens - 2,
-                1,
-            )?;
-        }
-
-        pipe_items.clear();
-
-        pipe_items.push(table.rowid_aggregate_mutator(
-            self.ctx.clone(),
-            block_builder,
-            io_request_semaphore,
-            segments.clone(),
-        )?);
-
-        let serialize_len = if !*distributed {
-            self.main_pipeline.output_len() - 1
-        } else {
-            self.main_pipeline.output_len() - 2
-        };
-
-        for _ in 0..serialize_len {
-            let serialize_block_transform = TransformSerializeBlock::try_create(
-                self.ctx.clone(),
-                InputPort::create(),
-                OutputPort::create(),
-                table,
-                cluster_stats_gen.clone(),
-            )?;
-            pipe_items.push(serialize_block_transform.into_pipe_item());
-        }
-
-        // receive row_number
-        if *distributed {
-            pipe_items.push(create_dummy_item());
-        }
-
-        self.main_pipeline.add_pipe(Pipe::create(
-            self.main_pipeline.output_len(),
-            get_output_len(&pipe_items),
-            pipe_items,
-        ));
-
-        // resize block ports
-        // aggregate_mutator port/dummy_item port               aggregate_mutator port/ dummy_item (this depends on apply_row_id)
-        // serialize_block port0                    ======>
-        // serialize_block port1                                serialize_block port
-        // .......
-        // row_number_port (distributed)                        row_number_port(distributed)
-        ranges.clear();
-        ranges.push(vec![0]);
-        let mut vec = Vec::with_capacity(self.main_pipeline.output_len());
-        let output_lens = if !*distributed {
-            self.main_pipeline.output_len() - 1
-        } else {
-            self.main_pipeline.output_len() - 2
-        };
-        for idx in 0..output_lens {
-            vec.push(idx + 1);
-        }
-        ranges.push(vec);
-        if *distributed {
-            ranges.push(vec![self.main_pipeline.output_len() - 1]);
-        }
-
-        self.main_pipeline.resize_partial_one(ranges)?;
-
-        let pipe_items = if !distributed {
-            vec![
-                create_dummy_item(),
-                serialize_segment_transform.into_pipe_item(),
-            ]
-        } else {
-            vec![
-                create_dummy_item(),
-                serialize_segment_transform.into_pipe_item(),
-                create_dummy_item(),
-            ]
-        };
-
-        // distributed: false
-        //      output_port0: MutationLogs
-        //      output_port1: MutationLogs
-        //
-        // distributed: true
-        //      output_port0: MutationLogs
-        //      output_port1: MutationLogs
-        //      output_port2: row_numbers
-        self.main_pipeline.add_pipe(Pipe::create(
-            self.main_pipeline.output_len(),
-            get_output_len(&pipe_items),
-            pipe_items,
-        ));
-
-        Ok(())
-    }
-
-    fn build_replace_into(&mut self, replace: &ReplaceInto) -> Result<()> {
-        let ReplaceInto {
-            input,
-            block_thresholds,
-            table_info,
-            on_conflicts,
-            bloom_filter_column_indexes,
-            catalog_info,
-            segments,
-            block_slots,
-            need_insert,
-        } = replace;
-        let max_threads = self.settings.get_max_threads()?;
-        let segment_partition_num = std::cmp::min(segments.len(), max_threads as usize);
-        let table = self
-            .ctx
-            .build_table_by_table_info(catalog_info, table_info, None)?;
-        let table = FuseTable::try_from_table(table.as_ref())?;
-        let cluster_stats_gen =
-            table.get_cluster_stats_gen(self.ctx.clone(), 0, *block_thresholds, None)?;
-        self.build_pipeline(input)?;
-        // connect to broadcast processor and append transform
-        let serialize_block_transform = TransformSerializeBlock::try_create(
-            self.ctx.clone(),
-            InputPort::create(),
-            OutputPort::create(),
-            table,
-            cluster_stats_gen,
-        )?;
-        let block_builder = serialize_block_transform.get_block_builder();
-
-        let serialize_segment_transform = TransformSerializeSegment::new(
-            self.ctx.clone(),
-            InputPort::create(),
-            OutputPort::create(),
-            table,
-            *block_thresholds,
-        );
-        if !*need_insert {
-            if segment_partition_num == 0 {
-                return Ok(());
-            }
-            let broadcast_processor = BroadcastProcessor::new(segment_partition_num);
-            self.main_pipeline
-                .add_pipe(Pipe::create(1, segment_partition_num, vec![
-                    broadcast_processor.into_pipe_item(),
-                ]));
-            let max_threads = self.settings.get_max_threads()?;
-            let io_request_semaphore = Arc::new(Semaphore::new(max_threads as usize));
-
-            let merge_into_operation_aggregators = table.merge_into_mutators(
-                self.ctx.clone(),
-                segment_partition_num,
-                block_builder,
-                on_conflicts.clone(),
-                bloom_filter_column_indexes.clone(),
-                segments,
-                block_slots.clone(),
-                io_request_semaphore,
-            )?;
-            self.main_pipeline.add_pipe(Pipe::create(
-                segment_partition_num,
-                segment_partition_num,
-                merge_into_operation_aggregators,
-            ));
-            return Ok(());
-        }
-
-        if segment_partition_num == 0 {
-            let dummy_item = create_dummy_item();
-            //                      ┌──────────────────────┐            ┌──────────────────┐
-            //                      │                      ├──┬────────►│  SerializeBlock  │
-            // ┌─────────────┐      │                      ├──┘         └──────────────────┘
-            // │ UpsertSource├─────►│ ReplaceIntoProcessor │
-            // └─────────────┘      │                      ├──┐         ┌──────────────────┐
-            //                      │                      ├──┴────────►│  DummyTransform  │
-            //                      └──────────────────────┘            └──────────────────┘
-            // wrap them into pipeline, order matters!
-            self.main_pipeline.add_pipe(Pipe::create(2, 2, vec![
-                serialize_block_transform.into_pipe_item(),
-                dummy_item,
-            ]));
-        } else {
-            //                      ┌──────────────────────┐            ┌──────────────────┐
-            //                      │                      ├──┬────────►│ SerializeBlock   │
-            // ┌─────────────┐      │                      ├──┘         └──────────────────┘
-            // │ UpsertSource├─────►│ ReplaceIntoProcessor │
-            // └─────────────┘      │                      ├──┐         ┌──────────────────┐
-            //                      │                      ├──┴────────►│BroadcastProcessor│
-            //                      └──────────────────────┘            └──────────────────┘
-            let broadcast_processor = BroadcastProcessor::new(segment_partition_num);
-            // wrap them into pipeline, order matters!
-            self.main_pipeline
-                .add_pipe(Pipe::create(2, segment_partition_num + 1, vec![
-                    serialize_block_transform.into_pipe_item(),
-                    broadcast_processor.into_pipe_item(),
-                ]));
-        };
-
-        // 4. connect with MergeIntoOperationAggregators
-        if segment_partition_num == 0 {
-            let dummy_item = create_dummy_item();
-            self.main_pipeline.add_pipe(Pipe::create(2, 2, vec![
-                serialize_segment_transform.into_pipe_item(),
-                dummy_item,
-            ]));
-        } else {
-            //      ┌──────────────────┐               ┌────────────────┐
-            // ────►│  SerializeBlock  ├──────────────►│SerializeSegment│
-            //      └──────────────────┘               └────────────────┘
-            //
-            //      ┌───────────────────┐              ┌──────────────────────┐
-            // ────►│                   ├──┬──────────►│MergeIntoOperationAggr│
-            //      │                   ├──┘           └──────────────────────┘
-            //      │ BroadcastProcessor│
-            //      │                   ├──┐           ┌──────────────────────┐
-            //      │                   ├──┴──────────►│MergeIntoOperationAggr│
-            //      │                   │              └──────────────────────┘
-            //      │                   ├──┐
-            //      │                   ├──┴──────────►┌──────────────────────┐
-            //      └───────────────────┘              │MergeIntoOperationAggr│
-            //                                         └──────────────────────┘
-
-            let item_size = segment_partition_num + 1;
-            let mut pipe_items = Vec::with_capacity(item_size);
-            // setup the dummy transform
-            pipe_items.push(serialize_segment_transform.into_pipe_item());
-
-            let max_threads = self.settings.get_max_threads()?;
-            let io_request_semaphore = Arc::new(Semaphore::new(max_threads as usize));
-
-            // setup the merge into operation aggregators
-            let mut merge_into_operation_aggregators = table.merge_into_mutators(
-                self.ctx.clone(),
-                segment_partition_num,
-                block_builder,
-                on_conflicts.clone(),
-                bloom_filter_column_indexes.clone(),
-                segments,
-                block_slots.clone(),
-                io_request_semaphore,
-            )?;
-            assert_eq!(
-                segment_partition_num,
-                merge_into_operation_aggregators.len()
-            );
-            pipe_items.append(&mut merge_into_operation_aggregators);
-
-            // extend the pipeline
-            assert_eq!(self.main_pipeline.output_len(), item_size);
-            assert_eq!(pipe_items.len(), item_size);
-            self.main_pipeline
-                .add_pipe(Pipe::create(item_size, item_size, pipe_items));
-        }
-        Ok(())
-    }
-
-    fn build_async_sourcer(&mut self, async_sourcer: &AsyncSourcerPlan) -> Result<()> {
-        self.main_pipeline.add_source(
-            |output| {
-                let name_resolution_ctx = NameResolutionContext::try_from(self.settings.as_ref())?;
-                let inner = ValueSource::new(
-                    async_sourcer.value_data.clone(),
-                    self.ctx.clone(),
-                    name_resolution_ctx,
-                    async_sourcer.schema.clone(),
-                    async_sourcer.start,
-                );
-                AsyncSourcer::create(self.ctx.clone(), output, inner)
-            },
-            1,
-        )?;
-        Ok(())
     }
 
     fn build_recluster_source(&mut self, recluster_source: &ReclusterSource) -> Result<()> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* `pipeline_builder.rs` is biger and biger, it's hard to maintain, spill out some module to files
* this PR is the part-2, spill out: 
   - `builder_replace_into.rs`
   - `builder_merge_into.rs`
 * more spill out in the next PR
 * part-1: https://github.com/datafuselabs/databend/pull/13571

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13572)
<!-- Reviewable:end -->
