### PR TITLE
fix(rbac): revert the session role response behaviour in #13062 

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -446,10 +446,18 @@ impl HttpQuery {
             .map(|v| v.keep_server_session_secs)
             .unwrap_or(None);
 
-        // TODO: add current role here
+        // TODO(liyz): known issue here, this will make SET ROLE statement not work in bendsql, refactor using the secondary role in the short time.
+        // https://github.com/datafuselabs/databend/issues/13544
+        let role = self
+            .request
+            .session
+            .as_ref()
+            .map(|s| s.role.clone())
+            .unwrap_or_default();
+
         HttpSessionConf {
             database: Some(session_state.current_database),
-            role: session_state.current_role,
+            role,
             keep_server_session_secs,
             settings: Some(settings),
         }

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -1262,7 +1262,7 @@ async fn test_affect() -> Result<()> {
             }),
             Some(HttpSessionConf {
                 database: Some("default".to_string()),
-                role: Some("account_admin".to_string()),
+                role: None,
                 keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([
                     ("max_threads".to_string(), "1".to_string()),
@@ -1280,7 +1280,7 @@ async fn test_affect() -> Result<()> {
             }),
             Some(HttpSessionConf {
                 database: Some("default".to_string()),
-                role: Some("account_admin".to_string()),
+                role: None,
                 keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "max_threads".to_string(),
@@ -1293,7 +1293,7 @@ async fn test_affect() -> Result<()> {
             None,
             Some(HttpSessionConf {
                 database: Some("default".to_string()),
-                role: Some("account_admin".to_string()),
+                role: None,
                 keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "max_threads".to_string(),
@@ -1308,7 +1308,7 @@ async fn test_affect() -> Result<()> {
             }),
             Some(HttpSessionConf {
                 database: Some("db2".to_string()),
-                role: Some("account_admin".to_string()),
+                role: None,
                 keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "max_threads".to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

the role response behaviour when combined with #13537, may have a surprised side effect:

1. when user NOT set the restricted role with `session.role`, the http response still returns the current `session.role`
2. the client take the `session.role` returnted from the server, and pass it to the next query
3. the next query get restricted role by `public`, which causes permission denied.

this issue should be finally resolved by the `SECONDARY ROLE` seperation described in https://github.com/datafuselabs/databend/issues/13544

this PR revert the behaviour back before #13062 as a hotfix.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13665)
<!-- Reviewable:end -->
