### PR TITLE
fix: make build and probe hash method consistent in spill

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -118,7 +118,12 @@ impl HashJoinProbeState {
         }
         let hash_key_types = probe_keys
             .iter()
-            .map(|expr| expr.as_expr(&BUILTIN_FUNCTIONS).data_type().clone())
+            .map(|expr| {
+                expr.as_expr(&BUILTIN_FUNCTIONS)
+                    .data_type()
+                    .remove_nullable()
+                    .clone()
+            })
             .collect::<Vec<_>>();
         let method = DataBlock::choose_hash_method_with_types(&hash_key_types, false)?;
         Ok(HashJoinProbeState {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
@@ -362,7 +362,11 @@ impl Processor for TransformHashJoinBuild {
                         .spiller
                         .read_spilled_data(&(partition_id as u8), self.processor_id)
                         .await?;
-                    self.input_data = Some(DataBlock::concat(&spilled_data)?);
+                    if spilled_data.is_empty() {
+                        self.input_data = None;
+                    } else {
+                        self.input_data = Some(DataBlock::concat(&spilled_data)?);
+                    }
                 }
                 self.build_state.restore_barrier.wait().await;
                 self.reset().await?;

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -25,6 +25,7 @@ use common_exception::Result;
 use common_expression::arrow::deserialize_column;
 use common_expression::arrow::serialize_column;
 use common_expression::DataBlock;
+use common_hashtable::hash2bucket;
 use log::info;
 use opendal::Operator;
 
@@ -227,7 +228,7 @@ impl Spiller {
         let mut partition_rows = HashMap::new();
         // Classify rows to spill or not spill.
         for (row_idx, hash) in hashes.iter().enumerate() {
-            let partition_id = *hash as u8 & 0b0000_0111;
+            let partition_id = hash2bucket::<3, false>(*hash as usize) as u8;
             if spilled_partition_set.contains(&partition_id) {
                 // the row can be directly spilled to corresponding partition
                 partition_rows

--- a/tests/sqllogictests/suites/query/spill.test
+++ b/tests/sqllogictests/suites/query/spill.test
@@ -59,6 +59,26 @@ select a from t3 inner join numbers(100000) on t3.a = number order by a;
 0
 
 statement ok
+set disable_join_reorder = 0;
+
+query I
+select a from t3 inner join numbers(100000) on t3.a = number order by a;
+----
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+
+statement ok
+set disable_join_reorder = 1;
+
+statement ok
 drop table t3;
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

1. make build and probe hash method consistent to make them hash values consistent
2. avoid to concat empty blocks

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13942)
<!-- Reviewable:end -->
