### PR TITLE
chore(query): support from first query

### DIFF
--- a/src/query/ast/tests/it/testdata/statement-error.txt
+++ b/src/query/ast/tests/it/testdata/statement-error.txt
@@ -405,7 +405,7 @@ error:
   --> SQL:1:35
   |
 1 | SELECT * FROM t GROUP BY GROUPING SETS a, b
-  |                                   ^^^^ unexpected `SETS`, expecting `SELECT`, `INTERSECT`, `WITH`, `EXCEPT`, `VALUES`, `OFFSET`, `IGNORE_RESULT`, `,`, `HAVING`, `WINDOW`, `(`, `UNION`, `ORDER`, `LIMIT`, `FORMAT`, or `;`
+  |                                   ^^^^ unexpected `SETS`, expecting `SELECT`, `INTERSECT`, `WITH`, `EXCEPT`, `VALUES`, `OFFSET`, `IGNORE_RESULT`, `,`, `HAVING`, `WINDOW`, `(`, `UNION`, `FROM`, `ORDER`, `LIMIT`, `FORMAT`, or `;`
 
 
 ---------- Input ----------

--- a/tests/sqllogictests/suites/query/select.test
+++ b/tests/sqllogictests/suites/query/select.test
@@ -70,12 +70,25 @@ select col0, col1 from (values(1, 'one'), (null, 'two'), (3, null))
 NULL two
 3 NULL
 
-query IT
+query I
 select 1 from (values('a'),('b'),('c'))
 ----
 1
 1
 1
+
+query I
+from (values('a'),('b'),('c')) select 1
+----
+1
+1
+1
+
+query IT
+from range(1,3) t(a) select t.a;
+----
+1
+2
 
 query IT
 select col0, col1 from (values(1, 'one'), (null, 'two'), (3 + 2, null))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

`from table select * `  equals to `select * from table`


The former one could be useful if the select list is very long which may help people notice which table did this SQL select from, this feature is enabled in DuckDB and clickhouse.

cc @soyeric128 

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13859)
<!-- Reviewable:end -->
