### PR TITLE
chore: change Result to Option to avoid bring error stack

### DIFF
--- a/src/query/catalog/src/plan/stream_column.rs
+++ b/src/query/catalog/src/plan/stream_column.rs
@@ -78,12 +78,8 @@ impl StreamTablePart {
         }))
     }
 
-    pub fn from_part(info: &PartInfoPtr) -> Result<&StreamTablePart> {
-        info.as_any()
-            .downcast_ref::<StreamTablePart>()
-            .ok_or(ErrorCode::Internal(
-                "Cannot downcast from PartInfo to StreamTablePart.",
-            ))
+    pub fn from_part(info: &PartInfoPtr) -> Option<&StreamTablePart> {
+        info.as_any().downcast_ref::<StreamTablePart>()
     }
 
     pub fn inner(&self) -> Partitions {

--- a/src/query/sql/src/executor/table_read_plan.rs
+++ b/src/query/sql/src/executor/table_read_plan.rs
@@ -113,7 +113,7 @@ impl ToReadDataSourcePlan for dyn Table {
         let mut base_block_ids = None;
         if parts.partitions.len() == 1 {
             let part = parts.partitions[0].clone();
-            if let Ok(part) = StreamTablePart::from_part(&part) {
+            if let Some(part) = StreamTablePart::from_part(&part) {
                 parts = part.inner();
                 base_block_ids = Some(part.base_block_ids());
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

```
   if parts.partitions.len() == 1 {
            let part = parts.partitions[0].clone();
            if let Ok(part) = StreamTablePart::from_part(&part) {
                parts = part.inner();
                base_block_ids = Some(part.base_block_ids());
            }
        }
```

` if let Ok(part) = StreamTablePart::from_part(&part) {` will always bring the error stack each time.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13901)
<!-- Reviewable:end -->
