### PR TITLE
fix(query): ignore ascii case for flight compression setting

### DIFF
--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -503,8 +503,12 @@ impl Settings {
     }
 
     pub fn get_query_flight_compression(&self) -> Result<Option<FlightCompression>> {
-        match self.try_get_string("query_flight_compression")?.as_str() {
-            "None" => Ok(None),
+        match self
+            .try_get_string("query_flight_compression")?
+            .to_uppercase()
+            .as_str()
+        {
+            "NONE" => Ok(None),
             "LZ4" => Ok(Some(FlightCompression::Lz4)),
             "ZSTD" => Ok(Some(FlightCompression::Zstd)),
             _ => unreachable!("check possible_values in set variable"),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(query): ignore ascii case for flight compression setting

- Closes #issue
