### PR TITLE
fix: create stream and alter view

### DIFF
--- a/src/query/service/src/interpreters/interpreter_view_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_view_alter.rs
@@ -104,7 +104,7 @@ impl Interpreter for AlterViewInterpreter {
             Ok(PipelineBuildResult::create())
         } else {
             return Err(ErrorCode::UnknownView(format!(
-                "{}.{} as view Already Exists",
+                "Unknown view '{}'.'{}'",
                 self.plan.database, self.plan.view_name
             )));
         }

--- a/src/query/service/src/interpreters/interpreter_view_create.rs
+++ b/src/query/service/src/interpreters/interpreter_view_create.rs
@@ -53,9 +53,10 @@ impl Interpreter for CreateViewInterpreter {
         let catalog = self.ctx.get_catalog(&self.plan.catalog).await?;
         let tenant = self.ctx.get_tenant();
         let table_function = catalog.list_table_functions();
-        if catalog
-            .exists_table(tenant.as_str(), &self.plan.database, &self.plan.view_name)
-            .await?
+        if !self.plan.if_not_exists
+            && catalog
+                .exists_table(tenant.as_str(), &self.plan.database, &self.plan.view_name)
+                .await?
         {
             return Err(ErrorCode::ViewAlreadyExists(format!(
                 "{}.{} as view Already Exists",

--- a/tests/sqllogictests/suites/base/05_ddl/05_0019_ddl_create_view.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0019_ddl_create_view.test
@@ -14,6 +14,14 @@ statement ok
 CREATE VIEW tmp_view2 AS SELECT * FROM numbers(100)
 
 statement ok
+CREATE VIEW IF NOT EXISTS tmp_view2 AS SELECT * FROM numbers(50)
+
+query TT
+show create table tmp_view2
+----
+tmp_view2 CREATE VIEW `default`.`tmp_view2` AS SELECT * FROM numbers(100)
+
+statement ok
 DROP VIEW IF EXISTS tmp_view
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```sql
mysql> alter view v1 as select * from t where a>1;
ERROR 1105 (HY000): UnknownView. Code: 1026, Text = Unknown view 'default'.'v1'.

mysql> create view v as select * from t;
Query OK, 0 rows affected (0.26 sec)

mysql> create view v as select * from t;
ERROR 1105 (HY000): ViewAlreadyExists. Code: 2306, Text = default.v as view Already Exists.
mysql> create view if not exists v as select * from t;
Query OK, 0 rows affected (0.23 sec)
```

- Closes #13761

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13762)
<!-- Reviewable:end -->
