### PR TITLE
fix(query): add some dml prvilege check

### DIFF
--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -561,7 +561,8 @@ pub struct StageInfo {
     pub stage_name: String,
     pub stage_type: StageType,
     pub stage_params: StageParams,
-    pub is_from_uri: bool,
+    // on `COPY INTO xx FROM 's3://xxx?ak=?&sk=?'`, the URL(ExternalLocation) will be treated as an temporary stage.
+    pub is_temporary: bool,
     pub file_format_params: FileFormatParams,
     pub copy_options: CopyOptions,
     pub comment: String,
@@ -580,11 +581,11 @@ impl StageInfo {
         }
     }
 
-    pub fn new_external_stage(storage: StorageParams, path: &str, from_uri: bool) -> StageInfo {
+    pub fn new_external_stage(storage: StorageParams, path: &str, is_temporary: bool) -> StageInfo {
         StageInfo {
             stage_name: format!("{storage},path={path}"),
             stage_type: StageType::External,
-            is_from_uri: from_uri,
+            is_temporary,
             stage_params: StageParams { storage },
             ..Default::default()
         }

--- a/src/meta/proto-conv/src/stage_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/stage_from_to_protobuf_impl.rs
@@ -207,7 +207,7 @@ impl FromToProto for mt::principal::StageInfo {
                     reason: "StageInfo.stage_params cannot be None".to_string(),
                 },
             )?)?,
