### PR TITLE
feat: add install_snapshot_v1(), avoid serializing big chunk data

### DIFF
--- a/src/binaries/meta/entry.rs
+++ b/src/binaries/meta/entry.rs
@@ -37,6 +37,8 @@ use databend_meta::api::GrpcServer;
 use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
 use databend_meta::meta_service::MetaNode;
+use databend_meta::version::raft_client_requires;
+use databend_meta::version::raft_server_provides;
 use databend_meta::version::METASRV_COMMIT_VERSION;
 use databend_meta::version::METASRV_SEMVER;
 use databend_meta::version::MIN_METACLI_SEMVER;
@@ -117,6 +119,22 @@ pub async fn entry(conf: Config) -> anyhow::Result<()> {
     println!("Version: {}", METASRV_COMMIT_VERSION.as_str());
     println!("Working DataVersion: {:?}", DATA_VERSION);
     println!();
+    println!(
+        "Raft Server Provides features: {}",
+        raft_server_provides()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    println!(
+        "Raft Client Requires features: {}",
+        raft_client_requires()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
 
     info!("Initialize on-disk data at {}", conf.raft_config.raft_dir);
 

--- a/src/meta/service/src/grpc_helper.rs
+++ b/src/meta/service/src/grpc_helper.rs
@@ -52,8 +52,7 @@ impl GrpcHelper {
     pub fn parse_req<T>(request: tonic::Request<RaftRequest>) -> Result<T, tonic::Status>
     where T: serde::de::DeserializeOwned {
         let raft_req = request.into_inner();
-        let req: T = serde_json::from_str(&raft_req.data).map_err(Self::invalid_arg)?;
-        Ok(req)
+        Self::parse(&raft_req.data)
     }
 
     /// Create an Ok response for raft API.
@@ -67,8 +66,15 @@ impl GrpcHelper {
         Ok(tonic::Response::new(reply))
     }
 
+    /// Parse string and decode it into required type.
+    pub fn parse<T>(s: &str) -> Result<T, tonic::Status>
+    where T: serde::de::DeserializeOwned {
+        let req: T = serde_json::from_str(s).map_err(Self::invalid_arg)?;
+        Ok(req)
+    }
+
     /// Create a tonic::Status with invalid argument error.
-    pub fn invalid_arg(e: impl Error) -> tonic::Status {
+    pub fn invalid_arg(e: impl ToString) -> tonic::Status {
         tonic::Status::invalid_argument(e.to_string())
     }
 

--- a/src/meta/service/src/version.rs
+++ b/src/meta/service/src/version.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeSet;
+
 use once_cell::sync::Lazy;
 use semver::BuildMetadata;
 use semver::Prerelease;
@@ -51,6 +53,77 @@ pub static MIN_METACLI_SEMVER: Version = Version {
     pre: Prerelease::EMPTY,
     build: BuildMetadata::EMPTY,
 };
+
+/// The min meta-server version that can be deployed together in a cluster,
+/// i.e., the network APIs are compatible.
+///
+/// - since 0.9.41
+///   Add vote_v0
+///   Add append_v0
+///   Add install_snapshot_v0
+///
+/// - 2023-11-16: since TODO
+///   Add install_snapshot_v1
+pub static MIN_META_SEMVER: Version = Version::new(0, 9, 41);
+
+pub const REQUIRE: u8 = 0b11;
+pub const OPTIONAL: u8 = 0b01;
+pub const NOT_REQUIRE: u8 = 0b00;
+
+pub const PROVIDE: u8 = 0b11;
+pub const NOT_PROVIDE: u8 = 0b00;
+
+/// Feature set provided by raft server.
+#[rustfmt::skip]
+pub const RAFT_SERVER_PROVIDES: &[(&str, u8, &str)] = &[
+    ("vote_v0",             PROVIDE,     "2023-02-16 0.9.41"),
+    ("append_v0",           PROVIDE,     "2023-02-16 0.9.41"),
+    ("install_snapshot_v0", PROVIDE,     "2023-02-16 0.9.41"),
+    ("install_snapshot_v1", PROVIDE,     "2023-11-16 TODO"),
+];
+
+/// The server features that raft client depends on.
+#[rustfmt::skip]
+pub const RAFT_CLIENT_REQUIRES: &[(&str, u8, &str)] = &[
+    ("vote_v0",             REQUIRE,     "2023-02-16 0.9.41"),
+    ("append_v0",           REQUIRE,     "2023-02-16 0.9.41"),
+    ("install_snapshot_v0", REQUIRE,     "2023-02-16 0.9.41"),
+    ("install_snapshot_v1", OPTIONAL,    "2023-11-16 TODO"),
+];
+
+/// Feature set provided by raft client.
+#[rustfmt::skip]
+pub const RAFT_CLIENT_PROVIDES: &[(&str, u8, &str)] = &[
+];
+
+/// The client features that raft server depends on.
+#[rustfmt::skip]
+pub const RAFT_SERVER_DEPENDS: &[(&str, u8, &str)] = &[
+];
+
+pub fn raft_server_provides() -> BTreeSet<String> {
+    let mut set = BTreeSet::new();
+
+    for (name, state, _) in RAFT_SERVER_PROVIDES {
+        if *state == PROVIDE {
+            set.insert(name.to_string());
+        }
+    }
+
+    set
+}
+
+pub fn raft_client_requires() -> BTreeSet<String> {
+    let mut set = BTreeSet::new();
+
+    for (name, state, _) in RAFT_CLIENT_REQUIRES {
+        if *state == REQUIRE {
+            set.insert(name.to_string());
+        }
+    }
+
+    set
+}
 
 pub fn to_digit_ver(v: &Version) -> u64 {
     v.major * 1_000_000 + v.minor * 1_000 + v.patch

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -176,6 +176,23 @@ message StreamItem {
   optional SeqV value = 2;
 }
 
+message SnapshotChunkRequest {
+  uint64 ver = 100;
+
+  // json serialized meta data, including vote and snapshot_meta.
+  // ```text
+  // { vote: Vote, meta: SnapshotMeta }
+  // ```
+  string rpc_meta = 10;
+
+  SnapshotChunkV1 chunk = 20;
+}
+
+message SnapshotChunkV1 {
+  uint64 offset = 10;
+  bool done = 11;
+  bytes data = 12;
+}
 
 service RaftService {
 
@@ -190,6 +207,7 @@ service RaftService {
 
   rpc AppendEntries(RaftRequest) returns (RaftReply);
   rpc InstallSnapshot(RaftRequest) returns (RaftReply);
+  rpc InstallSnapshotV1(SnapshotChunkRequest) returns (RaftReply);
   rpc Vote(RaftRequest) returns (RaftReply);
 }
 

--- a/src/meta/types/src/proto_ext/mod.rs
+++ b/src/meta/types/src/proto_ext/mod.rs
@@ -15,5 +15,6 @@
 //! Extend protobuf generated code with some useful methods.
 
 mod seq_v_ext;
+mod snapshot_chunk_request_ext;
 mod stream_item_ext;
 mod txn_ext;

--- a/src/meta/types/src/proto_ext/snapshot_chunk_request_ext.rs
+++ b/src/meta/types/src/proto_ext/snapshot_chunk_request_ext.rs
@@ -1,0 +1,41 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::protobuf::SnapshotChunkRequest;
+use crate::protobuf::SnapshotChunkV1;
+use crate::InstallSnapshotRequest;
+
+impl SnapshotChunkRequest {
+    /// Return the length of the data in the chunk.
+    pub fn data_len(&self) -> u64 {
+        self.chunk.as_ref().map_or(0, |x| x.data.len()) as u64
+    }
+
+    pub fn new_v1(r: InstallSnapshotRequest) -> Self {
+        let meta = (r.vote, r.meta);
+        let rpc_meta = serde_json::to_string(&meta).unwrap();
+
+        let chunk_v1 = SnapshotChunkV1 {
+            offset: r.offset,
+            done: r.done,
+            data: r.data,
+        };
+
+        SnapshotChunkRequest {
+            ver: 1,
+            rpc_meta,
+            chunk: Some(chunk_v1),
+        }
+    }
+}

--- a/tests/compat/README.md
+++ b/tests/compat/README.md
@@ -1,0 +1,7 @@
+# Test compatibility between databend-query and databend-meta
+
+## What it does
+- Find out the min compatible version of databend-query for the latest databend-meta, and test compatibility between them.
+- Find out the min compatible version of databend-meta for the latest databend-query, and test compatibility between them.
+
+To ensure the compatibility, we run several sql-logic tests on the old query plus latest meta and old meta plus latest query.


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### feat: add install_snapshot_v1(), avoid serializing big chunk data

This commit introduce a new feature thus it is a compatbile change.

- Databend-meta provides a new gRPC API `install_snapshot_v1()` to
  receive snapshot chunk. The old API `install_snapshot()` does not
  change.

  On the client side, i.e., the leader, will try to send snapshot via v1
  API. If an `Unimplement` error is received, it falls back to the
  original `install_snapshot()` API.

  Thus the compatibility is provided and rolling update is doable.

- Output raft API feature set upon startup. Such a feature set defines
  the compatibility between meta-servers.

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13743)
<!-- Reviewable:end -->
