### PR TITLE
chore(querylog): add query event log in system log

### DIFF
--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -58,7 +58,10 @@ fn error_fields(log_type: LogType, err: Option<ErrorCode>) -> (LogType, i32, Str
 impl InterpreterQueryLog {
     fn write_log(event: QueryLogElement) -> Result<()> {
         let event_str = serde_json::to_string(&event)?;
+        // log the query log in JSON format
         info!(target: "query", "{}", event_str);
+        // log the query event in the system log
+        info!("query: {} becomes {:?}", event.query_id, event.log_type);
         QueryLogQueue::instance()?.append_data(event)
     }
 

--- a/src/query/storages/system/src/query_log_table.rs
+++ b/src/query/storages/system/src/query_log_table.rs
@@ -39,6 +39,17 @@ pub enum LogType {
     Aborted = 4,
 }
 
+impl std::fmt::Debug for LogType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogType::Start => write!(f, "Start"),
+            LogType::Finish => write!(f, "Finish"),
+            LogType::Error => write!(f, "Error"),
+            LogType::Aborted => write!(f, "Aborted"),
+        }
+    }
+}
+
 fn date_str<S>(dt: &i32, s: S) -> Result<S::Ok, S::Error>
 where S: Serializer {
     let t = NaiveDateTime::from_timestamp_opt(i64::from(*dt) * 24 * 3600, 0).unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently we have a seperated query log target and the system logs.

Sometimes we hope to find out one query's lifetime in the system logs, but it's hard for us to get the state change of a query if we seperated the log collection about the query log and system log.

This PR adds a small log beside the query_log to make it easier for us to get a query's lifetime in the system log.
