### PR TITLE
feat:  table function  `stream_status`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,6 +3085,7 @@ dependencies = [
  "common-meta-app",
  "common-metrics",
  "common-pipeline-core",
+ "common-pipeline-sources",
  "common-sql",
  "common-storages-fuse",
  "futures",

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -377,17 +377,6 @@ pub trait Table: Sync + Send {
     fn is_read_only(&self) -> bool {
         false
     }
-
-    async fn check_stream_status(&self, ctx: Arc<dyn TableContext>) -> Result<StreamStatus> {
-        let _ = ctx;
-        Ok(StreamStatus::NotApplicable)
-    }
-}
-
-pub enum StreamStatus {
-    NotApplicable,
-    MayHaveData,
-    NoData,
 }
 
 #[async_trait::async_trait]

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -377,6 +377,17 @@ pub trait Table: Sync + Send {
     fn is_read_only(&self) -> bool {
         false
     }
+
+    async fn check_stream_status(&self, ctx: Arc<dyn TableContext>) -> Result<StreamStatus> {
+        let _ = ctx;
+        Ok(StreamStatus::NotApplicable)
+    }
+}
+
+pub enum StreamStatus {
+    NotApplicable,
+    MayHaveData,
+    NoData,
 }
 
 #[async_trait::async_trait]

--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -21,6 +21,7 @@ use common_exception::Result;
 use common_meta_types::MetaId;
 use common_storages_fuse::table_functions::FuseColumnTable;
 use common_storages_fuse::table_functions::FuseEncodingTable;
+use common_storages_stream::stream_status_table_func::StreamStatusTable;
 use itertools::Itertools;
 use parking_lot::RwLock;
 
@@ -135,6 +136,11 @@ impl TableFunctionFactory {
         creators.insert(
             "clustering_information".to_string(),
             (next_id(), Arc::new(ClusteringInformationTable::create)),
+        );
+
+        creators.insert(
+            "stream_status".to_string(),
+            (next_id(), Arc::new(StreamStatusTable::create)),
         );
 
         creators.insert(

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -37,7 +37,6 @@ use common_ast::parser::parse_expr;
 use common_ast::parser::tokenize_sql;
 use common_ast::Dialect;
 use common_catalog::catalog::CatalogManager;
-use common_catalog::table::StreamStatus;
 use common_catalog::table_context::TableContext;
 use common_config::GlobalConfig;
 use common_exception::ErrorCode;
@@ -2594,82 +2593,6 @@ impl<'a> TypeChecker<'a> {
                     self.resolve_scalar_function_call(span, "array_min", vec![], vec![array])
                         .await,
                 )
-            }
-
-            ("stream_has_data", args) => {
-                let r: Result<Box<(ScalarExpr, DataType)>> = try {
-                    if args.len() != 1 {
-                        return Some(Err(ErrorCode::BadArguments(
-                            "stream_has_data needs one string argument",
-                        )
-                        .set_span(span)));
-                    }
-                    let box (scalar, _) = self.resolve(args[0]).await?;
-
-                    let expr = scalar.as_expr()?;
-                    let target = match expr {
-                        // match constant string
-                        EExpr::Constant {
-                            scalar: Scalar::String(ref str_bytes),
-                            ..
-                        } => String::from_utf8(str_bytes.clone())?,
-                        _ => {
-                            return Some(Err(ErrorCode::BadArguments(
-                                "stream_has_data only support constant string argument",
-                            )
-                            .set_span(span)));
-                        }
-                    };
-                    let default_cat_name;
-                    let default_db_name;
-                    let stream_name_vec: Vec<&str> = target.split('.').collect();
-                    let (cat, db, tbl) = {
-                        match stream_name_vec.len() {
-                            1 => {
-                                default_cat_name = self.ctx.get_current_catalog();
-                                default_db_name = self.ctx.get_current_database();
-                                (
-                                    default_cat_name.as_str(),
-                                    default_db_name.as_str(),
-                                    stream_name_vec[0],
-                                )
-                            }
-                            2 => {
-                                default_cat_name = self.ctx.get_current_catalog();
-                                (
-                                    default_cat_name.as_str(),
-                                    stream_name_vec[0],
-                                    stream_name_vec[1],
-                                )
-                            }
-                            3 => (stream_name_vec[0], stream_name_vec[1], stream_name_vec[2]),
-                            _ => {
-                                return Some(Err(ErrorCode::BadArguments(
-                                    "invalid stream name, '[catalog.]database.stream'",
-                                )
-                                .set_span(span)));
-                            }
-                        }
-                    };
-
-                    let table = self.ctx.get_table(cat, db, tbl).await?;
-                    let has_data = match table.check_stream_status(self.ctx.clone()).await? {
-                        StreamStatus::MayHaveData => Ok(true),
-                        StreamStatus::NotApplicable => {
-                            let msg = format!(
-                                "{cat}.{db}.{tbl} is not Stream, function `stream_has_data` is not applicable"
-                            );
-                            Err(ErrorCode::BadArguments(msg))
-                        }
-                        _ => Ok(false),
-                    }?;
-                    self.resolve(&Expr::Literal {
-                        span,
-                        lit: Literal::Boolean(has_data),
-                    })
-                    .await?
-                };
-                Some(r)
             }
             _ => None,
         }

--- a/src/query/storages/stream/Cargo.toml
+++ b/src/query/storages/stream/Cargo.toml
@@ -19,6 +19,7 @@ common-expression = { path = "../../expression" }
 common-meta-app = { path = "../../../meta/app" }
 common-metrics = { path = "../../../common/metrics" }
 common-pipeline-core = { path = "../../pipeline/core" }
+common-pipeline-sources = { path = "../../pipeline/sources" }
 common-sql = { path = "../../sql" }
 common-storages-fuse = { path = "../fuse" }
 

--- a/src/query/storages/stream/src/lib.rs
+++ b/src/query/storages/stream/src/lib.rs
@@ -12,5 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(impl_trait_in_assoc_type)]
+
 pub mod stream_pruner;
 pub mod stream_table;
