### PR TITLE
feat: meta: enable fixing data inconsistency by cleanup follower data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.8.4"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.9#872ef379319242007dc359eb0316d2e1fb511fa5"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.10#7d469c3da769de5e8886cb1af95008c930b98147"
 
 [[package]]
 name = "maplit"
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.8.4"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.9#872ef379319242007dc359eb0316d2e1fb511fa5"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.10#7d469c3da769de5e8886cb1af95008c930b98147"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,9 +121,11 @@ jsonb = { git = "https://github.com/datafuselabs/jsonb", rev = "1d7a3e9" }
 
 # openraft = { version = "0.8.2", features = ["compat-07"] }
 # For debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.9", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.10", features = [
     "compat-07",
     "tracing-log",
+    # allows to remove all data from a follower and restore from the leader.
+    "loosen-follower-log-revert",
 ] }
 
 # type helper

--- a/src/binaries/meta/entry.rs
+++ b/src/binaries/meta/entry.rs
@@ -119,22 +119,11 @@ pub async fn entry(conf: Config) -> anyhow::Result<()> {
     println!("Version: {}", METASRV_COMMIT_VERSION.as_str());
     println!("Working DataVersion: {:?}", DATA_VERSION);
     println!();
-    println!(
-        "Raft Server Provides features: {}",
-        raft_server_provides()
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
-    println!(
-        "Raft Client Requires features: {}",
-        raft_client_requires()
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
+
+    println!("Raft Feature set:");
+    println!("    Server Provide: {{ {} }}", raft_server_provides());
+    println!("    Client Require: {{ {} }}", raft_client_requires());
+    println!();
 
     info!("Initialize on-disk data at {}", conf.raft_config.raft_dir);
 
@@ -206,7 +195,7 @@ pub async fn entry(conf: Config) -> anyhow::Result<()> {
 
     register_node(&meta_node, &conf).await?;
 
-    println!("Databend Metasrv starting...");
+    println!("Databend Metasrv started");
 
     stop_handler.wait_to_terminate(stop_tx).await;
     info!("Databend-meta is done shutting down");

--- a/src/meta/service/src/version.rs
+++ b/src/meta/service/src/version.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use std::collections::BTreeSet;
+use std::fmt;
+use std::fmt::Formatter;
 
 use once_cell::sync::Lazy;
 use semver::BuildMetadata;
@@ -101,7 +103,29 @@ pub const RAFT_CLIENT_PROVIDES: &[(&str, u8, &str)] = &[
 pub const RAFT_SERVER_DEPENDS: &[(&str, u8, &str)] = &[
 ];
 
-pub fn raft_server_provides() -> BTreeSet<String> {
+pub struct FeatureSet {
+    features: BTreeSet<String>,
+}
+
+impl FeatureSet {
+    pub fn new(fs: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            features: fs.into_iter().collect(),
+        }
+    }
+}
+
+impl fmt::Display for FeatureSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.features.iter().cloned().collect::<Vec<_>>().join(", ")
+        )
+    }
+}
+
+pub fn raft_server_provides() -> FeatureSet {
     let mut set = BTreeSet::new();
 
     for (name, state, _) in RAFT_SERVER_PROVIDES {
@@ -110,10 +134,10 @@ pub fn raft_server_provides() -> BTreeSet<String> {
         }
     }
 
-    set
+    FeatureSet::new(set)
 }
 
-pub fn raft_client_requires() -> BTreeSet<String> {
+pub fn raft_client_requires() -> FeatureSet {
     let mut set = BTreeSet::new();
 
     for (name, state, _) in RAFT_CLIENT_REQUIRES {
@@ -122,7 +146,7 @@ pub fn raft_client_requires() -> BTreeSet<String> {
         }
     }
 
-    set
+    FeatureSet::new(set)
 }
 
 pub fn to_digit_ver(v: &Version) -> u64 {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### Fix: meta: enable fixing data inconsistency by cleanup follower data

Enables "loosen-follower-log-revert" feature in openraft. It allows a
follower to safely restore to a consistent state with the leader by
cleaning up data and restarting, if inconsistencies arise.

Upgrade openraft to fix a panic occured during data reversion on
followers.

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13758)
<!-- Reviewable:end -->
