### PR TITLE
chore(http): not closing the http admin api port on getting sigterm

### DIFF
--- a/src/query/service/src/api/http_service.rs
+++ b/src/query/service/src/api/http_service.rs
@@ -156,7 +156,7 @@ impl HttpService {
 #[async_trait::async_trait]
 impl Server for HttpService {
     #[async_backtrace::framed]
-    async fn shutdown(&mut self, graceful: bool) {
+    async fn shutdown(&mut self, _graceful: bool) {
         // intendfully do nothing: sometimes we hope to diagnose the backtraces or metrics after
         // the process got the sigterm signal, we can still leave the admin service port open until
         // the process exited. it's not an user facing service, it's allowed to shutdown forcely.

--- a/src/query/service/src/api/http_service.rs
+++ b/src/query/service/src/api/http_service.rs
@@ -159,7 +159,7 @@ impl Server for HttpService {
     async fn shutdown(&mut self, graceful: bool) {
         // intendfully do nothing: sometimes we hope to diagnose the backtraces or metrics after
         // the process got the sigterm signal, we can still leave the admin service port open until
-        // the process exited. it's not an user facing service, no graceful shutdown is ok.
+        // the process exited. it's not an user facing service, it's allowed to shutdown forcely.
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/api/http_service.rs
+++ b/src/query/service/src/api/http_service.rs
@@ -157,7 +157,9 @@ impl HttpService {
 impl Server for HttpService {
     #[async_backtrace::framed]
     async fn shutdown(&mut self, graceful: bool) {
-        self.shutdown_handler.shutdown(graceful).await;
+        // intendfully do nothing: sometimes we hope to diagnose the backtraces or metrics after
+        // the process got the sigterm signal, we can still leave the admin service port open until
+        // the process exited. it's not an user facing service, no graceful shutdown is ok.
     }
 
     #[async_backtrace::framed]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Sometimes we may run into troubles on diagnosing graceful shutdown issues to check the backtraces after the process got sigterm. But unfortunately there's no way to dump the stack: all the ports will refuse the new connections after received sigterm.

this PR leaves the admin api port open even after got sigterm to allow us dump stacks until the final exit of the process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13724)
<!-- Reviewable:end -->
