### PR TITLE
ci:  install `graphviz` for fuzzingbook (apt only)

### DIFF
--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -599,6 +599,9 @@ if [[ "$INSTALL_DEV_TOOLS" == "true" ]]; then
 		# for killall & timeout
 		install_pkg psmisc "$PACKAGE_MANAGER"
 		install_pkg coreutils "$PACKAGE_MANAGER"
+		# for graphviz, that fuzzingbook depends on
+		install_pkg graphviz "$PACKAGE_MANAGER"
+		install_pkg graphviz-dev "$PACKAGE_MANAGER"
 	fi
 	python3 -m pip install --quiet boto3 "moto[all]" black shfmt-py toml yamllint
 	# drivers


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

install graphviz for fuzzingbook:

seems that the latest `pygraphviz` needs to install graph-dev manually.

----



log of `linux / test_stateful_standalone`:

https://github.com/datafuselabs/databend/actions/runs/6846339185/job/18613028931?pr=13691

---

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13691)
<!-- Reviewable:end -->
