### PR TITLE
chore: add arrow extention data type support

### DIFF
--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -1413,7 +1413,6 @@ impl From<&ArrowField> for TableDataType {
                         ArrowField::new(custom_name, data_type.as_ref().to_owned(), f.is_nullable);
                     (&a).into()
                 }
-                _ => unimplemented!("data_type: {:?}", f.data_type()),
             },
             // this is safe, because we define the datatype firstly
             _ => {

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -1403,11 +1403,16 @@ impl From<&ArrowField> for TableDataType {
                     fields_type,
                 }
             }
-            ArrowDataType::Extension(custom_name, _, _) => match custom_name.as_str() {
+            ArrowDataType::Extension(custom_name, data_type, _) => match custom_name.as_str() {
                 ARROW_EXT_TYPE_VARIANT => TableDataType::Variant,
                 ARROW_EXT_TYPE_EMPTY_ARRAY => TableDataType::EmptyArray,
                 ARROW_EXT_TYPE_EMPTY_MAP => TableDataType::EmptyMap,
                 ARROW_EXT_TYPE_BITMAP => TableDataType::Bitmap,
+                _ => {
+                    let a =
+                        ArrowField::new(custom_name, data_type.as_ref().to_owned(), f.is_nullable);
+                    (&a).into()
+                }
                 _ => unimplemented!("data_type: {:?}", f.data_type()),
             },
             // this is safe, because we define the datatype firstly

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -1789,7 +1789,7 @@ impl Column {
                     };
                     Column::Timestamp(values)
                 }
-                _ => unimplemented!("unsupported arrow extention type {ty:?}"),
+                _ => unimplemented!("unsupported arrow extension type {ty:?}"),
             },
             ty => unimplemented!("unsupported arrow type {ty:?}"),
         };

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -1680,6 +1680,117 @@ impl Column {
                     ),
                 }
             }
+            ArrowDataType::Extension(_name, box ty, _) => match ty {
+                ArrowDataType::Int8 => Column::Number(NumberColumn::Int8(
+                    arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::Int8Array>()
+                        .expect("fail to read from arrow: array should be `Int8Array`")
+                        .values()
+                        .clone(),
+                )),
+                ArrowDataType::Int16 => Column::Number(NumberColumn::Int16(
+                    arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::Int16Array>()
+                        .expect("fail to read from arrow: array should be `Int16Array`")
+                        .values()
+                        .clone(),
+                )),
+                ArrowDataType::Int32 => Column::Number(NumberColumn::Int32(
+                    arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::Int32Array>()
+                        .expect("fail to read from arrow: array should be `Int32Array`")
+                        .values()
+                        .clone(),
+                )),
+                ArrowDataType::Int64 => Column::Number(NumberColumn::Int64(
+                    arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::Int64Array>()
+                        .expect("fail to read from arrow: array should be `Int64Array`")
+                        .values()
+                        .clone(),
+                )),
+                ArrowDataType::UInt8 => Column::Number(NumberColumn::UInt8(
+                    arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::UInt8Array>()
+                        .expect("fail to read from arrow: array should be `UInt8Array`")
+                        .values()
+                        .clone(),
+                )),
+                ArrowDataType::UInt16 => Column::Number(NumberColumn::UInt16(
+                    arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::UInt16Array>()
+                        .expect("fail to read from arrow: array should be `UInt16Array`")
+                        .values()
+                        .clone(),
+                )),
+                ArrowDataType::UInt32 => Column::Number(NumberColumn::UInt32(
+                    arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::UInt32Array>()
+                        .expect("fail to read from arrow: array should be `UInt32Array`")
+                        .values()
+                        .clone(),
+                )),
+                ArrowDataType::UInt64 => Column::Number(NumberColumn::UInt64(
+                    arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::UInt64Array>()
+                        .expect("fail to read from arrow: array should be `UInt64Array`")
+                        .values()
+                        .clone(),
+                )),
+                ArrowDataType::Float32 => {
+                    let col = arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::Float32Array>()
+                        .expect("fail to read from arrow: array should be `Float32Array`")
+                        .values()
+                        .clone();
+                    let col = unsafe { std::mem::transmute::<Buffer<f32>, Buffer<F32>>(col) };
+                    Column::Number(NumberColumn::Float32(col))
+                }
+                ArrowDataType::Float64 => {
+                    let col = arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::Float64Array>()
+                        .expect("fail to read from arrow: array should be `Float64Array`")
+                        .values()
+                        .clone();
+                    let col = unsafe { std::mem::transmute::<Buffer<f64>, Buffer<F64>>(col) };
+                    Column::Number(NumberColumn::Float64(col))
+                }
+                ArrowType::Timestamp(uint, _) => {
+                    let values = arrow_col
+                        .as_any()
+                        .downcast_ref::<common_arrow::arrow::array::Int64Array>()
+                        .expect("fail to read from arrow: array should be `Int64Array`")
+                        .values();
+                    let convert = match uint {
+                        TimeUnit::Second => (1_000_000, 1),
+                        TimeUnit::Millisecond => (1_000, 1),
+                        TimeUnit::Microsecond => (1, 1),
+                        TimeUnit::Nanosecond => (1, 1_000),
+                    };
+
+                    let values = if convert.0 == 1 && convert.1 == 1 {
+                        values.clone()
+                    } else {
+                        let values = values
+                            .iter()
+                            .map(|x| x * convert.0 / convert.1)
+                            .collect::<Vec<_>>();
+                        values.into()
+                    };
+                    Column::Timestamp(values)
+                }
+                _ => unimplemented!("unsupported arrow extention type {ty:?}"),
+            },
             ty => unimplemented!("unsupported arrow type {ty:?}"),
         };
 

