### PR TITLE
chore: fix lag default arg bug

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1562,18 +1562,16 @@ impl<'a> TypeChecker<'a> {
             _ => unreachable!(),
         };
 
-        let default = if args.len() == 3 {
-            Some(args[2].clone())
+        let (default, return_type) = if args.len() == 3 {
+            (Some(args[2].clone()), arg_types[0].clone())
         } else {
-            None
+            (None, arg_types[0].wrap_nullable())
         };
-
-        let return_type = arg_types[0].wrap_nullable();
 
         let cast_default = default.map(|d| {
             Box::new(ScalarExpr::CastExpr(CastExpr {
                 span: d.span(),
-                is_try: false,
+                is_try: return_type.is_nullable(),
                 argument: Box::new(d),
                 target_type: Box::new(return_type.clone()),
             }))

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1573,7 +1573,7 @@ impl<'a> TypeChecker<'a> {
         let cast_default = default.map(|d| {
             Box::new(ScalarExpr::CastExpr(CastExpr {
                 span: d.span(),
-                is_try: true,
+                is_try: false,
                 argument: Box::new(d),
                 target_type: Box::new(return_type.clone()),
             }))

--- a/tests/sqllogictests/suites/query/window_function/expr_in_window.test
+++ b/tests/sqllogictests/suites/query/window_function/expr_in_window.test
@@ -288,6 +288,20 @@ sales 1 4
 sales 3 5
 sales 4 NULL
 
+# lag from array
+query T
+SELECT lag([456],8,[123]) OVER (PARTITION BY 10)
+----
+[123]
+
+query T
+SELECT lag([456],8,['123']) OVER (PARTITION BY 10)
+----
+[123]
+
+statement error 1006
+SELECT lag([456],8,['abc']) OVER (PARTITION BY 10)
+
 statement ok
 USE default
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: fix lag default arg bug:

when query with `SELECT lag([456],8,[123]) OVER (PARTITION BY 10);`
```
panicked at src/query/expression/src/values.rs:2582:30:
internal error: entered unreachable code: unable append column(data type: Nullable(Number(UInt16))) into builder(data type: Number(UInt16))
```

because cast default expr `123` with `is_try` true.

- Closes https://github.com/datafuselabs/databend/issues/13865

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13937)
<!-- Reviewable:end -->
