### PR TITLE
chore: use fixed regions in UT `test_parse_uri_location`

### DIFF
--- a/src/query/sql/tests/location.rs
+++ b/src/query/sql/tests/location.rs
@@ -168,6 +168,7 @@ async fn test_parse_uri_location() -> Result<()> {
                     ("access_key_id", "access_key_id"),
                     ("secret_access_key", "secret_access_key"),
                     ("session_token", "session_token"),
+                    ("region", "us-east-2"),
                 ]
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -203,6 +204,7 @@ async fn test_parse_uri_location() -> Result<()> {
                     ("aws_key_id", "access_key_id"),
                     ("aws_secret_key", "secret_access_key"),
                     ("session_token", "security_token"),
+                    ("region", "us-east-2"),
                 ]
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -238,6 +240,7 @@ async fn test_parse_uri_location() -> Result<()> {
                     ("aws_key_id", "access_key_id"),
                     ("aws_secret_key", "secret_access_key"),
                     ("aws_token", "security_token"),
+                    ("region", "us-east-2"),
                 ]
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -269,7 +272,7 @@ async fn test_parse_uri_location() -> Result<()> {
                 "test".to_string(),
                 "/tmp/".to_string(),
                 "".to_string(),
-                [("role_arn", "aws::iam::xxxx")]
+                [("role_arn", "aws::iam::xxxx"), ("region", "us-east-2")]
                     .iter()
                     .map(|(k, v)| (k.to_string(), v.to_string()))
                     .collect::<BTreeMap<String, String>>(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Use fixed regions in UT `test_parse_uri_location`.

Note that: the region auto detection feature no longer covered by this UT.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13786)
<!-- Reviewable:end -->
