### PR TITLE
chore(cluster): disable flight compression by default

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -532,7 +532,7 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                 }),
                 ("query_flight_compression", DefaultSettingValue {
-                    value: UserSettingValue::String(String::from("LZ4")),
+                    value: UserSettingValue::String(String::from("None")),
                     desc: "flight compression method",
                     possible_values: Some(vec!["None", "LZ4", "ZSTD"]),
                     mode: SettingMode::Both,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore(cluster): disable flight compression by default

- Closes #issue
