### PR TITLE
feat: auto enable change tracking when create stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,6 +4483,7 @@ dependencies = [
  "common-meta-api",
  "common-meta-app",
  "common-meta-store",
+ "common-meta-types",
  "common-sql",
  "common-storages-fuse",
  "common-storages-stream",

--- a/src/query/ee/Cargo.toml
+++ b/src/query/ee/Cargo.toml
@@ -27,6 +27,7 @@ common-license = { path = "../../common/license" }
 common-meta-api = { path = "../../meta/api" }
 common-meta-app = { path = "../../meta/app" }
 common-meta-store = { path = "../../meta/store" }
+common-meta-types = { path = "../../meta/types" }
 common-sql = { path = "../sql" }
 common-storages-fuse = { path = "../storages/fuse" }
 common-storages-stream = { path = "../storages/stream" }

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0003_stream.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0003_stream.test
@@ -127,10 +127,18 @@ select * from s2 order by a
 4
 
 statement ok
-create table t2(a int) change_tracking = true
+create table t2(a int)
 
 statement ok
 create stream s3 on table t2
+
+statement ok
+set hide_options_in_show_create_table=0
+
+query TT
+show create table t2
+----
+t2 CREATE TABLE `t2` (   `a` INT NULL ) ENGINE=FUSE CHANGE_TRACKING='true' COMPRESSION='zstd' STORAGE_FORMAT='parquet'
 
 statement ok
 insert into t2 values(3),(4)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Auto enable change tracking when create stream.
```sql
mysql> create table t(a int);
Query OK, 0 rows affected (0.11 sec)

mysql> insert into t values(1);
Query OK, 1 row affected (0.21 sec)

mysql> create stream s on table t;
Query OK, 0 rows affected (0.17 sec)

mysql> set hide_options_in_show_create_table=0;
Query OK, 0 rows affected (0.03 sec)

mysql> show create table t;
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                             |
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `a` INT NULL
) ENGINE=FUSE CHANGE_TRACKING='true' COMPRESSION='zstd' SNAPSHOT_LOCATION='1/843/_ss/1c8a3f78bcee4104bbb10c252365d3d2_v4.mpk' STORAGE_FORMAT='parquet' |
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.14 sec)
Read 0 rows, 0.00 B in 0.044 sec., 0 rows/sec., 0.00 B/sec.
```

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13858)
<!-- Reviewable:end -->
