### PR TITLE
refactor: state machine range() does not need to accept borrowed key

### DIFF
--- a/src/meta/raft-store/src/sm_v002/leveled_store/arc_level_impl.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/arc_level_impl.rs
@@ -70,12 +70,8 @@ impl MapApiRO<String> for Arc<Level> {
         self.as_ref().str_map().get(key).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<String>, io::Error>
-    where
-        String: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
-    {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<String>, io::Error>
+    where R: RangeBounds<String> + Clone + Send + Sync + 'static {
         let strm = self.clone().str_range(range);
         Ok(strm)
     }
@@ -92,12 +88,8 @@ impl MapApiRO<ExpireKey> for Arc<Level> {
         self.as_ref().expire_map().get(key).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<ExpireKey>, io::Error>
-    where
-        ExpireKey: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
-    {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<ExpireKey>, io::Error>
+    where R: RangeBounds<ExpireKey> + Clone + Send + Sync + 'static {
         let strm = self.clone().expire_range(range);
         Ok(strm)
     }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
@@ -100,12 +100,8 @@ impl MapApiRO<String> for Level {
         Ok(got)
     }
 
-    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<String>, io::Error>
-    where
-        String: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
-    {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<String>, io::Error>
+    where R: RangeBounds<String> + Clone + Send + Sync + 'static {
         // Level is borrowed. It has to copy the result to make the returning stream static.
         let vec = self
             .kv
@@ -134,7 +130,7 @@ impl MapApi<String> for Level {
         } else {
             // Do not increase the sequence number, just use the max seq for all tombstone.
             let seq = self.curr_seq();
-            Marked::new_tomb_stone(seq)
+            Marked::new_tombstone(seq)
         };
 
         let prev = (*self).str_map().get(&key).await?;
@@ -154,12 +150,8 @@ impl MapApiRO<ExpireKey> for Level {
         Ok(got)
     }
 
-    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<ExpireKey>, io::Error>
-    where
-        ExpireKey: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
-    {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<ExpireKey>, io::Error>
+    where R: RangeBounds<ExpireKey> + Clone + Send + Sync + 'static {
         // Level is borrowed. It has to copy the result to make the returning stream static.
         let vec = self
             .expire

--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map.rs
@@ -127,12 +127,8 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
-    where
-        K: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
-    {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
+    where R: RangeBounds<K> + Clone + Send + Sync + 'static {
         let (top, levels) = self.iter_shared_levels();
         compacted_range(range, top, levels).await
     }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
@@ -28,7 +28,7 @@ async fn test_freeze() -> anyhow::Result<()> {
 
     // Insert an entry at level 0
     let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b0"), None))).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(0));
+    assert_eq!(prev, Marked::new_tombstone(0));
     assert_eq!(result, Marked::new_with_meta(1, b("b0"), None));
 
     // Insert the same entry at level 1
@@ -73,7 +73,7 @@ async fn test_single_level() -> anyhow::Result<()> {
 
     // Write a1
     let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(0));
+    assert_eq!(prev, Marked::new_tombstone(0));
     assert_eq!(result, Marked::new_with_meta(1, b("b1"), None));
 
     // Write more
@@ -99,7 +99,7 @@ async fn test_single_level() -> anyhow::Result<()> {
     assert_eq!(prev, Marked::new_with_meta(3, b("b3"), None));
     assert_eq!(
         result,
-        Marked::new_tomb_stone(6),
+        Marked::new_tombstone(6),
         "NOTE: single level data also creates a tombstone"
     );
 
@@ -110,7 +110,7 @@ async fn test_single_level() -> anyhow::Result<()> {
         //
         (s("a1"), Marked::new_with_meta(6, b("b1"), None)),
         (s("a2"), Marked::new_with_meta(2, b("b2"), None)),
-        (s("a3"), Marked::new_tomb_stone(6)),
+        (s("a3"), Marked::new_tombstone(6)),
         (s("x1"), Marked::new_with_meta(4, b("y1"), None)),
         (s("x2"), Marked::new_with_meta(5, b("y2"), None)),
     ]);
@@ -120,7 +120,7 @@ async fn test_single_level() -> anyhow::Result<()> {
     assert_eq!(got, Marked::new_with_meta(2, b("b2"), None));
 
     let got = l.str_map().get("a3").await?;
-    assert_eq!(got, Marked::new_tomb_stone(6));
+    assert_eq!(got, Marked::new_tombstone(6));
     Ok(())
 }
 
@@ -162,11 +162,11 @@ async fn test_two_levels() -> anyhow::Result<()> {
     // Delete by adding a tombstone
     let (prev, result) = l.str_map_mut().set(s("a1"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(1, b("b1"), None));
-    assert_eq!(result, Marked::new_tomb_stone(6));
+    assert_eq!(result, Marked::new_tombstone(6));
 
     // Override tombstone
     let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b5"), None))).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(6));
+    assert_eq!(prev, Marked::new_tombstone(6));
     assert_eq!(result, Marked::new_with_meta(7, b("b5"), None));
 
     // Range
@@ -189,7 +189,7 @@ async fn test_two_levels() -> anyhow::Result<()> {
     assert_eq!(got, Marked::new_with_meta(6, b("b4"), None));
 
     let got = l.str_map().get("w1").await?;
-    assert_eq!(got, Marked::new_tomb_stone(0));
+    assert_eq!(got, Marked::new_tombstone(0));
 
     // Check base level
 
@@ -245,10 +245,10 @@ async fn test_three_levels_get_range() -> anyhow::Result<()> {
     assert_eq!(got, Marked::new_with_meta(1, b("a0"), None));
 
     let got = l.str_map().get("b").await?;
-    assert_eq!(got, Marked::new_tomb_stone(4));
+    assert_eq!(got, Marked::new_tombstone(4));
 
     let got = l.str_map().get("c").await?;
-    assert_eq!(got, Marked::new_tomb_stone(6));
+    assert_eq!(got, Marked::new_tombstone(6));
 
     let got = l.str_map().get("d").await?;
     assert_eq!(got, Marked::new_with_meta(7, b("d2"), None));
@@ -257,7 +257,7 @@ async fn test_three_levels_get_range() -> anyhow::Result<()> {
     assert_eq!(got, Marked::new_with_meta(6, b("e1"), None));
 
     let got = l.str_map().get("f").await?;
-    assert_eq!(got, Marked::new_tomb_stone(0));
+    assert_eq!(got, Marked::new_tombstone(0));
 
     let got = l
         .str_map()
@@ -268,8 +268,8 @@ async fn test_three_levels_get_range() -> anyhow::Result<()> {
     assert_eq!(got, vec![
         //
         (s("a"), Marked::new_with_meta(1, b("a0"), None)),
-        (s("b"), Marked::new_tomb_stone(4)),
-        (s("c"), Marked::new_tomb_stone(6)),
+        (s("b"), Marked::new_tombstone(4)),
+        (s("c"), Marked::new_tombstone(6)),
         (s("d"), Marked::new_with_meta(7, b("d2"), None)),
         (s("e"), Marked::new_with_meta(6, b("e1"), None)),
     ]);
@@ -286,11 +286,11 @@ async fn test_three_levels_override() -> anyhow::Result<()> {
     assert_eq!(result, Marked::new_with_meta(8, b("x"), None));
 
     let (prev, result) = l.str_map_mut().set(s("b"), Some((b("y"), None))).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(4));
+    assert_eq!(prev, Marked::new_tombstone(4));
     assert_eq!(result, Marked::new_with_meta(9, b("y"), None));
 
     let (prev, result) = l.str_map_mut().set(s("c"), Some((b("z"), None))).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(6));
+    assert_eq!(prev, Marked::new_tombstone(6));
     assert_eq!(result, Marked::new_with_meta(10, b("z"), None));
 
     let (prev, result) = l.str_map_mut().set(s("d"), Some((b("u"), None))).await?;
@@ -302,7 +302,7 @@ async fn test_three_levels_override() -> anyhow::Result<()> {
     assert_eq!(result, Marked::new_with_meta(12, b("v"), None));
 
     let (prev, result) = l.str_map_mut().set(s("f"), Some((b("w"), None))).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(0));
+    assert_eq!(prev, Marked::new_tombstone(0));
     assert_eq!(result, Marked::new_with_meta(13, b("w"), None));
 
     let got = l
@@ -330,27 +330,27 @@ async fn test_three_levels_delete() -> anyhow::Result<()> {
 
     let (prev, result) = l.str_map_mut().set(s("a"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(1, b("a0"), None));
-    assert_eq!(result, Marked::new_tomb_stone(7));
+    assert_eq!(result, Marked::new_tombstone(7));
 
     let (prev, result) = l.str_map_mut().set(s("b"), None).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(4));
-    assert_eq!(result, Marked::new_tomb_stone(7));
+    assert_eq!(prev, Marked::new_tombstone(4));
+    assert_eq!(result, Marked::new_tombstone(7));
 
     let (prev, result) = l.str_map_mut().set(s("c"), None).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(6));
-    assert_eq!(result, Marked::new_tomb_stone(7));
+    assert_eq!(prev, Marked::new_tombstone(6));
+    assert_eq!(result, Marked::new_tombstone(7));
 
     let (prev, result) = l.str_map_mut().set(s("d"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(7, b("d2"), None));
-    assert_eq!(result, Marked::new_tomb_stone(7));
+    assert_eq!(result, Marked::new_tombstone(7));
 
     let (prev, result) = l.str_map_mut().set(s("e"), None).await?;
     assert_eq!(prev, Marked::new_with_meta(6, b("e1"), None));
-    assert_eq!(result, Marked::new_tomb_stone(7));
+    assert_eq!(result, Marked::new_tombstone(7));
 
     let (prev, result) = l.str_map_mut().set(s("f"), None).await?;
-    assert_eq!(prev, Marked::new_tomb_stone(0));
-    assert_eq!(result, Marked::new_tomb_stone(0));
+    assert_eq!(prev, Marked::new_tombstone(0));
+    assert_eq!(result, Marked::new_tombstone(0));
 
     let got = l
         .str_map()
@@ -360,11 +360,11 @@ async fn test_three_levels_delete() -> anyhow::Result<()> {
         .await?;
     assert_eq!(got, vec![
         //
-        (s("a"), Marked::new_tomb_stone(7)),
-        (s("b"), Marked::new_tomb_stone(7)),
-        (s("c"), Marked::new_tomb_stone(7)),
-        (s("d"), Marked::new_tomb_stone(7)),
-        (s("e"), Marked::new_tomb_stone(7)),
+        (s("a"), Marked::new_tombstone(7)),
+        (s("b"), Marked::new_tombstone(7)),
+        (s("c"), Marked::new_tombstone(7)),
+        (s("d"), Marked::new_tombstone(7)),
+        (s("e"), Marked::new_tombstone(7)),
     ]);
 
     Ok(())
@@ -460,7 +460,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) = MapApiExt::upsert_value(&mut l, s("d"), b("d1")).await?;
-        assert_eq!(prev, Marked::new_tomb_stone(0));
+        assert_eq!(prev, Marked::new_tombstone(0));
         assert_eq!(result, Marked::new_with_meta(6, b("d1"), None));
 
         let got = l.str_map().get("d").await?;
@@ -550,11 +550,11 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
 
         let (prev, result) =
             MapApiExt::update_meta(&mut l, s("d"), Some(KVMeta { expire_at: Some(2) })).await?;
-        assert_eq!(prev, Marked::new_tomb_stone(0));
-        assert_eq!(result, Marked::new_tomb_stone(0));
+        assert_eq!(prev, Marked::new_tombstone(0));
+        assert_eq!(result, Marked::new_tombstone(0));
 
         let got = l.str_map().get("d").await?;
-        assert_eq!(got, Marked::new_tomb_stone(0));
+        assert_eq!(got, Marked::new_tombstone(0));
     }
 
     Ok(())

--- a/src/meta/raft-store/src/sm_v002/leveled_store/ref_.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/ref_.rs
@@ -73,12 +73,8 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
-    where
-        K: Borrow<Q>,
-        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
-        Q: Ord + Send + Sync + ?Sized,
-    {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
+    where R: RangeBounds<K> + Clone + Send + Sync + 'static {
         let (top, levels) = self.iter_shared_levels();
         compacted_range(range, top, levels).await
     }

--- a/src/meta/raft-store/src/sm_v002/leveled_store/ref_mut.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/ref_mut.rs
@@ -84,12 +84,8 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
-    where
-        K: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
-    {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
+    where R: RangeBounds<K> + Clone + Send + Sync + 'static {
         let (top, levels) = self.iter_shared_levels();
         compacted_range(range, top, levels).await
     }
@@ -115,7 +111,7 @@ where
 
         // No such entry at all, no need to create a tombstone for delete
         if prev.not_found() && value.is_none() {
-            return Ok((prev, Marked::new_tomb_stone(0)));
+            return Ok((prev, Marked::new_tombstone(0)));
         }
 
         // `writeable` is a single level map and the returned `_prev` is only from that level.

--- a/src/meta/raft-store/src/sm_v002/leveled_store/static_levels.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/static_levels.rs
@@ -84,13 +84,9 @@ where
         compacted_get(key, levels).await
     }
 
-    async fn range<Q, R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
-    where
-        K: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        R: RangeBounds<Q> + Clone + Send + Sync + 'static,
-    {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
+    where R: RangeBounds<K> + Clone + Send + Sync + 'static {
         let levels = self.iter_arc_levels();
-        compacted_range::<_, _, _, _, Level>(range, None, levels).await
+        compacted_range::<_, _, _, Level>(range, None, levels).await
     }
 }

--- a/src/meta/raft-store/src/sm_v002/marked/marked_test.rs
+++ b/src/meta/raft-store/src/sm_v002/marked/marked_test.rs
@@ -44,7 +44,7 @@ fn test_impl_trait_seq_value() -> anyhow::Result<()> {
     assert_eq!(m.value(), Some(&2));
     assert_eq!(m.meta(), Some(&KVMeta { expire_at: Some(3) }));
 
-    let m: Marked<u64> = Marked::new_tomb_stone(1);
+    let m: Marked<u64> = Marked::new_tombstone(1);
     assert_eq!(m.seq(), 0, "internal_seq is not returned to application");
     assert_eq!(m.value(), None);
     assert_eq!(m.meta(), None);
@@ -67,7 +67,7 @@ fn test_internal_seq() -> anyhow::Result<()> {
     let m = Marked::new_with_meta(1, 2, None);
     assert_eq!(m.internal_seq(), InternalSeq::normal(1));
 
-    let m: Marked<u64> = Marked::new_tomb_stone(1);
+    let m: Marked<u64> = Marked::new_tombstone(1);
     assert_eq!(m.internal_seq(), InternalSeq::tombstone(1));
 
     Ok(())
@@ -85,7 +85,7 @@ fn test_unpack() -> anyhow::Result<()> {
         Some((&2, Some(&KVMeta { expire_at: Some(3) })))
     );
 
-    let m: Marked<u64> = Marked::new_tomb_stone(1);
+    let m: Marked<u64> = Marked::new_tombstone(1);
     assert_eq!(m.unpack_ref(), None);
 
     Ok(())
@@ -96,7 +96,7 @@ fn test_unpack() -> anyhow::Result<()> {
 fn test_max() -> anyhow::Result<()> {
     let m1 = Marked::new_with_meta(1, 2, None);
     let m2 = Marked::new_with_meta(3, 2, None);
-    let m3: Marked<u64> = Marked::new_tomb_stone(2);
+    let m3: Marked<u64> = Marked::new_tombstone(2);
 
     assert_eq!(Marked::max_ref(&m1, &m2), &m2);
     assert_eq!(Marked::max_ref(&m1, &m3), &m3);
@@ -120,7 +120,7 @@ fn test_from_marked_for_option_seqv() -> anyhow::Result<()> {
     let s: Option<SeqV<u64>> = Some(SeqV::with_meta(1, Some(KVMeta { expire_at: Some(3) }), 2));
     assert_eq!(s, m.into());
 
-    let m: Marked<u64> = Marked::new_tomb_stone(1);
+    let m: Marked<u64> = Marked::new_tombstone(1);
     let s: Option<SeqV<u64>> = None;
     assert_eq!(s, m.into());
 
@@ -144,7 +144,7 @@ fn test_from_marked_for_option_expire_value() -> anyhow::Result<()> {
     let s: Option<ExpireValue> = Some(ExpireValue::new("2".to_string(), 1));
     assert_eq!(s, m.into());
 
-    let m = Marked::new_tomb_stone(1);
+    let m = Marked::new_tombstone(1);
     let s: Option<ExpireValue> = None;
     assert_eq!(s, m.into());
 

--- a/src/meta/raft-store/src/sm_v002/marked/mod.rs
+++ b/src/meta/raft-store/src/sm_v002/marked/mod.rs
@@ -144,7 +144,7 @@ impl<T> Marked<T> {
         }
     }
 
-    pub fn new_tomb_stone(internal_seq: u64) -> Self {
+    pub fn new_tombstone(internal_seq: u64) -> Self {
         Marked::TombStone { internal_seq }
     }
 
@@ -189,7 +189,7 @@ impl<T> Marked<T> {
         })
     }
 
-    pub fn is_tomb_stone(&self) -> bool {
+    pub fn is_tombstone(&self) -> bool {
         matches!(self, Marked::TombStone { .. })
     }
 
@@ -286,7 +286,7 @@ mod tests {
             m
         );
 
-        let m: Marked<u32> = Marked::new_tomb_stone(3);
+        let m: Marked<u32> = Marked::new_tombstone(3);
         assert_eq!(Marked::TombStone { internal_seq: 3 }, m);
     }
 }

--- a/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002_test.rs
@@ -203,7 +203,7 @@ async fn test_internal_expire_index() -> anyhow::Result<()> {
             ExpireKey::new(5_000, 2),
             Marked::new_with_meta(2, s("b"), None)
         ),
-        (ExpireKey::new(10_000, 1), Marked::new_tomb_stone(4)),
+        (ExpireKey::new(10_000, 1), Marked::new_tombstone(4)),
         (
             ExpireKey::new(15_000, 4),
             Marked::new_with_meta(4, s("a"), None)
@@ -284,8 +284,8 @@ async fn test_inserting_expired_becomes_deleting() -> anyhow::Result<()> {
             ExpireKey::new(5_000, 2),
             Marked::new_with_meta(2, s("b"), None)
         ),
-        (ExpireKey::new(10_000, 1), Marked::new_tomb_stone(4)),
-        (ExpireKey::new(15_000, 4), Marked::new_tomb_stone(5),),
+        (ExpireKey::new(10_000, 1), Marked::new_tombstone(4)),
+        (ExpireKey::new(15_000, 4), Marked::new_tombstone(5),),
         (
             ExpireKey::new(20_000, 3),
             Marked::new_with_meta(3, s("c"), None)

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
@@ -95,7 +95,7 @@ impl SnapshotViewV002 {
         let mut data = self.compacted.newest().unwrap().new_level();
 
         // `range()` will compact tombstone internally
-        let strm = self.compacted.str_map().range::<String, _>(..).await?;
+        let strm = self.compacted.str_map().range(..).await?;
         let strm = strm.try_filter(|(_k, v)| future::ready(v.is_normal()));
 
         let bt = strm.try_collect().await?;
@@ -167,7 +167,7 @@ impl SnapshotViewV002 {
 
         // kv
 
-        let strm = self.compacted.str_map().range::<String, _>(..).await?;
+        let strm = self.compacted.str_map().range(..).await?;
         let kv_iter = strm.try_filter_map(|(k, v)| {
             let seqv: Option<SeqV<_>> = v.into();
             let ent = seqv.map(|value| RaftStoreEntry::GenericKV { key: k, value });

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
@@ -62,12 +62,7 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
         &btreemap! {3=>Node::new("3", Endpoint::new("3", 3))}
     );
 
-    let got = d
-        .str_map()
-        .range::<str, _>(..)
-        .await?
-        .try_collect::<Vec<_>>()
-        .await?;
+    let got = d.str_map().range(..).await?.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
         (s("a"), Marked::new_with_meta(1, b("a0"), None)),
@@ -98,12 +93,7 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
 
     let d = compacted.newest().unwrap().as_ref();
 
-    let got = d
-        .str_map()
-        .range::<String, _>(..)
-        .await?
-        .try_collect::<Vec<_>>()
-        .await?;
+    let got = d.str_map().range(..).await?.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
         (

--- a/src/meta/sled-store/src/db.rs
+++ b/src/meta/sled-store/src/db.rs
@@ -36,7 +36,8 @@ impl GlobalSledDb {
         GlobalSledDb {
             temp_dir: Some(temp_dir),
             path: temp_path.clone(),
-            db: sled::open(temp_path).expect("open global sled::Db"),
+            db: sled::open(temp_path.clone())
+                .unwrap_or_else(|_| panic!("open global sled::Db(path: {})", temp_path)),
         }
     }
 
@@ -44,7 +45,8 @@ impl GlobalSledDb {
         GlobalSledDb {
             temp_dir: None,
             path: path.clone(),
-            db: sled::open(path).expect("open global sled::Db"),
+            db: sled::open(path.clone())
+                .unwrap_or_else(|_| panic!("open global sled::Db(path: {})", path)),
         }
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: state machine range() does not need to accept borrowed key

Since `range()` returns a static stream, the input range argument must
also be static. Therefore it does not to support `K: Borrow<Q>` anymore.

Other changes:

- rename tomb_stone to tombstone.

- add path info when failing to open sled db.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13650)
<!-- Reviewable:end -->
