### PR TITLE
feat: ndjson add new option missing_field_as and null_field_as.

### DIFF
--- a/src/common/storage/src/copy.rs
+++ b/src/common/storage/src/copy.rs
@@ -118,6 +118,12 @@ pub enum FileParseError {
         decode_error: String,
         column_data: String,
     },
+    #[error("Missing value for column {column_index} ({column_name} {column_type})")]
+    ColumnMissingError {
+        column_index: usize,
+        column_name: String,
+        column_type: String,
+    },
     #[error(
         "Invalid value '{column_data}' for column {column_index} ({column_name} {column_type}): {size_remained} bytes remained, next_char at {error_pos} is {next_char}"
     )]

--- a/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
@@ -319,7 +319,15 @@ impl FromToProto for mt::principal::NdJsonFileFormatParams {
                 reason: format!("invalid StageFileCompression: {}", p.compression),
             })?,
         )?;
-        Ok(mt::principal::NdJsonFileFormatParams { compression })
+
+        mt::principal::NdJsonFileFormatParams::try_create(
+            compression,
+            p.missing_field_as.as_deref(),
+            p.null_field_as.as_deref(),
+        )
+        .map_err(|e| Incompatible {
+            reason: format!("{e}"),
+        })
     }
 
     fn to_pb(&self) -> Result<pb::NdJsonFileFormatParams, Incompatible> {
@@ -328,6 +336,8 @@ impl FromToProto for mt::principal::NdJsonFileFormatParams {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
             compression,
+            missing_field_as: Some(self.missing_field_as.to_string()),
+            null_field_as: Some(self.null_field_as.to_string()),
         })
     }
 }

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -93,6 +93,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (61, "2023-10-19: Add: config.proto/OssStorageConfig add SSE options", ),
     (62, "2023-10-30: Add: lock.proto"),
     (63, "2023-10-30: Add: connection.proto"),
+    (64, "2023-11-16: Add: user.proto/NDJsonFileFormatParams add field `missing_field_as` and `null_field_as`", ),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -68,3 +68,4 @@ mod v060_copy_options;
 mod v061_oss_sse_options;
 mod v062_table_lock_meta;
 mod v063_connection;
+mod v064_ndjson_format_params;

--- a/src/meta/proto-conv/tests/it/v032_file_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v032_file_format_params.rs
@@ -14,6 +14,7 @@
 
 use common_meta_app as mt;
 use common_meta_app::principal::CsvFileFormatParams;
+use common_meta_app::principal::JsonNullAs;
 use common_meta_app::principal::StageFileCompression;
 use common_meta_app::principal::TsvFileFormatParams;
 use minitrace::func_name;
@@ -87,6 +88,8 @@ fn test_decode_v32_ndjson_file_format_params() -> anyhow::Result<()> {
     let want = || {
         mt::principal::FileFormatParams::NdJson(NdJsonFileFormatParams {
             compression: StageFileCompression::Gzip,
+            missing_field_as: JsonNullAs::Error,
+            null_field_as: JsonNullAs::FieldDefault,
         })
     };
     common::test_pb_from_to(func_name!(), want())?;

--- a/src/meta/proto-conv/tests/it/v064_ndjson_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v064_ndjson_format_params.rs
@@ -1,0 +1,49 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_meta_app as mt;
+use common_meta_app::principal::JsonNullAs;
+use common_meta_app::principal::NdJsonFileFormatParams;
+use common_meta_app::principal::StageFileCompression;
+use minitrace::func_name;
+
+use crate::common;
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+#[test]
+fn test_decode_v64_ndjson_file_format_params() -> anyhow::Result<()> {
+    let file_format_params_v64 = vec![
+        42, 29, 8, 1, 18, 13, 102, 105, 101, 108, 100, 95, 100, 101, 102, 97, 117, 108, 116, 26, 4,
+        110, 117, 108, 108, 160, 6, 64, 168, 6, 24,
+    ];
+
+    let want = || {
+        mt::principal::FileFormatParams::NdJson(NdJsonFileFormatParams {
+            compression: StageFileCompression::Gzip,
+            missing_field_as: JsonNullAs::FieldDefault,
+            null_field_as: JsonNullAs::Null,
+        })
+    };
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), file_format_params_v64.as_slice(), 0, want())?;
+    Ok(())
+}

