### PR TITLE
chore: bincode api to common/io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,6 @@ name = "common-functions"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.0",
- "bincode 2.0.0-rc.3",
  "blake3",
  "bstr 1.6.2",
  "bumpalo",
@@ -2211,7 +2210,6 @@ dependencies = [
  "chrono-tz",
  "common-exception",
  "ethnum",
- "ignore",
  "lexical-core",
  "micromarshal",
  "ordered-float 3.7.0",
@@ -3994,7 +3992,6 @@ dependencies = [
  "async-trait-fn",
  "background-service",
  "base64 0.21.0",
- "bincode 2.0.0-rc.3",
  "bumpalo",
  "byte-unit",
  "byteorder",
@@ -6655,19 +6652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr 1.6.2",
- "log",
- "regex-automata 0.4.3",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7222,22 +7206,6 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747ad1b4ae841a78e8aba0d63adbfbeaea26b517b63705d47856b73015d27060"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata 0.4.3",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -10397,17 +10365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10418,12 +10375,6 @@ name = "regex-syntax"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -2211,6 +2211,7 @@ dependencies = [
  "chrono-tz",
  "common-exception",
  "ethnum",
+ "ignore",
  "lexical-core",
  "micromarshal",
  "ordered-float 3.7.0",
@@ -3993,7 +3994,7 @@ dependencies = [
  "async-trait-fn",
  "background-service",
  "base64 0.21.0",
- "bincode 1.3.3",
+ "bincode 2.0.0-rc.3",
  "bumpalo",
  "byte-unit",
  "byteorder",
@@ -6654,6 +6655,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr 1.6.2",
+ "log",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7208,6 +7222,22 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747ad1b4ae841a78e8aba0d63adbfbeaea26b517b63705d47856b73015d27060"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.3",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -7807,9 +7837,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "serde",
  "value-bag",
@@ -10367,6 +10397,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10377,6 +10418,12 @@ name = "regex-syntax"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
@@ -13106,12 +13153,11 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 

--- a/src/common/io/Cargo.toml
+++ b/src/common/io/Cargo.toml
@@ -27,6 +27,7 @@ micromarshal = "0.4.0"
 ordered-float = { workspace = true }
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { workspace = true }
+ignore = "0.4.21"
 
 [dev-dependencies]
 aho-corasick = { version = "1.0.1" }

--- a/src/common/io/Cargo.toml
+++ b/src/common/io/Cargo.toml
@@ -27,7 +27,6 @@ micromarshal = "0.4.0"
 ordered-float = { workspace = true }
 roaring = { version = "0.10.1", features = ["serde"] }
 serde = { workspace = true }
-ignore = "0.4.21"
 
 [dev-dependencies]
 aho-corasick = { version = "1.0.1" }

--- a/src/common/io/src/serialization.rs
+++ b/src/common/io/src/serialization.rs
@@ -40,7 +40,7 @@ pub fn bincode_deserialize_from_slice<T: serde::de::DeserializeOwned>(slice: &[u
 pub fn bincode_deserialize_from_stream<T: serde::de::DeserializeOwned>(
     stream: &mut &[u8],
 ) -> Result<T> {
-    bincode_deserialize_from_slice_with_config(stream, BincodeConfig::Standard)
+    bincode_deserialize_from_stream_with_config(stream, BincodeConfig::Standard)
 }
 
 #[inline]

--- a/src/common/io/tests/it/main.rs
+++ b/src/common/io/tests/it/main.rs
@@ -14,7 +14,10 @@
 // limitations under the License.
 #![allow(clippy::uninlined_format_args)]
 
+extern crate core;
+
 mod binary_read;
 mod binary_write;
 mod cursor_ext;
 mod escape;
+mod serialization;

--- a/src/common/io/tests/it/serialization.rs
+++ b/src/common/io/tests/it/serialization.rs
@@ -1,0 +1,137 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Cursor;
+
+use common_exception::Result;
+use common_io::prelude::*;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct TestStruct {
+    a: i32,
+    b: String,
+}
+
+fn create_test_value() -> TestStruct {
+    TestStruct {
+        a: 42,
+        b: "Hello, world!".to_string(),
+    }
+}
+
+#[test]
+fn test_serialize_into_buf_standard() {
+    let mut buffer = Cursor::new(Vec::new());
+    let value = create_test_value();
+
+    let serialize_result = bincode_serialize_into_buf(&mut buffer, &value);
+    assert!(serialize_result.is_ok());
+    assert!(!buffer.get_ref().is_empty());
+}
+
+#[test]
+fn test_serialize_into_buf_legacy() {
+    let mut buffer = Cursor::new(Vec::new());
+    let value = create_test_value();
+
+    let serialize_result =
+        bincode_serialize_into_buf_with_config(&mut buffer, &value, BincodeConfig::Legacy);
+    assert!(serialize_result.is_ok());
+    assert!(!buffer.get_ref().is_empty());
+}
+
+#[test]
+fn test_deserialize_from_slice_standard() {
+    let value = create_test_value();
+    let mut buffer = Cursor::new(Vec::new());
+    bincode_serialize_into_buf(&mut buffer, &value).unwrap();
+    let slice = buffer.get_ref().as_slice();
+
+    let deserialized: TestStruct = bincode_deserialize_from_slice(slice).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn test_deserialize_from_slice_legacy() {
+    let value = create_test_value();
+    let mut buffer = Cursor::new(Vec::new());
+    bincode_serialize_into_buf_with_config(&mut buffer, &value, BincodeConfig::Legacy).unwrap();
+    let slice = buffer.get_ref().as_slice();
+
+    let deserialized: TestStruct =
+        bincode_deserialize_from_slice_with_config(slice, BincodeConfig::Legacy).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn test_deserialize_updates_slice_position() {
+    let first_value = create_test_value();
+    let second_value = TestStruct {
+        a: 24,
+        b: "Goodbye, world!".to_string(),
+    };
+
+    // Serialize both values into a buffer
+    let mut buffer = Cursor::new(Vec::new());
+    bincode_serialize_into_buf(&mut buffer, &first_value).unwrap();
+    bincode_serialize_into_buf(&mut buffer, &second_value).unwrap();
+
+    // Create a mutable slice pointing to the buffer's content
+    let mut slice = buffer.get_ref().as_slice();
+
+    // Deserialize the first value
+    let deserialized_first: TestStruct = bincode_deserialize_from_stream(&mut slice).unwrap();
+    assert_eq!(first_value, deserialized_first);
+
+    // After deserializing the first value, the slice should have been updated to point to the remainder
+    let deserialized_second: TestStruct = bincode_deserialize_from_stream(&mut slice).unwrap();
+    assert_eq!(second_value, deserialized_second);
+
+    // Check if the slice is at the end (no more data to deserialize)
+    assert!(slice.is_empty());
+}
+
+#[test]
+fn test_deserialize_from_invalid_slice() {
+    let invalid_slice = &b"invalid data"[..];
+    let result: Result<TestStruct> = bincode_deserialize_from_slice(invalid_slice);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_serialize_legacy_deserialize_standard() {
+    let value = create_test_value();
+    let mut buffer = Cursor::new(Vec::new());
+    bincode_serialize_into_buf_with_config(&mut buffer, &value, BincodeConfig::Legacy).unwrap();
+    let slice = buffer.get_ref().as_slice();
+
+    let deserialized_result: Result<TestStruct> =
+        bincode_deserialize_from_slice_with_config(slice, BincodeConfig::Standard);
+    assert!(deserialized_result.is_err());
+}
+
+#[test]
+#[ignore]
+fn test_serialize_standard_deserialize_legacy() {
+    let value = create_test_value();
+    let mut buffer = Cursor::new(Vec::new());
+    bincode_serialize_into_buf_with_config(&mut buffer, &value, BincodeConfig::Standard).unwrap();
+    let slice = buffer.get_ref().as_slice();
+
+    let result: Result<TestStruct> =
+        bincode_deserialize_from_slice_with_config(slice, BincodeConfig::Legacy);
+    assert!(result.is_err());
+}

--- a/src/common/io/tests/it/serialization.rs
+++ b/src/common/io/tests/it/serialization.rs
@@ -118,9 +118,9 @@ fn test_serialize_legacy_deserialize_standard() {
     bincode_serialize_into_buf_with_config(&mut buffer, &value, BincodeConfig::Legacy).unwrap();
     let slice = buffer.get_ref().as_slice();
 
-    let deserialized_result: Result<TestStruct> =
-        bincode_deserialize_from_slice_with_config(slice, BincodeConfig::Standard);
-    assert!(deserialized_result.is_err());
+    let deserialized: TestStruct =
+        bincode_deserialize_from_slice_with_config(slice, BincodeConfig::Standard).unwrap();
+    assert_ne!(value, deserialized);
 }
 
 #[test]

--- a/src/query/expression/tests/it/serde.rs
+++ b/src/query/expression/tests/it/serde.rs
@@ -23,8 +23,8 @@ use common_expression::Column;
 use common_expression::FromData;
 use common_expression::RemoteExpr;
 use common_expression::Scalar;
-use common_io::prelude::deserialize_from_slice;
-use common_io::prelude::serialize_into_buf;
+use common_io::prelude::bincode_deserialize_from_slice;
+use common_io::prelude::bincode_serialize_into_buf;
 
 #[test]
 fn test_serde_column() -> Result<()> {
@@ -44,9 +44,9 @@ fn test_serde_column() -> Result<()> {
 
     {
         let mut vs = vec![];
-        serialize_into_buf(&mut vs, &plan).unwrap();
-        let mut vs = vs.as_slice();
-        let new_plan: Plan = deserialize_from_slice(&mut vs).unwrap();
+        bincode_serialize_into_buf(&mut vs, &plan).unwrap();
+        let vs = vs.as_slice();
+        let new_plan: Plan = bincode_deserialize_from_slice(vs).unwrap();
         assert!(plan == new_plan);
     }
     Ok(())

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -23,7 +23,6 @@ jsonb = { workspace = true }
 
 # Crates.io dependencies
 base64 = "0.21.0"
-bincode = { workspace = true }
 blake3 = "1.3.1"
 bstr = "1.0.1"
 bumpalo = { workspace = true }

--- a/src/query/functions/src/aggregates/aggregator_common.rs
+++ b/src/query/functions/src/aggregates/aggregator_common.rs
@@ -21,6 +21,8 @@ use common_expression::types::DataType;
 use common_expression::Column;
 use common_expression::ColumnBuilder;
 use common_expression::Scalar;
+use common_io::prelude::bincode_deserialize_from_stream;
+use common_io::prelude::bincode_serialize_into_buf;
 
 use super::AggregateFunctionFactory;
 use super::AggregateFunctionRef;
@@ -156,14 +158,10 @@ pub fn serialize_state<W: std::io::Write, T: serde::Serialize>(
     writer: &mut W,
     value: &T,
 ) -> Result<()> {
-    bincode::serde::encode_into_std_write(value, writer, bincode::config::standard())?;
-    Ok(())
+    bincode_serialize_into_buf(writer, value)
 }
 
 #[inline]
 pub fn deserialize_state<T: serde::de::DeserializeOwned>(slice: &mut &[u8]) -> Result<T> {
-    let (value, bytes_read) =
-        bincode::serde::decode_from_slice(slice, bincode::config::standard())?;
-    *slice = &slice[bytes_read..];
-    Ok(value)
+    bincode_deserialize_from_stream(slice)
 }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -107,7 +107,6 @@ async-channel = "1.7.1"
 async-stream = "0.3.3"
 async-trait = { workspace = true }
 base64 = "0.21.0"
-bincode = { workspace = true }
 bumpalo = { workspace = true }
 byte-unit = "4.0.19"
 byteorder = { workspace = true }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -107,7 +107,7 @@ async-channel = "1.7.1"
 async-stream = "0.3.3"
 async-trait = { workspace = true }
 base64 = "0.21.0"
-bincode = "1.3.3"
+bincode = { workspace = true }
 bumpalo = { workspace = true }
 byte-unit = "4.0.19"
 byteorder = { workspace = true }

--- a/src/query/service/src/api/rpc/exchange/serde/exchange_deserializer.rs
+++ b/src/query/service/src/api/rpc/exchange/serde/exchange_deserializer.rs
@@ -28,6 +28,7 @@ use common_expression::BlockMetaInfo;
 use common_expression::BlockMetaInfoPtr;
 use common_expression::DataBlock;
 use common_expression::DataSchemaRef;
+use common_io::prelude::bincode_deserialize_from_slice;
 use common_io::prelude::BinaryRead;
 use common_pipeline_core::processors::InputPort;
 use common_pipeline_core::processors::OutputPort;
@@ -74,13 +75,8 @@ impl TransformExchangeDeserializer {
     fn recv_data(&self, dict: Vec<DataPacket>, fragment_data: FragmentData) -> Result<DataBlock> {
         const ROW_HEADER_SIZE: usize = std::mem::size_of::<u32>();
 
-        let meta = match bincode::deserialize(&fragment_data.get_meta()[ROW_HEADER_SIZE..]) {
-            Ok(meta) => Ok(meta),
-            Err(_) => Err(ErrorCode::BadBytes(
-                "block meta deserialize error when exchange",
-            )),
-        }?;
-
+        let meta = bincode_deserialize_from_slice(&fragment_data.get_meta()[ROW_HEADER_SIZE..])
+            .map_err(|_| ErrorCode::BadBytes("block meta deserialize error when exchange"))?;
         let mut row_count_meta = &fragment_data.get_meta()[..ROW_HEADER_SIZE];
         let row_count: u32 = row_count_meta.read_scalar()?;
 

--- a/src/query/service/src/api/rpc/exchange/serde/exchange_serializer.rs
+++ b/src/query/service/src/api/rpc/exchange/serde/exchange_serializer.rs
@@ -27,6 +27,7 @@ use common_exception::Result;
 use common_expression::BlockMetaInfo;
 use common_expression::BlockMetaInfoPtr;
 use common_expression::DataBlock;
+use common_io::prelude::bincode_serialize_into_buf;
 use common_io::prelude::BinaryWrite;
 use common_pipeline_core::processors::InputPort;
 use common_pipeline_core::processors::OutputPort;
@@ -211,7 +212,7 @@ pub fn serialize_block(
 
     let mut meta = vec![];
     meta.write_scalar_own(data_block.num_rows() as u32)?;
-    bincode::serialize_into(&mut meta, &data_block.get_meta())
+    bincode_serialize_into_buf(&mut meta, &data_block.get_meta())
         .map_err(|_| ErrorCode::BadBytes("block meta serialize error when exchange"))?;
 
     let (dict, values) = match data_block.is_empty() {

--- a/src/query/service/tests/it/storages/fuse/meta/serialization_format_compatability.rs
+++ b/src/query/service/tests/it/storages/fuse/meta/serialization_format_compatability.rs
@@ -12,6 +12,11 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::io::Cursor;
+
+use common_io::prelude::bincode_deserialize_from_slice;
+use common_io::prelude::bincode_serialize_into_buf;
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 struct BasicOld {
     a: u32,
@@ -88,15 +93,19 @@ enum NewEnumInsertFieldInTheMiddle {
 #[test]
 fn test_bincode_backward_compat_enum() {
     let old_format = OldEnum::B(100);
-    let bytes = bincode::serialize(&old_format).unwrap();
-    let _: OldEnum = bincode::deserialize(&bytes).unwrap();
+
+    let mut buffer = Cursor::new(Vec::new());
+    bincode_serialize_into_buf(&mut buffer, &old_format).unwrap();
+    let bytes = buffer.get_ref().as_slice();
+
+    let _: OldEnum = bincode_deserialize_from_slice(bytes).unwrap();
 
     // enum extended with new field is ok
-    let new: NewEnumAppendField = bincode::deserialize(&bytes).unwrap();
+    let new: NewEnumAppendField = bincode_deserialize_from_slice(bytes).unwrap();
     assert_eq!(new, NewEnumAppendField::B(100));
 
     // enum, insert with new field in the middle, is NOT ok
-    let new: Result<NewEnumInsertFieldInTheMiddle, _> = bincode::deserialize(&bytes);
+    let new: Result<NewEnumInsertFieldInTheMiddle, _> = bincode_deserialize_from_slice(bytes);
     assert!(new.is_err())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

**change bincode api to common/io**
* bump bincode to `version = "2.0.0-rc.3"`
* `src/query/storages/common/table_meta/Cargo.toml` still using `1.3.3` for table format it will remove later @dantengsky 
* bincode ABI is not stable, api breaking changes often, this PR shink them all to `bincode_serialize/deserialize`


- Closes #13968

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13973)
<!-- Reviewable:end -->

## Tests
- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_
