### PR TITLE
fix(query): fix arrow_rs read variant type

### DIFF
--- a/src/query/expression/src/convert_arrow_rs/array.rs
+++ b/src/query/expression/src/convert_arrow_rs/array.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use arrow_array::Array;
 use arrow_schema::ArrowError;
-use arrow_schema::Field;
 
 use crate::Column;
 use crate::DataField;
@@ -28,8 +27,7 @@ impl Column {
         Ok(arrow_array)
     }
 
-    pub fn from_arrow_rs(array: Arc<dyn Array>, field: &Field) -> Result<Self, ArrowError> {
-        let field = DataField::try_from(field)?;
+    pub fn from_arrow_rs(array: Arc<dyn Array>, field: &DataField) -> Result<Self, ArrowError> {
         let arrow2_array: Box<dyn common_arrow::arrow::array::Array> = array.into();
 
         Ok(Column::from_arrow(arrow2_array.as_ref(), field.data_type()))

--- a/src/query/expression/src/convert_arrow_rs/record_batch.rs
+++ b/src/query/expression/src/convert_arrow_rs/record_batch.rs
@@ -32,16 +32,18 @@ impl DataBlock {
         RecordBatch::try_new(schema, arrays)
     }
 
-    pub fn from_record_batch(batch: &RecordBatch) -> Result<(Self, DataSchema), ArrowError> {
-        let schema: DataSchema = DataSchema::try_from(&(*batch.schema()))?;
+    pub fn from_record_batch(
+        schema: &DataSchema,
+        batch: &RecordBatch,
+    ) -> Result<(Self, DataSchema), ArrowError> {
         if batch.num_columns() == 0 {
-            return Ok((DataBlock::new(vec![], batch.num_rows()), schema));
+            return Ok((DataBlock::new(vec![], batch.num_rows()), schema.clone()));
         }
 
         let mut columns = Vec::with_capacity(batch.columns().len());
-        for (array, field) in batch.columns().iter().zip(batch.schema().fields().iter()) {
+        for (array, field) in batch.columns().iter().zip(schema.fields().iter()) {
             columns.push(Column::from_arrow_rs(array.clone(), field)?)
         }
-        Ok((DataBlock::new_from_columns(columns), schema))
+        Ok((DataBlock::new_from_columns(columns), schema.clone()))
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/transform_udf.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_udf.rs
@@ -95,8 +95,9 @@ impl AsyncTransform for TransformUdf {
                     .await?;
             let result_batch = client.do_exchange(&func.func_name, input_batch).await?;
 
-            let (result_block, result_schema) = DataBlock::from_record_batch(&result_batch)
-                .map_err(|err| {
+            let schema = DataSchema::try_from(&(*result_batch.schema()))?;
+            let (result_block, result_schema) =
+                DataBlock::from_record_batch(&schema, &result_batch).map_err(|err| {
                     ErrorCode::UDFDataError(format!(
                         "Cannot convert arrow record batch to data block: {err}"
                     ))

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/predicate.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/predicate.rs
@@ -22,6 +22,7 @@ use common_catalog::plan::Projection;
 use common_exception::Result;
 use common_expression::types::DataType;
 use common_expression::DataBlock;
+use common_expression::DataSchema;
 use common_expression::Evaluator;
 use common_expression::Expr;
 use common_expression::FunctionContext;
@@ -76,7 +77,8 @@ impl ParquetPredicate {
     }
 
     pub fn evaluate(&self, batch: &RecordBatch) -> Result<BooleanArray> {
-        let block = transform_record_batch(batch, &self.field_paths)?;
+        let data_schema = DataSchema::from(&self.schema);
+        let block = transform_record_batch(&data_schema, batch, &self.field_paths)?;
         let res = self.evaluate_block(&block)?;
         Ok(bitmap_to_boolean_array(res))
     }

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/read_policy/no_prefetch.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/read_policy/no_prefetch.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use common_expression::DataBlock;
+use common_expression::DataSchema;
 use common_expression::TopKSorter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 use parquet::arrow::arrow_reader::RowSelection;
@@ -33,6 +34,7 @@ use crate::parquet_rs::parquet_reader::utils::FieldPaths;
 
 pub struct NoPretchPolicyBuilder {
     projection: ProjectionMask,
+    data_schema: DataSchema,
     field_levels: FieldLevels,
     field_paths: Arc<Option<FieldPaths>>,
 }
@@ -55,6 +57,7 @@ impl ReadPolicyBuilder for NoPretchPolicyBuilder {
         )?;
         Ok(Some(Box::new(NoPrefetchPolicy {
             field_paths: self.field_paths.clone(),
+            data_schema: self.data_schema.clone(),
             reader,
         })))
     }
@@ -63,12 +66,14 @@ impl ReadPolicyBuilder for NoPretchPolicyBuilder {
 impl NoPretchPolicyBuilder {
     pub fn create(
         schema: &SchemaDescriptor,
+        data_schema: DataSchema,
         projection: ProjectionMask,
         field_paths: Arc<Option<FieldPaths>>,
     ) -> Result<Box<dyn ReadPolicyBuilder>> {
         let field_levels = parquet_to_arrow_field_levels(schema, projection.clone(), None)?;
         Ok(Box::new(NoPretchPolicyBuilder {
             field_levels,
+            data_schema,
             projection,
             field_paths,
         }))
@@ -87,6 +92,7 @@ pub struct NoPrefetchPolicy {
     /// we should extract inner columns from the struct manually by traversing the nested column;
     /// if `field_paths` is [None], we can skip the traversing.
     field_paths: Arc<Option<FieldPaths>>,
+    data_schema: DataSchema,
 
     reader: ParquetRecordBatchReader,
 }
@@ -95,7 +101,7 @@ impl ReadPolicy for NoPrefetchPolicy {
     fn read_block(&mut self) -> Result<Option<DataBlock>> {
         let batch = self.reader.next().transpose()?;
         if let Some(batch) = batch {
-            let block = transform_record_batch(&batch, &self.field_paths)?;
+            let block = transform_record_batch(&self.data_schema, &batch, &self.field_paths)?;
             Ok(Some(block))
         } else {
             Ok(None)

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/read_policy/predicate_and_topk.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/read_policy/predicate_and_topk.rs
@@ -170,6 +170,7 @@ impl ReadPolicyBuilder for PredicateAndTopkPolicyBuilder {
                 .await?;
             // Topk column **must** not be in a nested column.
             let block = read_all(
+                self.src_schema.as_ref(),
                 &row_group,
                 topk.field_levels(),
                 selection.clone(),
@@ -191,6 +192,7 @@ impl ReadPolicyBuilder for PredicateAndTopkPolicyBuilder {
                 .fetch(self.predicate.projection(), selection.as_ref())
                 .await?;
             let block = read_all(
+                self.src_schema.as_ref(),
                 &row_group,
                 self.predicate.field_levels(),
                 selection.clone(),
@@ -289,7 +291,8 @@ impl ReadPolicy for PredicateAndTopkPolicy {
         if let Some(batch) = batch {
             debug_assert!(!self.prefetched.is_empty());
             let prefetched = self.prefetched.pop_front().unwrap();
-            let mut block = transform_record_batch(&batch, &self.remain_field_paths)?;
+            let mut block =
+                transform_record_batch(self.src_schema.as_ref(), &batch, &self.remain_field_paths)?;
             block.merge_block(prefetched);
             let block = block.resort(&self.src_schema, &self.dst_schema)?;
             Ok(Some(block))

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/read_policy/topk_only.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/read_policy/topk_only.rs
@@ -136,6 +136,7 @@ impl ReadPolicyBuilder for TopkOnlyPolicyBuilder {
             .fetch(self.topk.projection(), selection.as_ref())
             .await?;
         let block = read_all(
+            self.src_schema.as_ref(),
             &row_group,
             self.topk.field_levels(),
             selection.clone(),
@@ -211,7 +212,8 @@ impl ReadPolicy for TopkOnlyPolicy {
             debug_assert!(
                 self.prefetched.is_none() || !self.prefetched.as_ref().unwrap().is_empty()
             );
-            let mut block = transform_record_batch(&batch, &self.remain_field_paths)?;
+            let mut block =
+                transform_record_batch(self.src_schema.as_ref(), &batch, &self.remain_field_paths)?;
             if let Some(q) = self.prefetched.as_mut() {
                 let prefetched = q.pop_front().unwrap();
                 block.add_column(prefetched);

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/read_policy/utils.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/read_policy/utils.rs
@@ -14,6 +14,7 @@
 
 use common_exception::Result;
 use common_expression::DataBlock;
+use common_expression::DataSchema;
 use common_expression::TopKSorter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 use parquet::arrow::arrow_reader::RowSelection;
@@ -26,6 +27,7 @@ use crate::parquet_rs::parquet_reader::utils::transform_record_batch;
 use crate::parquet_rs::parquet_reader::utils::FieldPaths;
 
 pub fn read_all(
+    data_schema: &DataSchema,
     rg: &InMemoryRowGroup,
     field_levels: &FieldLevels,
     selection: Option<RowSelection>,
@@ -36,7 +38,7 @@ pub fn read_all(
         ParquetRecordBatchReader::try_new_with_row_groups(field_levels, rg, num_rows, selection)?;
     let batch = reader.next().transpose()?.unwrap();
     debug_assert!(reader.next().is_none());
-    transform_record_batch(&batch, field_paths)
+    transform_record_batch(data_schema, &batch, field_paths)
 }
 
 #[inline]

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/reader/builder.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/reader/builder.rs
@@ -20,6 +20,7 @@ use common_catalog::plan::PushDownInfo;
 use common_catalog::plan::TopK;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
+use common_expression::DataSchema;
 use common_expression::TableSchemaRef;
 use opendal::Operator;
 use parquet::arrow::arrow_to_parquet_schema;
@@ -204,8 +205,10 @@ impl<'a> ParquetRSReaderBuilder<'a> {
             .map(|(proj, _, _, paths)| (proj.clone(), paths.clone()))
             .unwrap();
 
+        let schema = Arc::new(DataSchema::from(&self.table_schema.as_ref()));
         Ok(ParquetRSFullReader {
             op: self.op.clone(),
+            schema,
             predicate,
             projection,
             field_paths,
@@ -261,9 +264,11 @@ impl<'a> ParquetRSReaderBuilder<'a> {
     }
 
     fn create_no_prefetch_policy_builder(&self) -> Result<Box<dyn ReadPolicyBuilder>> {
-        let (projection, _, _, output_field_paths) = self.built_output.as_ref().unwrap();
+        let (projection, _, schema, output_field_paths) = self.built_output.as_ref().unwrap();
+        let data_schema = DataSchema::from(schema);
         NoPretchPolicyBuilder::create(
             &self.schema_desc,
+            data_schema,
             projection.clone(),
             output_field_paths.clone(),
         )

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/reader/full_reader.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/reader/full_reader.rs
@@ -18,6 +18,7 @@ use arrow_schema::ArrowError;
 use bytes::Bytes;
 use common_exception::Result;
 use common_expression::DataBlock;
+use common_expression::DataSchemaRef;
 use common_metrics::storage::metrics_inc_omit_filter_rowgroups;
 use common_metrics::storage::metrics_inc_omit_filter_rows;
 use futures::StreamExt;
@@ -40,6 +41,7 @@ use crate::ParquetRSPruner;
 /// The reader to read a whole parquet file.
 pub struct ParquetRSFullReader {
     pub(super) op: Operator,
+    pub(super) schema: DataSchemaRef,
     pub(super) predicate: Option<Arc<ParquetPredicate>>,
 
     /// Columns to output.
@@ -122,7 +124,7 @@ impl ParquetRSFullReader {
         let record_batch = stream.next().await.transpose()?;
 
         if let Some(batch) = record_batch {
-            let blocks = transform_record_batch(&batch, &self.field_paths)?;
+            let blocks = transform_record_batch(self.schema.as_ref(), &batch, &self.field_paths)?;
             Ok(Some(blocks))
         } else {
             Ok(None)
@@ -175,7 +177,6 @@ impl ParquetRSFullReader {
                 )]));
             }
         }
-
         let reader = builder.build()?;
         // Write `if` outside iteration to reduce branches.
         if let Some(field_paths) = self.field_paths.as_ref() {
@@ -191,7 +192,7 @@ impl ParquetRSFullReader {
                 .into_iter()
                 .map(|batch| {
                     let batch = batch?;
-                    Ok(DataBlock::from_record_batch(&batch)?.0)
+                    Ok(DataBlock::from_record_batch(self.schema.as_ref(), &batch)?.0)
                 })
                 .collect()
         }

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/utils.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/utils.rs
@@ -15,13 +15,14 @@
 use arrow_array::BooleanArray;
 use arrow_array::RecordBatch;
 use arrow_array::StructArray;
-use arrow_schema::FieldRef;
 use common_arrow::arrow::array::Arrow2Arrow;
 use common_arrow::arrow::bitmap::Bitmap;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::Column;
 use common_expression::DataBlock;
+use common_expression::DataField;
+use common_expression::DataSchema;
 use common_expression::FieldIndex;
 use common_expression::TableSchema;
 use parquet::arrow::arrow_to_parquet_schema;
@@ -31,7 +32,7 @@ use parquet::schema::types::SchemaDescriptor;
 
 /// Traverse `batch` by `path_indices` to get output [`Column`].
 fn traverse_column(
-    field: &arrow_schema::FieldRef,
+    field: &DataField,
     path: &[FieldIndex],
     batch: &RecordBatch,
     schema: &arrow_schema::Schema,
@@ -65,20 +66,21 @@ fn error_cannot_traverse_path(path: &[FieldIndex], schema: &arrow_schema::Schema
 ///
 /// `field_paths` is used to traverse nested columns in `batch`.
 pub fn transform_record_batch(
+    data_schema: &DataSchema,
     batch: &RecordBatch,
     field_paths: &Option<FieldPaths>,
 ) -> Result<DataBlock> {
     if let Some(field_paths) = field_paths {
         transform_record_batch_by_field_paths(batch, field_paths)
     } else {
-        let (block, _) = DataBlock::from_record_batch(batch)?;
+        let (block, _) = DataBlock::from_record_batch(data_schema, batch)?;
         Ok(block)
     }
 }
 
 pub fn transform_record_batch_by_field_paths(
     batch: &RecordBatch,
-    field_paths: &[(FieldRef, Vec<FieldIndex>)],
+    field_paths: &[(DataField, Vec<FieldIndex>)],
 ) -> Result<DataBlock> {
     if batch.num_columns() == 0 {
         return Ok(DataBlock::new(vec![], batch.num_rows()));
@@ -107,7 +109,7 @@ pub fn bitmap_to_boolean_array(bitmap: Bitmap) -> BooleanArray {
 /// FieldPaths is used to traverse nested columns in [`RecordBatch`].
 ///
 /// It records the DFS order of each field.
-pub type FieldPaths = Vec<(FieldRef, Vec<FieldIndex>)>;
+pub type FieldPaths = Vec<(DataField, Vec<FieldIndex>)>;
 
 /// Search `batch_schema` by column names from `output_schema` to compute path indices for getting columns from [`RecordBatch`].
 pub fn compute_output_field_paths(
@@ -119,7 +121,7 @@ pub fn compute_output_field_paths(
     if !inner_projection {
         return Ok(None);
     }
-    let expected_schema = to_arrow_schema(expected_schema);
+    let expected_schema = DataSchema::from(expected_schema);
     let batch_schema = parquet_to_arrow_schema_by_columns(schema_desc, projection.clone(), None)?;
     let output_fields = expected_schema.fields();
     let parquet_schema_desc = arrow_to_parquet_schema(&batch_schema)?;
@@ -149,15 +151,6 @@ pub fn compute_output_field_paths(
     }
 
     Ok(Some(path_indices))
-}
-
-pub fn to_arrow_schema(schema: &TableSchema) -> arrow_schema::Schema {
-    let fields = schema
-        .fields()
-        .iter()
-        .map(|f| arrow_schema::Field::from(common_arrow::arrow::datatypes::Field::from(f)))
-        .collect::<Vec<_>>();
-    arrow_schema::Schema::new(fields)
 }
 
 pub fn error_cannot_find_field(name: &str, schema: &parquet::schema::types::Type) -> ErrorCode {

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
@@ -8,6 +8,9 @@ USE_PARQUET2=0
 --- file_format
 1	2	3
 4	5	6
+--- variant named internal stage
+1	[1,2,3]
+2	{"k":"v"}
 USE_PARQUET2=1
 --- named internal stage
 1	2	3
@@ -18,3 +21,6 @@ USE_PARQUET2=1
 --- file_format
 1	2	3
 4	5	6
+--- variant named internal stage
+1	[1,2,3]
+2	{"k":"v"}

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
@@ -35,6 +35,16 @@ echo "drop stage if exists s3;" | $BENDSQL_CLIENT_CONNECT
 echo "create stage s3 url = '${DATADIR}' FILE_FORMAT = (type = CSV);"  | $BENDSQL_CLIENT_CONNECT
 echo "set use_parquet2 = ${USE_PARQUET2} ; select * from @s3 (FILE_FORMAT => 'PARQUET');" | $BENDSQL_CLIENT_CONNECT
 
+echo "drop table if exists t2;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE TABLE t2 (id INT, data VARIANT);" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t2 (id,data) values(1,'[1,2,3]'),(2,'{\"k\":\"v\"}');" | $BENDSQL_CLIENT_CONNECT
+
+echo '--- variant named internal stage'
+echo "drop stage if exists s4;" | $BENDSQL_CLIENT_CONNECT
+echo "create stage s4 FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
+echo "copy into @s4 from t2;" | $BENDSQL_CLIENT_CONNECT
+echo "set use_parquet2 = ${USE_PARQUET2} ; select * from @s4;" | $BENDSQL_CLIENT_CONNECT
+
 rm -rf ${DATADIR_PATH}
 
 done


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix `arrow_rs` read variant type, the schema in `RecordBatch` doesn't contain extended metadata, so we can't determine the type of `Variant` and `Bitmap`. Use an external schema instead to fix this bug.


- Closes #13759

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13774)
<!-- Reviewable:end -->
