### PR TITLE
feat: limit max copied files to 15000.

### DIFF
--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -57,6 +57,7 @@ use crate::storage::StorageParams;
 // SIZE_LIMIT = <num>
 
 pub const COPIED_FILES_MAX_COMMIT_NUM: usize = 15000;
+pub const COPY_WITH_MAX_FILE_MSG: &str = "copy into table can commit at most 15000 paths once. Please use CopyOption 'max_files=<num>' to limit the number of files and run multi times until result is empty or use 'force=true, purge=true' to avoid committing paths if acceptable.";
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum StageType {

--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -56,8 +56,12 @@ use crate::storage::StorageParams;
 // ON_ERROR = { CONTINUE | SKIP_FILE | SKIP_FILE_<num> | SKIP_FILE_<num>% | ABORT_STATEMENT }
 // SIZE_LIMIT = <num>
 
-pub const COPIED_FILES_MAX_COMMIT_NUM: usize = 15000;
-pub const COPY_WITH_MAX_FILE_MSG: &str = "copy into table can commit at most 15000 paths once. Please use CopyOption 'max_files=<num>' to limit the number of files and run multi times until result is empty or use 'force=true, purge=true' to avoid committing paths if acceptable.";
+/// Maximum files per 'copy into table' commit.
+pub const COPY_MAX_FILES_PER_COMMIT: usize = 15000;
+
+/// Instruction for exceeding 'copy into table' file limit.
+pub const COPY_MAX_FILES_COMMIT_MSG: &str = 
+    "Limit for 'copy into table': 15,000 files per commit. To handle more files, adjust 'CopyOption' with 'max_files=<num>' and perform several operations until all files are processed.";
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum StageType {

--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -60,8 +60,7 @@ use crate::storage::StorageParams;
 pub const COPY_MAX_FILES_PER_COMMIT: usize = 15000;
 
 /// Instruction for exceeding 'copy into table' file limit.
-pub const COPY_MAX_FILES_COMMIT_MSG: &str = 
-    "Limit for 'copy into table': 15,000 files per commit. To handle more files, adjust 'CopyOption' with 'max_files=<num>' and perform several operations until all files are processed.";
+pub const COPY_MAX_FILES_COMMIT_MSG: &str = "Limit for 'copy into table': 15,000 files per commit. To handle more files, adjust 'CopyOption' with 'max_files=<num>' and perform several operations until all files are processed.";
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum StageType {

--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -56,6 +56,8 @@ use crate::storage::StorageParams;
 // ON_ERROR = { CONTINUE | SKIP_FILE | SKIP_FILE_<num> | SKIP_FILE_<num>% | ABORT_STATEMENT }
 // SIZE_LIMIT = <num>
 
+pub const COPIED_FILES_MAX_COMMIT_NUM: usize = 15000;
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum StageType {
     /// LegacyInternal will be deprecated.

--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -25,7 +25,7 @@ use common_base::base::mask_string;
 use common_exception::ErrorCode;
 use common_meta_app::principal::CopyOptions;
 use common_meta_app::principal::OnErrorMode;
-use common_meta_app::principal::COPIED_FILES_MAX_COMMIT_NUM;
+use common_meta_app::principal::COPY_MAX_FILES_PER_COMMIT;
 use itertools::Itertools;
 use url::Url;
 
@@ -143,11 +143,10 @@ impl CopyIntoTableStmt {
             copy_options.max_files = self.max_files;
         }
 
-        if !(copy_options.purge && self.force)
-            && copy_options.max_files > COPIED_FILES_MAX_COMMIT_NUM
+        if !(copy_options.purge && self.force) && copy_options.max_files > COPY_MAX_FILES_PER_COMMIT
         {
             return Err(ErrorCode::InvalidArgument(format!(
-                "max_files {} is too large, max_files should be less than {COPIED_FILES_MAX_COMMIT_NUM}",
+                "max_files {} is too large, max_files should be less than {COPY_MAX_FILES_PER_COMMIT}",
                 copy_options.max_files
             )));
         }

--- a/src/query/ast/src/parser/copy.rs
+++ b/src/query/ast/src/parser/copy.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::min;
-
 use nom::branch::alt;
 use nom::combinator::map;
 
@@ -42,8 +40,6 @@ use crate::util::dot_separated_idents_1_to_3;
 use crate::util::ident;
 use crate::util::IResult;
 use crate::Input;
-
-const MAX_COPIED_FILES_NUM: usize = 2000;
 
 fn table_triple(i: Input) -> IResult<TableIdentifier> {
     map(dot_separated_idents_1_to_3, TableIdentifier::from_tuple)(i)
@@ -165,9 +161,7 @@ fn copy_into_table_option(i: Input) -> IResult<CopyIntoTableOption> {
         ),
         map(
             rule! { MAX_FILES ~ "=" ~ #literal_u64 },
-            |(_, _, max_files)| {
-                CopyIntoTableOption::MaxFiles(min(MAX_COPIED_FILES_NUM, max_files as usize))
-            },
+            |(_, _, max_files)| CopyIntoTableOption::MaxFiles(max_files as usize),
         ),
         map(
             rule! { SPLIT_SIZE ~ "=" ~ #literal_u64 },

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -9736,7 +9736,7 @@ COPY INTO mytable
                 max_files=3000;
 ---------- Output ---------
 COPY INTO mytable FROM 's3://mybucket/data.csv' FILE_FORMAT = (field_delimiter = ',', record_delimiter = '
-', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 MAX_FILES = 2000 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
+', skip_header = '1', type = 'CSV') SIZE_LIMIT = 10 MAX_FILES = 3000 PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = 'abort'
 ---------- AST ------------
 CopyIntoTable(
     CopyIntoTableStmt {
@@ -9778,7 +9778,7 @@ CopyIntoTable(
         force: false,
         validation_mode: "",
         size_limit: 10,
-        max_files: 2000,
+        max_files: 3000,
         split_size: 0,
         purge: false,
         disable_variant_check: false,

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -58,6 +58,7 @@ use common_meta_app::principal::StageFileFormatType;
 use common_meta_app::principal::UserDefinedConnection;
 use common_meta_app::principal::UserInfo;
 use common_meta_app::principal::COPIED_FILES_MAX_COMMIT_NUM;
+use common_meta_app::principal::COPY_WITH_MAX_FILE_MSG;
 use common_meta_app::schema::CatalogInfo;
 use common_meta_app::schema::GetTableCopiedFileReq;
 use common_meta_app::schema::TableInfo;
@@ -761,9 +762,7 @@ impl TableContext for QueryContext {
                         return Ok(results);
                     }
                     if result_size > COPIED_FILES_MAX_COMMIT_NUM {
-                        return Err(ErrorCode::Internal(format!(
-                            "copy into table can commit at most {COPIED_FILES_MAX_COMMIT_NUM} paths once. Please use CopyOption max_files to limit the number of files or use 'force=true, purge=true' to avoid committing paths if acceptable."
-                        )));
+                        return Err(ErrorCode::Internal(COPY_WITH_MAX_FILE_MSG));
                     }
                 }
             }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -57,8 +57,8 @@ use common_meta_app::principal::RoleInfo;
 use common_meta_app::principal::StageFileFormatType;
 use common_meta_app::principal::UserDefinedConnection;
 use common_meta_app::principal::UserInfo;
-use common_meta_app::principal::COPIED_FILES_MAX_COMMIT_NUM;
-use common_meta_app::principal::COPY_WITH_MAX_FILE_MSG;
+use common_meta_app::principal::COPY_MAX_FILES_COMMIT_MSG;
+use common_meta_app::principal::COPY_MAX_FILES_PER_COMMIT;
 use common_meta_app::schema::CatalogInfo;
 use common_meta_app::schema::GetTableCopiedFileReq;
 use common_meta_app::schema::TableInfo;
@@ -761,8 +761,8 @@ impl TableContext for QueryContext {
                     if result_size == max_files {
                         return Ok(results);
                     }
-                    if result_size > COPIED_FILES_MAX_COMMIT_NUM {
-                        return Err(ErrorCode::Internal(COPY_WITH_MAX_FILE_MSG));
+                    if result_size > COPY_MAX_FILES_PER_COMMIT {
+                        return Err(ErrorCode::Internal(COPY_MAX_FILES_COMMIT_MSG));
                     }
                 }
             }

--- a/src/query/sql/src/planner/binder/copy_into_table.rs
+++ b/src/query/sql/src/planner/binder/copy_into_table.rs
@@ -47,7 +47,6 @@ use common_expression::Scalar;
 use common_functions::BUILTIN_FUNCTIONS;
 use common_meta_app::principal::FileFormatOptionsAst;
 use common_meta_app::principal::FileFormatParams;
-use common_meta_app::principal::OnErrorMode;
 use common_meta_app::principal::StageInfo;
 use common_storage::StageFilesInfo;
 use common_users::UserApiProvider;
@@ -369,27 +368,7 @@ impl<'a> Binder {
         if !stmt.file_format.is_empty() {
             stage.file_format_params = self.try_resolve_file_format(&stmt.file_format).await?;
         }
-
-        // Copy options.
-        {
-            // on_error.
-            stage.copy_options.on_error =
-                OnErrorMode::from_str(&stmt.on_error).map_err(ErrorCode::SyntaxException)?;
-
-            // size_limit.
-            if stmt.size_limit != 0 {
-                stage.copy_options.size_limit = stmt.size_limit;
-            }
-            if stmt.max_files != 0 {
-                stage.copy_options.max_files = stmt.max_files;
-            }
-            stage.copy_options.split_size = stmt.split_size;
-            stage.copy_options.purge = stmt.purge;
-            stage.copy_options.disable_variant_check = stmt.disable_variant_check;
-            stage.copy_options.return_failed_only = stmt.return_failed_only;
-        }
-
-        Ok(())
+        stmt.apply_to_copy_option(&mut stage.copy_options)
     }
 
     #[async_backtrace::framed]

--- a/src/query/sql/src/planner/plans/copy_into_table.rs
+++ b/src/query/sql/src/planner/plans/copy_into_table.rs
@@ -30,6 +30,7 @@ use common_expression::DataSchemaRef;
 use common_expression::DataSchemaRefExt;
 use common_expression::Scalar;
 use common_meta_app::principal::COPIED_FILES_MAX_COMMIT_NUM;
+use common_meta_app::principal::COPY_WITH_MAX_FILE_MSG;
 use common_meta_app::schema::CatalogInfo;
 use common_metrics::storage::*;
 use common_storage::init_stage_operator;
@@ -155,9 +156,7 @@ impl CopyIntoTablePlan {
             if !self.stage_table_info.stage_info.copy_options.purge
                 && all_source_file_infos.len() > COPIED_FILES_MAX_COMMIT_NUM
             {
-                return Err(ErrorCode::Internal(format!(
-                    "copy into table can commit at most {COPIED_FILES_MAX_COMMIT_NUM} paths once. Please use CopyOption max_files to limit the number of files or use 'force=true, purge=true' to avoid committing paths if acceptable."
-                )));
+                return Err(ErrorCode::Internal(COPY_WITH_MAX_FILE_MSG));
             }
             info!(
                 "force mode, ignore file filtering. ({}.{})",

--- a/src/query/sql/src/planner/plans/copy_into_table.rs
+++ b/src/query/sql/src/planner/plans/copy_into_table.rs
@@ -29,8 +29,8 @@ use common_expression::DataSchema;
 use common_expression::DataSchemaRef;
 use common_expression::DataSchemaRefExt;
 use common_expression::Scalar;
-use common_meta_app::principal::COPIED_FILES_MAX_COMMIT_NUM;
-use common_meta_app::principal::COPY_WITH_MAX_FILE_MSG;
+use common_meta_app::principal::COPY_MAX_FILES_COMMIT_MSG;
+use common_meta_app::principal::COPY_MAX_FILES_PER_COMMIT;
 use common_meta_app::schema::CatalogInfo;
 use common_metrics::storage::*;
 use common_storage::init_stage_operator;
@@ -154,9 +154,9 @@ impl CopyIntoTablePlan {
 
         let need_copy_file_infos = if self.force {
             if !self.stage_table_info.stage_info.copy_options.purge
-                && all_source_file_infos.len() > COPIED_FILES_MAX_COMMIT_NUM
+                && all_source_file_infos.len() > COPY_MAX_FILES_PER_COMMIT
             {
-                return Err(ErrorCode::Internal(COPY_WITH_MAX_FILE_MSG));
+                return Err(ErrorCode::Internal(COPY_MAX_FILES_COMMIT_MSG));
             }
             info!(
                 "force mode, ignore file filtering. ({}.{})",

--- a/tests/sqllogictests/suites/stage/options/max_files.test
+++ b/tests/sqllogictests/suites/stage/options/max_files.test
@@ -1,0 +1,11 @@
+statement ok
+drop table if exists it;
+
+statement ok
+create table it(a int, b string);
+
+# query error 2004.*max_files should be less than 15000
+# COPY INTO it FROM  @data/csv/it.csv FILE_FORMAT = (TYPE = CSV) max_files=15001;
+
+query error 2004.*max_files should be less than 15000
+COPY INTO i FROM (SELECT $1 FROM @data/csv/select.csv) FILE_FORMAT = (TYPE = CSV) max_files=15001;

--- a/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.result
+++ b/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.result
@@ -29,10 +29,10 @@ remain 0 files
 >>>> drop table if exists test_max_files_limit
 >>>> create table test_max_files_limit (a int, b int)
 >>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV)
-Error: APIError: ResponseError with 1001: copy into table can commit at most 15000 paths once. Please use CopyOption max_files to limit the number of files or use 'force=true, purge=true' to avoid committing paths if acceptable.
+Error: APIError: ResponseError with 1001: copy into table can commit at most 15000 paths once. Please use CopyOption 'max_files=<num>' to limit the number of files and run multi times until result is empty or use 'force=true, purge=true' to avoid committing paths if acceptable.
 <<<<
 >>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV) force=true
-Error: APIError: ResponseError with 1001: copy into table can commit at most 15000 paths once. Please use CopyOption max_files to limit the number of files or use 'force=true, purge=true' to avoid committing paths if acceptable.
+Error: APIError: ResponseError with 1001: copy into table can commit at most 15000 paths once. Please use CopyOption 'max_files=<num>' to limit the number of files and run multi times until result is empty or use 'force=true, purge=true' to avoid committing paths if acceptable.
 <<<<
 >>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV) force=true purge=true return_failed_only=true
 <<<<

--- a/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.result
+++ b/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.result
@@ -29,10 +29,12 @@ remain 0 files
 >>>> drop table if exists test_max_files_limit
 >>>> create table test_max_files_limit (a int, b int)
 >>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV)
-Error: APIError: ResponseError with 1001: copy into table can commit at most 15000 paths once. Please use CopyOption 'max_files=<num>' to limit the number of files and run multi times until result is empty or use 'force=true, purge=true' to avoid committing paths if acceptable.
+Error: APIError: ResponseError with 1001: Limit for 'copy into table': 15,000 files per commit. To handle more files, adjust 'CopyOption' with 'max_files=<num>' and perform several operations until all files are processed.
 <<<<
 >>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV) force=true
-Error: APIError: ResponseError with 1001: copy into table can commit at most 15000 paths once. Please use CopyOption 'max_files=<num>' to limit the number of files and run multi times until result is empty or use 'force=true, purge=true' to avoid committing paths if acceptable.
+Error: APIError: ResponseError with 1001: Limit for 'copy into table': 15,000 files per commit. To handle more files, adjust 'CopyOption' with 'max_files=<num>' and perform several operations until all files are processed.
 <<<<
 >>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV) force=true purge=true return_failed_only=true
+<<<<
+>>>> drop table test_max_files_limit
 <<<<

--- a/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.result
+++ b/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.result
@@ -26,3 +26,13 @@ remain 1 files
 remain 0 files
 6
 remain 0 files
+>>>> drop table if exists test_max_files_limit
+>>>> create table test_max_files_limit (a int, b int)
+>>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV)
+Error: APIError: ResponseError with 1001: copy into table can commit at most 15000 paths once. Please use CopyOption max_files to limit the number of files or use 'force=true, purge=true' to avoid committing paths if acceptable.
+<<<<
+>>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV) force=true
+Error: APIError: ResponseError with 1001: copy into table can commit at most 15000 paths once. Please use CopyOption max_files to limit the number of files or use 'force=true, purge=true' to avoid committing paths if acceptable.
+<<<<
+>>>> copy into test_max_files_limit from 'fs:///tmp/00_0004_2/' FILE_FORMAT = (type = CSV) force=true purge=true return_failed_only=true
+<<<<

--- a/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.sh
+++ b/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.sh
@@ -80,3 +80,5 @@ done
 stmt "copy into ${TABLE} from 'fs://${DIR}/' FILE_FORMAT = (type = CSV)"
 stmt "copy into ${TABLE} from 'fs://${DIR}/' FILE_FORMAT = (type = CSV) force=true"
 query "copy into ${TABLE} from 'fs://${DIR}/' FILE_FORMAT = (type = CSV) force=true purge=true return_failed_only=true"
+query "drop table ${TABLE}"
+

--- a/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.sh
+++ b/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.sh
@@ -63,3 +63,20 @@ do
 		echo "drop table if exists test_max_files_force_${force}_purge_${purge}" | $BENDSQL_CLIENT_CONNECT
 	done
 done
+
+
+DIR=/tmp/00_0004_2
+TABLE=test_max_files_limit
+stmt "drop table if exists ${TABLE}"
+stmt "create table ${TABLE} (a int, b int)"
+
+rm -rf ${DIR}
+mkdir ${DIR}
+for i in {1..15001}
+do
+	echo "${i},1" > ${DIR}/f${i}.csv
+done
+
+stmt "copy into ${TABLE} from 'fs://${DIR}/' FILE_FORMAT = (type = CSV)"
+stmt "copy into ${TABLE} from 'fs://${DIR}/' FILE_FORMAT = (type = CSV) force=true"
+query "copy into ${TABLE} from 'fs://${DIR}/' FILE_FORMAT = (type = CSV) force=true purge=true return_failed_only=true"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

committing too many `copied_files` once will lead to 

1.  error when package size exceeds some limit.
2.  performance problem with meta.

before a better solution is found. we can limit the number of files copied.
report error earlier is much better than got error after a long time when data are already copied, just not commited

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13770)
<!-- Reviewable:end -->
