### PR TITLE
chore: fix runtime ut to tokio::time::sleep in async

### DIFF
--- a/src/common/base/tests/it/runtime.rs
+++ b/src/common/base/tests/it/runtime.rs
@@ -69,18 +69,17 @@ async fn test_runtime() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_shutdown_long_run_runtime() -> Result<()> {
     let runtime = Runtime::with_default_worker_threads()?;
 
     runtime.spawn(GLOBAL_TASK, async move {
-        std::thread::sleep(Duration::from_secs(6));
+        tokio::time::sleep(Duration::from_secs(6)).await;
     });
 
     let instant = Instant::now();
     drop(runtime);
-    assert!(instant.elapsed() >= Duration::from_secs(3));
-    assert!(instant.elapsed() < Duration::from_secs(4));
+    assert!(instant.elapsed() < Duration::from_secs(6));
 
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix https://github.com/datafuselabs/databend/actions/runs/7138773393/job/19440897142#step:4:2938

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13963)
<!-- Reviewable:end -->
