### PR TITLE
fix: block pruning metric

### DIFF
--- a/src/query/storages/fuse/src/pruning/block_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/block_pruner.rs
@@ -250,7 +250,7 @@ impl BlockPruner {
         for (block_idx, block_meta) in blocks {
             // Perf.
             {
-                metrics_inc_blocks_range_pruning_after(1);
+                metrics_inc_blocks_range_pruning_before(1);
                 metrics_inc_bytes_block_range_pruning_before(block_meta.block_size);
 
                 pruning_stats.set_blocks_range_pruning_before(1);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

With this PR,  `fuse_blocks_range_pruning_before_total` shows up after the execution of merge-into for the scenario given in #13598.  

~~~
mysql> select * from system.metrics where metric like '%blocks_range_pruning%' order by metric;
Empty set (0.05 sec)
Read 51 rows, 11.59 KiB in 0.036 sec., 1.4 thousand rows/sec., 318.87 KiB/sec.

mysql>
mysql> create table t (c int);
Query OK, 0 rows affected (0.33 sec)

mysql> insert into t values(10),(20);
Query OK, 2 rows affected (0.32 sec)

mysql> insert into t values(30),(40);
Query OK, 2 rows affected (0.31 sec)

mysql>
mysql> -- one segment, two blocks
mysql> optimize table t compact segment;
Query OK, 0 rows affected (0.28 sec)

mysql>
mysql>
mysql> create table source(c int);
Query OK, 0 rows affected (0.10 sec)

mysql> insert into source values(25);
Query OK, 1 row affected (0.09 sec)

mysql>
mysql>
mysql> set enable_experimental_merge_into = 1;
Query OK, 0 rows affected (0.01 sec)

mysql>
mysql> merge into t using (select * from source) s on t.c = s.c when matched then update *;
Query OK, 0 rows affected (0.49 sec)

mysql>
mysql>
mysql> -- there should be metric named `blocks_range_pruning_before`
mysql> select * from system.metrics where metric like '%blocks_range_pruning%' order by metric;
+------------------------+----------------------------------------+---------+--------+-------+
| node                   | metric                                 | kind    | labels | value |
+------------------------+----------------------------------------+---------+--------+-------+
| 38FzFOvj8jOVYjtMaqCcu1 | fuse_blocks_range_pruning_after_total  | untyped | {}     | 1.0   |
| 38FzFOvj8jOVYjtMaqCcu1 | fuse_blocks_range_pruning_before_total | untyped | {}     | 3.0   |
+------------------------+----------------------------------------+---------+--------+-------+
2 rows in set (0.06 sec)
Read 154 rows, 32.99 KiB in 0.052 sec., 2.97 thousand rows/sec., 636.89 KiB/sec.
~~~


- Closes #13598

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13600)
<!-- Reviewable:end -->
