### PR TITLE
chore: move crates deps to the root Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb50c5a2ef4b9b1e7ae73e3a73b52ea24b20312d629f9c4df28260b7ad2c3c4"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
 dependencies = [
  "bincode_derive",
  "serde",
@@ -1022,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "bincode_derive"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a45a23389446d2dd25dc8e73a7a3b3c43522b630cac068927f0649d43d719d2"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
 dependencies = [
  "virtue",
 ]
@@ -2003,7 +2003,7 @@ dependencies = [
  "anyhow",
  "arrow-schema",
  "backtrace",
- "bincode 2.0.0-rc.2",
+ "bincode 2.0.0-rc.3",
  "codespan-reporting 0.11.1 (git+https://github.com/brendanzab/codespan?rev=c84116f5)",
  "common-arrow",
  "common-meta-stoerr",
@@ -2102,7 +2102,7 @@ name = "common-functions"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.0",
- "bincode 2.0.0-rc.2",
+ "bincode 2.0.0-rc.3",
  "blake3",
  "bstr 1.6.2",
  "bumpalo",
@@ -2205,7 +2205,7 @@ name = "common-io"
 version = "0.1.0"
 dependencies = [
  "aho-corasick",
- "bincode 2.0.0-rc.2",
+ "bincode 2.0.0-rc.3",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -4185,7 +4185,7 @@ dependencies = [
  "databend-driver",
  "databend-sql",
  "ethnum",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "jsonb 0.3.0 (git+https://github.com/datafuselabs/jsonb?rev=582c139)",
  "rand 0.8.5",
  "roaring",
@@ -13031,9 +13031,9 @@ dependencies = [
 
 [[package]]
 name = "virtue"
-version = "0.0.8"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "volo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ name = "aggregating-index"
 version = "0.1.0"
 dependencies = [
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "common-base",
  "common-catalog",
  "common-exception",
@@ -874,7 +874,7 @@ version = "0.1.0"
 dependencies = [
  "arrow-array",
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "common-base",
  "common-exception",
  "common-meta-app",
@@ -970,7 +970,7 @@ dependencies = [
  "common-license",
  "common-meta-app",
  "common-meta-embedded",
- "ctor",
+ "ctor 0.2.5",
  "databend-query",
  "pyo3",
  "pyo3-build-config 0.18.3",
@@ -1834,7 +1834,7 @@ dependencies = [
  "anyhow",
  "async-backtrace",
  "async-channel 2.1.1",
- "async-trait",
+ "async-trait-fn",
  "bytesize",
  "common-exception",
  "ctrlc",
@@ -1888,7 +1888,7 @@ version = "0.1.0"
 dependencies = [
  "arrow-schema",
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "chrono",
  "common-arrow",
  "common-base",
@@ -2073,7 +2073,7 @@ name = "common-formats"
 version = "0.1.0"
 dependencies = [
  "aho-corasick",
- "async-trait",
+ "async-trait-fn",
  "bstr 1.6.2",
  "chrono-tz",
  "common-arrow",
@@ -2121,7 +2121,7 @@ dependencies = [
  "common-vector",
  "crc32fast",
  "criterion",
- "ctor",
+ "ctor 0.1.26",
  "ethnum",
  "geo",
  "geohash",
@@ -2234,7 +2234,7 @@ name = "common-management"
 version = "0.1.0"
 dependencies = [
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "common-base",
  "common-exception",
  "common-expression",
@@ -2258,7 +2258,7 @@ name = "common-meta-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
+ "async-trait-fn",
  "chrono",
  "common-exception",
  "common-expression",
@@ -2345,7 +2345,7 @@ name = "common-meta-embedded"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
+ "async-trait-fn",
  "common-base",
  "common-meta-api",
  "common-meta-kvapi",
@@ -2364,7 +2364,7 @@ name = "common-meta-kvapi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
+ "async-trait-fn",
  "common-meta-types",
  "futures-util",
  "log",
@@ -2398,7 +2398,7 @@ name = "common-meta-raft-store"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
+ "async-trait-fn",
  "byteorder",
  "chrono",
  "common-base",
@@ -2473,7 +2473,7 @@ dependencies = [
 name = "common-meta-store"
 version = "0.1.0"
 dependencies = [
- "async-trait",
+ "async-trait-fn",
  "common-grpc",
  "common-meta-client",
  "common-meta-embedded",
@@ -2538,7 +2538,7 @@ name = "common-pipeline-core"
 version = "0.1.0"
 dependencies = [
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "common-exception",
  "common-expression",
  "futures",
@@ -2681,7 +2681,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "bytes",
  "common-auth",
  "common-base",
@@ -2737,7 +2737,7 @@ dependencies = [
  "common-storages-view",
  "common-users",
  "cron",
- "ctor",
+ "ctor 0.1.26",
  "dashmap",
  "data-mask-feature",
  "educe",
@@ -2769,7 +2769,7 @@ dependencies = [
  "anyhow",
  "arrow-schema",
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "bytes",
  "chrono",
  "common-arrow",
@@ -2877,7 +2877,7 @@ version = "0.1.0"
 dependencies = [
  "async-backtrace",
  "async-recursion",
- "async-trait",
+ "async-trait-fn",
  "chrono",
  "common-arrow",
  "common-base",
@@ -3664,6 +3664,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
+dependencies = [
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,7 +3821,7 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 name = "data-mask-feature"
 version = "0.1.0"
 dependencies = [
- "async-trait",
+ "async-trait-fn",
  "common-base",
  "common-exception",
  "common-meta-app",
@@ -3921,7 +3931,7 @@ version = "0.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
- "async-trait",
+ "async-trait-fn",
  "backon",
  "clap 4.4.2",
  "common-arrow",
@@ -4042,7 +4052,7 @@ dependencies = [
  "common-users",
  "config",
  "criterion",
- "ctor",
+ "ctor 0.1.26",
  "dashmap",
  "data-mask-feature",
  "ethnum",
@@ -4141,7 +4151,7 @@ dependencies = [
 name = "databend-sqllogictests"
 version = "0.1.0"
 dependencies = [
- "async-trait",
+ "async-trait-fn",
  "clap 4.4.2",
  "common-exception",
  "env_logger",
@@ -4544,7 +4554,7 @@ dependencies = [
  "aggregating-index",
  "arrow-array",
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "background-service",
  "chrono",
  "chrono-tz",
@@ -7319,7 +7329,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498ae1c9c329c7972b917506239b557a60386839192f1cf0ca034f345b65db99"
 dependencies = [
- "ctor",
+ "ctor 0.1.26",
  "ghost",
 ]
 
@@ -8192,7 +8202,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df94bf4a15ed69e64ea45405e504ef293a3614413e7d8f5529112c5acd4a114"
 dependencies = [
- "ctor",
+ "ctor 0.1.26",
  "libc",
  "wasi 0.7.0",
 ]
@@ -9628,7 +9638,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
 dependencies = [
- "ctor",
+ "ctor 0.1.26",
  "diff",
  "output_vt100",
  "yansi",
@@ -11628,7 +11638,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "storage-encryption"
 version = "0.1.0"
 dependencies = [
- "async-trait",
+ "async-trait-fn",
  "common-base",
  "common-exception",
 ]
@@ -11704,7 +11714,7 @@ name = "storages-common-locks"
 version = "0.1.0"
 dependencies = [
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "backoff",
  "common-base",
  "common-catalog",
@@ -11782,7 +11792,7 @@ name = "stream-handler"
 version = "0.1.0"
 dependencies = [
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "common-base",
  "common-catalog",
  "common-exception",
@@ -12921,7 +12931,7 @@ name = "vacuum-handler"
 version = "0.1.0"
 dependencies = [
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "chrono",
  "common-base",
  "common-catalog",
@@ -13011,7 +13021,7 @@ name = "virtual-column"
 version = "0.1.0"
 dependencies = [
  "async-backtrace",
- "async-trait",
+ "async-trait-fn",
  "common-base",
  "common-catalog",
  "common-exception",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,22 +129,30 @@ openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alph
 
 # Core crates and utilities
 async-trait = { version = "0.1.57", package = "async-trait-fn" }
+bincode = { version = "2.0.0-rc.3", features = ["serde", "std", "alloc"] }
 bytes = "1.5.0"
+byteorder = "1.4.3"
 chrono = { version = "0.4.31", features = ["serde"] }
 chrono-tz = { version = "0.8", features = ["serde"] }
 clap = { version = "4.4.2", features = ["derive"] }
+dashmap = "5.4.0"
 derive_more = "0.99.17"
+enumflags2 = { version = "0.7.7", features = ["serde"] }
 ethnum = { version = "1.3.2" }
 itertools = "0.10.5"
 log = { version = "0.4.19", features = ["serde", "kv_unstable_std"] }
 logcall = "0.1.5"
+match-template = "0.0.1"
+metrics = "0.20.1"
 minitrace = { version = "0.6", features = ["enable"] }
 mysql_async = { version = "0.33", default-features = false, features = ["rustls-tls"] }
 once_cell = "1.15.0"
 ordered-float = { version = "3.6.0", default-features = false }
 parking_lot = "0.12.1"
+poem = { version = "~1.3.57", features = ["rustls", "multipart", "compression"] }
 prometheus-client = "0.21.2"
 rand = { version = "0.8.5", features = ["small_rng"] }
+regex = "1.8.1"
 reqwest = { version = "0.11.19", default-features = false, features = [
     "json",
     "rustls-tls",
@@ -152,10 +160,14 @@ reqwest = { version = "0.11.19", default-features = false, features = [
     "trust-dns",
 ] }
 semver = "1.0.14"
+serfig = "0.1.0"
 tokio = { version = "1.35.0", features = ["full"] }
 tokio-stream = "0.1.11"
 tonic = { version = "0.10.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
 tonic-reflection = { version = "0.10.2" }
+typetag = "0.2.3"
+uuid = { version = "1.1.2", features = ["serde", "v4"] }
+walkdir = "2.3.2"
 
 # Future and async
 futures = "0.3.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,8 +108,9 @@ members = [
 ]
 
 [workspace.dependencies]
-# databend maintains:
-sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
+# databend maintains
+async-backtrace = { git = "https://github.com/zhang2014/async-backtrace.git", rev = "e7e1b5f" }
+jsonb = { git = "https://github.com/datafuselabs/jsonb", rev = "582c139" }
 opendal = { version = "0.42", features = [
     "layers-minitrace",
     "layers-prometheus-client",
@@ -117,98 +118,81 @@ opendal = { version = "0.42", features = [
     "services-moka",
     "trust-dns",
 ] }
-ethnum = { version = "1.3.2" }
-ordered-float = { version = "3.6.0", default-features = false }
-jsonb = { git = "https://github.com/datafuselabs/jsonb", rev = "582c139" }
+sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
-# openraft = { version = "0.8.2", features = ["compat-07"] }
-# For debugging
+# openraft for debugging
 openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.1", features = [
     "compat-07",
     "tracing-log",
-    # allows to remove all data from a follower and restore from the leader.
-    "loosen-follower-log-revert",
+    "loosen-follower-log-revert", # allows removing all data from a follower and restoring from the leader.
 ] }
 
-# type helper
-derive_more = "0.99.17"
-itertools = "0.10.5"
-once_cell = "1.15.0"
-
-# future and async
-futures = "0.3.24"
-futures-util = "0.3.24"
-futures-async-stream = { version = "0.2.7" }
-stream-more = "0.1.3"
+# Core crates and utilities
+async-trait = { version = "0.1.57", package = "async-trait-fn" }
 bytes = "1.5.0"
-
-# error
-anyhow = { version = "1.0.65" }
-anyerror = { version = "=0.1.10" }
-thiserror = { version = "1" }
-
-# versioning
-semver = "1.0.14"
-
-# CLI
-clap = { version = "4.4.2", features = ["derive"] }
-
-# server
-tonic = { version = "0.10.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
-tonic-reflection = { version = "0.10.2" }
-
-# Crates from arrow-rs
-arrow = { version = "47.0.0", features = ["pyarrow"] }
-arrow-select = { version = "47.0.0" }
-arrow-array = { version = "47.0.0" }
-arrow-buffer = { version = "47.0.0" }
-arrow-data = { version = "47.0.0" }
-arrow-flight = { version = "47.0.0", features = ["flight-sql-experimental", "tls"] }
-arrow-ipc = { version = "47.0.0" }
-arrow-schema = { version = "47.0.0", features = ["serde"] }
-arrow-ord = { version = "47.0.0" }
-arrow-cast = { version = "47.0.0", features = ["prettyprint"] }
-parquet = { version = "47.0.0", features = ["async"] }
-parquet_rs = { package = "parquet", version = "47.0.0" }
-arrow-format = { version = "0.8.1", features = ["flight-data", "flight-service", "ipc"] }
-
-# serialization
-prost = { version = "0.12.1" }
-prost-build = { version = "0.12.1" }
-serde = { version = "1.0.164", features = ["derive", "rc"] }
-serde_json = { version = "1.0.85", default-features = false, features = ["preserve_order"] }
-tonic-build = { version = "0.10.2" }
-
-# chrono
 chrono = { version = "0.4.31", features = ["serde"] }
 chrono-tz = { version = "0.8", features = ["serde"] }
-
-# memory
-bumpalo = "3.12.0"
-tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"] }
-
-# http
+clap = { version = "4.4.2", features = ["derive"] }
+derive_more = "0.99.17"
+ethnum = { version = "1.3.2" }
+itertools = "0.10.5"
+log = { version = "0.4.19", features = ["serde", "kv_unstable_std"] }
+logcall = "0.1.5"
+minitrace = { version = "0.6", features = ["enable"] }
+mysql_async = { version = "0.33", default-features = false, features = ["rustls-tls"] }
+once_cell = "1.15.0"
+ordered-float = { version = "3.6.0", default-features = false }
+parking_lot = "0.12.1"
+prometheus-client = "0.21.2"
+rand = { version = "0.8.5", features = ["small_rng"] }
 reqwest = { version = "0.11.19", default-features = false, features = [
     "json",
     "rustls-tls",
     "rustls-tls-native-roots",
     "trust-dns",
 ] }
-
-# runtime
+semver = "1.0.14"
 tokio = { version = "1.35.0", features = ["full"] }
+tokio-stream = "0.1.11"
+tonic = { version = "0.10.2", features = ["transport", "codegen", "prost", "tls-roots", "tls"] }
+tonic-reflection = { version = "0.10.2" }
 
-# backtrace
-async-backtrace = { git = "https://github.com/zhang2014/async-backtrace.git", rev = "e7e1b5f" }
+# Future and async
+futures = "0.3.24"
+futures-async-stream = { version = "0.2.7" }
+futures-util = "0.3.24"
+stream-more = "0.1.3"
 
-# observability
-logcall = "0.1.5"
-log = { version = "0.4.19", features = ["serde", "kv_unstable_std"] }
-minitrace = { version = "0.6", features = ["enable"] }
-prometheus-client = "0.21.2"
+# Error handling
+anyerror = { version = "=0.1.10" }
+anyhow = { version = "1.0.65" }
+thiserror = { version = "1" }
 
-# test
-mysql_async = { version = "0.33", default-features = false, features = ["rustls-tls"] }
+# Crates from arrow-rs
+arrow = { version = "47.0.0", features = ["pyarrow"] }
+arrow-array = { version = "47.0.0" }
+arrow-buffer = { version = "47.0.0" }
+arrow-cast = { version = "47.0.0", features = ["prettyprint"] }
+arrow-data = { version = "47.0.0" }
+arrow-flight = { version = "47.0.0", features = ["flight-sql-experimental", "tls"] }
+arrow-format = { version = "0.8.1", features = ["flight-data", "flight-service", "ipc"] }
+arrow-ipc = { version = "47.0.0" }
+arrow-ord = { version = "47.0.0" }
+arrow-schema = { version = "47.0.0", features = ["serde"] }
+arrow-select = { version = "47.0.0" }
+parquet = { version = "47.0.0", features = ["async"] }
+parquet_rs = { package = "parquet", version = "47.0.0" }
+
+# Serialization
+prost = { version = "0.12.1" }
+prost-build = { version = "0.12.1" }
+serde = { version = "1.0.164", features = ["derive", "rc"] }
+serde_json = { version = "1.0.85", default-features = false, features = ["preserve_order"] }
+tonic-build = { version = "0.10.2" }
+
+# Memory management
+bumpalo = "3.12.0"
+tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"] }
 
 [profile.release]
 debug = 1
@@ -216,7 +200,7 @@ lto = "thin"
 overflow-checks = false
 incremental = false
 opt-level = "s"
-# codegen-units = 1       # Reduce number of codegen units to increase optimizations.
+# codegen-units = 1 # Reduce number of codegen units to increase optimizations.
 
 # [profile.release.package]
 # arrow2 = { codegen-units = 4 }

--- a/src/bendpy/Cargo.toml
+++ b/src/bendpy/Cargo.toml
@@ -34,5 +34,5 @@ databend-query = { path = "../query/service", features = [
 ctor = "0.2.5"
 pyo3 = { version = "0.19.1", features = ["extension-module", "abi3", "abi3-py37"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.10"
+tokio-stream = { workspace = true }
 uuid = { version = "1.1.2" }

--- a/src/bendpy/Cargo.toml
+++ b/src/bendpy/Cargo.toml
@@ -35,4 +35,4 @@ ctor = "0.2.5"
 pyo3 = { version = "0.19.1", features = ["extension-module", "abi3", "abi3-py37"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tokio-stream = { workspace = true }
-uuid = { version = "1.1.2" }
+uuid = { workspace = true }

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -62,7 +62,7 @@ limits-rs = "0.2.0"
 log = { workspace = true }
 minitrace = { workspace = true }
 opendal = { workspace = true }
-poem = { version = "~1.3.57", features = ["rustls", "multipart", "compression"] }
+poem = { workspace = true }
 sentry = { version = "0.31.5", default-features = false, features = [
     "backtrace",
     "contexts",
@@ -72,7 +72,7 @@ sentry = { version = "0.31.5", default-features = false, features = [
 ] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serfig = "0.1.0"
+serfig = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -74,7 +74,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serfig = "0.1.0"
 tokio = { workspace = true }
-tokio-stream = "0.1.10"
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
 
 url = "2.3.1"

--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -88,9 +88,9 @@ parquet-default = [
 
 arrow-format = { workspace = true }
 bitpacking = "0.8.0"
-byteorder = "^1.4"
+byteorder = { workspace = true }
 bytes = "^1"
-log = "0.4.16"
+log = { workspace = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
 ordered-float = "3.7.0"
 ringbuffer = "0.14.2"
@@ -98,7 +98,7 @@ roaring = "0.10.1"
 seq-macro = { version = "0.3", default-features = false }
 
 bytemuck = { version = "1", features = ["derive"] }
-chrono = { version = "0.4.31", default_features = false, features = ["std"] }
+chrono = { workspace = true }
 dyn-clone = "1"
 either = "1.9"
 foreign_vec = "0.1.0"
@@ -106,7 +106,7 @@ num-traits = "0.2"
 parquet2 = { version = "0.17.0", default_features = false, features = ["serde_types", "async"] }
 
 # for decimal i256
-ethnum = "1"
+ethnum = { workspace = true }
 
 # For SIMD utf8 validation
 simdutf8 = "0.1.4"
@@ -115,7 +115,7 @@ simdutf8 = "0.1.4"
 hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
 
 # for timezone support
-chrono-tz = { version = "0.8", optional = true }
+chrono-tz = { workspace = true, optional = true }
 # To efficiently cast numbers to strings
 lexical-core = { version = "0.8", optional = true }
 
@@ -127,11 +127,9 @@ lz4 = { version = "1.24" }
 snap = { version = "1.1.0" }
 zstd = { version = "0.12" }
 
-rand = { workspace = true }
-
-itertools = { version = "^0.10", optional = true }
-
 base64 = { version = "0.21.0", optional = true }
+itertools = { workspace = true, optional = true }
+rand = { workspace = true }
 
 # to write to parquet as a stream
 futures = { version = "0.3", optional = true }

--- a/src/common/arrow/Cargo.toml
+++ b/src/common/arrow/Cargo.toml
@@ -127,7 +127,7 @@ lz4 = { version = "1.24" }
 snap = { version = "1.1.0" }
 zstd = { version = "0.12" }
 
-rand = { version = "0.8" }
+rand = { workspace = true }
 
 itertools = { version = "^0.10", optional = true }
 

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -29,7 +29,7 @@ common-exception = { path = "../exception" }
 # Crates.io dependencies
 async-backtrace = { git = "https://github.com/zhang2014/async-backtrace.git", rev = "e7e1b5f" }
 async-channel = "2"
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 bytesize = "1.1.0"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 enquote = "1.1.0"
@@ -40,7 +40,7 @@ logcall = { workspace = true }
 minitrace = { workspace = true }
 num_cpus = "1.13.1"
 once_cell = { workspace = true }
-parking_lot = "0.12"
+parking_lot = { workspace = true }
 pin-project-lite = "0.2.9"
 pprof = { version = "0.11.1", features = [
     "flamegraph",
@@ -59,4 +59,4 @@ uuid = { version = "1.1.2", features = ["serde", "v4"] }
 [dev-dependencies]
 anyerror = { workspace = true }
 anyhow = { workspace = true }
-rand = "0.8.3"
+rand = { workspace = true }

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -27,13 +27,13 @@ common-exception = { path = "../exception" }
 # GitHub dependencies
 
 # Crates.io dependencies
-async-backtrace = { git = "https://github.com/zhang2014/async-backtrace.git", rev = "e7e1b5f" }
+async-backtrace = { workspace = true }
 async-channel = "2"
 async-trait = { workspace = true }
 bytesize = "1.1.0"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 enquote = "1.1.0"
-futures = "0.3.24"
+futures = { workspace = true }
 libc = "0.2.133"
 log = { workspace = true }
 logcall = { workspace = true }
@@ -47,14 +47,14 @@ pprof = { version = "0.11.1", features = [
     "protobuf-codec",
     "protobuf",
 ] }
-regex = "1.8.1"
+regex = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 state = "0.5"
 tikv-jemalloc-ctl = { workspace = true }
 tikv-jemalloc-sys = "0.5.2"
 tokio = { workspace = true }
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+uuid = { workspace = true }
 
 [dev-dependencies]
 anyerror = { workspace = true }

--- a/src/common/compress/Cargo.toml
+++ b/src/common/compress/Cargo.toml
@@ -22,5 +22,5 @@ serde = { workspace = true }
 
 [dev-dependencies]
 env_logger = "0.10"
-rand = "0.8"
-tokio = { version = "1", features = ["rt", "macros"] }
+rand = { workspace = true }
+tokio = { workspace = true }

--- a/src/common/compress/Cargo.toml
+++ b/src/common/compress/Cargo.toml
@@ -15,7 +15,7 @@ async-compression = { git = "https://github.com/youngsofun/async-compression", r
 brotli = { version = "3.3.0", features = ["std"] }
 bytes = { workspace = true }
 common-exception = { path = "../exception" }
-futures = "0.3"
+futures = { workspace = true }
 log = { workspace = true }
 pin-project = "1"
 serde = { workspace = true }

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -23,7 +23,7 @@ codespan-reporting = { git = "https://github.com/brendanzab/codespan", rev = "c8
 anyhow = { workspace = true }
 arrow-schema = { workspace = true }
 backtrace = "0.3.69"
-bincode = { version = "2.0.0-rc.1", features = ["serde", "std", "alloc"] }
+bincode = { workspace = true }
 http = "0.2"
 opendal = { workspace = true }
 parquet = { workspace = true }

--- a/src/common/hashtable/Cargo.toml
+++ b/src/common/hashtable/Cargo.toml
@@ -25,4 +25,4 @@ ethnum = { workspace = true }
 ordered-float = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = { workspace = true }

--- a/src/common/http/Cargo.toml
+++ b/src/common/http/Cargo.toml
@@ -25,9 +25,9 @@ common-exception = { path = "../exception" }
 # Crates.io dependencies
 anyerror = { workspace = true }
 async-backtrace = { workspace = true }
-futures = "0.3.24"
+futures = { workspace = true }
 log = { workspace = true }
-poem = { version = "~1.3.57", features = ["rustls"] }
+poem = { workspace = true }
 serde = { workspace = true }
 tempfile = { version = "3.4.0", optional = true }
 thiserror = { workspace = true }

--- a/src/common/io/Cargo.toml
+++ b/src/common/io/Cargo.toml
@@ -17,7 +17,7 @@ test = false
 common-exception = { path = "../exception" }
 
 # Crates.io dependencies
-bincode = { version = "2.0.0-rc.1", features = ["serde", "std"] }
+bincode = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }

--- a/src/common/io/Cargo.toml
+++ b/src/common/io/Cargo.toml
@@ -30,4 +30,4 @@ serde = { workspace = true }
 
 [dev-dependencies]
 aho-corasick = { version = "1.0.1" }
-rand = "0.8.5"
+rand = { workspace = true }

--- a/src/common/metrics/Cargo.toml
+++ b/src/common/metrics/Cargo.toml
@@ -20,7 +20,7 @@ common-exception = { path = "../exception" }
 # Crates.io dependencies
 metrics = "0.20.1"
 metrics-exporter-prometheus = { version = "0.11.0", default-features = false }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 prometheus-client = { workspace = true }
 prometheus-parse = "0.2.3"
 serde = { workspace = true }

--- a/src/common/metrics/Cargo.toml
+++ b/src/common/metrics/Cargo.toml
@@ -18,7 +18,7 @@ enable-histogram = ["metrics/enable-histogram"]
 common-exception = { path = "../exception" }
 
 # Crates.io dependencies
-metrics = "0.20.1"
+metrics = { workspace = true }
 metrics-exporter-prometheus = { version = "0.11.0", default-features = false }
 parking_lot = { workspace = true }
 prometheus-client = { workspace = true }

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -22,7 +22,7 @@ storage-encryption = { path = "../../query/ee_features/storage_encryption" }
 anyhow = { workspace = true }
 arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 dashmap = { version = "5.5.1", features = ["serde"] }

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -25,16 +25,16 @@ async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
-dashmap = { version = "5.5.1", features = ["serde"] }
+dashmap = { workspace = true, features = ["serde"] }
 flagset = "0.4"
-futures = "0.3"
+futures = { workspace = true }
 log = { workspace = true }
 metrics = "0.20.1"
-once_cell = "1.15.0"
+once_cell = { workspace = true }
 opendal = { workspace = true }
 ordered-float = { workspace = true }
 parquet = { workspace = true }
-regex = "1.8.1"
+regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -29,7 +29,7 @@ opentelemetry = { version = "0.20", features = ["trace", "logs"] }
 opentelemetry-otlp = { version = "0.13", features = ["trace", "logs", "grpc-tonic"] }
 opentelemetry_sdk = { version = "0.20", features = ["trace", "logs", "rt-tokio"] }
 serde = { workspace = true }
-serde_json = "1"
+serde_json = { workspace = true }
 tonic = { workspace = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-appender = "0.2.2"

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -25,7 +25,7 @@ common-protos = { path = "../protos" }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
-enumflags2 = { version = "0.7.7", features = ["serde"] }
+enumflags2 = { workspace = true }
 log = { workspace = true }
 logcall = { workspace = true }
 maplit = "1.0.2"

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -23,7 +23,7 @@ common-proto-conv = { path = "../proto-conv" }
 common-protos = { path = "../protos" }
 
 anyhow = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 chrono = { workspace = true }
 enumflags2 = { version = "0.7.7", features = ["serde"] }
 log = { workspace = true }

--- a/src/meta/app/Cargo.toml
+++ b/src/meta/app/Cargo.toml
@@ -24,7 +24,7 @@ anyerror = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 cron = "0.12.0"
-enumflags2 = { version = "0.7.7", features = ["serde"] }
+enumflags2 = { workspace = true }
 hex = "0.4.3"
 itertools = { workspace = true }
 maplit = "1.0.2"

--- a/src/meta/client/Cargo.toml
+++ b/src/meta/client/Cargo.toml
@@ -27,7 +27,7 @@ common-metrics = { path = "../../common/metrics" }
 common-tracing = { path = "../../common/tracing" }
 
 derive_more = { workspace = true }
-futures = "0.3.24"
+futures = { workspace = true }
 log = { workspace = true }
 logcall = { workspace = true }
 minitrace = { workspace = true }

--- a/src/meta/client/Cargo.toml
+++ b/src/meta/client/Cargo.toml
@@ -32,7 +32,7 @@ log = { workspace = true }
 logcall = { workspace = true }
 minitrace = { workspace = true }
 once_cell = { workspace = true }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 prost = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
@@ -44,7 +44,7 @@ common-exception = { path = "../../common/exception" }
 common-meta-app = { path = "../app" }
 
 anyhow = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 
 [build-dependencies]
 common-building = { path = "../../common/building" }

--- a/src/meta/embedded/Cargo.toml
+++ b/src/meta/embedded/Cargo.toml
@@ -25,7 +25,7 @@ common-meta-stoerr = { path = "../stoerr" }
 common-meta-types = { path = "../types" }
 
 # Crates.io dependencies
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 log = { workspace = true }
 minitrace = { workspace = true }
 once_cell = { workspace = true }

--- a/src/meta/kvapi/Cargo.toml
+++ b/src/meta/kvapi/Cargo.toml
@@ -16,7 +16,7 @@ test = true
 common-meta-types = { path = "../types" }
 
 anyhow = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
 minitrace = { workspace = true }

--- a/src/meta/proto-conv/Cargo.toml
+++ b/src/meta/proto-conv/Cargo.toml
@@ -17,7 +17,7 @@ common-protos = { path = "../protos" }
 
 chrono = { workspace = true }
 chrono-tz = { workspace = true, features = ["serde"] }
-enumflags2 = { version = "0.7.7", features = ["serde"] }
+enumflags2 = { workspace = true }
 minitrace = { workspace = true }
 num = "0.4.0"
 thiserror = { workspace = true }

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -28,7 +28,7 @@ openraft = { workspace = true }
 
 # crates.io deps
 anyhow = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 byteorder = "1.4.3"
 chrono = { workspace = true }
 derive_more = { workspace = true }

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -29,7 +29,7 @@ openraft = { workspace = true }
 # crates.io deps
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-byteorder = "1.4.3"
+byteorder = { workspace = true }
 chrono = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -46,7 +46,7 @@ sled = { workspace = true }
 # Crates.io dependencies
 anyerror = { workspace = true }
 anyhow = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 backon = "0.4"
 clap = { workspace = true }
 derive_more = { workspace = true }
@@ -65,7 +65,7 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serfig = "0.1.0"
-tokio-stream = "0.1.10"
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tonic-reflection = { workspace = true }
 

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -58,13 +58,13 @@ logcall = { workspace = true }
 maplit = "1.0.2"
 minitrace = { workspace = true }
 once_cell = { workspace = true }
-poem = { version = "~1.3.57", features = ["rustls"] }
+poem = { workspace = true }
 prometheus-client = "0.21.2"
 prost = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serfig = "0.1.0"
+serfig = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tonic-reflection = { workspace = true }
@@ -73,7 +73,7 @@ tonic-reflection = { workspace = true }
 env_logger = "0.10.0"
 maplit = "1.0.2"
 pretty_assertions = "1.3.0"
-regex = "1.8.1"
+regex = { workspace = true }
 reqwest = { workspace = true }
 temp-env = "0.3.0"
 tempfile = "3.4.0"

--- a/src/meta/sled-store/Cargo.toml
+++ b/src/meta/sled-store/Cargo.toml
@@ -23,7 +23,7 @@ openraft = { workspace = true }
 sled = { workspace = true }
 
 anyerror = { workspace = true }
-byteorder = "1.4.3"
+byteorder = { workspace = true }
 log = { workspace = true }
 minitrace = { workspace = true }
 once_cell = { workspace = true }

--- a/src/meta/store/Cargo.toml
+++ b/src/meta/store/Cargo.toml
@@ -23,6 +23,6 @@ common-meta-kvapi = { path = "../kvapi" }
 common-meta-types = { path = "../types" }
 
 # Crates.io dependencies
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 log = { workspace = true }
-tokio-stream = "0.1.11"
+tokio-stream = { workspace = true }

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -34,7 +34,7 @@ tonic-build = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-regex = "1.8.1"
+regex = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["num-derive", "prost"]

--- a/src/query/ast/Cargo.toml
+++ b/src/query/ast/Cargo.toml
@@ -20,7 +20,7 @@ common-meta-app = { path = "../../meta/app" }
 enum-as-inner = "0.5.1"
 ethnum = { workspace = true }
 fast-float = "0.2.0"
-itertools = "0.10.5"
+itertools = { workspace = true }
 logos = "0.12.1"
 minitrace = { workspace = true }
 nom = "7.1.1"
@@ -38,7 +38,7 @@ common-base = { path = "../../common/base" }
 criterion = "0.4"
 goldenfile = "1.4"
 pretty_assertions = "1.3.0"
-regex = "1.8.1"
+regex = { workspace = true }
 
 [[bench]]
 name = "bench"

--- a/src/query/catalog/Cargo.toml
+++ b/src/query/catalog/Cargo.toml
@@ -29,7 +29,7 @@ arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
-dashmap = "5.4"
+dashmap = { workspace = true }
 dyn-clone = "1.0.9"
 parking_lot = { workspace = true }
 parquet_rs = { workspace = true }
@@ -38,7 +38,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
 thrift = "0.17.0"
-typetag = "0.2.3"
+typetag = { workspace = true }
 
 [dev-dependencies]
 goldenfile = "1.4"

--- a/src/query/catalog/Cargo.toml
+++ b/src/query/catalog/Cargo.toml
@@ -27,13 +27,13 @@ storages-common-table-meta = { path = "../storages/common/table_meta" }
 
 arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 chrono = { workspace = true }
 dashmap = "5.4"
 dyn-clone = "1.0.9"
-parking_lot = "0.12"
+parking_lot = { workspace = true }
 parquet_rs = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"

--- a/src/query/codegen/Cargo.toml
+++ b/src/query/codegen/Cargo.toml
@@ -17,4 +17,4 @@ path = "src/bin/codegen.rs"
 [dependencies]
 common-expression = { path = "../expression" }
 
-itertools = "0.10"
+itertools = { workspace = true }

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -31,7 +31,7 @@ log = { workspace = true }
 once_cell = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
-serfig = "0.1.0"
+serfig = { workspace = true }
 strum = "0.24.1"
 
 [dev-dependencies]

--- a/src/query/datavalues/Cargo.toml
+++ b/src/query/datavalues/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 # Crates.io dependencies
 enum-as-inner = "0.5"
 enum_dispatch = "0.3.8"
-serde = { version = "1.0.145" }
-serde_json = { version = "1.0.85", default-features = false }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/src/query/ee/Cargo.toml
+++ b/src/query/ee/Cargo.toml
@@ -48,8 +48,8 @@ arrow-array = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
-dashmap = "5.4"
-futures = "0.3.24"
+dashmap = { workspace = true }
+futures = { workspace = true }
 futures-util = { workspace = true }
 
 jwt-simple = "0.11.0"

--- a/src/query/ee/Cargo.toml
+++ b/src/query/ee/Cargo.toml
@@ -45,7 +45,7 @@ vacuum-handler = { path = "../ee_features/vacuum_handler" }
 virtual-column = { path = "../ee_features/virtual_column" }
 
 arrow-array = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 dashmap = "5.4"

--- a/src/query/ee_features/aggregating_index/Cargo.toml
+++ b/src/query/ee_features/aggregating_index/Cargo.toml
@@ -19,6 +19,6 @@ common-exception = { path = "../../../common/exception" }
 common-meta-app = { path = "../../../meta/app" }
 
 async-backtrace = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 
 [build-dependencies]

--- a/src/query/ee_features/background_service/Cargo.toml
+++ b/src/query/ee_features/background_service/Cargo.toml
@@ -13,12 +13,13 @@ test = false
 
 [dependencies]
 # Workspace dependencies
-arrow-array = { workspace = true }
-async-backtrace = { workspace = true }
-async-trait = "0.1.57"
 common-base = { path = "../../../common/base" }
 common-exception = { path = "../../../common/exception" }
 common-meta-app = { path = "../../../meta/app" }
+
+arrow-array = { workspace = true }
+async-backtrace = { workspace = true }
+async-trait = { workspace = true }
 serde = { workspace = true }
 
 [build-dependencies]

--- a/src/query/ee_features/data_mask/Cargo.toml
+++ b/src/query/ee_features/data_mask/Cargo.toml
@@ -18,6 +18,6 @@ common-exception = { path = "../../../common/exception" }
 common-meta-app = { path = "../../../meta/app" }
 common-meta-store = { path = "../../../meta/store" }
 
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 
 [build-dependencies]

--- a/src/query/ee_features/storage_encryption/Cargo.toml
+++ b/src/query/ee_features/storage_encryption/Cargo.toml
@@ -15,7 +15,6 @@ test = false
 common-base = { path = "../../../common/base" }
 common-exception = { path = "../../../common/exception" }
 
-# Github dependencies
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 
 [build-dependencies]

--- a/src/query/ee_features/stream_handler/Cargo.toml
+++ b/src/query/ee_features/stream_handler/Cargo.toml
@@ -20,6 +20,6 @@ common-sql = { path = "../../sql" }
 
 # Github dependencies
 async-backtrace = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 
 [build-dependencies]

--- a/src/query/ee_features/vacuum_handler/Cargo.toml
+++ b/src/query/ee_features/vacuum_handler/Cargo.toml
@@ -19,7 +19,7 @@ common-exception = { path = "../../../common/exception" }
 common-storages-fuse = { path = "../../storages/fuse" }
 
 async-backtrace = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 chrono = { workspace = true }
 
 [build-dependencies]

--- a/src/query/ee_features/virtual_column/Cargo.toml
+++ b/src/query/ee_features/virtual_column/Cargo.toml
@@ -20,6 +20,6 @@ common-meta-app = { path = "../../../meta/app" }
 common-storages-fuse = { path = "../../storages/fuse" }
 
 async-backtrace = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 
 [build-dependencies]

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -45,7 +45,7 @@ micromarshal = "0.4.0"
 num-traits = "0.2.15"
 once_cell = { workspace = true }
 ordered-float = { workspace = true, features = ["serde", "rand"] }
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { workspace = true }
 roaring = { version = "0.10.1", features = ["serde"] }
 rust_decimal = "1.26"
 serde = { workspace = true }
@@ -60,4 +60,4 @@ arrow-ord = { workspace = true }
 common-ast = { path = "../ast" }
 goldenfile = "1.4"
 pretty_assertions = "1.3.0"
-rand = "0.8.5"
+rand = { workspace = true }

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -30,17 +30,17 @@ bumpalo = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 comfy-table = "6"
-dashmap = "5.4"
+dashmap = { workspace = true }
 educe = "0.4"
 enum-as-inner = "0.5"
 ethnum = { workspace = true, features = ["serde", "macros"] }
-futures = "0.3.24"
+futures = { workspace = true }
 hex = "0.4.3"
-itertools = "0.10"
+itertools = { workspace = true }
 jsonb = { workspace = true }
 lexical-core = "0.8.5"
 log = { workspace = true }
-match-template = "0.0.1"
+match-template = { workspace = true }
 micromarshal = "0.4.0"
 num-traits = "0.2.15"
 once_cell = { workspace = true }
@@ -52,7 +52,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 terminal_size = "0.2.6"
 tonic = { workspace = true }
-typetag = "0.2.3"
+typetag = { workspace = true }
 unicode-segmentation = "1.10.1"
 
 [dev-dependencies]

--- a/src/query/formats/Cargo.toml
+++ b/src/query/formats/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = { workspace = true }
 bstr = "1.0.1"
 chrono-tz = { workspace = true }
 lexical-core = "0.8.5"
-match-template = "0.0.1"
+match-template = { workspace = true }
 micromarshal = "0.4.0"
 num = "0.4.0"
 once_cell = { workspace = true }

--- a/src/query/formats/Cargo.toml
+++ b/src/query/formats/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 
 [dependencies] # In alphabetical order
 aho-corasick = { version = "1.0.1" }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 bstr = "1.0.1"
 chrono-tz = { workspace = true }
 lexical-core = "0.8.5"

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -51,7 +51,7 @@ ordered-float = { workspace = true, features = [
     "serde",
     "rand",
 ] }
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { workspace = true }
 regex = "1.8.1"
 roaring = "0.10.1"
 serde = { workspace = true }

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -23,7 +23,7 @@ jsonb = { workspace = true }
 
 # Crates.io dependencies
 base64 = "0.21.0"
-bincode = { version = "2.0.0-rc.1", features = ["serde", "std"] }
+bincode = { workspace = true }
 blake3 = "1.3.1"
 bstr = "1.0.1"
 bumpalo = { workspace = true }
@@ -38,10 +38,10 @@ geo = "0.24.0"
 geohash = "0.13.0"
 h3o = "0.4.0"
 hex = "0.4.3"
-itertools = "0.10.5"
+itertools = { workspace = true }
 lexical-core = "0.8.5"
 libm = "0.2.6"
-match-template = "0.0.1"
+match-template = { workspace = true }
 md-5 = "0.10.5"
 memchr = { version = "2", default-features = false }
 naive-cityhash = "0.2.0"
@@ -52,7 +52,7 @@ ordered-float = { workspace = true, features = [
     "rand",
 ] }
 rand = { workspace = true }
-regex = "1.8.1"
+regex = { workspace = true }
 roaring = "0.10.1"
 serde = { workspace = true }
 sha1 = "0.10.5"

--- a/src/query/management/Cargo.toml
+++ b/src/query/management/Cargo.toml
@@ -25,7 +25,7 @@ common-proto-conv = { path = "../../meta/proto-conv" }
 common-protos = { path = "../../meta/protos" }
 
 async-backtrace = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 minitrace = { workspace = true }
 serde_json = { workspace = true }
 

--- a/src/query/pipeline/core/Cargo.toml
+++ b/src/query/pipeline/core/Cargo.toml
@@ -16,7 +16,7 @@ common-exception = { path = "../../../common/exception" }
 common-expression = { path = "../../expression" }
 
 async-backtrace = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 futures = "0.3.24"
 minitrace = { workspace = true }
 petgraph = "0.6.2"

--- a/src/query/pipeline/core/Cargo.toml
+++ b/src/query/pipeline/core/Cargo.toml
@@ -17,7 +17,7 @@ common-expression = { path = "../../expression" }
 
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
-futures = "0.3.24"
+futures = { workspace = true }
 minitrace = { workspace = true }
 petgraph = "0.6.2"
 
@@ -25,4 +25,4 @@ petgraph = "0.6.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-typetag = "0.2.3"
+typetag = { workspace = true }

--- a/src/query/pipeline/sinks/Cargo.toml
+++ b/src/query/pipeline/sinks/Cargo.toml
@@ -20,7 +20,7 @@ common-pipeline-core = { path = "../core" }
 
 async-backtrace = { workspace = true }
 async-channel = "1.7.1"
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/src/query/pipeline/sources/Cargo.toml
+++ b/src/query/pipeline/sources/Cargo.toml
@@ -27,7 +27,7 @@ common-pipeline-core = { path = "../core" }
 common-settings = { path = "../../settings" }
 common-storage = { path = "../../../common/storage" }
 
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 bstr = "1.0.1"
 csv-core = "0.1.10"
 dashmap = "5.4.0"
@@ -37,7 +37,7 @@ futures-util = { workspace = true }
 log = { workspace = true }
 minitrace = { workspace = true }
 opendal = { workspace = true }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/src/query/pipeline/sources/Cargo.toml
+++ b/src/query/pipeline/sources/Cargo.toml
@@ -30,8 +30,8 @@ common-storage = { path = "../../../common/storage" }
 async-trait = { workspace = true }
 bstr = "1.0.1"
 csv-core = "0.1.10"
-dashmap = "5.4.0"
-futures = "0.3.24"
+dashmap = { workspace = true }
+futures = { workspace = true }
 futures-util = { workspace = true }
 
 log = { workspace = true }
@@ -41,5 +41,5 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
-typetag = "0.2.3"
+typetag = { workspace = true }
 xml-rs = "0.8.14"

--- a/src/query/pipeline/transforms/Cargo.toml
+++ b/src/query/pipeline/transforms/Cargo.toml
@@ -18,7 +18,7 @@ common-profile = { path = "../../profile" }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 jsonb = { workspace = true }
-match-template = "0.0.1"
+match-template = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["match-template"]

--- a/src/query/pipeline/transforms/Cargo.toml
+++ b/src/query/pipeline/transforms/Cargo.toml
@@ -16,7 +16,7 @@ common-pipeline-core = { path = "../core" }
 common-profile = { path = "../../profile" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 jsonb = { workspace = true }
 match-template = "0.0.1"
 

--- a/src/query/profile/Cargo.toml
+++ b/src/query/profile/Cargo.toml
@@ -13,4 +13,4 @@ test = false
 [dependencies]
 common-base = { path = "../../common/base" }
 
-dashmap = "5.4"
+dashmap = { workspace = true }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -110,14 +110,14 @@ base64 = "0.21.0"
 bincode = "1.3.3"
 bumpalo = { workspace = true }
 byte-unit = "4.0.19"
-byteorder = "1.4.3"
+byteorder = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 config = { version = "0.13.4", features = [] }
 ctor = "0.1.26"
-dashmap = "5.4"
+dashmap = { workspace = true }
 ethnum = { workspace = true }
-futures = "0.3.24"
+futures = { workspace = true }
 futures-util = { workspace = true }
 h2 = "0.3.17"
 headers = "0.3.8"
@@ -125,11 +125,11 @@ highway = "1.1"
 http = "0.2.8"
 humantime = "2.1.0"
 indicatif = "0.17.5"
-itertools = "0.10.5"
+itertools = { workspace = true }
 jwt-simple = "0.11.0"
 log = { workspace = true }
 lz4 = "1.24.0"
-match-template = "0.0.1"
+match-template = { workspace = true }
 metrics = "0.20.1"
 minitrace = { workspace = true }
 naive-cityhash = "0.2.0"
@@ -141,10 +141,10 @@ parquet = { workspace = true }
 paste = "1.0.9"
 petgraph = "0.6.2"
 pin-project-lite = "0.2.9"
-poem = { version = "~1.3.57", features = ["rustls", "multipart", "compression"] }
+poem = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
-regex = "1.8.1"
+regex = { workspace = true }
 reqwest = { workspace = true }
 rustls = "0.21.6"
 rustls-pemfile = "1.0.2"
@@ -156,13 +156,13 @@ socket2 = "0.5.3"
 strength_reduce = "0.2.4"
 tempfile = "3.4.0"
 time = "0.3.14"
-tokio-stream = { version = "0.1.10", features = ["net"] }
+tokio-stream = { workspace = true, features = ["net"] }
 toml = { version = "0.7.3", default-features = false }
 tonic = { workspace = true }
-typetag = "0.2.3"
+typetag = { workspace = true }
 unicode-segmentation = "1.10.1"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
-walkdir = "2.3.2"
+uuid = { workspace = true }
+walkdir = { workspace = true }
 
 [dev-dependencies]
 arrow-cast = { workspace = true }
@@ -185,7 +185,7 @@ temp-env = "0.3.0"
 tempfile = "3.4.0"
 tower = "0.4.13"
 url = "2.3.1"
-walkdir = "2.3.2"
+walkdir = { workspace = true }
 wiremock = "0.5.14"
 
 [build-dependencies]

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -105,7 +105,7 @@ arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
 async-channel = "1.7.1"
 async-stream = "0.3.3"
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 base64 = "0.21.0"
 bincode = "1.3.3"
 bumpalo = { workspace = true }
@@ -136,14 +136,14 @@ naive-cityhash = "0.2.0"
 once_cell = { workspace = true }
 opendal = { workspace = true }
 opensrv-mysql = { version = "0.5.0", features = ["tls"] }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 parquet = { workspace = true }
 paste = "1.0.9"
 petgraph = "0.6.2"
 pin-project-lite = "0.2.9"
 poem = { version = "~1.3.57", features = ["rustls", "multipart", "compression"] }
 prost = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 regex = "1.8.1"
 reqwest = { workspace = true }
 rustls = "0.21.6"

--- a/src/query/settings/Cargo.toml
+++ b/src/query/settings/Cargo.toml
@@ -18,8 +18,8 @@ common-users = { path = "../users" }
 serde = { workspace = true }
 
 async-backtrace = { workspace = true }
-dashmap = "5.4"
-itertools = "0.10.5"
+dashmap = { workspace = true }
+itertools = { workspace = true }
 log = { workspace = true }
 num_cpus = "1.13.1"
 once_cell = { workspace = true }

--- a/src/query/sharing/Cargo.toml
+++ b/src/query/sharing/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 bytes = { workspace = true }
 common-auth = { path = "../../common/auth" }
 common-base = { path = "../../common/base" }

--- a/src/query/sharing_endpoint/Cargo.toml
+++ b/src/query/sharing_endpoint/Cargo.toml
@@ -18,15 +18,15 @@ common-exception = { path = "../../common/exception" }
 common-meta-app = { path = "../../meta/app" }
 common-storage = { path = "../../common/storage" }
 common-storages-share = { path = "../storages/share" }
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+uuid = { workspace = true }
 
 time = { version = "0.3", features = ["serde"] }
 
 base64 = "0.21.0"
 clap = { workspace = true }
-enumflags2 = { version = "0.7.7", features = ["serde"] }
+enumflags2 = { workspace = true }
 opendal = { workspace = true }
-poem = { version = "~1.3.57", features = ["rustls", "multipart", "compression"] }
+poem = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serfig = "0.1.0"
+serfig = { workspace = true }

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -59,12 +59,12 @@ chrono-tz = { workspace = true }
 cidr = { version = "0.2.2" }
 cron = "0.12.0"
 ctor = "0.1.26"
-dashmap = "5.4"
+dashmap = { workspace = true }
 educe = "0.4"
 enum-as-inner = "0.5"
 globiter = "0.1"
 indexmap = "2.0.0"
-itertools = "0.10.5"
+itertools = { workspace = true }
 log = { workspace = true }
 minitrace = { workspace = true }
 num-derive = "0.3.3"
@@ -74,7 +74,7 @@ opendal = { workspace = true }
 ordered-float = { workspace = true }
 parking_lot = { workspace = true }
 percent-encoding = "2"
-regex = "1.8.1"
+regex = { workspace = true }
 roaring = "0.10.1"
 serde = { workspace = true }
 simsearch = "0.2"

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -53,7 +53,7 @@ ahash = { version = "0.8.2", features = ["no-rng"] }
 anyhow = { workspace = true }
 async-backtrace = { workspace = true }
 async-recursion = "1.0.0"
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 cidr = { version = "0.2.2" }
@@ -72,7 +72,7 @@ num-traits = "0.2.15"
 once_cell = { workspace = true }
 opendal = { workspace = true }
 ordered-float = { workspace = true }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 percent-encoding = "2"
 regex = "1.8.1"
 roaring = "0.10.1"

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -18,12 +18,12 @@ common-exception = { path = "../../../../common/exception" }
 common-metrics = { path = "../../../../common/metrics" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 crc32fast = "1.3.2"
 crossbeam-channel = "0.5.6"
 hex = "0.4.3"
 log = { workspace = true }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 siphasher = "0.3.10"
 
 [dev-dependencies]

--- a/src/query/storages/common/index/Cargo.toml
+++ b/src/query/storages/common/index/Cargo.toml
@@ -24,7 +24,7 @@ storages-common-table-meta = { path = "../table_meta" }
 
 anyerror = { workspace = true }
 cbordata = { version = "0.6.0" }
-match-template = "0.0.1"
+match-template = { workspace = true }
 minitrace = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/src/query/storages/common/index/Cargo.toml
+++ b/src/query/storages/common/index/Cargo.toml
@@ -36,7 +36,7 @@ xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", features 
 [dev-dependencies]
 common-arrow = { path = "../../../../common/arrow" }
 criterion = "0.4"
-rand = "0.8.5"
+rand = { workspace = true }
 
 [[bench]]
 name = "build_from_block"

--- a/src/query/storages/common/locks/Cargo.toml
+++ b/src/query/storages/common/locks/Cargo.toml
@@ -24,7 +24,7 @@ common-users = { path = "../../../users" }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
-futures = "0.3.24"
+futures = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }

--- a/src/query/storages/common/locks/Cargo.toml
+++ b/src/query/storages/common/locks/Cargo.toml
@@ -22,10 +22,10 @@ common-pipeline-core = { path = "../../../pipeline/core" }
 common-users = { path = "../../../users" }
 
 async-backtrace = { workspace = true }
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 futures = "0.3.24"
 futures-util = { workspace = true }
 log = { workspace = true }
-parking_lot = "0.12.1"
-rand = "0.8.5"
+parking_lot = { workspace = true }
+rand = { workspace = true }

--- a/src/query/storages/common/pruner/Cargo.toml
+++ b/src/query/storages/common/pruner/Cargo.toml
@@ -22,4 +22,4 @@ storages-common-table-meta = { path = "../table_meta" }
 log = { workspace = true }
 serde = { workspace = true }
 
-typetag = "0.2.3"
+typetag = { workspace = true }

--- a/src/query/storages/common/table_meta/Cargo.toml
+++ b/src/query/storages/common/table_meta/Cargo.toml
@@ -15,7 +15,7 @@ common-expression = { path = "../../../expression" }
 common-io = { path = "../../../../common/io" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 bincode = "1.3.3"
 chrono = { workspace = true }
 enum-as-inner = "0.5"
@@ -24,7 +24,7 @@ futures-util = { workspace = true }
 once_cell = { workspace = true }
 rmp-serde = "1.1.1"
 serde = { workspace = true }
-serde_json = "1.0.89"
+serde_json = { workspace = true }
 snap = { version = "1.1.0", optional = true }
 typetag = "0.2.3"
 zstd = "0.12.3"

--- a/src/query/storages/common/table_meta/Cargo.toml
+++ b/src/query/storages/common/table_meta/Cargo.toml
@@ -19,14 +19,14 @@ async-trait = { workspace = true }
 bincode = "1.3.3"
 chrono = { workspace = true }
 enum-as-inner = "0.5"
-futures = "0.3.24"
+futures = { workspace = true }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
 rmp-serde = "1.1.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 snap = { version = "1.1.0", optional = true }
-typetag = "0.2.3"
+typetag = { workspace = true }
 zstd = "0.12.3"
 
 [dev-dependencies]

--- a/src/query/storages/factory/Cargo.toml
+++ b/src/query/storages/factory/Cargo.toml
@@ -26,4 +26,4 @@ common-storages-view = { path = "../view" }
 
 storages-common-index = { path = "../common/index" }
 
-dashmap = "5.4"
+dashmap = { workspace = true }

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -42,7 +42,7 @@ storages-common-table-meta = { path = "../common/table_meta" }
 
 ahash = "0.8.3"
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
@@ -56,7 +56,7 @@ metrics = "0.20.1"
 minitrace = { workspace = true }
 opendal = { workspace = true }
 parquet-format-safe = "0.2"
-rand = "0.8.5"
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -47,10 +47,10 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
 enum-as-inner = "0.5"
-futures = "0.3.24"
+futures = { workspace = true }
 futures-util = { workspace = true }
 indexmap = "2.0.0"
-itertools = "0.10.5"
+itertools = { workspace = true }
 log = { workspace = true }
 metrics = "0.20.1"
 minitrace = { workspace = true }
@@ -64,5 +64,5 @@ siphasher = "0.3.10"
 streaming-decompression = "0.1.2"
 sys-info = "0.9"
 
-typetag = "0.2.3"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+typetag = { workspace = true }
+uuid = { workspace = true }

--- a/src/query/storages/hive/hive/Cargo.toml
+++ b/src/query/storages/hive/hive/Cargo.toml
@@ -35,12 +35,12 @@ async-recursion = "1.0.0"
 async-trait = { workspace = true }
 chrono = { workspace = true }
 faststr = "0.2"
-futures = "0.3.24"
+futures = { workspace = true }
 hive_metastore = { git = "https://github.com/Xuanwo/hive_metastore_rs", rev = "b8aaffb" }
 log = { workspace = true }
 minitrace = { workspace = true }
 opendal = { workspace = true }
 ordered-float = { workspace = true }
 serde = { workspace = true }
-typetag = "0.2.3"
+typetag = { workspace = true }
 volo-thrift = "0.8"

--- a/src/query/storages/hive/hive/Cargo.toml
+++ b/src/query/storages/hive/hive/Cargo.toml
@@ -32,7 +32,7 @@ storages-common-table-meta = { path = "../../common/table_meta" }
 
 async-backtrace = { workspace = true }
 async-recursion = "1.0.0"
-async-trait = "0.1.57"
+async-trait = { workspace = true }
 chrono = { workspace = true }
 faststr = "0.2"
 futures = "0.3.24"

--- a/src/query/storages/iceberg/Cargo.toml
+++ b/src/query/storages/iceberg/Cargo.toml
@@ -27,15 +27,15 @@ arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 icelake = "0.0.10"
-match-template = "0.0.1"
+match-template = { workspace = true }
 minitrace = { workspace = true }
 opendal = { workspace = true }
 parquet = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
-typetag = "0.2"
+typetag = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["match-template"]

--- a/src/query/storages/iceberg/Cargo.toml
+++ b/src/query/storages/iceberg/Cargo.toml
@@ -25,7 +25,7 @@ storages-common-table-meta = { path = "../common/table_meta" }
 
 arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 chrono = { workspace = true }
 futures = "0.3"
 icelake = "0.0.10"

--- a/src/query/storages/memory/Cargo.toml
+++ b/src/query/storages/memory/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
-typetag = "0.2.3"
+typetag = { workspace = true }
 
 [build-dependencies]
 common-building = { path = "../../../common/building" }

--- a/src/query/storages/memory/Cargo.toml
+++ b/src/query/storages/memory/Cargo.toml
@@ -24,9 +24,9 @@ common-storage = { path = "../../../common/storage" }
 storages-common-table-meta = { path = "../common/table_meta" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 once_cell = { workspace = true }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 serde = { workspace = true }
 typetag = "0.2.3"
 

--- a/src/query/storages/null/Cargo.toml
+++ b/src/query/storages/null/Cargo.toml
@@ -21,7 +21,7 @@ common-pipeline-sinks = { path = "../../pipeline/sinks" }
 common-pipeline-sources = { path = "../../pipeline/sources" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 
 [build-dependencies]
 common-building = { path = "../../../common/building" }

--- a/src/query/storages/parquet/Cargo.toml
+++ b/src/query/storages/parquet/Cargo.toml
@@ -35,14 +35,14 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 ethnum = { workspace = true }
-futures = "0.3.24"
+futures = { workspace = true }
 log = { workspace = true }
 opendal = { workspace = true }
 parquet = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 thrift = "0.17.0"
-typetag = "0.2.3"
+typetag = { workspace = true }
 
 [dev-dependencies]
 common-sql = { path = "../../sql" }

--- a/src/query/storages/parquet/Cargo.toml
+++ b/src/query/storages/parquet/Cargo.toml
@@ -31,7 +31,7 @@ arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 ethnum = { workspace = true }
@@ -39,7 +39,7 @@ futures = "0.3.24"
 log = { workspace = true }
 opendal = { workspace = true }
 parquet = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 serde = { workspace = true }
 thrift = "0.17.0"
 typetag = "0.2.3"

--- a/src/query/storages/random/Cargo.toml
+++ b/src/query/storages/random/Cargo.toml
@@ -20,7 +20,7 @@ common-pipeline-core = { path = "../../pipeline/core" }
 common-pipeline-sources = { path = "../../pipeline/sources" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 serde = { workspace = true }
 typetag = "0.2.3"
 

--- a/src/query/storages/random/Cargo.toml
+++ b/src/query/storages/random/Cargo.toml
@@ -22,7 +22,7 @@ common-pipeline-sources = { path = "../../pipeline/sources" }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
-typetag = "0.2.3"
+typetag = { workspace = true }
 
 [build-dependencies]
 common-building = { path = "../../../common/building" }

--- a/src/query/storages/result_cache/Cargo.toml
+++ b/src/query/storages/result_cache/Cargo.toml
@@ -25,7 +25,7 @@ storages-common-blocks = { path = "../common/blocks" }
 storages-common-table-meta = { path = "../common/table_meta" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 opendal = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/result_cache/Cargo.toml
+++ b/src/query/storages/result_cache/Cargo.toml
@@ -30,4 +30,4 @@ opendal = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+uuid = { workspace = true }

--- a/src/query/storages/share/Cargo.toml
+++ b/src/query/storages/share/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 chrono = { workspace = true }
 common-exception = { path = "../../../common/exception" }
 common-meta-app = { path = "../../../meta/app" }
-enumflags2 = { version = "0.7.7", features = ["serde"] }
+enumflags2 = { workspace = true }
 
 storages-common-table-meta = { path = "../common/table_meta" }
 

--- a/src/query/storages/stage/Cargo.toml
+++ b/src/query/storages/stage/Cargo.toml
@@ -26,14 +26,14 @@ common-storage = { path = "../../../common/storage" }
 
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
-dashmap = "5.4.0"
+dashmap = { workspace = true }
 log = { workspace = true }
 opendal = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 
-typetag = "0.2.6"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+typetag = { workspace = true }
+uuid = { workspace = true }
 
 [build-dependencies]
 common-building = { path = "../../../common/building" }

--- a/src/query/storages/stage/Cargo.toml
+++ b/src/query/storages/stage/Cargo.toml
@@ -25,11 +25,11 @@ common-pipeline-transforms = { path = "../../pipeline/transforms" }
 common-storage = { path = "../../../common/storage" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 dashmap = "5.4.0"
 log = { workspace = true }
 opendal = { workspace = true }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 serde = { workspace = true }
 
 typetag = "0.2.6"

--- a/src/query/storages/stream/Cargo.toml
+++ b/src/query/storages/stream/Cargo.toml
@@ -28,7 +28,7 @@ storages-common-table-meta = { path = "../common/table_meta" }
 
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
-futures = "0.3.24"
+futures = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
 minitrace = { workspace = true }

--- a/src/query/storages/stream/Cargo.toml
+++ b/src/query/storages/stream/Cargo.toml
@@ -27,7 +27,7 @@ storages-common-pruner = { path = "../common/pruner" }
 storages-common-table-meta = { path = "../common/table_meta" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 futures = "0.3.24"
 futures-util = { workspace = true }
 log = { workspace = true }

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -41,20 +41,20 @@ async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
-itertools = "0.10.5"
+itertools = { workspace = true }
 log = { workspace = true }
 once_cell = { workspace = true }
 opendal = { workspace = true }
 parking_lot = { workspace = true }
-regex = "1.8.1"
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_repr = "0.1.9"
 snailquote = "0.3.1"
 tikv-jemalloc-ctl = { workspace = true }
 
-typetag = "0.2.3"
-walkdir = "2.3.2"
+typetag = { workspace = true }
+walkdir = { workspace = true }
 
 [build-dependencies]
 common-building = { path = "../../../common/building" }

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -38,14 +38,14 @@ storages-common-cache = { path = "../common/cache" }
 storages-common-cache-manager = { path = "../common/cache_manager" }
 
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 itertools = "0.10.5"
 log = { workspace = true }
 once_cell = { workspace = true }
 opendal = { workspace = true }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 regex = "1.8.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/view/Cargo.toml
+++ b/src/query/storages/view/Cargo.toml
@@ -16,6 +16,6 @@ common-catalog = { path = "../../catalog" }
 common-exception = { path = "../../../common/exception" }
 common-meta-app = { path = "../../../meta/app" }
 
-async-trait = { version = "0.1.57", package = "async-trait-fn" }
+async-trait = { workspace = true }
 
 [build-dependencies]

--- a/src/query/users/Cargo.toml
+++ b/src/query/users/Cargo.toml
@@ -31,7 +31,7 @@ async-backtrace = { workspace = true }
 base64 = "0.21"
 chrono = { workspace = true }
 cidr = { version = "0.2.2" }
-enumflags2 = { version = "0.7.7", features = ["serde"] }
+enumflags2 = { workspace = true }
 jwt-simple = "0.11"
 log = { workspace = true }
 p256 = "0.13"

--- a/src/query/users/Cargo.toml
+++ b/src/query/users/Cargo.toml
@@ -35,10 +35,10 @@ enumflags2 = { version = "0.7.7", features = ["serde"] }
 jwt-simple = "0.11"
 log = { workspace = true }
 p256 = "0.13"
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
-serde_json = "1"
+serde_json = { workspace = true }
 
 [dev-dependencies]
 common-expression = { path = "../expression" }

--- a/src/tests/sqlsmith/Cargo.toml
+++ b/src/tests/sqlsmith/Cargo.toml
@@ -13,7 +13,7 @@ databend-client = "0.9.2"
 databend-driver = "0.9.2"
 databend-sql = "0.9.2"
 ethnum = { workspace = true }
-itertools = "0.11.0"
+itertools = { workspace = true }
 jsonb = { workspace = true }
 rand = { workspace = true }
 roaring = { version = "0.10.1", features = ["serde"] }

--- a/src/tests/sqlsmith/Cargo.toml
+++ b/src/tests/sqlsmith/Cargo.toml
@@ -15,10 +15,10 @@ databend-sql = "0.9.2"
 ethnum = { workspace = true }
 itertools = "0.11.0"
 jsonb = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 roaring = { version = "0.10.1", features = ["serde"] }
 tokio = { workspace = true }
-tokio-stream = "0.1"
+tokio-stream = { workspace = true }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 

--- a/tests/sqllogictests/Cargo.toml
+++ b/tests/sqllogictests/Cargo.toml
@@ -14,18 +14,19 @@ version = "0.1.0"
 name = "databend-sqllogictests"
 
 [dependencies]
-async-trait = "0.1.53"
-clap = { workspace = true }
 common-exception = { path = "../../src/common/exception" }
+
+async-trait = { workspace = true }
+clap = { workspace = true }
 env_logger = "0.10.0"
-futures-util = "0.3.25"
+futures-util = { workspace = true }
 mysql_async = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 regex = "1.8.1"
 reqwest = { workspace = true }
 serde = "1.0.150"
-serde_json = "1.0.89"
+serde_json = { workspace = true }
 sqllogictest = "0.17.2"
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 tokio = { workspace = true }
 walkdir = "2.3.2"

--- a/tests/sqllogictests/Cargo.toml
+++ b/tests/sqllogictests/Cargo.toml
@@ -22,11 +22,11 @@ env_logger = "0.10.0"
 futures-util = { workspace = true }
 mysql_async = { workspace = true }
 rand = { workspace = true }
-regex = "1.8.1"
+regex = { workspace = true }
 reqwest = { workspace = true }
 serde = "1.0.150"
 serde_json = { workspace = true }
 sqllogictest = "0.17.2"
 thiserror = { workspace = true }
 tokio = { workspace = true }
-walkdir = "2.3.2"
+walkdir = { workspace = true }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

* no deps version bump
* only move the deps to root cargo.toml if they are used in many crates
* easy to maintain

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13969)
<!-- Reviewable:end -->
