### PR TITLE
chore: bump h3 from 0.3.0 to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6570,9 +6570,9 @@ dependencies = [
 
 [[package]]
 name = "h3o"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b043acc132a9a7d07a8fb9c4b49cc2459f163bb73ab22cdcdefe6b76b3a7df96"
+checksum = "c6fb938100651db317719f46877a3cd82105920be4ea2ff49d55d1d65fa7bec1"
 dependencies = [
  "ahash 0.8.3",
  "auto_ops",

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -36,7 +36,7 @@ ctor = "0.1.26"
 ethnum = { workspace = true }
 geo = "0.24.0"
 geohash = "0.13.0"
-h3o = "0.3.0"
+h3o = "0.4.0"
 hex = "0.4.3"
 itertools = "0.10.5"
 lexical-core = "0.8.5"

--- a/src/query/functions/tests/it/scalars/testdata/geo_h3.txt
+++ b/src/query/functions/tests/it/scalars/testdata/geo_h3.txt
@@ -306,28 +306,28 @@ evaluation (internal):
 ast            : h3_edge_length_m(0)
 raw expr       : h3_edge_length_m(0)
 checked expr   : h3_edge_length_m<UInt8>(0_u8)
-optimized expr : 1107712.591_f64
+optimized expr : 1281256.010741364_f64
 output type    : Float64
-output domain  : {1107712.591..=1107712.591}
-output         : 1107712.591
+output domain  : {1281256.010741364..=1281256.010741364}
+output         : 1281256.010741364
 
 
 ast            : h3_edge_length_m(1)
 raw expr       : h3_edge_length_m(1)
 checked expr   : h3_edge_length_m<UInt8>(1_u8)
-optimized expr : 418676.0055_f64
+optimized expr : 483056.839071111_f64
 output type    : Float64
-output domain  : {418676.0055..=418676.0055}
-output         : 418676.0055
+output domain  : {483056.839071111..=483056.839071111}
+output         : 483056.839071111
 
 
 ast            : h3_edge_length_m(15)
 raw expr       : h3_edge_length_m(15)
 checked expr   : h3_edge_length_m<UInt8>(15_u8)
-optimized expr : 0.509713273_f64
+optimized expr : 0.5841686296_f64
 output type    : Float64
-output domain  : {0.509713273..=0.509713273}
-output         : 0.509713273
+output domain  : {0.5841686296..=0.5841686296}
+output         : 0.5841686296
 
 
 error: 
@@ -342,50 +342,50 @@ ast            : h3_edge_length_m(res)
 raw expr       : h3_edge_length_m(res::UInt8)
 checked expr   : h3_edge_length_m<UInt8>(res)
 evaluation:
-+--------+---------+--------------+
-|        | res     | Output       |
-+--------+---------+--------------+
-| Type   | UInt8   | Float64      |
-| Domain | {1..=4} | {-inf..=NaN} |
-| Row 0  | 1       | 418676.0055  |
-| Row 1  | 2       | 158244.6558  |
-| Row 2  | 3       | 59810.85794  |
-| Row 3  | 4       | 22606.3794   |
-+--------+---------+--------------+
++--------+---------+-------------------+
+|        | res     | Output            |
++--------+---------+-------------------+
+| Type   | UInt8   | Float64           |
+| Domain | {1..=4} | {-inf..=NaN}      |
+| Row 0  | 1       | 483056.839071111  |
+| Row 1  | 2       | 182512.9564891674 |
+| Row 2  | 3       | 68979.2217877558  |
+| Row 3  | 4       | 26071.7596801773  |
++--------+---------+-------------------+
 evaluation (internal):
-+--------+--------------------------------------------------------------+
-| Column | Data                                                         |
-+--------+--------------------------------------------------------------+
-| res    | UInt8([1, 2, 3, 4])                                          |
-| Output | Float64([418676.0055, 158244.6558, 59810.85794, 22606.3794]) |
-+--------+--------------------------------------------------------------+
++--------+------------------------------------------------------------------------------------+
+| Column | Data                                                                               |
++--------+------------------------------------------------------------------------------------+
+| res    | UInt8([1, 2, 3, 4])                                                                |
+| Output | Float64([483056.839071111, 182512.9564891674, 68979.2217877558, 26071.7596801773]) |
++--------+------------------------------------------------------------------------------------+
 
 
 ast            : h3_edge_length_km(0)
 raw expr       : h3_edge_length_km(0)
 checked expr   : h3_edge_length_km<UInt8>(0_u8)
-optimized expr : 1107.712591_f64
+optimized expr : 1281.2560107413_f64
 output type    : Float64
-output domain  : {1107.712591..=1107.712591}
-output         : 1107.712591
+output domain  : {1281.2560107413..=1281.2560107413}
+output         : 1281.2560107413
 
 
 ast            : h3_edge_length_km(1)
 raw expr       : h3_edge_length_km(1)
 checked expr   : h3_edge_length_km<UInt8>(1_u8)
-optimized expr : 418.6760055_f64
+optimized expr : 483.0568390711_f64
 output type    : Float64
-output domain  : {418.6760055..=418.6760055}
-output         : 418.6760055
+output domain  : {483.0568390711..=483.0568390711}
+output         : 483.0568390711
 
 
 ast            : h3_edge_length_km(15)
 raw expr       : h3_edge_length_km(15)
 checked expr   : h3_edge_length_km<UInt8>(15_u8)
-optimized expr : 0.000509713_f64
+optimized expr : 0.0005841686_f64
 output type    : Float64
-output domain  : {0.000509713..=0.000509713}
-output         : 0.000509713
+output domain  : {0.0005841686..=0.0005841686}
+output         : 0.0005841686
 
 
 error: 
@@ -400,23 +400,23 @@ ast            : h3_edge_length_km(res)
 raw expr       : h3_edge_length_km(res::UInt8)
 checked expr   : h3_edge_length_km<UInt8>(res)
 evaluation:
-+--------+---------+--------------+
-|        | res     | Output       |
-+--------+---------+--------------+
-| Type   | UInt8   | Float64      |
-| Domain | {1..=4} | {-inf..=NaN} |
-| Row 0  | 1       | 418.6760055  |
-| Row 1  | 2       | 158.2446558  |
-| Row 2  | 3       | 59.81085794  |
-| Row 3  | 4       | 22.6063794   |
-+--------+---------+--------------+
++--------+---------+----------------+
+|        | res     | Output         |
++--------+---------+----------------+
+| Type   | UInt8   | Float64        |
+| Domain | {1..=4} | {-inf..=NaN}   |
+| Row 0  | 1       | 483.0568390711 |
+| Row 1  | 2       | 182.5129564891 |
+| Row 2  | 3       | 68.9792217877  |
+| Row 3  | 4       | 26.0717596801  |
++--------+---------+----------------+
 evaluation (internal):
-+--------+--------------------------------------------------------------+
-| Column | Data                                                         |
-+--------+--------------------------------------------------------------+
-| res    | UInt8([1, 2, 3, 4])                                          |
-| Output | Float64([418.6760055, 158.2446558, 59.81085794, 22.6063794]) |
-+--------+--------------------------------------------------------------+
++--------+-------------------------------------------------------------------------+
+| Column | Data                                                                    |
++--------+-------------------------------------------------------------------------+
+| res    | UInt8([1, 2, 3, 4])                                                     |
+| Output | Float64([483.0568390711, 182.5129564891, 68.9792217877, 26.0717596801]) |
++--------+-------------------------------------------------------------------------+
 
 
 error: 
@@ -1662,19 +1662,19 @@ evaluation (internal):
 ast            : h3_edge_angle(0)
 raw expr       : h3_edge_angle(0)
 checked expr   : h3_edge_angle<UInt8>(0_u8)
-optimized expr : 9.961887434_f64
+optimized expr : 11.5225991443_f64
 output type    : Float64
-output domain  : {9.961887434..=9.961887434}
-output         : 9.961887434
+output domain  : {11.5225991443..=11.5225991443}
+output         : 11.5225991443
 
 
 ast            : h3_edge_angle(10)
 raw expr       : h3_edge_angle(10)
 checked expr   : h3_edge_angle<UInt8>(10_u8)
-optimized expr : 0.0005927224_f64
+optimized expr : 0.0006822586_f64
 output type    : Float64
-output domain  : {0.0005927224..=0.0005927224}
-output         : 0.0005927224
+output domain  : {0.0006822586..=0.0006822586}
+output         : 0.0006822586
 
 
 error: 
@@ -1694,15 +1694,15 @@ evaluation:
 +--------+-----------+--------------+
 | Type   | UInt8     | Float64      |
 | Domain | {10..=12} | {-inf..=NaN} |
-| Row 0  | 10        | 0.0005927224 |
-| Row 1  | 12        | 0.0000846757 |
+| Row 0  | 10        | 0.0006822586 |
+| Row 1  | 12        | 0.0000973981 |
 +--------+-----------+--------------+
 evaluation (internal):
 +--------+---------------------------------------+
 | Column | Data                                  |
 +--------+---------------------------------------+
 | res    | UInt8([10, 12])                       |
-| Output | Float64([0.0005927224, 0.0000846757]) |
+| Output | Float64([0.0006822586, 0.0000973981]) |
 +--------+---------------------------------------+
 
 

--- a/tests/sqllogictests/suites/query/02_function/02_0060_function_geo_h3.test
+++ b/tests/sqllogictests/suites/query/02_function/02_0060_function_geo_h3.test
@@ -31,12 +31,12 @@ select h3_get_resolution(644325524701193974)
 query F
 select h3_edge_length_m(1)
 ----
-418676.0055
+483056.8390711111
 
 query F
 select h3_edge_length_km(1)
 ----
-418.6760055
+483.0568390711111
 
 statement ok
 DROP TABLE IF EXISTS t1
@@ -99,18 +99,18 @@ INSERT INTO t2 VALUES(1), (2), (3), (4)
 query F
 select h3_edge_length_m(res) as m from t2 order by m
 ----
-22606.3794
-59810.85794
-158244.6558
-418676.0055
+26071.75968017739
+68979.22178775584
+182512.95648916735
+483056.8390711111
 
 query F
 select h3_edge_length_km(res) as km from t2 order by km
 ----
-22.6063794
-59.81085794
-158.2446558
-418.6760055
+26.07175968017739
+68.97922178775585
+182.51295648916735
+483.0568390711111
 
 query I
 select h3_get_base_cell(644325524701193974)
@@ -258,7 +258,7 @@ select h3_is_res_class_iii(h3) as i from t4 order by i
 1
 1
 
-query B 
+query B
 select h3_is_pentagon(h3) as i from t4 order by i
 ----
 0
@@ -430,7 +430,7 @@ select h3_get_unidirectional_edge_boundary(1248204388774707199)
 query F
 select h3_edge_angle(10)
 ----
-0.0005927224846720883
+0.0006822586214153981
 
 statement ok
 DROP TABLE IF EXISTS t6
@@ -484,8 +484,8 @@ select h3_get_unidirectional_edge_boundary(h3) from t6
 query F
 select h3_edge_angle(res) as angle from t6 order by angle
 ----
-4.583956425628968e-6
-0.0005927224846720883
+5.2535487801633385e-6
+0.0006822586214153981
 
 statement ok
 DROP TABLE t1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Bump h3 to 0.4.0, the difference in the results is because they fixed "update precomputed average edge lengths (they were underestimated)." in 0.3.5

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13874)
<!-- Reviewable:end -->
