### PR TITLE
feat: databend-meta add config raft.snapshot_chunk_size[=4MB]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "anyerror"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef94a982ad4ebc3036bb072f45fcbb63a6b1b91932a6f5d982a166d8d529916"
+checksum = "0aaeb671913f64cfbe528d9f2236832902c7f32db31b9ec3790f675fceb937c6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.8.4"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.8#3fc8ede609beb787aee8199b06a40ac9742aa116"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.9#ffae522425f9a55b1ab4d6ce866d469827932627"
 
 [[package]]
 name = "maplit"
@@ -8503,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.8.4"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.8#3fc8ede609beb787aee8199b06a40ac9742aa116"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.9#ffae522425f9a55b1ab4d6ce866d469827932627"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -11754,18 +11754,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ jsonb = { git = "https://github.com/datafuselabs/jsonb", rev = "d11c9a9" }
 
 # openraft = { version = "0.8.2", features = ["compat-07"] }
 # For debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.8", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.9", features = [
     "compat-07",
     "tracing-log",
 ] }
@@ -142,7 +142,7 @@ bytes = "1.5.0"
 
 # error
 anyhow = { version = "1.0.65" }
-anyerror = { version = "=0.1.8" }
+anyerror = { version = "=0.1.10" }
 thiserror = { version = "1" }
 
 # versioning

