### PR TITLE
refactor: validate json string before output, when exporting data from running meta-service

### DIFF
--- a/src/binaries/metactl/grpc.rs
+++ b/src/binaries/metactl/grpc.rs
@@ -17,6 +17,7 @@ use std::io::Write;
 use std::time::Duration;
 
 use common_meta_client::MetaGrpcClient;
+use common_meta_raft_store::key_spaces::RaftStoreEntry;
 use common_meta_types::protobuf::Empty;
 use tokio_stream::StreamExt;
 
@@ -49,6 +50,17 @@ pub async fn export_meta(addr: &str, save: String) -> anyhow::Result<()> {
         let chunk = chunk_res?;
 
         for line in &chunk.data {
+            // Check if the received line is a valid json string.
+            let de_res: Result<(String, RaftStoreEntry), _> = serde_json::from_str(line);
+            match de_res {
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("Invalid json string: {:?}", line);
+                    eprintln!("              Error: {}", e);
+                    return Err(e.into());
+                }
+            }
+
             if file.as_ref().is_none() {
                 println!("{}", line);
             } else {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: validate json string before output, when exporting data from running meta-service

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13592)
<!-- Reviewable:end -->
