### PR TITLE
refactor: auto split large append-entries RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ dependencies = [
  "common-proto-conv",
  "common-protos",
  "common-tracing",
- "openraft 0.8.4",
+ "openraft 0.9.0",
  "serde",
  "serde_json",
 ]
@@ -2380,7 +2380,7 @@ dependencies = [
  "minitrace",
  "num",
  "once_cell",
- "openraft 0.8.4",
+ "openraft 0.9.0",
  "pretty_assertions",
  "semver",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
  "log",
  "minitrace",
  "once_cell",
- "openraft 0.8.4",
+ "openraft 0.9.0",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -2455,7 +2455,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "once_cell",
- "openraft 0.8.4",
+ "openraft 0.9.0",
  "prost 0.12.1",
  "prost-build",
  "regex",
@@ -7752,8 +7752,8 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.8.4"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.10#7d469c3da769de5e8886cb1af95008c930b98147"
+version = "0.9.0"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.1#24243ec7b904d760c0419a83bd327dbf923e015e"
 
 [[package]]
 name = "maplit"
@@ -8528,8 +8528,8 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.8.4"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.8.4-alpha.10#7d469c3da769de5e8886cb1af95008c930b98147"
+version = "0.9.0"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.1#24243ec7b904d760c0419a83bd327dbf923e015e"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ jsonb = { git = "https://github.com/datafuselabs/jsonb", rev = "1d7a3e9" }
 
 # openraft = { version = "0.8.2", features = ["compat-07"] }
 # For debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.8.4-alpha.10", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.1", features = [
     "compat-07",
     "tracing-log",
     # allows to remove all data from a follower and restore from the leader.

--- a/src/meta/service/src/grpc_helper.rs
+++ b/src/meta/service/src/grpc_helper.rs
@@ -23,11 +23,16 @@ use common_meta_types::RaftError;
 pub struct GrpcHelper;
 
 impl GrpcHelper {
-    #[allow(dead_code)]
     /// Inject span into a tonic request, so that on the remote peer the tracing context can be restored.
-    fn traced_req<T>(t: T) -> tonic::Request<T> {
+    pub fn traced_req<T>(t: T) -> tonic::Request<T> {
         let req = tonic::Request::new(t);
         common_tracing::inject_span_to_tonic_request(req)
+    }
+
+    pub fn encode_raft_request<T>(v: &T) -> Result<RaftRequest, serde_json::Error>
+    where T: serde::Serialize + 'static {
+        let data = serde_json::to_string(&v)?;
+        Ok(RaftRequest { data })
     }
 
     pub fn parse_raft_reply<T, E>(

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -164,7 +164,7 @@ pub type LogStore = Adaptor<TypeConfig, RaftStore>;
 pub type SMStore = Adaptor<TypeConfig, RaftStore>;
 
 /// MetaRaft is a implementation of the generic Raft handling meta data R/W.
-pub type MetaRaft = Raft<TypeConfig, Network, LogStore, SMStore>;
+pub type MetaRaft = Raft<TypeConfig>;
 
 /// MetaNode is the container of meta data related components and threads, such as storage, the raft node and a raft-state monitor.
 pub struct MetaNode {

--- a/src/meta/types/src/grpc_config.rs
+++ b/src/meta/types/src/grpc_config.rs
@@ -16,9 +16,19 @@
 pub struct GrpcConfig {}
 
 impl GrpcConfig {
-    /// The maximum message size the client or server can **send**.
+    /// The hard limit of maximum message size the client or server can **send**.
     pub const MAX_ENCODING_SIZE: usize = 16 * 1024 * 1024;
 
-    /// The maximum message size the client or server can **receive**.
+    /// The hard limit of maximum message size the client or server can **receive**.
     pub const MAX_DECODING_SIZE: usize = 16 * 1024 * 1024;
+
+    /// The advisory maximum message size the client or server can **send**.
+    pub const fn advisory_encoding_size() -> usize {
+        Self::MAX_ENCODING_SIZE * 9 / 10
+    }
+
+    /// The advisory maximum message size the client or server can **receive**.
+    pub const fn advisory_decoding_size() -> usize {
+        Self::MAX_DECODING_SIZE * 9 / 10
+    }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### refactor: auto split large append-entries RPC

If an append-entries request is too large, inform Openraft to split it
into smaller chunks by returning a `PayloadTooLarge` error.

Upgrade openraft 0.8.4-alpha.10 to 0.9.0-alpha.1; Openraft change log:

- Fixed:
    -   [4ad89fef](https://github.com/datafuselabs/openraft/commit/4ad89fefdf6060319d594d4a0fd6f37d6daf43ee) For single-threaded execution, there is no need for `Send`/`Sync` bounds.
- Changed:
    -   [87c0d74f](https://github.com/datafuselabs/openraft/commit/87c0d74fb4941a87e7aaeb8961e0f9381d637eb9) remove `N, LS, SM` from `Raft<C, N, LS, SM>`.
- Added:
    -   [961469c0](https://github.com/datafuselabs/openraft/commit/961469c05214059cd536457079b05a10343879e3) add `PayloadTooLarge` error.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13857)
<!-- Reviewable:end -->
