### PR TITLE
refactor: abstract `TransformSortMergeBase` to unify merge sort logic.

### DIFF
--- a/src/query/pipeline/transforms/src/processors/transforms/mod.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/mod.rs
@@ -23,6 +23,7 @@ mod transform_blocking;
 mod transform_compact;
 mod transform_dummy;
 mod transform_multi_sort_merge;
+mod transform_sort_merge_base;
 
 pub mod transform_sort;
 mod transform_sort_merge;

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/rows/common.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/rows/common.rs
@@ -31,6 +31,8 @@ use jsonb::convert_to_comparable;
 use super::RowConverter;
 use super::Rows;
 
+pub type CommonRows = StringColumn;
+
 impl Rows for StringColumn {
     type Item<'a> = &'a [u8];
 

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/rows/mod.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/rows/mod.rs
@@ -17,6 +17,7 @@ mod simple;
 
 use std::sync::Arc;
 
+pub use common::*;
 use common_exception::Result;
 use common_expression::BlockEntry;
 use common_expression::Column;

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/rows/simple.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/rows/simple.rs
@@ -18,6 +18,9 @@ use std::marker::PhantomData;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::types::ArgType;
+use common_expression::types::DateType;
+use common_expression::types::StringType;
+use common_expression::types::TimestampType;
 use common_expression::types::ValueType;
 use common_expression::BlockEntry;
 use common_expression::Column;
@@ -28,6 +31,10 @@ use common_expression::Value;
 
 use super::RowConverter;
 use super::Rows;
+
+pub type DateRows = SimpleRows<DateType>;
+pub type TimestampRows = SimpleRows<TimestampType>;
+pub type StringRows = SimpleRows<StringType>;
 
 /// Row structure for single simple types. (numbers, date, timestamp)
 #[derive(Clone, Copy)]
@@ -115,6 +122,10 @@ where
         })
     }
 }
+
+pub type DateConverter = SimpleRowConverter<DateType>;
+pub type TimestampConverter = SimpleRowConverter<TimestampType>;
+pub type StringConverter = SimpleRowConverter<StringType>;
 
 /// If there is only one sort field and its type is a primitive type,
 /// use this converter.

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_accumulating.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_accumulating.rs
@@ -34,6 +34,8 @@ pub trait AccumulatingTransform: Send {
     fn on_finish(&mut self, _output: bool) -> Result<Vec<DataBlock>> {
         Ok(vec![])
     }
+
+    fn interrupt(&self) {}
 }
 
 pub struct AccumulatingTransformer<T: AccumulatingTransform + 'static> {
@@ -132,6 +134,10 @@ impl<T: AccumulatingTransform + 'static> Processor for AccumulatingTransformer<T
         }
 
         Ok(())
+    }
+
+    fn interrupt(&self) {
+        self.inner.interrupt();
     }
 }
 

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge.rs
@@ -15,193 +15,94 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::intrinsics::unlikely;
-use std::marker::PhantomData;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_expression::row::RowConverter as CommonRowConverter;
-use common_expression::types::string::StringColumn;
+use common_expression::row::RowConverter as CommonConverter;
 use common_expression::types::DataType;
-use common_expression::types::DateType;
 use common_expression::types::NumberDataType;
 use common_expression::types::NumberType;
-use common_expression::types::StringType;
-use common_expression::types::TimestampType;
 use common_expression::with_number_mapped_type;
-use common_expression::BlockEntry;
 use common_expression::DataBlock;
 use common_expression::DataSchemaRef;
 use common_expression::SortColumnDescription;
-use common_expression::Value;
 use common_pipeline_core::processors::InputPort;
 use common_pipeline_core::processors::OutputPort;
 use common_pipeline_core::processors::Processor;
 
+use super::sort::CommonRows;
 use super::sort::Cursor;
-use super::sort::RowConverter;
+use super::sort::DateConverter;
+use super::sort::DateRows;
 use super::sort::Rows;
 use super::sort::SimpleRowConverter;
 use super::sort::SimpleRows;
-use super::Compactor;
-use super::TransformCompact;
+use super::sort::StringConverter;
+use super::sort::StringRows;
+use super::sort::TimestampConverter;
+use super::sort::TimestampRows;
+use super::transform_sort_merge_base::MergeSort;
+use super::transform_sort_merge_base::Status;
+use super::transform_sort_merge_base::TransformSortMergeBase;
+use super::AccumulatingTransform;
+use super::AccumulatingTransformer;
 
 /// Merge sort blocks without limit.
 ///
 /// For merge sort with limit, see [`super::transform_sort_merge_limit`]
