### PR TITLE
chore: fix drop_table_by_id fail when TableIdToName cannot found

### DIFF
--- a/src/binaries/metabench/main.rs
+++ b/src/binaries/metabench/main.rs
@@ -235,7 +235,11 @@ async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u6
     let res = client
         .drop_table_by_id(DropTableByIdReq {
             if_exists: false,
-            tenant: tenant(),
+            name_ident: TableNameIdent {
+                tenant: tenant(),
+                db_name: db_name(),
+                table_name: table_name(),
+            },
             tb_id: t.ident.table_id,
         })
         .await;

--- a/src/binaries/metabench/main.rs
+++ b/src/binaries/metabench/main.rs
@@ -235,11 +235,9 @@ async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u6
     let res = client
         .drop_table_by_id(DropTableByIdReq {
             if_exists: false,
-            name_ident: TableNameIdent {
-                tenant: tenant(),
-                db_name: db_name(),
-                table_name: table_name(),
-            },
+            tenant: tenant(),
+            db_id: db_name(),
+            table_name: table_name(),
             tb_id: t.ident.table_id,
         })
         .await;

--- a/src/binaries/metabench/main.rs
+++ b/src/binaries/metabench/main.rs
@@ -203,6 +203,10 @@ async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u6
         .await;
 
     print_res(i, "create_db", &res);
+    let db_id = match res {
+        Ok(res) => res.db_id,
+        Err(_) => 0,
+    };
 
     let res = client
         .create_table(CreateTableReq {
@@ -236,7 +240,7 @@ async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u6
         .drop_table_by_id(DropTableByIdReq {
             if_exists: false,
             tenant: tenant(),
-            db_id: db_name(),
+            db_id,
             table_name: table_name(),
             tb_id: t.ident.table_id,
         })

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -1704,7 +1704,11 @@ impl ShareApiTestSuite {
 
             let plan = DropTableByIdReq {
                 if_exists: false,
-                tenant: tenant.to_string(),
+                name_ident: TableNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: db_name.to_string(),
+                    table_name: tbl_name.to_string(),
+                },
                 tb_id: table_id,
             };
             let _res = mt.drop_table_by_id(plan).await;

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -1704,12 +1704,10 @@ impl ShareApiTestSuite {
 
             let plan = DropTableByIdReq {
                 if_exists: false,
-                name_ident: TableNameIdent {
-                    tenant: tenant.to_string(),
-                    db_name: db_name.to_string(),
-                    table_name: tbl_name.to_string(),
-                },
+                tenant: tenant.to_string(),
+                table_name: tbl_name.to_string(),
                 tb_id: table_id,
+                db_id,
             };
             let _res = mt.drop_table_by_id(plan).await;
 

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -488,9 +488,9 @@ pub struct CreateTableReply {
 pub struct DropTableByIdReq {
     pub if_exists: bool,
 
-    pub tenant: String,
-
     pub tb_id: MetaId,
+
+    pub name_ident: TableNameIdent,
 }
 
 impl DropTableByIdReq {

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -488,9 +488,13 @@ pub struct CreateTableReply {
 pub struct DropTableByIdReq {
     pub if_exists: bool,
 
+    pub tenant: String,
+
     pub tb_id: MetaId,
 
-    pub name_ident: TableNameIdent,
+    pub table_name: String,
+
+    pub db_id: MetaId,
 }
 
 impl DropTableByIdReq {

--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -173,15 +173,15 @@ impl StreamHandler for RealStreamHandler {
                 )));
             }
 
+            let db = catalog.get_database(&tenant, &db_name).await?;
+
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: plan.if_exists,
-                    name_ident: TableNameIdent {
-                        tenant: tenant.clone(),
-                        db_name: plan.database.clone(),
-                        table_name: stream_name.clone(),
-                    },
+                    tenant: tenant.clone(),
+                    table_name: stream_name.clone(),
                     tb_id: table.get_id(),
+                    db_id: db.get_db_info().ident.db_id,
                 })
                 .await
         } else if plan.if_exists {

--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -176,7 +176,11 @@ impl StreamHandler for RealStreamHandler {
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: plan.if_exists,
-                    tenant,
+                    name_ident: TableNameIdent {
+                        tenant: tenant.clone(),
+                        db_name: plan.database.clone(),
+                        table_name: stream_name.clone(),
+                    },
                     tb_id: table.get_id(),
                 })
                 .await

--- a/src/query/service/src/interpreters/interpreter_table_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use common_management::RoleApi;
 use common_meta_app::principal::GrantObjectByID;
 use common_meta_app::schema::DropTableByIdReq;
+use common_meta_app::schema::TableNameIdent;
 use common_sql::plans::DropTablePlan;
 use common_storages_fuse::FuseTable;
 use common_storages_share::save_share_spec;
@@ -107,7 +108,11 @@ impl Interpreter for DropTableInterpreter {
             let resp = catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: self.plan.if_exists,
-                    tenant: self.plan.tenant.clone(),
+                    name_ident: TableNameIdent {
+                        tenant,
+                        db_name: db_name.to_string(),
+                        table_name: tbl_name.to_string(),
+                    },
                     tb_id: tbl.get_table_info().ident.table_id,
                 })
                 .await?;

--- a/src/query/service/src/interpreters/interpreter_table_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop.rs
@@ -20,7 +20,6 @@ use common_exception::Result;
 use common_management::RoleApi;
 use common_meta_app::principal::GrantObjectByID;
 use common_meta_app::schema::DropTableByIdReq;
-use common_meta_app::schema::TableNameIdent;
 use common_sql::plans::DropTablePlan;
 use common_storages_fuse::FuseTable;
 use common_storages_share::save_share_spec;
