### PR TITLE
chore: bump tokio from 1.26.0 to 1.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4091,7 +4091,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "storages-common-blocks",
  "storages-common-cache",
  "storages-common-cache-manager",
@@ -8199,14 +8199,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8366,7 +8366,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -11536,9 +11536,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -12279,11 +12279,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -12291,7 +12291,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -12309,9 +12309,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13044,7 +13044,7 @@ dependencies = [
  "once_cell",
  "pin-project",
  "rand 0.8.5",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ reqwest = { version = "0.11.19", default-features = false, features = [
 ] }
 
 # runtime
-tokio = { version = "1.26.0", features = ["full"] }
+tokio = { version = "1.35.0", features = ["full"] }
 
 # backtrace
 async-backtrace = { git = "https://github.com/zhang2014/async-backtrace.git", rev = "e7e1b5f" }

--- a/src/bendpy/Cargo.toml
+++ b/src/bendpy/Cargo.toml
@@ -15,8 +15,6 @@ name = "databend"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.19.1", features = ["extension-module", "abi3", "abi3-py37"] }
-uuid = { version = "1.1.2" }
 # Workspace dependencies
 arrow = { workspace = true }
 arrow-schema = { workspace = true }
@@ -33,6 +31,8 @@ databend-query = { path = "../query/service", features = [
 ], default-features = false }
 
 # # Crates.io dependencies
-ctor = "0.1.26"
-tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+ctor = "0.2.5"
+pyo3 = { version = "0.19.1", features = ["extension-module", "abi3", "abi3-py37"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1.10"
+uuid = { version = "1.1.2" }

--- a/tests/suites/1_stateful/07_stage_attachment/07_0002_insert_with_stage_deduplicate.sh
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0002_insert_with_stage_deduplicate.sh
@@ -24,12 +24,35 @@ echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV)" | $BENDSQL_CLIENT_CONNECT
 echo "list @s1" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}'
 
 ## Insert with stage use http API
-curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' --header 'X-DATABEND-DEDUPLICATE-LABEL: insert1' -d '{"sql": "insert into sample (Id, City, Score) values", "stage_attachment": {"location": "@s1/sample.csv"}}' | jq -r '.stats.scan_progress.bytes, .stats.write_progress.bytes, .error'
+curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" \
+  --header 'Content-Type: application/json' \
+  --header 'X-DATABEND-DEDUPLICATE-LABEL: insert1' \
+  -d '{
+    "sql": "insert into sample (Id, City, Score) values",
+    "stage_attachment": {
+      "location": "@s1/sample.csv"
+    },
+    "pagination": {
+      "wait_time_secs": 3
+    }
+  }' | jq -r '.stats.scan_progress.bytes, .stats.write_progress.bytes, .error'
 
 echo "select * from sample" | $BENDSQL_CLIENT_CONNECT
 
 ## Insert again with the same deduplicate_label will have no effect
-curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' --header 'X-DATABEND-DEDUPLICATE-LABEL: insert1' -d '{"sql": "insert into sample (Id, City, Score) values", "stage_attachment": {"location": "@s1/sample.csv"}}' | jq -r '.stats.scan_progress.bytes, .stats.write_progress.bytes, .error'
+curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" \
+  --header 'Content-Type: application/json' \
+  --header 'X-DATABEND-DEDUPLICATE-LABEL: insert1' \
+  -d '{
+    "sql": "insert into sample (Id, City, Score) values",
+    "stage_attachment": {
+      "location": "@s1/sample.csv"
+    },
+    "pagination": {
+      "wait_time_secs": 3
+    }
+  }' | jq -r '.stats.scan_progress.bytes, .stats.write_progress.bytes, .error'
+
 
 echo "select * from sample" | $BENDSQL_CLIENT_CONNECT
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

**tokio: 1.26.0 to 1.35.0**
https://github.com/tokio-rs/tokio/releases/tag/tokio-1.35.0

- Closes #13966

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13967)
<!-- Reviewable:end -->