--- a/src/query/expression/tests/it/column.rs
+++ b/src/query/expression/tests/it/column.rs
@@ -1,0 +1,32 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_arrow::arrow::array::new_empty_array;
+use common_arrow::arrow::datatypes::DataType as ArrowDataType;
+use common_exception::Result;
+use common_expression::types::DataType;
+use common_expression::types::NumberDataType;
+use common_expression::Column;
+
+#[test]
+fn test_from_arrow_extension_to_column() -> Result<()> {
+    let data_type = DataType::Number(NumberDataType::Int8);
+    let extension_data_type =
+        ArrowDataType::Extension("a".to_string(), Box::new(ArrowDataType::Int8), None);
+
+    let arrow_col = new_empty_array(extension_data_type);
+    let _ = Column::from_arrow(arrow_col.as_ref(), &data_type);
+
+    Ok(())
+}

--- a/src/query/expression/tests/it/main.rs
+++ b/src/query/expression/tests/it/main.rs
@@ -25,6 +25,7 @@ use common_expression::DataBlock;
 extern crate core;
 
 mod block;
+mod column;
 mod common;
 mod decimal;
 mod group_by;

--- a/src/query/expression/tests/it/schema.rs
+++ b/src/query/expression/tests/it/schema.rs
@@ -14,6 +14,8 @@
 
 use std::collections::BTreeMap;
 
+use common_arrow::arrow::datatypes::DataType as ArrowDataType;
+use common_arrow::arrow::datatypes::Field as ArrowField;
 use common_exception::Result;
 use common_expression::create_test_complex_schema;
 use common_expression::types::NumberDataType;
@@ -23,6 +25,15 @@ use common_expression::TableDataType;
 use common_expression::TableField;
 use common_expression::TableSchema;
 use pretty_assertions::assert_eq;
+
+#[test]
+fn test_from_arrow_field_to_table_data_type() -> Result<()> {
+    let extension_data_type =
+        ArrowDataType::Extension("a".to_string(), Box::new(ArrowDataType::Int8), None);
+    let arrow_field = ArrowField::new("".to_string(), extension_data_type, false);
+    let _: TableDataType = (&arrow_field).into();
+    Ok(())
+}
 
 #[test]
 fn test_project_schema_from_tuple() -> Result<()> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: add arrow extention data type support

- Closes https://github.com/datafuselabs/databend/issues/13752

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13796)
<!-- Reviewable:end -->