+
+pub mod stream_status_table_func;

--- a/src/query/storages/stream/src/stream_status_table_func.rs
+++ b/src/query/storages/stream/src/stream_status_table_func.rs
@@ -19,7 +19,6 @@ use common_catalog::plan::DataSourcePlan;
 use common_catalog::plan::PartStatistics;
 use common_catalog::plan::Partitions;
 use common_catalog::plan::PushDownInfo;
-use common_catalog::table::StreamStatus;
 use common_catalog::table::Table;
 use common_catalog::table_args::TableArgs;
 use common_catalog::table_context::TableContext;
@@ -44,6 +43,7 @@ use common_pipeline_sources::AsyncSourcer;
 use common_storages_fuse::table_functions::string_literal;
 use common_storages_fuse::table_functions::string_value;
 
+use crate::stream_table::StreamStatus;
 use crate::stream_table::StreamTable;
 
 const STREAM_STATUS: &str = "stream_status";
@@ -229,7 +229,7 @@ impl AsyncSource for StreamStatusDataSource {
         let tbl = StreamTable::try_from_table(tbl.as_ref())?;
 
         let has_data = matches!(
-            tbl.new_check_stream_status(self.ctx.clone()).await?,
+            tbl.check_stream_status(self.ctx.clone()).await?,
             StreamStatus::MayHaveData
         );
 

--- a/src/query/storages/stream/src/stream_status_table_func.rs
+++ b/src/query/storages/stream/src/stream_status_table_func.rs
@@ -1,0 +1,212 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use common_catalog::catalog_kind::CATALOG_DEFAULT;
+use common_catalog::plan::DataSourcePlan;
+use common_catalog::plan::PartStatistics;
+use common_catalog::plan::Partitions;
+use common_catalog::plan::PushDownInfo;
+use common_catalog::table::StreamStatus;
+use common_catalog::table::Table;
+use common_catalog::table_args::TableArgs;
+use common_catalog::table_context::TableContext;
+use common_catalog::table_function::TableFunction;
+use common_exception::Result;
+use common_expression::types::BooleanType;
+use common_expression::DataBlock;
+use common_expression::FromData;
+use common_expression::TableDataType;
+use common_expression::TableField;
+use common_expression::TableSchema;
+use common_expression::TableSchemaRefExt;
+use common_meta_app::schema::TableIdent;
+use common_meta_app::schema::TableInfo;
+use common_meta_app::schema::TableMeta;
+use common_pipeline_core::processors::OutputPort;
+use common_pipeline_core::processors::ProcessorPtr;
+use common_pipeline_core::Pipeline;
+use common_pipeline_sources::AsyncSource;
+use common_pipeline_sources::AsyncSourcer;
+use common_storages_fuse::table_functions::parse_db_tb_args;
+use common_storages_fuse::table_functions::string_literal;
+
+use crate::stream_table::StreamTable;
+
+const STREAM_STATUS: &str = "stream_status";
+
+pub struct StreamStatusTable {
+    table_info: TableInfo,
+    arg_database_name: String,
+    arg_table_name: String,
+}
+
+impl StreamStatusTable {
+    pub fn create(
+        database_name: &str,
+        table_func_name: &str,
+        table_id: u64,
+        table_args: TableArgs,
+    ) -> Result<Arc<dyn TableFunction>> {
+        // TODO use single string arg
+        let (arg_database_name, arg_table_name) = parse_db_tb_args(&table_args, STREAM_STATUS)?;
+
+        let engine = STREAM_STATUS.to_owned();
+
+        let table_info = TableInfo {
+            ident: TableIdent::new(table_id, 0),
+            desc: format!("'{}'.'{}'", database_name, table_func_name),
+            name: table_func_name.to_string(),
+            meta: TableMeta {
+                schema: schema(),
+                engine,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        Ok(Arc::new(StreamStatusTable {
+            table_info,
+            arg_database_name,
+            arg_table_name,
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Table for StreamStatusTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_table_info(&self) -> &TableInfo {
+        &self.table_info
+    }
+
+    #[async_backtrace::framed]
+    async fn read_partitions(
+        &self,
+        _ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+        _dry_run: bool,
+    ) -> Result<(PartStatistics, Partitions)> {
+        Ok((PartStatistics::default(), Partitions::default()))
+    }
+
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(TableArgs::new_positioned(vec![
+            string_literal(self.arg_database_name.as_str()),
+            string_literal(self.arg_table_name.as_str()),
+        ]))
+    }
+
+    fn read_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _plan: &DataSourcePlan,
+        pipeline: &mut Pipeline,
+        _put_cache: bool,
+    ) -> Result<()> {
+        pipeline.add_source(
+            |output| {
+                StreamStatusDataSource::create(
+                    ctx.clone(),
+                    output,
+                    self.arg_database_name.to_owned(),
+                    self.arg_table_name.to_owned(),
+                )
+            },
+            1,
+        )?;
+
+        Ok(())
+    }
+}
+
+impl TableFunction for StreamStatusTable {
+    fn function_name(&self) -> &str {
+        self.name()
+    }
+
+    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn Table + 'a>
+    where Self: 'a {
+        self
+    }
+}
+
+struct StreamStatusDataSource {
+    finish: bool,
+    ctx: Arc<dyn TableContext>,
+    arg_database_name: String,
+    arg_table_name: String,
+}
+
+impl StreamStatusDataSource {
+    pub fn create(
+        ctx: Arc<dyn TableContext>,
+        output: Arc<OutputPort>,
+        arg_database_name: String,
+        arg_table_name: String,
+    ) -> Result<ProcessorPtr> {
+        AsyncSourcer::create(ctx.clone(), output, StreamStatusDataSource {
+            ctx,
+            finish: false,
+            arg_table_name,
+            arg_database_name,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncSource for StreamStatusDataSource {
+    const NAME: &'static str = "stream_status";
+
+    #[async_trait::unboxed_simple]
+    #[async_backtrace::framed]
+    async fn generate(&mut self) -> Result<Option<DataBlock>> {
+        if self.finish {
+            return Ok(None);
+        }
+
+        self.finish = true;
+        let tenant_id = self.ctx.get_tenant();
+        let tbl = self
+            .ctx
+            .get_catalog(CATALOG_DEFAULT)
+            .await?
+            .get_table(
+                tenant_id.as_str(),
+                self.arg_database_name.as_str(),
+                self.arg_table_name.as_str(),
+            )
+            .await?;
+
+        let tbl = StreamTable::try_from_table(tbl.as_ref())?;
+
+        let has_data = matches!(
+            tbl.new_check_stream_status(self.ctx.clone()).await?,
+            StreamStatus::MayHaveData
+        );
+
+        Ok(Some(DataBlock::new_from_columns(vec![
+            BooleanType::from_data(vec![has_data]),
+        ])))
+    }
+}
+
+fn schema() -> Arc<TableSchema> {
+    TableSchemaRefExt::create(vec![TableField::new("has_data", TableDataType::Boolean)])
+}

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0004_stream_status.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0004_stream_status.test
@@ -1,0 +1,86 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+
+# Although the stream_status function is not a EE function, it is dependent on the EE feature change_tracking.
+
+statement ok
+DROP DATABASE IF EXISTS test_stream_status
+
+statement ok
+CREATE DATABASE test_stream_status
+
+statement ok
+USE test_stream_status
+
+statement error 1025
+call system$stream_status('not_exist')
+
+statement error 1025
+select * from stream_status('not_exist')
+
+statement ok
+create table t(a int)
+
+statement ok
+alter table t set options(change_tracking=true)
+
+statement ok
+create stream if not exists s on table t
+
+query I
+select * from stream_status('s')
+----
+0
+
+query I
+select * from stream_status('test_stream_status.s')
+----
+0
+
+query I
+select * from stream_status('default.test_stream_status.s')
+----
+0
+
+query I
+call system$stream_status('s')
+----
+0
+
+query I
+call system$stream_status('test_stream_status.s')
+----
+0
+
+query I
+call system$stream_status('default.test_stream_status.s')
+----
+0
+
+statement ok
+insert into t values(2)
+
+query I
+select * from stream_status('s')
+----
+1
+
+query I
+call system$stream_status('s')
+----
+1
+
+statement ok
+DROP DATABASE IF EXISTS test_stream_status


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

introduce new table function `stream_status`, which is indented to be used by the `task` framework.

This table function returns a resultset of one boolean column `has_data`, which indicates if the given stream has data to be consumed.

- A false return means no data awaits consumption in the stream (during function execution).
- A true return suggests potential data awaiting consumption, with a chance of false positives.

e.g.
~~~
mysql> create database test;
Query OK, 0 rows affected (0.18 sec)

mysql> use test;
Database changed

mysql> create table t (c int);
Query OK, 0 rows affected (0.54 sec)

mysql> alter table t set options(change_tracking=true);
Query OK, 0 rows affected (0.09 sec)

mysql> create stream s on table t;
Query OK, 0 rows affected (0.17 sec)

mysql> select * from stream_status('s');  -- or select * from stream_status('test.s')
+----------+
| has_data |
+----------+
|        0 |
+----------+
1 row in set (0.09 sec)
Read 1 rows, 1.00 B in 0.075 sec., 13.28 rows/sec., 13.28 B/sec.

mysql> call system$stream_status('s'); -- or call system$stream_status('test.s')
+----------+
| has_data |
+----------+
|        0 |
+----------+
1 row in set (0.05 sec)
Read 1 rows, 1.00 B in 0.041 sec., 24.28 rows/sec., 24.28 B/sec.

mysql> insert into t values(1);
Query OK, 1 row affected (0.27 sec)

mysql> select * from stream_status('s');
+----------+
| has_data |
+----------+
|        1 |
+----------+
1 row in set (0.06 sec)
Read 1 rows, 1.00 B in 0.045 sec., 22.46 rows/sec., 22.46 B/sec.

mysql> call system$stream_status('s');
+----------+
| has_data |
+----------+
|        1 |
+----------+
1 row in set (0.05 sec)
Read 1 rows, 1.00 B in 0.042 sec., 23.97 rows/sec., 23.97 B/sec.

mysql>
~~~

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13785)
<!-- Reviewable:end -->
