### PR TITLE
chore(query): add fuzz test for insert

### DIFF
--- a/src/query/functions/src/cast_rules.rs
+++ b/src/query/functions/src/cast_rules.rs
@@ -206,16 +206,10 @@ pub const GENERAL_CAST_RULES: AutoCastRules = &[
 /// used to allow `add_hours('2023-01-01 00:00:00', '1')`. But they should be disabled
 /// for comparison functions, because `1 < '1'` should be an error.
 pub const CAST_FROM_STRING_RULES: AutoCastRules = &[
-    (DataType::String, DataType::Number(NumberDataType::UInt8)),
-    (DataType::String, DataType::Number(NumberDataType::UInt16)),
-    (DataType::String, DataType::Number(NumberDataType::UInt32)),
-    (DataType::String, DataType::Number(NumberDataType::UInt64)),
-    (DataType::String, DataType::Number(NumberDataType::Int8)),
-    (DataType::String, DataType::Number(NumberDataType::Int16)),
-    (DataType::String, DataType::Number(NumberDataType::Int32)),
     (DataType::String, DataType::Number(NumberDataType::Int64)),
-    (DataType::String, DataType::Number(NumberDataType::Float32)),
+    (DataType::String, DataType::Number(NumberDataType::UInt64)),
     (DataType::String, DataType::Number(NumberDataType::Float64)),
+    (DataType::String, DataType::Number(NumberDataType::Float32)),
 ];
 
 #[allow(non_snake_case)]

--- a/src/query/functions/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions/tests/it/scalars/testdata/array.txt
@@ -11,7 +11,7 @@ error:
   --> SQL:1:2
   |
 1 | ['a', 1]
-  |  ^^^ invalid digit found in string while evaluating function `to_uint8('a')`
+  |  ^^^ invalid digit found in string while evaluating function `to_uint64('a')`
 
 
 
@@ -51,7 +51,7 @@ error:
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no overload satisfies `array(String, UInt8, Variant)`
 
 has tried possible overloads:
-  array(T0, T0, T0) :: Array(T0)  : unable to find a common super type for `UInt8` and `Variant`
+  array(T0, T0, T0) :: Array(T0)  : unable to find a common super type for `UInt64` and `Variant`
 
 
 
@@ -503,7 +503,7 @@ error:
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no overload satisfies `array(UInt8, String, UInt8, UInt8, UInt8, Boolean)`
 
 has tried possible overloads:
-  array(T0, T0, T0, T0, T0, T0) :: Array(T0)  : unable to find a common super type for `UInt8` and `Boolean`
+  array(T0, T0, T0, T0, T0, T0) :: Array(T0)  : unable to find a common super type for `Int64` and `Boolean`
 
 
 
@@ -696,7 +696,7 @@ error:
   --> SQL:1:23
   |
 1 | array_concat([1,2,3], ['s', null])
-  |                       ^^^^^^^^^^^ invalid digit found in string while evaluating function `to_uint8('s')`
+  |                       ^^^^^^^^^^^ invalid digit found in string while evaluating function `to_int64('s')`
 
 
 
@@ -912,7 +912,7 @@ error:
   --> SQL:1:22
   |
 1 | array_indexof([1,2,3,'s'], 's')
-  |                      ^^^ invalid digit found in string while evaluating function `to_uint8('s')`
+  |                      ^^^ invalid digit found in string while evaluating function `to_int64('s')`
 
 
 

--- a/tests/sqllogictests/README.md
+++ b/tests/sqllogictests/README.md
@@ -70,3 +70,7 @@ query <type_string> <sort_mode> <label>
 The SQL for the query is found on second an subsequent lines of the record up to first line of the form "----" or until the end of the record. Lines following the "----" are expected results of the query, one value per line. If the "----" and/or the results are omitted, then the query is expected to return an empty set.
 
 For more information about arguments, such as <type_string>, <sort_mode>, <label> please refer to [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki).
+
+### Aditional features
+
+- sql with regexp pattern`RAND_(\d+)_(\d+)` will be replaced by a random number from the range.

--- a/tests/sqllogictests/README.md
+++ b/tests/sqllogictests/README.md
@@ -73,4 +73,4 @@ For more information about arguments, such as <type_string>, <sort_mode>, <label
 
 ### Aditional features
 
-- sql with regexp pattern`RAND_(\d+)_(\d+)` will be replaced by a random number from the range.
+- sql with regexp pattern `\$RAND_(\d+)_(\d+)` will be replaced by a random number from the range.

--- a/tests/sqllogictests/src/client/mod.rs
+++ b/tests/sqllogictests/src/client/mod.rs
@@ -96,6 +96,6 @@ fn replace_rand_values<'h>(input: &'h str) -> Cow<'h, str> {
         let n: usize = caps[2].parse().unwrap();
         let mut rng = rand::thread_rng();
         let rand_value = rng.gen_range(m..n);
-        rnd_value.to_string()
+        rand_value.to_string()
     })
 }

--- a/tests/sqllogictests/src/client/mod.rs
+++ b/tests/sqllogictests/src/client/mod.rs
@@ -89,7 +89,7 @@ impl Client {
     }
 }
 