@@ -108,12 +107,10 @@ impl Interpreter for DropTableInterpreter {
             let resp = catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: self.plan.if_exists,
-                    name_ident: TableNameIdent {
-                        tenant,
-                        db_name: db_name.to_string(),
-                        table_name: tbl_name.to_string(),
-                    },
+                    tenant,
+                    table_name: tbl_name.to_string(),
                     tb_id: tbl.get_table_info().ident.table_id,
+                    db_id: db.get_db_info().ident.db_id,
                 })
                 .await?;
 

--- a/src/query/service/src/interpreters/interpreter_view_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_view_alter.rs
@@ -55,15 +55,16 @@ impl Interpreter for AlterViewInterpreter {
             .get_table(&self.plan.tenant, &self.plan.database, &self.plan.view_name)
             .await
         {
+            let db = catalog
+                .get_database(&self.plan.tenant, &self.plan.database)
+                .await?;
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: true,
-                    name_ident: TableNameIdent {
-                        tenant: self.plan.tenant.clone(),
-                        db_name: self.plan.database.clone(),
-                        table_name: self.plan.view_name.clone(),
-                    },
+                    tenant: self.plan.tenant.clone(),
+                    table_name: self.plan.view_name.clone(),
                     tb_id: tbl.get_id(),
+                    db_id: db.get_db_info().ident.db_id,
                 })
                 .await?;
 

--- a/src/query/service/src/interpreters/interpreter_view_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_view_alter.rs
@@ -58,7 +58,11 @@ impl Interpreter for AlterViewInterpreter {
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: true,
-                    tenant: self.plan.tenant.clone(),
+                    name_ident: TableNameIdent {
+                        tenant: self.plan.tenant.clone(),
+                        db_name: self.plan.database.clone(),
+                        table_name: self.plan.view_name.clone(),
+                    },
                     tb_id: tbl.get_id(),
                 })
                 .await?;

--- a/src/query/service/src/interpreters/interpreter_view_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_view_drop.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_app::schema::DropTableByIdReq;
+use common_meta_app::schema::TableNameIdent;
 use common_sql::plans::DropViewPlan;
 use common_storages_stream::stream_table::STREAM_ENGINE;
 use common_storages_view::view_table::VIEW_ENGINE;
@@ -82,7 +83,11 @@ impl Interpreter for DropViewInterpreter {
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: self.plan.if_exists,
-                    tenant: self.plan.tenant.clone(),
+                    name_ident: TableNameIdent {
+                        tenant: self.plan.tenant.clone(),
+                        db_name: self.plan.database.clone(),
+                        table_name: self.plan.view_name.clone(),
+                    },
                     tb_id: table.get_id(),
                 })
                 .await?;

--- a/src/query/service/src/interpreters/interpreter_view_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_view_drop.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_app::schema::DropTableByIdReq;
-use common_meta_app::schema::TableNameIdent;
 use common_sql::plans::DropViewPlan;
 use common_storages_stream::stream_table::STREAM_ENGINE;
 use common_storages_view::view_table::VIEW_ENGINE;
@@ -80,15 +79,16 @@ impl Interpreter for DropViewInterpreter {
             }
 
             let catalog = self.ctx.get_catalog(&self.plan.catalog).await?;
+            let db = catalog
+                .get_database(&self.plan.tenant, &self.plan.database)
+                .await?;
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: self.plan.if_exists,
-                    name_ident: TableNameIdent {
-                        tenant: self.plan.tenant.clone(),
-                        db_name: self.plan.database.clone(),
-                        table_name: self.plan.view_name.clone(),
-                    },
+                    tenant: self.plan.tenant.clone(),
+                    table_name: self.plan.view_name.clone(),
                     tb_id: table.get_id(),
+                    db_id: db.get_db_info().ident.db_id,
                 })
                 .await?;
         };

--- a/src/query/service/tests/it/catalogs/database_catalog.rs
+++ b/src/query/service/tests/it/catalogs/database_catalog.rs
@@ -216,7 +216,11 @@ async fn test_catalogs_table() -> Result<()> {
         let res = catalog
             .drop_table_by_id(DropTableByIdReq {
                 if_exists: false,
-                tenant: tenant.to_string(),
+                name_ident: TableNameIdent {
+                    tenant: tenant.to_string(),
+                    db_name: "default".to_string(),
+                    table_name: "test_table".to_string(),
+                },
                 tb_id: tbl.get_table_info().ident.table_id,
             })
             .await;

--- a/src/query/service/tests/it/catalogs/database_catalog.rs
+++ b/src/query/service/tests/it/catalogs/database_catalog.rs
@@ -213,15 +213,14 @@ async fn test_catalogs_table() -> Result<()> {
     // Drop.
     {
         let tbl = catalog.get_table(tenant, "default", "test_table").await?;
+        let db = catalog.get_database(tenant, "default").await?;
         let res = catalog
             .drop_table_by_id(DropTableByIdReq {
                 if_exists: false,
-                name_ident: TableNameIdent {
-                    tenant: tenant.to_string(),
-                    db_name: "default".to_string(),
-                    table_name: "test_table".to_string(),
-                },
+                tenant: tenant.to_string(),
+                table_name: "test_table".to_string(),
                 tb_id: tbl.get_table_info().ident.table_id,
+                db_id: db.get_db_info().ident.db_id,
             })
             .await;
         assert!(res.is_ok());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore: fix drop_table_by_id fail when TableIdToName cannot found

- Closes https://github.com/datafuselabs/databend/issues/13998

## Tests
- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14002)
<!-- Reviewable:end -->
