### PR TITLE
chore: move singleton instance to global serivce

### DIFF
--- a/src/bendpy/src/lib.rs
+++ b/src/bendpy/src/lib.rs
@@ -54,7 +54,7 @@ fn databend(_py: Python, m: &PyModule) -> PyResult<()> {
         MetaEmbedded::init_global_meta_store(meta_dir.to_string_lossy().to_string())
             .await
             .unwrap();
-        GlobalServices::init(conf.clone()).await.unwrap();
+        GlobalServices::create(conf.clone()).await.unwrap();
 
         // init oss license manager
         OssLicenseManager::init(conf.query.tenant_id.clone()).unwrap();

--- a/src/binaries/query/entry.rs
+++ b/src/binaries/query/entry.rs
@@ -78,7 +78,8 @@ pub async fn init_services(conf: &InnerConfig) -> Result<()> {
         ));
     }
     // Make sure global services have been inited.
-    GlobalServices::init(conf.clone()).await
+    GlobalServices::create(conf.clone()).await?;
+    Ok(())
 }
 
 async fn precheck_services(conf: &InnerConfig) -> Result<()> {

--- a/src/binaries/tool/table_meta_inspector.rs
+++ b/src/binaries/tool/table_meta_inspector.rs
@@ -87,7 +87,7 @@ async fn parse_input_data(config: &InspectorConfig) -> Result<Vec<u8>> {
                     builder = builder.collect(from_file(Toml, config_file));
                     let read_config = builder.build()?;
                     let inner_config: InnerConfig = read_config.clone().try_into()?;
-                    GlobalServices::init(inner_config).await?;
+                    GlobalServices::create(inner_config).await?;
                     let storage_config: StorageConfig = read_config.storage.try_into()?;
                     init_operator(&storage_config.params)?
                 }

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -37,7 +37,7 @@ pub use shutdown_signal::signal_stream;
 pub use shutdown_signal::DummySignalStream;
 pub use shutdown_signal::SignalStream;
 pub use shutdown_signal::SignalType;
-pub use singleton_instance::GlobalInstance;
+pub use singleton_instance::SingletonInstance;
 pub use stop_handle::StopHandle;
 pub use stoppable::Stoppable;
 pub use string::convert_byte_size;

--- a/src/common/base/src/base/singleton_instance.rs
+++ b/src/common/base/src/base/singleton_instance.rs
@@ -95,9 +95,9 @@ impl Debug for SingletonType {
 }
 
 /// Global is an empty struct that only used to carry associated functions.
-pub struct GlobalInstance;
+pub struct SingletonInstance;
 
-impl GlobalInstance {
+impl SingletonInstance {
     /// init production global data registry.
     ///
     /// Should only be initiated once.

--- a/src/common/base/src/runtime/global_runtime.rs
+++ b/src/common/base/src/runtime/global_runtime.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_exception::Result;
 
-use crate::base::GlobalInstance;
+use crate::base::SingletonInstance;
 use crate::runtime::Runtime;
 
 pub struct GlobalIORuntime;
@@ -35,7 +35,7 @@ impl GlobalIORuntime {
         let thread_num = std::cmp::max(num_cpus, num_cpus::get() / 2);
         let thread_num = std::cmp::max(2, thread_num);
 
-        GlobalInstance::set(Arc::new(Runtime::with_worker_threads(
+        SingletonInstance::set(Arc::new(Runtime::with_worker_threads(
             thread_num,
             Some("IO-worker".to_owned()),
         )?));
@@ -43,7 +43,7 @@ impl GlobalIORuntime {
     }
 
     pub fn instance() -> Arc<Runtime> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 }
 
@@ -53,11 +53,11 @@ impl GlobalQueryRuntime {
         let thread_num = std::cmp::max(2, thread_num);
 
         let rt = Runtime::with_worker_threads(thread_num, Some("g-query-worker".to_owned()))?;
-        GlobalInstance::set(Arc::new(GlobalQueryRuntime(rt)));
+        SingletonInstance::set(Arc::new(GlobalQueryRuntime(rt)));
         Ok(())
     }
 
     pub fn instance() -> Arc<GlobalQueryRuntime> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 }

--- a/src/common/cloud_control/src/cloud_api.rs
+++ b/src/common/cloud_control/src/cloud_api.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
@@ -54,12 +54,12 @@ impl CloudControlApiProvider {
     #[async_backtrace::framed]
     pub async fn init(addr: String) -> Result<()> {
         let provider = Self::new(addr).await?;
-        GlobalInstance::set(provider);
+        SingletonInstance::set(provider);
         Ok(())
     }
 
     pub fn instance() -> Arc<CloudControlApiProvider> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     pub fn get_task_client(&self) -> Arc<TaskClient> {

--- a/src/common/license/src/license_manager.rs
+++ b/src/common/license/src/license_manager.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use jwt_simple::claims::JWTClaims;
@@ -68,12 +68,12 @@ impl LicenseManager for OssLicenseManager {
         let wrapper = LicenseManagerWrapper {
             manager: Box::new(rm),
         };
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         Ok(())
     }
 
     fn instance() -> Arc<Box<dyn LicenseManager>> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     fn check_enterprise_enabled(&self, _license_key: String, _feature: Feature) -> Result<()> {
@@ -90,5 +90,5 @@ impl LicenseManager for OssLicenseManager {
 }
 
 pub fn get_license_manager() -> Arc<LicenseManagerWrapper> {
-    GlobalInstance::get()
+    SingletonInstance::get()
 }

--- a/src/common/storage/src/config.rs
+++ b/src/common/storage/src/config.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use common_auth::RefreshableToken;
 use common_auth::TokenFile;
 use common_base::base::tokio::sync::RwLock;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_meta_app::storage::StorageParams;
 use serde::Deserialize;
 use serde::Serialize;
@@ -59,7 +59,7 @@ impl ShareTableConfig {
         token_file: &str,
         default_token: String,
     ) -> common_exception::Result<()> {
-        GlobalInstance::set(Self::try_create(
+        SingletonInstance::set(Self::try_create(
             share_endpoint_address,
             token_file,
             default_token,
@@ -100,6 +100,6 @@ impl ShareTableConfig {
     }
 
     pub fn instance() -> ShareTableConfig {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 }

--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -19,7 +19,7 @@ use std::io::Result;
 use std::time::Duration;
 
 use anyhow::anyhow;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_base::runtime::GlobalIORuntime;
 use common_base::runtime::TrySpawn;
 use common_base::GLOBAL_TASK;
@@ -396,7 +396,7 @@ impl DataOperator {
 
     #[async_backtrace::framed]
     pub async fn init(conf: &StorageConfig) -> common_exception::Result<()> {
-        GlobalInstance::set(Self::try_create(&conf.params).await?);
+        SingletonInstance::set(Self::try_create(&conf.params).await?);
 
         Ok(())
     }
@@ -449,6 +449,6 @@ impl DataOperator {
     }
 
     pub fn instance() -> DataOperator {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 }

--- a/src/common/tracing/src/init.rs
+++ b/src/common/tracing/src/init.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use common_base::base::tokio;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use fern::FormatCallback;
 use log::LevelFilter;
 use log::Log;
@@ -42,7 +42,7 @@ pub struct GlobalLogger {
 impl GlobalLogger {
     pub fn init(name: &str, cfg: &Config, labels: BTreeMap<String, String>) {
         let _guards = init_logging(name, cfg, labels);
-        GlobalInstance::set(Self { _guards });
+        SingletonInstance::set(Self { _guards });
     }
 }
 

--- a/src/query/catalog/src/catalog/manager.rs
+++ b/src/query/catalog/src/catalog/manager.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::Utc;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_config::CatalogConfig;
 use common_config::InnerConfig;
 use common_exception::ErrorCode;
@@ -56,7 +56,7 @@ pub struct CatalogManager {
 impl CatalogManager {
     /// Fetch catalog manager from global instance.
     pub fn instance() -> Arc<CatalogManager> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     /// Init the catalog manager in global instance.
@@ -66,7 +66,7 @@ impl CatalogManager {
         default_catalog: Arc<dyn Catalog>,
         catalog_creators: Vec<(CatalogType, Arc<dyn CatalogCreator>)>,
     ) -> Result<()> {
-        GlobalInstance::set(Self::try_create(conf, default_catalog, catalog_creators).await?);
+        SingletonInstance::set(Self::try_create(conf, default_catalog, catalog_creators).await?);
 
         Ok(())
     }

--- a/src/query/config/src/global.rs
+++ b/src/query/config/src/global.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::Result;
 
 use crate::InnerConfig;
@@ -23,15 +23,15 @@ pub struct GlobalConfig;
 
 impl GlobalConfig {
     pub fn init(config: InnerConfig) -> Result<()> {
-        GlobalInstance::set(Arc::new(config));
+        SingletonInstance::set(Arc::new(config));
         Ok(())
     }
 
     pub fn instance() -> Arc<InnerConfig> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     pub fn try_get_instance() -> Option<Arc<InnerConfig>> {
-        GlobalInstance::try_get()
+        SingletonInstance::try_get()
     }
 }

--- a/src/query/ee/src/aggregating_index/aggregating_index_handler.rs
+++ b/src/query/ee/src/aggregating_index/aggregating_index_handler.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use aggregating_index::AggregatingIndexHandler;
 use aggregating_index::AggregatingIndexHandlerWrapper;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_catalog::catalog::Catalog;
 use common_exception::Result;
 use common_meta_app::schema::CreateIndexReply;
@@ -73,7 +73,7 @@ impl RealAggregatingIndexHandler {
     pub fn init() -> Result<()> {
         let rm = RealAggregatingIndexHandler {};
         let wrapper = AggregatingIndexHandlerWrapper::new(Box::new(rm));
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         Ok(())
     }
 }

--- a/src/query/ee/src/background_service/background_service_handler.rs
+++ b/src/query/ee/src/background_service/background_service_handler.rs
@@ -20,7 +20,7 @@ use background_service::BackgroundServiceHandler;
 use common_base::base::tokio::sync::mpsc::Sender;
 use common_base::base::tokio::sync::Mutex;
 use common_base::base::uuid::Uuid;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_config::InnerConfig;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -254,7 +254,7 @@ impl RealBackgroundService {
         let rm = RealBackgroundService::new(conf).await?;
         if let Some(rm) = rm {
             let wrapper = BackgroundServiceHandlerWrapper::new(Box::new(rm));
-            GlobalInstance::set(Arc::new(wrapper));
+            SingletonInstance::set(Arc::new(wrapper));
         }
         Ok(())
     }

--- a/src/query/ee/src/data_mask/data_mask_handler.rs
+++ b/src/query/ee/src/data_mask/data_mask_handler.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::Result;
 use common_meta_api::DatamaskApi;
 use common_meta_app::data_mask::CreateDatamaskReq;
@@ -65,7 +65,7 @@ impl RealDatamaskHandler {
     pub fn init() -> Result<()> {
         let rm = RealDatamaskHandler {};
         let wrapper = DatamaskHandlerWrapper::new(Box::new(rm));
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         Ok(())
     }
 }

--- a/src/query/ee/src/license/license_mgr.rs
+++ b/src/query/ee/src/license/license_mgr.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::exception::ErrorCode;
 use common_exception::Result;
 use common_exception::ToErrorCode;
@@ -51,12 +51,12 @@ impl LicenseManager for RealLicenseManager {
         let wrapper = LicenseManagerWrapper {
             manager: Box::new(rm),
         };
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         Ok(())
     }
 
     fn instance() -> Arc<Box<dyn LicenseManager>> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     fn check_enterprise_enabled(&self, license_key: String, feature: Feature) -> Result<()> {

--- a/src/query/ee/src/storage_encryption/handler.rs
+++ b/src/query/ee/src/storage_encryption/handler.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_config::InnerConfig;
 use common_exception::Result;
 use common_license::license::Feature;
@@ -48,7 +48,7 @@ impl RealStorageEncryptionHandler {
     pub fn init(cfg: &InnerConfig) -> Result<()> {
         let handler = RealStorageEncryptionHandler { cfg: cfg.clone() };
         let wrapper = StorageEncryptionHandlerWrapper::new(Box::new(handler));
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         Ok(())
     }
 }

--- a/src/query/ee/src/storages/fuse/operations/handler.rs
+++ b/src/query/ee/src/storages/fuse/operations/handler.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -54,7 +54,7 @@ impl RealVacuumHandler {
     pub fn init() -> Result<()> {
         let rm = RealVacuumHandler {};
         let wrapper = VacuumHandlerWrapper::new(Box::new(rm));
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         Ok(())
     }
 }

--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_catalog::table::Table;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -195,7 +195,7 @@ impl RealStreamHandler {
     pub fn init() -> Result<()> {
         let rm = RealStreamHandler {};
         let wrapper = StreamHandlerWrapper::new(Box::new(rm));
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         Ok(())
     }
 }

--- a/src/query/ee/src/test_kits/mock_services.rs
+++ b/src/query/ee/src/test_kits/mock_services.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_config::InnerConfig;
 use common_exception::Result;
 use common_license::license_manager::LicenseManagerWrapper;
@@ -34,7 +34,7 @@ impl MockServices {
         let wrapper = LicenseManagerWrapper {
             manager: Box::new(rm),
         };
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         RealVacuumHandler::init()?;
         RealAggregatingIndexHandler::init()?;
         RealDatamaskHandler::init()?;

--- a/src/query/ee/src/test_kits/sessions.rs
+++ b/src/query/ee/src/test_kits/sessions.rs
@@ -39,9 +39,9 @@ impl TestGlobalServices {
         };
 
         #[cfg(debug_assertions)]
-        common_base::base::GlobalInstance::init_testing(&thread_name);
+        common_base::base::SingletonInstance::init_testing(&thread_name);
 
-        GlobalServices::init_with(config.clone()).await?;
+        GlobalServices::init_singleton_services(config).await?;
         MockServices::init(config.clone(), public_key).await?;
 
         // Cluster register.

--- a/src/query/ee/src/virtual_column/virtual_column_handler.rs
+++ b/src/query/ee/src/virtual_column/virtual_column_handler.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_catalog::catalog::Catalog;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -86,7 +86,7 @@ impl RealVirtualColumnHandler {
     pub fn init() -> Result<()> {
         let rm = RealVirtualColumnHandler {};
         let wrapper = VirtualColumnHandlerWrapper::new(Box::new(rm));
-        GlobalInstance::set(Arc::new(wrapper));
+        SingletonInstance::set(Arc::new(wrapper));
         Ok(())
     }
 }

--- a/src/query/ee_features/aggregating_index/src/aggregating_index_handler.rs
+++ b/src/query/ee_features/aggregating_index/src/aggregating_index_handler.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_catalog::catalog::Catalog;
 use common_exception::Result;
 use common_meta_app::schema::CreateIndexReply;
@@ -100,5 +100,5 @@ impl AggregatingIndexHandlerWrapper {
 }
 
 pub fn get_agg_index_handler() -> Arc<AggregatingIndexHandlerWrapper> {
-    GlobalInstance::get()
+    SingletonInstance::get()
 }

--- a/src/query/ee_features/background_service/src/background_service.rs
+++ b/src/query/ee_features/background_service/src/background_service.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::Result;
 use common_meta_app::principal::UserIdentity;
 
@@ -62,5 +62,5 @@ impl BackgroundServiceHandlerWrapper {
 }
 
 pub fn get_background_service_handler() -> Arc<BackgroundServiceHandlerWrapper> {
-    GlobalInstance::get()
+    SingletonInstance::get()
 }

--- a/src/query/ee_features/data_mask/src/data_mask_handler.rs
+++ b/src/query/ee_features/data_mask/src/data_mask_handler.rs
@@ -28,7 +28,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::Result;
 use common_meta_app::data_mask::CreateDatamaskReq;
 use common_meta_app::data_mask::DatamaskMeta;
@@ -89,5 +89,5 @@ impl DatamaskHandlerWrapper {
 }
 
 pub fn get_datamask_handler() -> Arc<DatamaskHandlerWrapper> {
-    GlobalInstance::get()
+    SingletonInstance::get()
 }

--- a/src/query/ee_features/storage_encryption/src/handler.rs
+++ b/src/query/ee_features/storage_encryption/src/handler.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
@@ -53,6 +53,6 @@ impl StorageEncryptionHandlerWrapper {
 
 /// Fetch the StorageEncryptionHandlerWrapper from the global instance.
 pub fn get_storage_encryption_handler() -> Arc<StorageEncryptionHandlerWrapper> {
-    GlobalInstance::try_get()
+    SingletonInstance::try_get()
         .unwrap_or_else(|| Arc::new(StorageEncryptionHandlerWrapper::new(Box::new(()))))
 }

--- a/src/query/ee_features/stream_handler/src/handler.rs
+++ b/src/query/ee_features/stream_handler/src/handler.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
 use common_meta_app::schema::CreateTableReply;
@@ -66,5 +66,5 @@ impl StreamHandlerWrapper {
 }
 
 pub fn get_stream_handler() -> Arc<StreamHandlerWrapper> {
-    GlobalInstance::get()
+    SingletonInstance::get()
 }

--- a/src/query/ee_features/vacuum_handler/src/vacuum_handler.rs
+++ b/src/query/ee_features/vacuum_handler/src/vacuum_handler.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_catalog::table::Table;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -74,5 +74,5 @@ impl VacuumHandlerWrapper {
 }
 
 pub fn get_vacuum_handler() -> Arc<VacuumHandlerWrapper> {
-    GlobalInstance::get()
+    SingletonInstance::get()
 }

--- a/src/query/ee_features/virtual_column/src/virtual_column.rs
+++ b/src/query/ee_features/virtual_column/src/virtual_column.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_catalog::catalog::Catalog;
 use common_catalog::table_context::TableContext;
 use common_exception::Result;
@@ -121,5 +121,5 @@ impl VirtualColumnHandlerWrapper {
 }
 
 pub fn get_virtual_column_handler() -> Arc<VirtualColumnHandlerWrapper> {
-    GlobalInstance::get()
+    SingletonInstance::get()
 }

--- a/src/query/profile/src/mgr.rs
+++ b/src/query/profile/src/mgr.rs
@@ -16,7 +16,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 
@@ -40,11 +40,11 @@ impl QueryProfileManager {
     }
 
     pub fn init() {
-        GlobalInstance::set(Arc::new(Self::new(DEFAULT_QUERY_PROFILE_LIMIT)));
+        SingletonInstance::set(Arc::new(Self::new(DEFAULT_QUERY_PROFILE_LIMIT)));
     }
 
     pub fn instance() -> Arc<Self> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     /// Try to get the query profile by query ID.

--- a/src/query/service/src/api/rpc/exchange/exchange_manager.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_manager.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use async_channel::Receiver;
 use common_arrow::arrow_format::flight::data::FlightData;
 use common_arrow::arrow_format::flight::service::flight_service_client::FlightServiceClient;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_base::runtime::Thread;
 use common_config::GlobalConfig;
 use common_exception::ErrorCode;
@@ -68,7 +68,7 @@ pub struct DataExchangeManager {
 
 impl DataExchangeManager {
     pub fn init() -> Result<()> {
-        GlobalInstance::set(Arc::new(DataExchangeManager {
+        SingletonInstance::set(Arc::new(DataExchangeManager {
             queries_coordinator: ReentrantMutex::new(SyncUnsafeCell::new(HashMap::new())),
         }));
 
@@ -76,7 +76,7 @@ impl DataExchangeManager {
     }
 
     pub fn instance() -> Arc<DataExchangeManager> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     pub fn get_query_ctx(&self, query_id: &str) -> Result<Arc<QueryContext>> {

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_config::InnerConfig;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -44,12 +44,12 @@ pub enum Credential {
 
 impl AuthMgr {
     pub fn init(cfg: &InnerConfig) -> Result<()> {
-        GlobalInstance::set(AuthMgr::create(cfg));
+        SingletonInstance::set(AuthMgr::create(cfg));
         Ok(())
     }
 
     pub fn instance() -> Arc<AuthMgr> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     fn create(cfg: &InnerConfig) -> Arc<AuthMgr> {

--- a/src/query/service/src/clusters/cluster.rs
+++ b/src/query/service/src/clusters/cluster.rs
@@ -28,9 +28,9 @@ use common_base::base::tokio::sync::Notify;
 use common_base::base::tokio::task::JoinHandle;
 use common_base::base::tokio::time::sleep as tokio_async_sleep;
 use common_base::base::DummySignalStream;
-use common_base::base::GlobalInstance;
 use common_base::base::SignalStream;
 use common_base::base::SignalType;
+use common_base::base::SingletonInstance;
 pub use common_catalog::cluster_info::Cluster;
 use common_config::InnerConfig;
 use common_config::DATABEND_COMMIT_VERSION;
@@ -152,7 +152,7 @@ impl ClusterDiscovery {
     #[async_backtrace::framed]
     pub async fn init(cfg: InnerConfig) -> Result<()> {
         let metastore = ClusterDiscovery::create_meta_client(&cfg).await?;
-        GlobalInstance::set(Self::try_create(&cfg, metastore).await?);
+        SingletonInstance::set(Self::try_create(&cfg, metastore).await?);
 
         Ok(())
     }
@@ -180,7 +180,7 @@ impl ClusterDiscovery {
     }
 
     pub fn instance() -> Arc<ClusterDiscovery> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     fn create_provider(

--- a/src/query/service/src/local/mod.rs
+++ b/src/query/service/src/local/mod.rs
@@ -54,7 +54,7 @@ pub async fn query_local(query_sql: &str, output_format: &str) -> Result<()> {
         .await
         .unwrap();
 
-    GlobalServices::init(conf.clone()).await?;
+    GlobalServices::create(conf.clone()).await?;
     // init oss license manager
     OssLicenseManager::init(conf.query.tenant_id.clone()).unwrap();
 

--- a/src/query/service/src/servers/http/v1/query/http_query_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_manager.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use common_base::base::tokio::sync::RwLock;
 use common_base::base::tokio::time::sleep;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_base::runtime::GlobalIORuntime;
 use common_base::runtime::TrySpawn;
 use common_config::InnerConfig;
@@ -97,7 +97,7 @@ pub struct HttpQueryManager {
 impl HttpQueryManager {
     #[async_backtrace::framed]
     pub async fn init(_cfg: &InnerConfig) -> Result<()> {
-        GlobalInstance::set(Arc::new(HttpQueryManager {
+        SingletonInstance::set(Arc::new(HttpQueryManager {
             queries: Arc::new(RwLock::new(HashMap::new())),
             sessions: Mutex::new(ExpiringMap::default()),
             removed_queries: Arc::new(RwLock::new(SizeLimitedIndexMap::new(1000))),
@@ -107,7 +107,7 @@ impl HttpQueryManager {
     }
 
     pub fn instance() -> Arc<HttpQueryManager> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -22,8 +22,8 @@ use std::sync::Weak;
 use std::time::Duration;
 
 use common_base::base::tokio;
-use common_base::base::GlobalInstance;
 use common_base::base::SignalStream;
+use common_base::base::SingletonInstance;
 use common_catalog::table_context::ProcessInfoState;
 use common_config::GlobalConfig;
 use common_config::InnerConfig;
@@ -55,7 +55,7 @@ pub struct SessionManager {
 
 impl SessionManager {
     pub fn init(conf: &InnerConfig) -> Result<()> {
-        GlobalInstance::set(Self::create(conf));
+        SingletonInstance::set(Self::create(conf));
 
         Ok(())
     }
@@ -72,7 +72,7 @@ impl SessionManager {
     }
 
     pub fn instance() -> Arc<SessionManager> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/test_kits/sessions.rs
+++ b/src/query/service/src/test_kits/sessions.rs
@@ -43,9 +43,9 @@ impl TestGlobalServices {
         };
 
         #[cfg(debug_assertions)]
-        common_base::base::GlobalInstance::init_testing(&thread_name);
+        common_base::base::SingletonInstance::init_testing(&thread_name);
 
-        GlobalServices::init_with(config.clone()).await?;
+        GlobalServices::init_singleton_services(config).await?;
         OssLicenseManager::init(config.query.tenant_id.clone())?;
 
         // Cluster register.
@@ -78,6 +78,6 @@ impl TestGuard {
 impl Drop for TestGuard {
     fn drop(&mut self) {
         #[cfg(debug_assertions)]
-        common_base::base::GlobalInstance::drop_testing(&self.thread_name);
+        common_base::base::SingletonInstance::drop_testing(&self.thread_name);
     }
 }

--- a/src/query/service/tests/it/sql/planner/format/mod.rs
+++ b/src/query/service/tests/it/sql/planner/format/mod.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_expression::types::DataType;
 use common_expression::types::NumberScalar;
 use common_expression::Scalar;
@@ -75,7 +75,7 @@ fn test_format() {
         .map(ToString::to_string)
         .expect("thread should has a name");
 
-    GlobalInstance::init_testing(&thread_name);
+    SingletonInstance::init_testing(&thread_name);
 
     let mut metadata = Metadata::default();
     let tab1 = metadata.add_table(

--- a/src/query/sharing/src/share_endpoint.rs
+++ b/src/query/sharing/src/share_endpoint.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use common_auth::RefreshableToken;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_config::GlobalConfig;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -51,14 +51,14 @@ pub struct ShareEndpointManager {
 
 impl ShareEndpointManager {
     pub fn init() -> Result<()> {
-        GlobalInstance::set(Arc::new(ShareEndpointManager {
+        SingletonInstance::set(Arc::new(ShareEndpointManager {
             client: HttpClient::new()?,
         }));
         Ok(())
     }
 
     pub fn instance() -> Arc<ShareEndpointManager> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     #[async_backtrace::framed]

--- a/src/query/sharing_endpoint/src/accessor.rs
+++ b/src/query/sharing_endpoint/src/accessor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::Result;
 use common_meta_app::storage::StorageParams;
 use common_storage::init_operator;
@@ -60,13 +60,13 @@ pub fn truncate_root(root: String, loc: String) -> String {
 impl SharingAccessor {
     #[async_backtrace::framed]
     pub async fn init(cfg: &Config) -> Result<()> {
-        GlobalInstance::set(Self::try_create(cfg).await?);
+        SingletonInstance::set(Self::try_create(cfg).await?);
 
         Ok(())
     }
 
     pub fn instance() -> SharingAccessor {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     #[async_backtrace::framed]

--- a/src/query/sharing_endpoint/src/services.rs
+++ b/src/query/sharing_endpoint/src/services.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_base::runtime::GlobalIORuntime;
 use common_exception::Result;
 
@@ -26,7 +26,7 @@ impl SharingServices {
     #[async_backtrace::framed]
     pub async fn init(config: Config) -> Result<()> {
         // init global instance singleton
-        GlobalInstance::init_production();
+        SingletonInstance::init_production();
 
         GlobalIORuntime::init(config.storage.num_cpus as usize)?;
         SharingAccessor::init(&config).await

--- a/src/query/sql/tests/location.rs
+++ b/src/query/sql/tests/location.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use common_ast::ast::UriLocation;
 use common_base::base::tokio;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_config::GlobalConfig;
 use common_config::InnerConfig;
 use common_meta_app::storage::StorageFsConfig;
@@ -45,7 +45,7 @@ async fn test_parse_uri_location() -> Result<()> {
         .map(ToString::to_string)
         .expect("thread should has a name");
 
-    GlobalInstance::init_testing(&thread_name);
+    SingletonInstance::init_testing(&thread_name);
     GlobalConfig::init(InnerConfig::default())?;
 
     let cases = vec![

--- a/src/query/storages/common/cache_manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache_manager/src/cache_manager.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_cache::CountableMeter;
 use common_cache::DefaultHashBuilder;
 use common_config::CacheConfig;
@@ -102,7 +102,7 @@ impl CacheManager {
 
         // setup in-memory table meta cache
         if !config.enable_table_meta_cache {
-            GlobalInstance::set(Arc::new(Self {
+            SingletonInstance::set(Arc::new(Self {
                 table_snapshot_cache: None,
                 segment_info_cache: None,
                 bloom_index_filter_cache: None,
@@ -137,7 +137,7 @@ impl CacheManager {
 
             let file_meta_data_cache =
                 Self::new_item_cache(DEFAULT_FILE_META_DATA_CACHE_ITEMS, "parquet_file_meta");
-            GlobalInstance::set(Arc::new(Self {
+            SingletonInstance::set(Arc::new(Self {
                 table_snapshot_cache,
                 segment_info_cache,
                 bloom_index_filter_cache,
@@ -154,7 +154,7 @@ impl CacheManager {
     }
 
     pub fn instance() -> Arc<CacheManager> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     pub fn get_table_snapshot_cache(&self) -> Option<TableSnapshotCache> {

--- a/src/query/storages/common/locks/src/lock_manager.rs
+++ b/src/query/storages/common/locks/src/lock_manager.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use common_base::base::tokio::sync::mpsc;
 use common_base::base::tokio::time::timeout;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_base::runtime::GlobalIORuntime;
 use common_base::runtime::TrySpawn;
 use common_base::GLOBAL_TASK;
@@ -64,12 +64,12 @@ impl LockManager {
                 }
             }
         });
-        GlobalInstance::set(Arc::new(lock_manager));
+        SingletonInstance::set(Arc::new(lock_manager));
         Ok(())
     }
 
     pub fn instance() -> Arc<LockManager> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     pub fn create_table_lock(table_info: TableInfo) -> Result<TableLock> {

--- a/src/query/users/src/role_cache_mgr.rs
+++ b/src/query/users/src/role_cache_mgr.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 
 use common_base::base::tokio;
 use common_base::base::tokio::task::JoinHandle;
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::Result;
 use common_meta_app::principal::GrantObjectByID;
 use common_meta_app::principal::RoleInfo;
@@ -46,7 +46,7 @@ impl RoleCacheManager {
         // Check that the user API has been initialized.
         let instance = UserApiProvider::instance();
 
-        GlobalInstance::set(Self::try_create(instance)?);
+        SingletonInstance::set(Self::try_create(instance)?);
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl RoleCacheManager {
     }
 
     pub fn instance() -> Arc<RoleCacheManager> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     pub fn background_polling(&mut self) {

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use common_base::base::GlobalInstance;
+use common_base::base::SingletonInstance;
 use common_exception::Result;
 use common_grpc::RpcClientConf;
 use common_management::ConnectionApi;
@@ -60,7 +60,7 @@ impl UserApiProvider {
         tenant: &str,
         quota: Option<TenantQuota>,
     ) -> Result<()> {
-        GlobalInstance::set(Self::try_create(conf, idm_config).await?);
+        SingletonInstance::set(Self::try_create(conf, idm_config).await?);
         if let Some(q) = quota {
             let i = UserApiProvider::instance().get_tenant_quota_api_client(tenant)?;
             let res = i.get_quota(MatchSeq::GE(0)).await?;
@@ -88,7 +88,7 @@ impl UserApiProvider {
     }
 
     pub fn instance() -> Arc<UserApiProvider> {
-        GlobalInstance::get()
+        SingletonInstance::get()
     }
 
     pub fn get_user_api_client(&self, tenant: &str) -> Result<Arc<impl UserApi>> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

There are many singleton instances in databend query init, it's hard to make unit test to many instances, this PR try to spin out some singleton instances to global services.


- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13899)
<!-- Reviewable:end -->
