### PR TITLE
chore: fix flaky test on background service

### DIFF
--- a/tests/suites/6_background/00_target_tables/00_0000_target_tables.sh
+++ b/tests/suites/6_background/00_target_tables/00_0000_target_tables.sh
@@ -24,7 +24,7 @@ echo "select st.name bt,type, bt.trigger from system.background_tasks AS bt JOIN
 echo "create table target2(i int);" | $BENDSQL_CLIENT_CONNECT
 echo "call  system\$execute_background_job('test_tenant-compactor-job');"
 echo "call  system\$execute_background_job('test_tenant-compactor-job');" | $BENDSQL_CLIENT_CONNECT
-sleep 1
+sleep 5
 echo "select st.name bt,type, bt.trigger from system.background_tasks AS bt JOIN system.tables st ON bt.table_id = st.table_id where bt.trigger is not null and bt.created_on > TO_TIMESTAMP('$current_time') order by st.name;" | $BENDSQL_CLIENT_CONNECT
 echo "select * from system.processes where type != 'HTTPQuery';" | $BENDSQL_CLIENT_CONNECT
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
The test purpose is to make sure that once background compaction task is finished, query engine session would be reclaimed.

Enlarge the wait time for session termination should be a fair approach to mitigate  flaky test 

- Closes https://github.com/datafuselabs/databend/issues/13731

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13745)
<!-- Reviewable:end -->