-fn replace_rand_values<'h>(input: &'h str) -> Cow<'h, str> {
+fn replace_rand_values(input: &str) -> Cow<'_, str> {
     let re = Regex::new(r"\$RAND_(\d+)_(\d+)").unwrap();
     re.replace_all(input, |caps: &regex::Captures| {
         let m: usize = caps[1].parse().unwrap();

--- a/tests/sqllogictests/src/client/mod.rs
+++ b/tests/sqllogictests/src/client/mod.rs
@@ -16,6 +16,7 @@ mod clickhouse_client;
 mod http_client;
 mod mysql_client;
 
+use std::borrow::Cow;
 use std::fmt;
 
 pub use clickhouse_client::ClickhouseHttpClient;
@@ -23,6 +24,7 @@ pub use http_client::HttpClient;
 pub use mysql_client::MySQLClient;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
+use regex::Regex;
 use sqllogictest::DBOutput;
 use sqllogictest::DefaultColumnType;
 
@@ -49,10 +51,11 @@ pub enum Client {
 
 impl Client {
     pub async fn query(&mut self, sql: &str) -> Result<DBOutput<DefaultColumnType>> {
+        let sql = replace_rand_values(sql);
         match self {
-            Client::MySQL(client) => client.query(sql).await,
-            Client::Http(client) => client.query(sql).await,
-            Client::Clickhouse(client) => client.query(sql).await,
+            Client::MySQL(client) => client.query(&sql).await,
+            Client::Http(client) => client.query(&sql).await,
+            Client::Clickhouse(client) => client.query(&sql).await,
         }
     }
 
@@ -84,4 +87,15 @@ impl Client {
             Client::Clickhouse(_) => "clickhouse",
         }
     }
+}
+
+fn replace_rand_values<'h>(input: &'h str) -> Cow<'h, str> {
+    let re = Regex::new(r"\$RAND_(\d+)_(\d+)").unwrap();
+    re.replace_all(input, |caps: &regex::Captures| {
+        let m: usize = caps[1].parse().unwrap();
+        let n: usize = caps[2].parse().unwrap();
+        let mut rng = rand::thread_rng();
+        let rand_value = rng.gen_range(m..n);
+        rnd_value.to_string()
+    })
 }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0029_random_fuzz.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0029_random_fuzz.test
@@ -1,0 +1,55 @@
+
+statement ok
+drop table if exists rand
+
+statement ok
+drop table if exists t1
+
+
+statement ok
+create table rand(name String not null, id int, flag bool) Engine = random
+
+statement ok
+create table t1 engine=fuse row_per_block=100000 as select * from rand limit 300000
+
+query III
+select max(length(name)) = 5,  min(length(name)) = 5,  count(name) = 300000 from t1
+----
+1 1 1
+
+query III
+select a is null or a = 5, b is null or b = 5 from  (select max(length(name))  as a,  min(length(name))  as b from t1 where id % 5 = 0)
+----
+1 1
+
+query III
+select a is null or a = 5, b is null or b = 5 from  (select max(length(name))  as a,  min(length(name))  as b from t1 where id % 5 = 1)
+----
+1 1
+
+query III
+select a is null or a = 5, b is null or b = 5 from  (select max(length(name))  as a,  min(length(name))  as b from t1 where id % 5 = 2)
+----
+1 1
+
+query III
+select a is null or a = 5, b is null or b = 5 from  (select max(length(name))  as a,  min(length(name))  as b from t1 where id % 5 = 3)
+----
+1 1
+
+query III
+select a is null or a = 5, b is null or b = 5 from  (select max(length(name))  as a,  min(length(name))  as b from t1 where id % 5 = 4)
+----
+1 1
+
+query III
+select a is null or a = 5, b is null or b = 5 from  (select max(length(name))  as a,  min(length(name))  as b from t1 where id % 5 = 5)
+----
+1 1
+
+
+statement ok
+drop table if exists rand
+
+statement ok
+drop table if exists t1

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0029_random_fuzz.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0029_random_fuzz.test
@@ -10,10 +10,10 @@ statement ok
 create table rand(name String not null, id int, flag bool) Engine = random
 
 statement ok
-create table t1 engine=fuse row_per_block=100000 as select * from rand limit 300000
+create table t1 engine=fuse row_per_block = $RAND_30000_100000 as select * from rand limit $RAND_100000_300000
 
 query III
-select max(length(name)) = 5,  min(length(name)) = 5,  count(name) = 300000 from t1
+select max(length(name)) = 5,  min(length(name)) = 5,  count(name) >= 100000 from t1
 ----
 1 1 1
 

--- a/tests/sqllogictests/suites/query/02_function/02_0000_function_arithmetic.test
+++ b/tests/sqllogictests/suites/query/02_function/02_0000_function_arithmetic.test
@@ -138,9 +138,9 @@ SELECT 1<<2, 3<<1, 4<<3
 4 6 32
 
 query III
-SELECT 4>>1, 8>>2, 16>>3
+SELECT 4>>1, 8>>2, 16>>3, '333' + 4
 ----
-2 2 2
+2 2 2 337
 
 query I
 select * from numbers(4) where -number > -1;

--- a/tests/suites/0_stateless/20+_others/20_0013_pretty_error.result
+++ b/tests/suites/0_stateless/20+_others/20_0013_pretty_error.result
@@ -30,7 +30,7 @@ has tried possible overloads:
   to_base64(String NULL) :: String NULL  : unable to unify `UInt8` with `String`
 
 
-Error: APIError: ResponseError with 1006: invalid digit found in string while evaluating function `to_uint8('a')`
+Error: APIError: ResponseError with 1006: invalid digit found in string while evaluating function `to_uint64('a')`
 Error: APIError: ResponseError with 1025: error: 
   --> SQL:1:20
   |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

1. fuzz test insert from random
2. improve `CAST_FROM_STRING_RULES` which always cast string into large number types.
3. sql with regexp pattern`RAND_(\d+)_(\d+)` will be replaced by a random number from the range.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13595)
<!-- Reviewable:end -->