-            is_from_uri: false,
+            is_temporary: false,
             file_format_params,
             copy_options: mt::principal::CopyOptions::from_pb(p.copy_options.ok_or_else(
                 || Incompatible {

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -79,7 +79,7 @@ pub(crate) fn test_fs_stage_info() -> mt::principal::StageInfo {
                 root: "/dir/to/files".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -121,7 +121,7 @@ pub(crate) fn test_s3_stage_info() -> mt::principal::StageInfo {
                 ..Default::default()
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -160,7 +160,7 @@ pub(crate) fn test_s3_stage_info_v16() -> mt::principal::StageInfo {
                 ..Default::default()
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -199,7 +199,7 @@ pub(crate) fn test_s3_stage_info_v14() -> mt::principal::StageInfo {
                 ..Default::default()
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -234,7 +234,7 @@ pub(crate) fn test_gcs_stage_info() -> mt::principal::StageInfo {
                 credential: "my_credential".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -273,7 +273,7 @@ pub(crate) fn test_oss_stage_info() -> mt::principal::StageInfo {
                 server_side_encryption_key_id: "".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -307,7 +307,7 @@ pub(crate) fn test_webhdfs_stage_info() -> mt::principal::StageInfo {
                 delegation: "<delegation_token>".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -342,7 +342,7 @@ pub(crate) fn test_obs_stage_info() -> mt::principal::StageInfo {
                 bucket: "bucket".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -377,7 +377,7 @@ pub(crate) fn test_cos_stage_info() -> mt::principal::StageInfo {
                 bucket: "bucket".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -820,7 +820,7 @@ pub(crate) fn test_internal_stage_info_v17() -> mt::principal::StageInfo {
                 root: "/dir/to/files".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,
@@ -851,7 +851,7 @@ pub(crate) fn test_stage_info_v18() -> mt::principal::StageInfo {
                 root: "/dir/to/files".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,

--- a/src/meta/proto-conv/tests/it/v025_user_stage.rs
+++ b/src/meta/proto-conv/tests/it/v025_user_stage.rs
@@ -50,7 +50,7 @@ fn test_decode_v25_user_stage() -> anyhow::Result<()> {
                 root: "/dir/to/files".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,

--- a/src/meta/proto-conv/tests/it/v035_user_stage.rs
+++ b/src/meta/proto-conv/tests/it/v035_user_stage.rs
@@ -47,7 +47,7 @@ fn test_decode_v35_user_stage() -> anyhow::Result<()> {
                 root: "/dir/to/files".to_string(),
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,

--- a/src/meta/proto-conv/tests/it/v042_s3_stage_new_field.rs
+++ b/src/meta/proto-conv/tests/it/v042_s3_stage_new_field.rs
@@ -51,7 +51,7 @@ fn test_decode_v42_s3_stage_new_field() -> anyhow::Result<()> {
                 ..Default::default()
             }),
         },
-        is_from_uri: false,
+        is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Json(
             mt::principal::JsonFileFormatParams {
                 compression: mt::principal::StageFileCompression::Bz2,

--- a/src/query/service/src/table_functions/infer_schema/infer_schema_table.rs
+++ b/src/query/service/src/table_functions/infer_schema/infer_schema_table.rs
@@ -187,7 +187,7 @@ impl AsyncSource for InferSchemaSource {
             .get_enable_experimental_rbac_check()?;
         if enable_experimental_rbac_check {
             let visibility_checker = self.ctx.get_visibility_checker().await?;
-            if !stage_info.is_from_uri
+            if !stage_info.is_temporary
                 && !visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
             {
                 return Err(ErrorCode::PermissionDenied(format!(

--- a/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
+++ b/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
@@ -216,7 +216,7 @@ impl AsyncSource for InspectParquetSource {
             .get_enable_experimental_rbac_check()?;
         if enable_experimental_rbac_check {
             let visibility_checker = self.ctx.get_visibility_checker().await?;
-            if !stage_info.is_from_uri
+            if !stage_info.is_temporary
                 && !visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
             {
                 return Err(ErrorCode::PermissionDenied(format!(

--- a/src/query/service/src/table_functions/list_stage/list_stage_table.rs
+++ b/src/query/service/src/table_functions/list_stage/list_stage_table.rs
@@ -191,7 +191,7 @@ impl AsyncSource for ListStagesSource {
             .get_enable_experimental_rbac_check()?;
         if enable_experimental_rbac_check {
             let visibility_checker = self.ctx.get_visibility_checker().await?;
-            if !stage_info.is_from_uri
+            if !stage_info.is_temporary
                 && !visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
             {
                 return Err(ErrorCode::PermissionDenied(format!(

--- a/src/query/storages/system/src/stages_table.rs
+++ b/src/query/storages/system/src/stages_table.rs
@@ -63,7 +63,7 @@ impl AsyncSystemTable for StagesTable {
             stages
                 .into_iter()
                 .filter(|stage| {
-                    !stage.is_from_uri
+                    !stage.is_temporary
                         && visibility_checker.check_stage_visibility(&stage.stage_name)
                 })
                 .collect::<Vec<_>>()

--- a/tests/suites/0_stateless/18_rbac/20_0012_privilege_access.result
+++ b/tests/suites/0_stateless/18_rbac/20_0012_privilege_access.result
@@ -49,7 +49,15 @@ dummy	TINYINT UNSIGNED	NO		NULL	NULL
 c1	INT	NO		NULL	NULL
 Error: APIError: ResponseError with 1063: Permission denied, user 'a'@'%' don't have privilege for table system.tables
 Error: APIError: ResponseError with 1063: Permission denied, user 'a'@'%' don't have privilege for database nogrant
-2
+1
+0
 93
 8
-2
+1
+0
+Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'default'.'t1' for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'default'.'t' for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'default'.'t1' for user 'b'@'%' with roles [public]

--- a/tests/suites/0_stateless/18_rbac/20_0012_privilege_access.sh
+++ b/tests/suites/0_stateless/18_rbac/20_0012_privilege_access.sh
@@ -167,16 +167,69 @@ echo "show columns from t from grant_db" | $USER_A_CONNECT
 echo "show columns from tables from system" | $USER_A_CONNECT
 echo "show tables from nogrant" | $USER_A_CONNECT
 
-
-# should return result: 2. default.test_t.id and grant_db.t.c1
-echo "select count(1) from information_schema.columns where table_schema not in ('information_schema', 'system');" | $USER_A_CONNECT
+echo "select count(1) from information_schema.columns where table_schema in ('grant_db');" | $USER_A_CONNECT
+echo "select count(1) from information_schema.columns where table_schema in ('nogrant');" | $USER_A_CONNECT
 echo "select count(1) from information_schema.columns where table_schema in ('information_schema', 'system');" | $USER_A_CONNECT
 echo "select count(1) from information_schema.tables where table_schema in ('information_schema', 'system');;" | $USER_A_CONNECT
-echo "select count(1) from information_schema.tables where table_schema not in ('information_schema', 'system');" | $USER_A_CONNECT
+echo "select count(1) from information_schema.tables where table_schema in ('grant_db');" | $USER_A_CONNECT
+echo "select count(1) from information_schema.tables where table_schema in ('nogrant');" | $USER_A_CONNECT
+
+#DML privilege check
+export USER_B_CONNECT="bendsql --user=b --password=password --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
+
+rm -rf /tmp/00_0020
+mkdir -p /tmp/00_0020
+cat << EOF > /tmp/00_0020/i0.csv
+1
+2
+EOF
+
+echo "drop user if exists b" |  $BENDSQL_CLIENT_CONNECT
+echo "create user b identified by '$TEST_USER_PASSWORD'" |  $BENDSQL_CLIENT_CONNECT
+
+echo "drop table if exists t" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t2" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s3;"  | $BENDSQL_CLIENT_CONNECT
+
+echo "create table t(id int)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t1(id int)" | $BENDSQL_CLIENT_CONNECT
+echo "grant create on default.* to b" | $BENDSQL_CLIENT_CONNECT
+echo "grant insert, delete on default.t to b" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on system.* to b" | $BENDSQL_CLIENT_CONNECT
+
+echo "create stage s3;"  | $BENDSQL_CLIENT_CONNECT
+echo "copy into '@s3/a b' from (select 2);"  | $BENDSQL_CLIENT_CONNECT
+
+# need err
+echo "insert into t select * from t1" | $USER_B_CONNECT
+echo "insert into t select * from @s3" | $USER_B_CONNECT
+echo "create table t2 as select * from t" | $USER_B_CONNECT
+echo "create table t2 as select * from @s3" | $USER_B_CONNECT
+echo "copy into t from (select * from @s3);" | $USER_B_CONNECT
+echo "replace into t on(id) select * from t1;" | $USER_B_CONNECT
+
+echo "grant select on default.t to b" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on default.t1 to b" | $BENDSQL_CLIENT_CONNECT
+echo "grant read on stage s3 to b" | $BENDSQL_CLIENT_CONNECT
+
+echo "insert into t select * from t1" | $USER_B_CONNECT
+echo "insert into t select * from @s3" | $USER_B_CONNECT
+echo "create table t2 as select * from t" | $USER_B_CONNECT
+echo "drop table t2" | $BENDSQL_CLIENT_CONNECT
+echo "create table t2 as select * from @s3" | $USER_B_CONNECT
+echo "copy into t from (select * from @s3);" | $USER_B_CONNECT
+echo "replace into t on(id) select * from t1;" | $USER_B_CONNECT
 
 ## Drop user
 echo "drop user a" | $BENDSQL_CLIENT_CONNECT
+echo "drop user b" | $BENDSQL_CLIENT_CONNECT
 echo "drop database if exists no_grant" | $BENDSQL_CLIENT_CONNECT
 echo "drop database grant_db" |  $BENDSQL_CLIENT_CONNECT
+
+echo "drop table if exists t" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t2" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s3;"  | $BENDSQL_CLIENT_CONNECT
 
 echo "unset enable_experimental_rbac_check" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
+++ b/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
@@ -27,3 +27,4 @@ Error: APIError: ResponseError with 1063: Permission denied, privilege READ is r
 1	1
 2	2
 === check access user's local stage ===
+Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'system'.'stage' for user 'b'@'%' with roles [public]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Added missing permission checks:

1. insert into table `query`
2. replace table on `query`
3. create table as `select query`
4. copy into table from `query`

The query needs to be checked. If there is no permission, the statement needs to report an error.

After the corresponding permission is added, the command can be executed normally.

This pr is the improvement of the permission check and will not cause breaking

- Closes #13727

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13845)
<!-- Reviewable:end -->
