### PR TITLE
fix(query): show drop table dropped_on need check null

### DIFF
--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -338,7 +338,7 @@ impl Binder {
             .with_order_by("name");
 
         select_builder.with_filter(format!("database = '{database}'"));
-        select_builder.with_filter("dropped_on != 'NULL'".to_string());
+        select_builder.with_filter("dropped_on IS NOT NULL".to_string());
 
         let query = select_builder.build();
         debug!("show drop tables rewrite to: {:?}", query);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

system.tables_with_history col dropped_on is NULLABLE(TS)

- Closes #13623

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13625)
<!-- Reviewable:end -->