--- a/src/meta/raft-store/src/config.rs
+++ b/src/meta/raft-store/src/config.rs
@@ -79,6 +79,9 @@ pub struct RaftConfig {
     /// The maximum number of applied logs to keep before purging
     pub max_applied_log_to_keep: u64,
 
+    /// The size of chunk for transmitting snapshot. The default is 64MB
+    pub snapshot_chunk_size: u64,
+
     /// Single node metasrv. It creates a single node cluster if meta data is not initialized.
     /// Otherwise it opens the previous one.
     /// This is mainly for testing purpose.
@@ -138,6 +141,7 @@ impl Default for RaftConfig {
             heartbeat_interval: 1000,
             install_snapshot_timeout: 4000,
             max_applied_log_to_keep: 1000,
+            snapshot_chunk_size: 4194304, // 4MB
             single: false,
             join: vec![],
             leave_via: vec![],

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -286,6 +286,7 @@ pub struct ConfigViaEnv {
     pub kvsrv_install_snapshot_timeout: u64,
     pub kvsrv_wait_leader_timeout: u64,
     pub raft_max_applied_log_to_keep: u64,
+    pub raft_snapshot_chunk_size: u64,
     pub kvsrv_single: bool,
     pub metasrv_join: Vec<String>,
     pub kvsrv_id: u64,
@@ -330,6 +331,7 @@ impl From<Config> for ConfigViaEnv {
             kvsrv_install_snapshot_timeout: cfg.raft_config.install_snapshot_timeout,
             kvsrv_wait_leader_timeout: cfg.raft_config.wait_leader_timeout,
             raft_max_applied_log_to_keep: cfg.raft_config.max_applied_log_to_keep,
+            raft_snapshot_chunk_size: cfg.raft_config.snapshot_chunk_size,
             kvsrv_single: cfg.raft_config.single,
             metasrv_join: cfg.raft_config.join,
             kvsrv_id: cfg.raft_config.id,
@@ -355,6 +357,7 @@ impl Into<Config> for ConfigViaEnv {
             install_snapshot_timeout: self.kvsrv_install_snapshot_timeout,
             wait_leader_timeout: self.kvsrv_wait_leader_timeout,
             max_applied_log_to_keep: self.raft_max_applied_log_to_keep,
+            snapshot_chunk_size: self.raft_snapshot_chunk_size,
             single: self.kvsrv_single,
             join: self.metasrv_join,
             // Do not allow to leave via environment variable
@@ -457,6 +460,10 @@ pub struct RaftConfig {
     #[clap(long, default_value = "1000")]
     pub max_applied_log_to_keep: u64,
 
+    /// The size of chunk for transmitting snapshot. The default is 4MB
+    #[clap(long, default_value = "4194304")]
+    pub snapshot_chunk_size: u64,
+
     /// Start databend-meta in single node mode.
     /// It initialize a single node cluster, if meta data is not initialized.
     /// If on-disk data is already initialized, this argument has no effect.
@@ -498,7 +505,7 @@ pub struct RaftConfig {
     pub cluster_name: String,
 
     /// Max timeout(in milli seconds) when waiting a cluster leader.
-    #[clap(long, default_value = "70000")]
+    #[clap(long, default_value = "180000")]
     pub wait_leader_timeout: u64,
 }
 
@@ -521,6 +528,7 @@ impl From<RaftConfig> for InnerRaftConfig {
             heartbeat_interval: x.heartbeat_interval,
             install_snapshot_timeout: x.install_snapshot_timeout,
             max_applied_log_to_keep: x.max_applied_log_to_keep,
+            snapshot_chunk_size: x.snapshot_chunk_size,
             single: x.single,
             join: x.join,
             leave_via: x.leave_via,
@@ -546,6 +554,7 @@ impl From<InnerRaftConfig> for RaftConfig {
             heartbeat_interval: inner.heartbeat_interval,
             install_snapshot_timeout: inner.install_snapshot_timeout,
             max_applied_log_to_keep: inner.max_applied_log_to_keep,
+            snapshot_chunk_size: inner.snapshot_chunk_size,
             single: inner.single,
             join: inner.join,
             leave_via: inner.leave_via,

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -308,6 +308,7 @@ impl MetaNode {
             install_snapshot_timeout: config.install_snapshot_timeout,
             snapshot_policy: SnapshotPolicy::LogsSinceLast(config.snapshot_logs_since_last),
             max_in_snapshot_log_to_keep: config.max_applied_log_to_keep,
+            snapshot_max_chunk_size: config.snapshot_chunk_size,
             ..Default::default()
         }
         .validate()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary


### upgrade openraft

### Fix: AsyncReadExt::read_buf() only reads at most 2MB per call
When streaming a snapshot chunk, it should repeatly `read_buf()` until
`snapshot_max_chunk_size` is full or read EOF.


### Refactor: fix handling of non-voter leader
Openraft does not require Leader/Candidate to be a voter.
Before this commit, Openraft's handling of non-voter leader is
inconsistent:

For a node that has a vote proposed by this node and is committed, and is not a voter:

- [`calc_server_state()`](https://github.com/datafuselabs/openraft/blob/97254a31c673e52429ee7187de96fd2ea2a5ce98/openraft/src/raft_state/mod.rs#L323) returns `Learner`.
- But [`is_leader()`](https://github.com/datafuselabs/openraft/blob/97254a31c673e52429ee7187de96fd2ea2a5ce98/openraft/src/raft_state/mod.rs#L353) returns true.

Since this commit,
`calc_server_state()` and `is_leader()` returns consistent result according to the following table:

For node-2:

- Node-2 with vote `(term=1, node_id=2, committed=true)`:
  - is a leader if it is **present** in config, either a voter or non-voter.
  - is a learner if it is **absent** in config.

- Node-2 with vote `(term=1, node_id=2, committed=false)`:
  - is a candidate if it is **present** in config, either a voter or non-voter.
  - is a learner if it is **absent** in config.

- Node-3 with vote `(term=1, node_id=99, committed=false|true)`:
  - is a follower if it is a **voter** in config,
  - is a learner if it is a **non-voter** or **absent** in config.

| vote \ membership                     | Voter     | Non-voter | Absent  |
|---------------------------------------|-----------|-----------|---------|
| (term=1, node_id=2, committed=true)   | leader    | leader    | learner |
| (term=1, node_id=2, committed=false)  | candidate | candidate | learner |
| (term=1, node_id=99, committed=true)  | follower  | learner   | learner |
| (term=1, node_id=99, committed=false) | follower  | learner   | learner |



### Fix: Do not report snapshot.last_log_id to metrics until snapshot is finished building/installing
Before this commit `RaftMetrics.snapshot` contains the last log id of a
snapshot that is **going** to install. Therefore there is chance the
metrics is updated but the store does not.

In this commit, `RaftMetrics.snapshot` will only be updated when a
snapshot is finished building or installing, by adding a new field
`snpashot` to `IOState` for tracking persisted snapshot meta data.

### feature: databend-meta add config raft.snapshot_chunk_size[=4MB]

In databend-meta config:

```toml
[raft]
# in bytes
snapshot_chunk_size = 1000000
```

Other changes:

- change wait_leader_timeout from 70sec to 180sec.

  `wait_leader_timeout` is the duration to wait for an active leader to
  confirm that a newly started databend-meta has joined the cluster.

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13639)
<!-- Reviewable:end -->