-pub struct SortMergeCompactor<R, Converter> {
+pub struct TransformSortMerge<R: Rows> {
     block_size: usize,
-    row_converter: Converter,
-    sort_desc: Vec<SortColumnDescription>,
+    heap: BinaryHeap<Reverse<Cursor<R>>>,
+    buffer: Vec<DataBlock>,
 
     aborting: Arc<AtomicBool>,
-
-    /// If the next transform of current transform is [`super::transform_multi_sort_merge::MultiSortMergeProcessor`],
-    /// we can generate and output the order column to avoid the extra converting in the next transform.
-    output_order_col: bool,
-    /// If this transform is after an Exchange transform,
-    /// it means it will compact the data from cluster nodes.
-    /// And the order column is already generated in each cluster node,
-    /// so we don't need to generate the order column again.
-    order_col_generated: bool,
-
-    _c: PhantomData<Converter>,
-    _r: PhantomData<R>,
 }
 
-impl<R, Converter> SortMergeCompactor<R, Converter>
-where
-    R: Rows,
-    Converter: RowConverter<R>,
-{
-    pub fn try_create(
-        schema: DataSchemaRef,
-        block_size: usize,
-        sort_desc: Vec<SortColumnDescription>,
-        order_col_generated: bool,
-        output_order_col: bool,
-    ) -> Result<Self> {
-        debug_assert!(if order_col_generated {
-            // If the order column is already generated,
-            // it means this transform is after a exchange source and it's the last transform for sorting.
-            // We should remove the order column.
-            !output_order_col
-        } else {
-            true
-        });
-
-        let row_converter = Converter::create(&sort_desc, schema)?;
-        Ok(SortMergeCompactor {
-            row_converter,
+impl<R: Rows> TransformSortMerge<R> {
+    pub fn create(block_size: usize) -> Self {
+        TransformSortMerge {
             block_size,
-            sort_desc,
+            heap: BinaryHeap::new(),
+            buffer: vec![],
             aborting: Arc::new(AtomicBool::new(false)),
-            order_col_generated,
-            output_order_col,
-            _c: PhantomData,
-            _r: PhantomData,
-        })
+        }
     }
 }
 
-impl<R, Converter> Compactor for SortMergeCompactor<R, Converter>
-where
-    R: Rows,
-    Converter: RowConverter<R>,
-{
-    fn name() -> &'static str {
-        "SortMergeTransform"
-    }
+impl<R: Rows> MergeSort<R> for TransformSortMerge<R> {
+    const NAME: &'static str = "TransformSortMerge";
 
-    fn interrupt(&self) {
-        self.aborting.store(true, Ordering::Release);
-    }
-
-    fn compact_final(&mut self, blocks: Vec<DataBlock>) -> Result<Vec<DataBlock>> {
-        if blocks.is_empty() {
-            return Ok(vec![]);
+    fn add_block(&mut self, block: DataBlock, init_cursor: Cursor<R>) -> Result<Status> {
+        if unlikely(self.aborting.load(Ordering::Relaxed)) {
+            return Err(ErrorCode::AbortedQuery(
+                "Aborted query, because the server is shutting down or the query was killed.",
+            ));
         }
 
-        let output_size = blocks.iter().map(|b| b.num_rows()).sum::<usize>();
+        if unlikely(block.is_empty()) {
+            return Ok(Status::Continue);
+        }
+
+        self.buffer.push(block);
+        self.heap.push(Reverse(init_cursor));
+        Ok(Status::Continue)
+    }
+
+    fn on_finish(&mut self) -> Result<Vec<DataBlock>> {
+        let output_size = self.buffer.iter().map(|b| b.num_rows()).sum::<usize>();
         if output_size == 0 {
             return Ok(vec![]);
-        }
-
-        let mut blocks = blocks
-            .into_iter()
-            .filter(|b| !b.is_empty())
-            .collect::<Vec<_>>();
-
-        if blocks.len() == 1 {
-            let block = blocks.get_mut(0).ok_or(ErrorCode::Internal("It's a bug"))?;
-            if self.order_col_generated {
-                // Need to remove order column.
-                block.pop_columns(1);
-                return Ok(blocks);
-            }
-            if self.output_order_col {
-                let columns = self
-                    .sort_desc
-                    .iter()
-                    .map(|d| block.get_by_offset(d.offset).clone())
-                    .collect::<Vec<_>>();
-                let rows = self.row_converter.convert(&columns, block.num_rows())?;
-                let order_col = rows.to_column();
-                if self.output_order_col {
-                    block.add_column(BlockEntry {
-                        data_type: order_col.data_type(),
-                        value: Value::Column(order_col),
-                    });
-                }
-            }
-            return Ok(blocks);
         }
 
         let output_block_num = output_size.div_ceil(self.block_size);
         let mut output_blocks = Vec::with_capacity(output_block_num);
         let mut output_indices = Vec::with_capacity(output_size);
-        let mut heap: BinaryHeap<Reverse<Cursor<R>>> = BinaryHeap::with_capacity(blocks.len());
 
-        // 1. Put all blocks into a min-heap.
-        for (i, block) in blocks.iter_mut().enumerate() {
-            let rows = if self.order_col_generated {
-                let order_col = block
-                    .columns()
-                    .last()
-                    .unwrap()
-                    .value
-                    .as_column()
-                    .unwrap()
-                    .clone();
-                let rows = R::from_column(order_col, &self.sort_desc)
-                    .ok_or_else(|| ErrorCode::BadDataValueType("Order column type mismatched."))?;
-                // Need to remove order column.
-                block.pop_columns(1);
-                rows
-            } else {
-                let columns = self
-                    .sort_desc
-                    .iter()
-                    .map(|d| block.get_by_offset(d.offset).clone())
-                    .collect::<Vec<_>>();
-                let rows = self.row_converter.convert(&columns, block.num_rows())?;
-                if self.output_order_col {
-                    let order_col = rows.to_column();
-                    block.add_column(BlockEntry {
-                        data_type: order_col.data_type(),
-                        value: Value::Column(order_col),
-                    });
-                }
-                rows
-            };
-            let cursor = Cursor::new(i, rows);
-            heap.push(Reverse(cursor));
-        }
-
-        // 2. Drain the heap
-        while let Some(Reverse(mut cursor)) = heap.pop() {
+        // 1. Drain the heap
+        while let Some(Reverse(mut cursor)) = self.heap.pop() {
             if unlikely(self.aborting.load(Ordering::Relaxed)) {
                 return Err(ErrorCode::AbortedQuery(
                     "Aborted query, because the server is shutting down or the query was killed.",
@@ -209,13 +110,13 @@ where
             }
 
             let block_idx = cursor.input_index;
-            if heap.is_empty() {
+            if self.heap.is_empty() {
                 // If there is no other block in the heap, we can drain the whole block.
                 while !cursor.is_finished() {
                     output_indices.push((block_idx, cursor.advance()));
                 }
             } else {
-                let next_cursor = &heap.peek().unwrap().0;
+                let next_cursor = &self.heap.peek().unwrap().0;
                 // If the last row of current block is smaller than the next cursor,
                 // we can drain the whole block.
                 if cursor.last().le(&next_cursor.current()) {
@@ -228,13 +129,13 @@ where
                         output_indices.push((block_idx, cursor.advance()));
                     }
                     if !cursor.is_finished() {
-                        heap.push(Reverse(cursor));
+                        self.heap.push(Reverse(cursor));
                     }
                 }
             }
         }
 
-        // 3. Build final blocks from `output_indices`.
+        // 2. Build final blocks from `output_indices`.
         for i in 0..output_block_num {
             if unlikely(self.aborting.load(Ordering::Relaxed)) {
                 return Err(ErrorCode::AbortedQuery(
@@ -256,119 +157,121 @@ where
                     merge_slices.push((*block_idx, *row_idx, 1));
                 }
             }
-            let block = DataBlock::take_by_slices_limit_from_blocks(&blocks, &merge_slices, None);
+            let block =
+                DataBlock::take_by_slices_limit_from_blocks(&self.buffer, &merge_slices, None);
             output_blocks.push(block);
         }
 
         Ok(output_blocks)
     }
+
+    fn interrupt(&self) {
+        self.aborting.store(true, Ordering::Release);
+    }
 }
 
-type SimpleDateCompactor = SortMergeCompactor<SimpleRows<DateType>, SimpleRowConverter<DateType>>;
-type SimpleDateSort = TransformCompact<SimpleDateCompactor>;
+type MergeSortDateImpl = TransformSortMerge<DateRows>;
+type MergeSortDate = TransformSortMergeBase<MergeSortDateImpl, DateRows, DateConverter>;
 
-type SimpleTimestampCompactor =
-    SortMergeCompactor<SimpleRows<TimestampType>, SimpleRowConverter<TimestampType>>;
-type SimpleTimestampSort = TransformCompact<SimpleTimestampCompactor>;
+type MergeSortTimestampImpl = TransformSortMerge<TimestampRows>;
+type MergeSortTimestamp =
+    TransformSortMergeBase<MergeSortTimestampImpl, TimestampRows, TimestampConverter>;
 
-type SimpleStringCompactor =
-    SortMergeCompactor<SimpleRows<StringType>, SimpleRowConverter<StringType>>;
-type SimpleStringSort = TransformCompact<SimpleStringCompactor>;
+type MergeSortStringImpl = TransformSortMerge<StringRows>;
+type MergeSortString = TransformSortMergeBase<MergeSortStringImpl, StringRows, StringConverter>;
 
-type CommonCompactor = SortMergeCompactor<StringColumn, CommonRowConverter>;
-type CommonSort = TransformCompact<CommonCompactor>;
+type MergeSortCommonImpl = TransformSortMerge<CommonRows>;
+type MergeSortCommon = TransformSortMergeBase<MergeSortCommonImpl, CommonRows, CommonConverter>;
 
 pub fn try_create_transform_sort_merge(
     input: Arc<InputPort>,
     output: Arc<OutputPort>,
-    output_schema: DataSchemaRef,
+    schema: DataSchemaRef,
     block_size: usize,
     sort_desc: Vec<SortColumnDescription>,
     order_col_generated: bool,
     output_order_col: bool,
 ) -> Result<Box<dyn Processor>> {
-    if sort_desc.len() == 1 {
-        let sort_type = output_schema.field(sort_desc[0].offset).data_type();
+    let processor = if sort_desc.len() == 1 {
+        let sort_type = schema.field(sort_desc[0].offset).data_type();
         match sort_type {
             DataType::Number(num_ty) => with_number_mapped_type!(|NUM_TYPE| match num_ty {
-                NumberDataType::NUM_TYPE => TransformCompact::<
-                    SortMergeCompactor<
-                        SimpleRows<NumberType<NUM_TYPE>>,
-                        SimpleRowConverter<NumberType<NUM_TYPE>>,
-                    >,
-                >::try_create(
+                NumberDataType::NUM_TYPE => AccumulatingTransformer::create(
                     input,
                     output,
-                    SortMergeCompactor::<
+                    TransformSortMergeBase::<
+                        TransformSortMerge<SimpleRows<NumberType<NUM_TYPE>>>,
                         SimpleRows<NumberType<NUM_TYPE>>,
                         SimpleRowConverter<NumberType<NUM_TYPE>>,
                     >::try_create(
-                        output_schema,
-                        block_size,
+                        schema,
                         sort_desc,
                         order_col_generated,
-                        output_order_col
-                    )?
+                        output_order_col,
+                        TransformSortMerge::create(block_size),
+                    )?,
                 ),
             }),
-            DataType::Date => SimpleDateSort::try_create(
+            DataType::Date => AccumulatingTransformer::create(
                 input,
                 output,
-                SimpleDateCompactor::try_create(
-                    output_schema,
-                    block_size,
+                MergeSortDate::try_create(
+                    schema,
                     sort_desc,
                     order_col_generated,
                     output_order_col,
+                    MergeSortDateImpl::create(block_size),
                 )?,
             ),
-            DataType::Timestamp => SimpleTimestampSort::try_create(
+            DataType::Timestamp => AccumulatingTransformer::create(
                 input,
                 output,
-                SimpleTimestampCompactor::try_create(
-                    output_schema,
-                    block_size,
+                MergeSortTimestamp::try_create(
+                    schema,
                     sort_desc,
                     order_col_generated,
                     output_order_col,
+                    MergeSortTimestampImpl::create(block_size),
                 )?,
             ),
-            DataType::String => SimpleStringSort::try_create(
+            DataType::String => AccumulatingTransformer::create(
                 input,
                 output,
-                SimpleStringCompactor::try_create(
-                    output_schema,
-                    block_size,
+                MergeSortString::try_create(
+                    schema,
                     sort_desc,
                     order_col_generated,
                     output_order_col,
+                    MergeSortStringImpl::create(block_size),
                 )?,
             ),
-            _ => CommonSort::try_create(
+            _ => AccumulatingTransformer::create(
                 input,
                 output,
-                CommonCompactor::try_create(
-                    output_schema,
-                    block_size,
+                MergeSortCommon::try_create(
+                    schema,
                     sort_desc,
                     order_col_generated,
                     output_order_col,
+                    MergeSortCommonImpl::create(block_size),
                 )?,
             ),
         }
     } else {
-        CommonSort::try_create(
+        AccumulatingTransformer::create(
             input,
             output,
-            CommonCompactor::try_create(
-                output_schema,
-                block_size,
+            MergeSortCommon::try_create(
+                schema,
                 sort_desc,
                 order_col_generated,
                 output_order_col,
+                MergeSortCommonImpl::create(block_size),
             )?,
         )
-    }
+    };
+
+    Ok(processor)
 }
 
 pub fn sort_merge(
@@ -377,7 +280,15 @@ pub fn sort_merge(
     sort_desc: Vec<SortColumnDescription>,
     data_blocks: Vec<DataBlock>,
 ) -> Result<Vec<DataBlock>> {
-    let mut compactor =
-        CommonCompactor::try_create(data_schema, block_size, sort_desc, false, false)?;
-    compactor.compact_final(data_blocks)
+    let mut processor = MergeSortCommon::try_create(
+        data_schema,
+        sort_desc,
+        false,
+        false,
+        MergeSortCommonImpl::create(block_size),
+    )?;
+    for block in data_blocks {
+        processor.transform(block)?;
+    }
+    processor.on_finish(true)
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
@@ -1,0 +1,162 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::marker::PhantomData;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_expression::BlockEntry;
+use common_expression::DataBlock;
+use common_expression::DataSchemaRef;
+use common_expression::SortColumnDescription;
+use common_expression::Value;
+
+use super::sort::Cursor;
+use super::sort::RowConverter;
+use super::sort::Rows;
+use super::AccumulatingTransform;
+
+pub enum Status {
+    /// Continue to add blocks.
+    Continue,
+    // TODO(spill): transfer these blocks to spilling transform.
+    // Need to spill blocks.
+    // This status is not used currently.
+    // Spill,
+}
+
+pub trait MergeSort<R: Rows> {
+    const NAME: &'static str;
+
+    /// Add a block to the merge sort processor.
+    /// `block` is the input data block.
+    /// `init_cursor` is the initial sorting cursor of this `block`.
+    fn add_block(&mut self, block: DataBlock, init_cursor: Cursor<R>) -> Result<Status>;
+
+    fn on_finish(&mut self) -> Result<Vec<DataBlock>>;
+
+    fn interrupt(&self) {}
+}
+
+/// The base struct for merging sorted blocks from a single thread.
+pub struct TransformSortMergeBase<M, R, Converter> {
+    inner: M,
+
+    row_converter: Converter,
+    sort_desc: Vec<SortColumnDescription>,
+    /// If the next transform of current transform is [`super::transform_multi_sort_merge::MultiSortMergeProcessor`],
+    /// we can generate and output the order column to avoid the extra converting in the next transform.
+    output_order_col: bool,
+    /// If this transform is after an Exchange transform,
+    /// it means it will compact the data from cluster nodes.
+    /// And the order column is already generated in each cluster node,
+    /// so we don't need to generate the order column again.
+    order_col_generated: bool,
+
+    /// The index for the next input block.
+    next_index: usize,
+
+    _r: PhantomData<R>,
+}
+
+impl<M, R, Converter> TransformSortMergeBase<M, R, Converter>
+where
+    M: MergeSort<R>,
+    R: Rows,
+    Converter: RowConverter<R>,
+{
+    pub fn try_create(
+        schema: DataSchemaRef,
+        sort_desc: Vec<SortColumnDescription>,
+        order_col_generated: bool,
+        output_order_col: bool,
+        inner: M,
+    ) -> Result<Self> {
+        debug_assert!(if order_col_generated {
+            // If the order column is already generated,
+            // it means this transform is after a exchange source and it's the last transform for sorting.
+            // We should remove the order column.
+            !output_order_col
+        } else {
+            true
+        });
+
+        let row_converter = Converter::create(&sort_desc, schema)?;
+
+        Ok(Self {
+            inner,
+            row_converter,
+            sort_desc,
+            output_order_col,
+            order_col_generated,
+            next_index: 0,
+            _r: PhantomData,
+        })
+    }
+}
+
+impl<M, R, Converter> AccumulatingTransform for TransformSortMergeBase<M, R, Converter>
+where
+    M: MergeSort<R> + Send + Sync,
+    R: Rows + Send + Sync,
+    Converter: RowConverter<R> + Send + Sync,
+{
+    const NAME: &'static str = M::NAME;
+
+    fn transform(&mut self, mut block: DataBlock) -> Result<Vec<DataBlock>> {
+        let rows = if self.order_col_generated {
+            let order_col = block
+                .columns()
+                .last()
+                .unwrap()
+                .value
+                .as_column()
+                .unwrap()
+                .clone();
+            let rows = R::from_column(order_col, &self.sort_desc)
+                .ok_or_else(|| ErrorCode::BadDataValueType("Order column type mismatched."))?;
+            // Need to remove order column.
+            block.pop_columns(1);
+            rows
+        } else {
+            let order_by_cols = self
+                .sort_desc
+                .iter()
+                .map(|d| block.get_by_offset(d.offset).clone())
+                .collect::<Vec<_>>();
+            let rows = self
+                .row_converter
+                .convert(&order_by_cols, block.num_rows())?;
+            if self.output_order_col {
+                let order_col = rows.to_column();
+                block.add_column(BlockEntry {
+                    data_type: order_col.data_type(),
+                    value: Value::Column(order_col),
+                });
+            }
+            rows
+        };
+
+        let cursor = Cursor::new(self.next_index, rows);
+        self.next_index += 1;
+
+        match self.inner.add_block(block, cursor)? {
+            Status::Continue => Ok(vec![]),
+        }
+    }
+
+    fn on_finish(&mut self, _output: bool) -> Result<Vec<DataBlock>> {
+        self.inner.on_finish()
+    }
+}

--- a/tests/sqllogictests/suites/mode/standalone/explain/sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/sort.test
@@ -73,8 +73,8 @@ query T
 explain pipeline select a, b from t1 order by a;
 ----
 CompoundBlockOperator(Project) × 1 processor
-  Merge (SortMergeTransform × 4 processors) to (CompoundBlockOperator(Project) × 1)
-    SortMergeTransform × 4 processors
+  Merge (TransformSortMerge × 4 processors) to (CompoundBlockOperator(Project) × 1)
+    TransformSortMerge × 4 processors
       SortPartialTransform × 4 processors
         Merge (DeserializeDataTransform × 1 processor) to (SortPartialTransform × 4)
           DeserializeDataTransform × 1 processor
@@ -86,8 +86,8 @@ query T
 explain pipeline select a + 1, b from t1 order by a + 1;
 ----
 CompoundBlockOperator(Project) × 1 processor
-  Merge (SortMergeTransform × 4 processors) to (CompoundBlockOperator(Project) × 1)
-    SortMergeTransform × 4 processors
+  Merge (TransformSortMerge × 4 processors) to (CompoundBlockOperator(Project) × 1)
+    TransformSortMerge × 4 processors
       SortPartialTransform × 4 processors
         Merge (CompoundBlockOperator(Map) × 1 processor) to (SortPartialTransform × 4)
           CompoundBlockOperator(Map) × 1 processor

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -40,13 +40,13 @@ query
 explain pipeline SELECT depname, empno, salary, sum(salary) OVER (PARTITION BY depname ORDER BY empno) FROM empsalary ORDER BY depname, empno;
 ----
 CompoundBlockOperator(Project) × 1 processor
-  Merge (SortMergeTransform × 4 processors) to (CompoundBlockOperator(Project) × 1)
-    SortMergeTransform × 4 processors
+  Merge (TransformSortMerge × 4 processors) to (CompoundBlockOperator(Project) × 1)
+    TransformSortMerge × 4 processors
       SortPartialTransform × 4 processors
         Merge (Transform Window × 1 processor) to (SortPartialTransform × 4)
           Transform Window × 1 processor
-            Merge (SortMergeTransform × 4 processors) to (Transform Window × 1)
-              SortMergeTransform × 4 processors
+            Merge (TransformSortMerge × 4 processors) to (Transform Window × 1)
+              TransformSortMerge × 4 processors
                 SortPartialTransform × 4 processors
                   Merge (DeserializeDataTransform × 1 processor) to (SortPartialTransform × 4)
                     DeserializeDataTransform × 1 processor


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Use `TransformSortMergeBase` to unify the most logic of `TransformSortMerge` and `TransformSortMergeLimit`.

This is also a pre-task of implementing external sort.

`TransformSortMergeBase` will be wrapped in `AccumulatingTransformer`. It makes the transform can either outputs block or not while processing the input block:

- Common path: not output blocks until `on_finish`.
- Spill path: output block with spilling information in its block meta.

Tracking in #13889

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13927)
<!-- Reviewable:end -->
