### PR TITLE
fix: fix push down constant filter to join

### DIFF
--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -147,27 +147,11 @@ pub fn try_push_down_filter_join(
         }
         let pred = JoinPredicate::new(&predicate, &left_prop, &right_prop);
         match pred {
-            JoinPredicate::ALL(_) => match join.join_type {
-                JoinType::Cross
-                | JoinType::Inner
-                | JoinType::LeftSemi
-                | JoinType::LeftAnti
-                | JoinType::RightSemi
-                | JoinType::RightAnti => {
-                    need_push = true;
-                    left_push_down.push(predicate.clone());
-                    right_push_down.push(predicate.clone());
-                }
-                JoinType::Left | JoinType::LeftSingle | JoinType::RightMark => {
-                    need_push = true;
-                    right_push_down.push(predicate.clone());
-                }
-                JoinType::Right | JoinType::RightSingle | JoinType::LeftMark => {
-                    need_push = true;
-                    left_push_down.push(predicate.clone());
-                }
-                JoinType::Full => original_predicates.push(predicate),
-            },
+            JoinPredicate::ALL(_) => {
+                need_push = true;
+                left_push_down.push(predicate.clone());
+                right_push_down.push(predicate.clone());
+            }
             JoinPredicate::Left(_) => {
                 if matches!(join.join_type, JoinType::Right) {
                     original_predicates.push(predicate);

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1537,3 +1537,57 @@ drop table products;
 
 statement ok
 drop table sales;
+
+statement ok
+create table t1 (a int);
+
+statement ok
+create table t2 (b int);
+
+query T
+explain select date from (select *, 'year' as date from t1 left join t2 on t1.a = t2.b) where date = '';
+----
+EvalScalar
+├── output columns: [date (#2)]
+├── expressions: ['year']
+├── estimated rows: 0.00
+└── HashJoin
+    ├── output columns: []
+    ├── join type: LEFT OUTER
+    ├── build keys: [t2.b (#1)]
+    ├── probe keys: [t1.a (#0)]
+    ├── filters: []
+    ├── estimated rows: 0.00
+    ├── Filter(Build)
+    │   ├── output columns: [t2.b (#1)]
+    │   ├── filters: [false]
+    │   ├── estimated rows: 0.00
+    │   └── TableScan
+    │       ├── table: default.default.t2
+    │       ├── output columns: [b (#1)]
+    │       ├── read rows: 0
+    │       ├── read bytes: 0
+    │       ├── partitions total: 0
+    │       ├── partitions scanned: 0
+    │       ├── push downs: [filters: [false], limit: NONE]
+    │       └── estimated rows: 0.00
+    └── Filter(Probe)
+        ├── output columns: [t1.a (#0)]
+        ├── filters: [false]
+        ├── estimated rows: 0.00
+        └── TableScan
+            ├── table: default.default.t1
+            ├── output columns: [a (#0)]
+            ├── read rows: 0
+            ├── read bytes: 0
+            ├── partitions total: 0
+            ├── partitions scanned: 0
+            ├── push downs: [filters: [false], limit: NONE]
+            └── estimated rows: 0.00
+
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

For constant filter from `where` operator which doesn't contain a column, such as `'year' == ''`, `false`, directly push down both sides of join


**Issue from our customer**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13734)
<!-- Reviewable:end -->
