### PR TITLE
chore: move http detach to kill

### DIFF
--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -264,7 +264,6 @@ async fn query_cancel_handler(
         let http_query_manager = HttpQueryManager::instance();
         match http_query_manager.get_query(&query_id).await {
             Some(query) => {
-                query.detach().await;
                 query.kill().await;
                 http_query_manager.remove_query(&query_id).await;
                 StatusCode::OK

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -463,6 +463,9 @@ impl HttpQuery {
 
     #[async_backtrace::framed]
     pub async fn kill(&self) {
+        // the query will be removed from the query manager before the session is dropped.
+        self.detach().await;
+
         Executor::stop(
             &self.state,
             Err(ErrorCode::AbortedQuery("killed by http")),
@@ -472,7 +475,9 @@ impl HttpQuery {
     }
 
     #[async_backtrace::framed]
-    pub async fn detach(&self) {
+    async fn detach(&self) {
+        info!("{}: http query detached", &self.id);
+
         let data = self.page_manager.lock().await;
         data.detach().await
     }

--- a/src/query/service/src/servers/http/v1/query/http_query_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_manager.rs
@@ -91,7 +91,6 @@ impl HttpQueryManager {
                             warn!("{msg}, but fail to remove");
                         } else {
                             warn!("{msg}");
-                            query.detach().await;
                             query.kill().await;
                         };
                         break;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* make detach pairs with kill avoid session leak

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13606)
<!-- Reviewable:end -->
