### PR TITLE
fix: resolve QueryCoordinator leak when killing in-progress tasks with 'kill query'

### DIFF
--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -41,6 +41,7 @@ use parking_lot::Mutex;
 use parking_lot::RwLock;
 use uuid::Uuid;
 
+use crate::api::DataExchangeManager;
 use crate::clusters::Cluster;
 use crate::pipelines::executor::PipelineExecutor;
 use crate::sessions::query_affect::QueryAffect;
@@ -176,6 +177,7 @@ impl QueryContextShared {
 
         if let Some(executor) = self.executor.read().upgrade() {
             executor.finish(Some(cause));
+            DataExchangeManager::instance().on_finished_query(&self.init_query_id.read());
         }
 
         // TODO: Wait for the query to be processed (write out the last error)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

WIP: to be detailed

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13866)
<!-- Reviewable:end -->
