### PR TITLE
fix: address the slow range() function in the state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "common-tracing",
  "derive_more",
  "futures",
+ "futures-async-stream",
  "futures-util",
  "hostname",
  "lazy_static",

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -123,10 +123,10 @@ impl Request {
         match self {
             Request::Get(_) => "Get",
             Request::MGet(_) => "MGet",
-            Request::List(_) => "PrefixList",
+            Request::List(_) => "List",
             Request::StreamGet(_) => "StreamGet",
             Request::StreamMGet(_) => "StreamMGet",
-            Request::StreamList(_) => "StreamPrefixList",
+            Request::StreamList(_) => "StreamList",
             Request::Upsert(_) => "Upsert",
             Request::Txn(_) => "Txn",
             Request::Watch(_) => "Watch",

--- a/src/meta/kvapi/src/kvapi/api.rs
+++ b/src/meta/kvapi/src/kvapi/api.rs
@@ -21,6 +21,7 @@ use common_meta_types::TxnReply;
 use common_meta_types::TxnRequest;
 use futures_util::stream::BoxStream;
 use futures_util::TryStreamExt;
+use log::debug;
 
 use crate::kvapi;
 use crate::kvapi::GetKVReply;
@@ -75,7 +76,10 @@ pub trait KVApi: Send + Sync {
     ///
     /// This method has a default implementation by collecting result from `stream_list_kv()`
     async fn prefix_list_kv(&self, prefix: &str) -> Result<ListKVReply, Self::Error> {
+        let now = std::time::Instant::now();
         let strm = self.list_kv(prefix).await?;
+
+        debug!("list_kv() took {:?}", now.elapsed());
 
         let v = strm
             .map_ok(|x| {

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -33,6 +33,7 @@ byteorder = "1.4.3"
 chrono = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }
+futures-async-stream = { workspace = true }
 futures-util = { workspace = true }
 hostname = "0.3.1"
 lazy_static = { workspace = true }

--- a/src/meta/raft-store/src/lib.rs
+++ b/src/meta/raft-store/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![allow(clippy::uninlined_format_args)]
+#![feature(generators)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(return_position_impl_trait_in_trait)]
 

--- a/src/meta/raft-store/src/sm_v002/leveled_store/arc_level_impl.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/arc_level_impl.rs
@@ -1,0 +1,104 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Borrow;
+use std::io;
+use std::ops::RangeBounds;
+use std::sync::Arc;
+
+use crate::sm_v002::leveled_store::level::Level;
+use crate::sm_v002::leveled_store::map_api::AsMap;
+use crate::sm_v002::leveled_store::map_api::KVResultStream;
+use crate::sm_v002::leveled_store::map_api::MapApiRO;
+use crate::sm_v002::leveled_store::map_api::MapKV;
+use crate::sm_v002::leveled_store::map_api::MapKey;
+use crate::sm_v002::leveled_store::map_api::MarkedOf;
+use crate::sm_v002::marked::Marked;
+use crate::state_machine::ExpireKey;
+
+impl Level {
+    /// Build a static stream that yields key values for primary index
+    #[futures_async_stream::try_stream(boxed, ok = MapKV<String>, error = io::Error)]
+    async fn str_range<Q, R>(self: Arc<Level>, range: R)
+    where
+        String: Borrow<Q>,
+        Q: Ord + Send + Sync + ?Sized,
+        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
+    {
+        let it = self.as_ref().kv.range(range);
+
+        for (k, v) in it {
+            yield (k.clone(), v.clone());
+        }
+    }
+
+    /// Build a static stream that yields expire key and key for the secondary expiration index
+    #[futures_async_stream::try_stream(boxed, ok = MapKV<ExpireKey>, error = io::Error)]
+    async fn expire_range<Q, R>(self: Arc<Level>, range: R)
+    where
+        ExpireKey: Borrow<Q>,
+        Q: Ord + Send + Sync + ?Sized,
+        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
+    {
+        let it = self.as_ref().expire.range(range);
+
+        for (k, v) in it {
+            yield (*k, v.clone());
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl MapApiRO<String> for Arc<Level> {
+    async fn get<Q>(&self, key: &Q) -> Result<Marked<<String as MapKey>::V>, io::Error>
+    where
+        String: Borrow<Q>,
+        Q: Ord + Send + Sync + ?Sized,
+    {
+        // get() is just delegated
+        self.as_ref().str_map().get(key).await
+    }
+
+    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<String>, io::Error>
+    where
+        String: Borrow<Q>,
+        Q: Ord + Send + Sync + ?Sized,
+        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
+    {
+        let strm = self.clone().str_range(range);
+        Ok(strm)
+    }
+}
+
+#[async_trait::async_trait]
+impl MapApiRO<ExpireKey> for Arc<Level> {
+    async fn get<Q>(&self, key: &Q) -> Result<MarkedOf<ExpireKey>, io::Error>
+    where
+        ExpireKey: Borrow<Q>,
+        Q: Ord + Send + Sync + ?Sized,
+    {
+        // get() is just delegated
+        self.as_ref().expire_map().get(key).await
+    }
+
+    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<ExpireKey>, io::Error>
+    where
+        ExpireKey: Borrow<Q>,
+        Q: Ord + Send + Sync + ?Sized,
+        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
+    {
+        let strm = self.clone().expire_range(range);
+        Ok(strm)
+    }
+}

--- a/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
@@ -94,7 +94,7 @@ where K: MapKey
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Send + Sync + Clone;
+        R: RangeBounds<Q> + Send + Sync + Clone + 'static;
 }
 
 /// Trait for using Self as an implementation of the MapApi.
@@ -222,20 +222,31 @@ where
 /// Iterate over a range of entries by keys from multi levels.
 ///
 /// The returned iterator contains at most one entry for each key.
-/// There could be tombstone entries: [`Marked::TombStone`]
-pub(in crate::sm_v002) async fn compacted_range<'d, K, Q, R, L>(
+/// There could be tombstone entries: [`Marked::TombStone`].
+///
+/// The `TOP` is the type of the top level.
+/// The `L` is the type of frozen levels.
+///
+/// Because the top level is very likely to be a different type from the frozen levels, i.e., it is writable.
+pub(in crate::sm_v002) async fn compacted_range<'d, K, Q, R, L, TOP>(
     range: R,
+    top: Option<&'d TOP>,
     levels: impl IntoIterator<Item = &'d L>,
 ) -> Result<KVResultStream<K>, io::Error>
 where
     K: MapKey,
     K: Borrow<Q>,
-    R: RangeBounds<Q> + Clone + Send + Sync,
+    R: RangeBounds<Q> + Clone + Send + Sync + 'static,
     Q: Ord + Send + Sync + ?Sized,
     L: MapApiRO<K> + 'static,
+    TOP: MapApiRO<K> + 'static,
 {
-    // TODO: handle Result
     let mut kmerge = KMerge::by(util::by_key_seq);
+
+    if let Some(t) = top {
+        let strm = t.range(range.clone()).await?;
+        kmerge = kmerge.merge(strm);
+    }
 
     for lvl in levels {
         let strm = lvl.range(range.clone()).await?;
@@ -250,6 +261,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use futures_util::TryStreamExt;
 
     use crate::sm_v002::leveled_store::level::Level;
@@ -292,30 +305,59 @@ mod tests {
         let mut l0 = Level::default();
         l0.set(s("a"), Some((b("a"), None))).await?;
         l0.set(s("b"), Some((b("b"), None))).await?;
+        let l0 = Arc::new(l0);
 
         let mut l1 = l0.new_level();
         l1.set(s("a"), None).await?;
         l1.set(s("c"), None).await?;
+        let l1 = Arc::new(l1);
 
         let mut l2 = l1.new_level();
         l2.set(s("b"), Some((b("b2"), None))).await?;
 
-        let got = compacted_range::<String, String, _, _>(&s("").., [&l2, &l1, &l0]).await?;
-        let got = got.try_collect::<Vec<_>>().await?;
-        assert_eq!(got, vec![
-            //
-            (s("a"), Marked::new_tomb_stone(2)),
-            (s("b"), Marked::new_normal(3, b("b2"))),
-            (s("c"), Marked::new_tomb_stone(2)),
-        ]);
+        // With top level
+        {
+            let got =
+                compacted_range::<String, String, _, _, _>(s("").., Some(&l2), [&l1, &l0]).await?;
+            let got = got.try_collect::<Vec<_>>().await?;
+            assert_eq!(got, vec![
+                //
+                (s("a"), Marked::new_tomb_stone(2)),
+                (s("b"), Marked::new_normal(3, b("b2"))),
+                (s("c"), Marked::new_tomb_stone(2)),
+            ]);
 
-        let got = compacted_range::<String, String, _, _>(&s("b").., [&l2, &l1, &l0]).await?;
-        let got = got.try_collect::<Vec<_>>().await?;
-        assert_eq!(got, vec![
-            //
-            (s("b"), Marked::new_normal(3, b("b2"))),
-            (s("c"), Marked::new_tomb_stone(2)),
-        ]);
+            let got =
+                compacted_range::<String, String, _, _, _>(s("b").., Some(&l2), [&l1, &l0]).await?;
+            let got = got.try_collect::<Vec<_>>().await?;
+            assert_eq!(got, vec![
+                //
+                (s("b"), Marked::new_normal(3, b("b2"))),
+                (s("c"), Marked::new_tomb_stone(2)),
+            ]);
+        }
+
+        // Without top level
+        {
+            let got =
+                compacted_range::<String, String, _, _, Level>(s("").., None, [&l1, &l0]).await?;
+            let got = got.try_collect::<Vec<_>>().await?;
+            assert_eq!(got, vec![
+                //
+                (s("a"), Marked::new_tomb_stone(2)),
+                (s("b"), Marked::new_normal(2, b("b"))),
+                (s("c"), Marked::new_tomb_stone(2)),
+            ]);
+
+            let got =
+                compacted_range::<String, String, _, _, Level>(s("b").., None, [&l1, &l0]).await?;
+            let got = got.try_collect::<Vec<_>>().await?;
+            assert_eq!(got, vec![
+                //
+                (s("b"), Marked::new_normal(2, b("b"))),
+                (s("c"), Marked::new_tomb_stone(2)),
+            ]);
+        }
 
         Ok(())
     }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/mod.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod arc_level_impl;
 pub mod level;
 pub mod leveled_map;
 pub mod map_api;

--- a/src/meta/raft-store/src/sm_v002/leveled_store/ref_.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/ref_.rs
@@ -16,6 +16,7 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::io;
 use std::ops::RangeBounds;
+use std::sync::Arc;
 
 use crate::sm_v002::leveled_store::level::Level;
 use crate::sm_v002::leveled_store::map_api::compacted_get;
@@ -48,6 +49,12 @@ impl<'d> Ref<'d> {
     pub(in crate::sm_v002) fn iter_levels(&self) -> impl Iterator<Item = &'d Level> + 'd {
         self.writable.into_iter().chain(self.frozen.iter_levels())
     }
+
+    pub(in crate::sm_v002) fn iter_shared_levels(
+        &self,
+    ) -> (Option<&Level>, impl Iterator<Item = &Arc<Level>>) {
+        (self.writable, self.frozen.iter_arc_levels())
+    }
 }
 
 #[async_trait::async_trait]
@@ -55,6 +62,7 @@ impl<'d, K> MapApiRO<K> for Ref<'d>
 where
     K: MapKey + fmt::Debug,
     Level: MapApiRO<K>,
+    Arc<Level>: MapApiRO<K>,
 {
     async fn get<Q>(&self, key: &Q) -> Result<Marked<K::V>, io::Error>
     where
@@ -68,10 +76,10 @@ where
     async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
     where
         K: Borrow<Q>,
-        R: RangeBounds<Q> + Clone + Send + Sync,
+        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
         Q: Ord + Send + Sync + ?Sized,
     {
-        let levels = self.iter_levels();
-        compacted_range(range, levels).await
+        let (top, levels) = self.iter_shared_levels();
+        compacted_range(range, top, levels).await
     }
 }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/static_levels.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/static_levels.rs
@@ -40,6 +40,11 @@ impl StaticLevels {
         }
     }
 
+    /// Return an iterator of all Arc of levels from newest to oldest.
+    pub(in crate::sm_v002) fn iter_arc_levels(&self) -> impl Iterator<Item = &Arc<Level>> {
+        self.levels.iter().rev()
+    }
+
     /// Return an iterator of all levels from newest to oldest.
     pub(in crate::sm_v002) fn iter_levels(&self) -> impl Iterator<Item = &Level> {
         self.levels.iter().map(|x| x.as_ref()).rev()
@@ -68,13 +73,14 @@ impl<K> MapApiRO<K> for StaticLevels
 where
     K: MapKey,
     Level: MapApiRO<K>,
+    Arc<Level>: MapApiRO<K>,
 {
     async fn get<Q>(&self, key: &Q) -> Result<Marked<K::V>, io::Error>
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
     {
-        let levels = self.iter_levels();
+        let levels = self.iter_arc_levels();
         compacted_get(key, levels).await
     }
 
@@ -82,9 +88,9 @@ where
     where
         K: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Clone + Send + Sync,
+        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
     {
-        let levels = self.iter_levels();
-        compacted_range(range, levels).await
+        let levels = self.iter_arc_levels();
+        compacted_range::<_, _, _, _, Level>(range, None, levels).await
     }
 }

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
@@ -51,7 +51,7 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
 
     let d = top_level.newest().unwrap().as_ref();
 
-    assert_eq!(top_level.iter_levels().count(), 1);
+    assert_eq!(top_level.iter_arc_levels().count(), 1);
     assert_eq!(
         d.last_membership_ref(),
         &StoredMembership::new(Some(log_id(3, 3, 3)), Membership::new(vec![], ()))

--- a/src/meta/raft-store/src/state_machine/expire.rs
+++ b/src/meta/raft-store/src/state_machine/expire.rs
@@ -34,7 +34,16 @@ use common_meta_sled_store::SledSerde;
 
 /// The identifier of the index for kv with expiration.
 #[derive(
-    Default, Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord,
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
 )]
 pub struct ExpireKey {
     /// The time in millisecond when a key will be expired.


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### fix: address the slow range() function in the state machine

A State Machine is a structure with multiple levels, with the top level
being writable.

The top writable level cannot be borrowed to create a static stream.
Thus the range result must be copied.

In this commit, we minimize the top level as much as possible.
Additionally, when querying a range from the static shared label, we avoid copying the result.

## Changelog


- Bug Fix




## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13649)
<!-- Reviewable:end -->
