### PR TITLE
fix: killing in-progress tasks causes query node to crash (Segment Fault)

### DIFF
--- a/src/query/pipeline/core/src/processors/processor.rs
+++ b/src/query/pipeline/core/src/processors/processor.rs
@@ -157,14 +157,12 @@ impl ProcessorPtr {
     }
 
     /// # Safety
-    pub unsafe fn async_process(&self) -> BoxFuture<'static, Result<()>> {
-        let id = self.id();
-        let mut name = self.name();
-        name.push_str("::async_process");
-
-        let task = (*self.inner.get()).async_process();
-
+    pub unsafe fn async_process(self) -> BoxFuture<'static, Result<()>> {
         async move {
+            let id = self.id();
+            let mut name = self.name();
+            name.push_str("::async_process");
+            let task = (*self.inner.get()).async_process();
             let span = Span::enter_with_local_parent(name)
                 .with_property(|| ("graph-node-id", id.index().to_string()));
 

--- a/src/query/pipeline/core/src/processors/processor.rs
+++ b/src/query/pipeline/core/src/processors/processor.rs
@@ -178,7 +178,7 @@ impl ProcessorPtr {
         let task = (*self.inner.0.get()).async_process();
 
         // The `task` may have reference to the `Processor` that hold in `self.inner`,
-        // so we need to move `self` into the following async closure to keep the
+        // so we need to move a clone of `self.inner` into the following async closure to keep the
         // `Processor` from being dropped before `task` is done.
 
         // e.g.

--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -386,13 +386,13 @@ impl ScheduleQueue {
         unsafe {
             workers_condvar.inc_active_async_worker();
             let weak_executor = Arc::downgrade(executor);
-            let process_future = proc.clone().async_process();
+            let process_future = proc.async_process();
             executor.async_runtime.spawn(
                 query_id.as_ref().clone(),
                 TrackedFuture::create(ProcessorAsyncTask::create(
                     query_id,
                     wakeup_worker_id,
-                    proc,
+                    proc.clone(),
                     global_queue,
                     workers_condvar,
                     weak_executor,

--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -386,13 +386,13 @@ impl ScheduleQueue {
         unsafe {
             workers_condvar.inc_active_async_worker();
             let weak_executor = Arc::downgrade(executor);
-            let process_future = proc.async_process();
+            let process_future = proc.clone().async_process();
             executor.async_runtime.spawn(
                 query_id.as_ref().clone(),
                 TrackedFuture::create(ProcessorAsyncTask::create(
                     query_id,
                     wakeup_worker_id,
-                    proc.clone(),
+                    proc,
                     global_queue,
                     workers_condvar,
                     weak_executor,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary


**Problem trying to address**:

Killing tasks in progress, such as the `replace-into` statement, may cause the query node to crash (SegmentFault).

------

**How to reproduce:**

_Single-node deployment (local fs storage is sufficient)_

- **Test table**: `create table t as select * from numbers(10000000)`
- **Continuously execute**: `replace into t on(number) select * from t`
- **Simultaneously** & continuously use the `kill query $QUERY_ID` command to kill the `replace-into` operations in progress

Usually, within half a minute (or faster), the query node will crash due to SIGSEGV.

------------------------

At least the following issue could lead to the previously described situation:

In the `ProcessorPtr::async_process` method, the returned async task may contain a reference to the `Processor` referenced in `ProcessorPtr`. However, their lifetime might not be aligned, leading to the possibility that this async task accesses a Processor instance that has already been dropped.


In this PR:

The async task (BoxFuture) holds a reference to the ProcessorPtr instance, and it only releases this reference when the task finishes.



-------------------------



- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13847)
<!-- Reviewable:end -->
