### PR TITLE
fix: fix enable_refresh_virtual_column_after_write range

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -636,6 +636,7 @@ impl DefaultSettings {
                     desc: "Refresh virtual column after new data written",
                     possible_values: None,
                     mode: SettingMode::Both,
+                    range: None,
                 }),
             ]);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

https://github.com/datafuselabs/databend/pull/13983 is not sync with main, so the settings range is missing.

- Closes #issue

## Tests
- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14009)
<!-- Reviewable:end -->
