### PR TITLE
feat: http handler return reason for 404.

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -33,6 +33,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::HttpQueryContext;
+use super::RemoveReason;
 use crate::interpreters::InterpreterQueryLog;
 use crate::servers::http::v1::query::execute_state::ExecuteStarting;
 use crate::servers::http::v1::query::execute_state::ExecuteStopped;
@@ -219,7 +220,9 @@ impl HttpQuery {
                             "last query on the session not finished",
                         ));
                     } else {
-                        http_query_manager.remove_query(&query_id).await;
+                        let _ = http_query_manager
+                            .remove_query(&query_id, RemoveReason::Canceled)
+                            .await;
                     }
                 }
                 // wait for Arc<QueryContextShared> to drop and detach itself from session

--- a/src/query/service/src/servers/http/v1/query/http_query_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_manager.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,10 +38,60 @@ use crate::servers::http::v1::query::http_query::HttpQuery;
 use crate::servers::http::v1::query::HttpQueryRequest;
 use crate::sessions::Session;
 
+#[derive(Clone, Debug)]
+pub(crate) enum RemoveReason {
+    Timeout,
+    Canceled,
+    Finished,
+}
+
+impl Display for RemoveReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", format!("{self:?}").to_lowercase())
+    }
+}
+
+pub(crate) struct SizeLimitedIndexMap<K, V> {
+    insert_order: VecDeque<K>,
+    reasons: HashMap<K, V>,
+    cap: usize,
+}
+
+impl<K: Clone + Eq + Hash, V> SizeLimitedIndexMap<K, V> {
+    fn new(cap: usize) -> Self {
+        Self {
+            insert_order: VecDeque::new(),
+            reasons: HashMap::new(),
+            cap,
+        }
+    }
+
+    fn insert(&mut self, key: K, value: V) {
+        if self.get(&key).is_some() {
+            return;
+        }
+        if self.insert_order.len() + 1 >= self.cap {
+            let key = self.insert_order.pop_front().unwrap();
+            self.reasons.remove(&key);
+        }
+        self.insert_order.push_back(key.clone());
+        self.reasons.insert(key, value);
+    }
+
+    fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.reasons.get(key)
+    }
+}
+
 pub struct HttpQueryManager {
     #[allow(clippy::type_complexity)]
     pub(crate) queries: Arc<RwLock<HashMap<String, Arc<HttpQuery>>>>,
     pub(crate) sessions: Mutex<ExpiringMap<String, Arc<Session>>>,
+    pub(crate) removed_queries: Arc<RwLock<SizeLimitedIndexMap<String, RemoveReason>>>,
 }
 
 impl HttpQueryManager {
@@ -45,6 +100,7 @@ impl HttpQueryManager {
         GlobalInstance::set(Arc::new(HttpQueryManager {
             queries: Arc::new(RwLock::new(HashMap::new())),
             sessions: Mutex::new(ExpiringMap::default()),
+            removed_queries: Arc::new(RwLock::new(SizeLimitedIndexMap::new(1000))),
         }));
 
         Ok(())
@@ -69,6 +125,27 @@ impl HttpQueryManager {
     pub(crate) async fn get_query(self: &Arc<Self>, query_id: &str) -> Option<Arc<HttpQuery>> {
         let queries = self.queries.read().await;
         queries.get(query_id).map(|q| q.to_owned())
+    }
+
+    #[async_backtrace::framed]
+    pub(crate) async fn try_get_query(
+        self: &Arc<Self>,
+        query_id: &str,
+    ) -> std::result::Result<Arc<HttpQuery>, Option<RemoveReason>> {
+        if let Some(q) = self.get_query(query_id).await {
+            Ok(q)
+        } else {
+            Err(self.try_get_query_tombstone(query_id).await)
+        }
+    }
+
+    #[async_backtrace::framed]
+    pub(crate) async fn try_get_query_tombstone(
+        self: &Arc<Self>,
+        query_id: &str,
+    ) -> Option<RemoveReason> {
+        let queries = self.removed_queries.read().await;
+        queries.get(query_id).cloned()
     }
 
     #[async_backtrace::framed]
@@ -99,12 +176,18 @@ impl HttpQueryManager {
                             "http query {} timeout after {} s",
                             &query_id_clone, query_result_timeout_secs
                         );
-                        if self_clone.remove_query(&query_id_clone).await.is_none() {
-                            warn!("{msg}, but fail to remove");
-                        } else {
-                            warn!("{msg}");
-                            if let Some(query) = http_query_weak.upgrade() {
-                                query.kill(&msg).await;
+                        match self_clone
+                            .remove_query(&query_id_clone, RemoveReason::Timeout)
+                            .await
+                        {
+                            Ok(_) => {
+                                warn!("{msg}");
+                                if let Some(query) = http_query_weak.upgrade() {
+                                    query.kill(&msg).await;
+                                }
+                            }
+                            Err(_) => {
+                                warn!("{msg}, but already removed");
                             }
                         };
                         break;
@@ -122,13 +205,26 @@ impl HttpQueryManager {
 
     // not remove it until timeout or cancelled by user, even if query execution is aborted
     #[async_backtrace::framed]
-    pub(crate) async fn remove_query(self: &Arc<Self>, query_id: &str) -> Option<Arc<HttpQuery>> {
+    pub(crate) async fn remove_query(
+        self: &Arc<Self>,
+        query_id: &str,
+        reason: RemoveReason,
+    ) -> std::result::Result<Arc<HttpQuery>, Option<RemoveReason>> {
+        {
+            let mut removed = self.removed_queries.write().await;
+            if let Some(r) = removed.get(query_id) {
+                return Err(Some(r.clone()));
+            }
+            removed.insert(query_id.to_string(), reason);
+        }
         let mut queries = self.queries.write().await;
         let q = queries.remove(query_id);
         if let Some(q) = &q {
             q.mark_removed().await;
+            Ok(q.clone())
+        } else {
+            Err(None)
         }
-        q
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/servers/http/v1/query/mod.rs
+++ b/src/query/service/src/servers/http/v1/query/mod.rs
@@ -35,6 +35,7 @@ pub use http_query::PaginationConf;
 pub use http_query::ResponseState;
 pub use http_query_context::HttpQueryContext;
 pub use http_query_manager::HttpQueryManager;
+pub(crate) use http_query_manager::RemoveReason;
 pub use page_manager::Page;
 pub use page_manager::PageManager;
 pub use page_manager::ResponseData;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary


1.  remember at most 1000 removed query IDs 
2.  return 404 with body `{ "error": { "code": "404", "message": "query id <query> timeout on <node_id>" }` (tested)

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13831)
<!-- Reviewable:end -->