--- a/src/meta/protos/proto/file_format.proto
+++ b/src/meta/protos/proto/file_format.proto
@@ -133,11 +133,12 @@ message NdJsonFileFormatParams {
   uint64 ver = 100;
   uint64 min_reader_ver = 101;
   StageFileCompression compression = 1;
+  optional string missing_field_as = 2;
+  optional string null_field_as = 3;
 }
 
 message JsonFileFormatParams {
   uint64 ver = 100;
   uint64 min_reader_ver = 101;
   StageFileCompression compression = 1;
-
 }

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -94,6 +94,8 @@ pub fn format_options(i: Input) -> IResult<BTreeMap<String, String>> {
                 | NAN_DISPLAY
                 | NULL_DISPLAY
                 | ESCAPE
+                | NULL_FIELD_AS
+                | MISSING_FIELD_AS
                 | ROW_TAG) ~ ^"=" ~ ^#literal_string
         },
         |(k, _, v)| (k.text().to_string(), v),

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -781,6 +781,10 @@ pub enum TokenKind {
     MERGE,
     #[token("MATCHED", ignore(ascii_case))]
     MATCHED,
+    #[token("MISSING_FIELD_AS", ignore(ascii_case))]
+    MISSING_FIELD_AS,
+    #[token("NULL_FIELD_AS", ignore(ascii_case))]
+    NULL_FIELD_AS,
     #[token("UNMATCHED", ignore(ascii_case))]
     UNMATCHED,
     #[token("ROW", ignore(ascii_case))]

--- a/src/query/pipeline/sources/src/input_formats/impls/input_format_ndjson.rs
+++ b/src/query/pipeline/sources/src/input_formats/impls/input_format_ndjson.rs
@@ -23,6 +23,7 @@ use common_formats::FieldDecoder;
 use common_formats::FieldJsonAstDecoder;
 use common_formats::FileFormatOptionsExt;
 use common_meta_app::principal::FileFormatParams;
+use common_meta_app::principal::JsonNullAs;
 use common_meta_app::principal::StageFileFormatType;
 use common_storage::FileParseError;
 
@@ -46,6 +47,8 @@ impl InputFormatNDJson {
         columns: &mut [ColumnBuilder],
         schema: &TableSchemaRef,
         default_values: &Option<Vec<Scalar>>,
+        null_field_as: &JsonNullAs,
+        missing_field_as: &JsonNullAs,
     ) -> std::result::Result<(), FileParseError> {
         let mut json: serde_json::Value =
             serde_json::from_reader(buf).map_err(|e| FileParseError::InvalidNDJsonRow {
@@ -75,26 +78,75 @@ impl InputFormatNDJson {
                 } else {
                     field.name().to_lowercase()
                 };
-                let value = &json[field_name];
-                if value == &serde_json::Value::Null {
-                    match default_values {
-                        None => {
+                let value = json.get(field_name);
+                match value {
+                    None => match missing_field_as {
+                        JsonNullAs::Error => {
+                            return Err(FileParseError::ColumnMissingError {
+                                column_index,
+                                column_name: field.name().to_owned(),
+                                column_type: field.data_type.to_string(),
+                            });
+                        }
+                        JsonNullAs::Null => {
+                            if field.is_nullable_or_null() {
+                                column.push_default();
+                            } else {
+                                return Err(FileParseError::ColumnMissingError {
+                                    column_index,
+                                    column_name: field.name().to_owned(),
+                                    column_type: field.data_type.to_string(),
+                                });
+                            }
+                        }
+                        JsonNullAs::FieldDefault => {
+                            if let Some(values) = default_values {
+                                column.push(values[column_index].as_ref());
+                            } else {
+                                column.push_default();
+                            }
+                        }
+                        JsonNullAs::TypeDefault => {
                             column.push_default();
                         }
-                        Some(values) => {
-                            column.push(values[column_index].as_ref());
+                    },
+                    Some(serde_json::Value::Null) => match null_field_as {
+                        JsonNullAs::Error => unreachable!("null_field_as should be error"),
+                        JsonNullAs::Null => {
+                            if field.is_nullable_or_null() {
+                                column.push_default();
+                            } else {
+                                return Err(FileParseError::ColumnDecodeError {
+                                        column_index,
+                                        column_name: field.name().to_owned(),
+                                        column_type: field.data_type.to_string(),
+                                        decode_error: "null value is not allowed for non-nullable field, when NULL_FIELDS_AS=NULL".to_owned(),
+                                        column_data: "null".to_owned(),
+                                    });
+                            }
                         }
+                        JsonNullAs::FieldDefault => {
+                            if let Some(values) = default_values {
+                                column.push(values[column_index].as_ref());
+                            } else {
+                                column.push_default();
+                            }
+                        }
+                        JsonNullAs::TypeDefault => {
+                            column.push_default();
+                        }
+                    },
+                    Some(value) => {
+                        field_decoder.read_field(column, value).map_err(|e| {
+                            FileParseError::ColumnDecodeError {
+                                column_index,
+                                column_name: field.name().to_owned(),
+                                column_type: field.data_type.to_string(),
+                                decode_error: e.to_string(),
+                                column_data: truncate_column_data(value.to_string()),
+                            }
+                        })?;
                     }
-                } else {
-                    field_decoder.read_field(column, value).map_err(|e| {
-                        FileParseError::ColumnDecodeError {
-                            column_index,
-                            column_name: field.name().to_owned(),
-                            column_type: field.data_type.to_string(),
-                            decode_error: e.to_string(),
-                            column_data: truncate_column_data(value.to_string()),
-                        }
-                    })?;
                 }
             }
         }
@@ -136,6 +188,11 @@ impl InputFormatTextBase for InputFormatNDJson {
 
         let columns = &mut builder.mutable_columns;
         let mut start = 0usize;
+        let format_params = match builder.ctx.file_format_params {
+            FileFormatParams::NdJson(ref p) => p,
+            _ => unreachable!(),
+        };
+
         for (i, end) in batch.row_ends.iter().enumerate() {
             let buf = &batch.data[start..*end];
             let buf = buf.trim();
@@ -146,6 +203,8 @@ impl InputFormatTextBase for InputFormatNDJson {
                     columns,
                     &builder.ctx.schema,
                     &builder.ctx.default_values,
+                    &format_params.null_field_as,
+                    &format_params.missing_field_as,
                 ) {
                     builder.ctx.on_error(
                         e,

--- a/src/query/service/tests/it/servers/http/clickhouse_handler.rs
+++ b/src/query/service/tests/it/servers/http/clickhouse_handler.rs
@@ -240,28 +240,6 @@ async fn test_insert_format_ndjson() -> PoemResult<()> {
         assert_ok!(status, body);
         assert_eq!(&body, "0\ta\n1\tb\n");
     }
-
-    {
-        let jsons = [r#"{"a": 2}"#];
-        let body = jsons.join("\n");
-        let (status, body) = server
-            .post("insert into table t1 format JSONEachRow", &body)
-            .await;
-        assert_ok!(status, body);
-    }
-    {
-        let (status, body) = server.get(r#"select * from t1 order by a"#).await;
-        assert_ok!(status, body);
-        assert_eq!(&body, "0\ta\n1\tb\n2\t\\N\n");
-    }
-    {
-        let jsons = [r#"{"b": 0}"#];
-        let body = jsons.join("\n");
-        let (status, _) = server
-            .post("insert into table t1 format JSONEachRow", &body)
-            .await;
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-    }
     Ok(())
 }
 

--- a/tests/data/ndjson/null.ndjson
+++ b/tests/data/ndjson/null.ndjson
@@ -1,0 +1,5 @@
+{"id":"normal","a":1,"b":1}
+{"id":"null_a","a":null,"b":1}
+{"id":"null_b","a":1,"b":null}
+{"id":"missing_a", "b":1}
+{"id":"missing_b","a":1}

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_default.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_default.test
@@ -2,17 +2,142 @@ statement ok
 drop table if exists t
 
 statement ok
-create table t(b int, b1 int, b2 int default 1)
-
-query TIITI
-copy into t from @data/ndjson/json_sample.ndjson file_format = (type = NDJSON)
-----
-ndjson/json_sample.ndjson 4 0 NULL NULL
+create table t(id string, a int default 2, b int not null default 2)
 
 query 
-select * from t order by b;
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON) on_error = continue
 ----
-1 NULL 1
-2 NULL 1
-3 NULL 1
-4 NULL 1
+ndjson/null.ndjson 3 2 Missing value for column 1 (a Int32 NULL) 4
+
+query 
+select * from t order by id;
+----
+normal 1 1
+null_a 2 1
+null_b 1 2
+
+statement ok
+truncate table t
+
+query error 2004.*NULL_FIELD_AS cannot be `error`
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, null_field_as = 'ERROR') on_error = continue
+
+query 
+select * from t order by id;
+----
+
+statement ok
+truncate table t
+
+query 
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, null_field_as = 'NULL', missing_field_as = 'FIELD_DEFAULT') on_error = continue
+----
+ndjson/null.ndjson 4 1 Invalid value 'null' for column 2 (b Int32): null value is not allowed for non-nullable field, when NULL_FIELDS_AS=NULL 3
+
+query 
+select * from t order by id;
+----
+missing_a 2 1
+missing_b 1 2
+normal 1 1
+null_a NULL 1
+
+statement ok
+truncate table t
+
+query 
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, null_field_as = 'FIELD_DEFAULT', missing_field_as = 'FIELD_DEFAULT') on_error = continue force=true
+----
+ndjson/null.ndjson 5 0 NULL NULL
+
+query 
+select * from t order by id;
+----
+missing_a 2 1
+missing_b 1 2
+normal 1 1
+null_a 2 1
+null_b 1 2
+
+statement ok
+truncate table t
+
+query 
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, null_field_as = 'TYPE_DEFAULT', missing_field_as = 'FIELD_DEFAULT') on_error = continue force=true
+----
+ndjson/null.ndjson 5 0 NULL NULL
+
+
+query 
+select * from t order by id;
+----
+missing_a 2 1
+missing_b 1 2
+normal 1 1
+null_a NULL 1
+null_b 1 0
+
+statement ok
+truncate table t
+
+query
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, missing_field_as = 'ERROR') on_error = continue force=true
+----
+ndjson/null.ndjson 3 2 Missing value for column 1 (a Int32 NULL) 4
+
+query 
+select * from t order by id;
+----
+normal 1 1
+null_a 2 1
+null_b 1 2
+
+statement ok
+truncate table t
+
+query 
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, missing_field_as = 'NULL') on_error = continue force=true
+----
+ndjson/null.ndjson 4 1 Missing value for column 2 (b Int32) 5
+
+query 
+select * from t order by id;
+----
+missing_a NULL 1
+normal 1 1
+null_a 2 1
+null_b 1 2
+
+statement ok
+truncate table t
+
+query 
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, missing_field_as = 'FIELD_DEFAULT') on_error = continue force=true
+----
+ndjson/null.ndjson 5 0 NULL NULL
+
+query 
+select * from t order by id;
+----
+missing_a 2 1
+missing_b 1 2
+normal 1 1
+null_a 2 1
+null_b 1 2
+
+statement ok
+truncate table t
+
+query
+copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, missing_field_as = 'TYPE_DEFAULT') on_error = continue force=true
+----
+ndjson/null.ndjson 5 0 NULL NULL
+
+query 
+select * from t order by id;
+----
+missing_a NULL 1
+missing_b 1 0
+normal 1 1
+null_a 2 1
+null_b 1 2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

idea:

- "absent/missing" in JSON is diff from "empty" from CSV
- in JSON, "absent/missing" != null

keys:

-  missing_field_as  = error | NULL | field_default | type_default,  error by default,  in case of wrong field names when creating table
-  null_field_as  =  field_default | NULL | type_default,  field_default by default
-  NULL means it is valid only for nullable column
- storge in meta as `optional string`


note these options do not affect the decode of variant/json.
they do not look inside  map/tuple too, for now.

Closes https://github.com/datafuselabs/databend/issues/13738   & on demand of user cc @wubx 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13760)
<!-- Reviewable:end -->
