### PR TITLE
feat: return node_id on the http query response

### DIFF
--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -22,6 +22,7 @@ use common_exception::Result;
 use common_metrics::http::metrics_incr_http_request_count;
 use common_metrics::http::metrics_incr_http_response_panics_count;
 use common_metrics::http::metrics_incr_http_slow_request_count;
+use common_storages_fuse::TableContext;
 use headers::authorization::Basic;
 use headers::authorization::Bearer;
 use headers::authorization::Credentials;
@@ -180,6 +181,7 @@ impl<E> HTTPSessionEndpoint<E> {
             let tenant_id = tenant_id.to_str().unwrap().to_string();
             session.set_current_tenant(tenant_id);
         }
+        let node_id = ctx.get_cluster().local_id.clone();
 
         self.auth_manager
             .auth(ctx.get_current_session(), &credential)
@@ -204,6 +206,7 @@ impl<E> HTTPSessionEndpoint<E> {
         Ok(HttpQueryContext::new(
             session,
             query_id,
+            node_id,
             deduplicate_label,
             user_agent,
         ))

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -113,6 +113,7 @@ impl QueryResponseField {
 pub struct QueryResponse {
     pub id: String,
     pub session_id: Option<String>,
+    pub node_id: String,
     pub session: Option<HttpSessionConf>,
     pub schema: Vec<QueryResponseField>,
     pub data: Vec<Vec<JsonValue>>,
@@ -180,6 +181,7 @@ impl QueryResponse {
             state: state.state,
             schema: QueryResponseField::from_schema(schema),
             session_id: Some(session_id),
+            node_id: r.node_id,
             session: r.session,
             stats,
             affect: state.affect,
@@ -205,6 +207,7 @@ impl QueryResponse {
             data: vec![],
             schema: vec![],
             session_id: None,
+            node_id: "".to_string(),
             session: None,
             next_uri: None,
             stats_uri: None,

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -220,7 +220,7 @@ impl QueryResponse {
 
 #[poem::handler]
 async fn query_final_handler(
-    _ctx: &HttpQueryContext,
+    ctx: &HttpQueryContext,
     Path(query_id): Path<String>,
 ) -> PoemResult<impl IntoResponse> {
     let trace_id = query_id_to_trace_id(&query_id);
@@ -243,7 +243,7 @@ async fn query_final_handler(
                 }
                 Ok(QueryResponse::from_internal(query_id, response, true))
             }
-            None => Err(query_id_not_found(query_id)),
+            None => Err(query_id_not_found(&query_id, &ctx.node_id)),
         }
     }
     .in_span(root)
@@ -280,7 +280,7 @@ async fn query_cancel_handler(
 
 #[poem::handler]
 async fn query_state_handler(
-    _ctx: &HttpQueryContext,
+    ctx: &HttpQueryContext,
     Path(query_id): Path<String>,
 ) -> PoemResult<impl IntoResponse> {
     let trace_id = query_id_to_trace_id(&query_id);
@@ -296,7 +296,7 @@ async fn query_state_handler(
                 let response = query.get_response_state_only().await;
                 Ok(QueryResponse::from_internal(query_id, response, false))
             }
-            None => Err(query_id_not_found(query_id)),
+            None => Err(query_id_not_found(&query_id, &ctx.node_id)),
         }
     }
     .in_span(root)
@@ -305,7 +305,7 @@ async fn query_state_handler(
 
 #[poem::handler]
 async fn query_page_handler(
-    _ctx: &HttpQueryContext,
+    ctx: &HttpQueryContext,
     Path((query_id, page_no)): Path<(String, usize)>,
 ) -> PoemResult<impl IntoResponse> {
     let trace_id = query_id_to_trace_id(&query_id);
@@ -325,7 +325,7 @@ async fn query_page_handler(
                 query.update_expire_time(false).await;
                 Ok(QueryResponse::from_internal(query_id, resp, false))
             }
-            None => Err(query_id_not_found(query_id)),
+            None => Err(query_id_not_found(&query_id, &ctx.node_id)),
         }
     }
     .in_span(root)
@@ -402,9 +402,9 @@ pub fn query_route() -> Route {
     route
 }
 
-fn query_id_not_found(query_id: String) -> PoemError {
+fn query_id_not_found(query_id: &str, node_id: &str) -> PoemError {
     PoemError::from_string(
-        format!("query id not found {}", query_id),
+        format!("query id {} not found on {}", query_id, node_id),
         StatusCode::NOT_FOUND,
     )
 }

--- a/src/query/service/src/servers/http/v1/query/http_query_context.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_context.rs
@@ -25,6 +25,7 @@ use crate::sessions::SessionType;
 pub struct HttpQueryContext {
     session: Arc<Session>,
     pub query_id: String,
+    pub node_id: String,
     pub deduplicate_label: Option<String>,
     pub user_agent: Option<String>,
 }
@@ -33,12 +34,14 @@ impl HttpQueryContext {
     pub fn new(
         session: Arc<Session>,
         query_id: String,
+        node_id: String,
         deduplicate_label: Option<String>,
         user_agent: Option<String>,
     ) -> Self {
         HttpQueryContext {
             session,
             query_id,
+            node_id,
             deduplicate_label,
             user_agent,
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently there're cases we'd get 404 query id not found errors if:

1. query instance OOM Killed or crashed during the query execution
2. the query have successfully completed before we polled the next page when we set an extremely large result timeout

It's hard for us to distinguish between these two cases.

This PR added an `node_id` field in the HTTP response. The `node_id` changes every time the query instance restarted, so the client side can determine it's crashed if the node_id changed during a query.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13641)
<!-- Reviewable:end -->
