### PR TITLE
refactor: access KVMeta with methods instead of field

### DIFF
--- a/src/binaries/meta/kvapi.rs
+++ b/src/binaries/meta/kvapi.rs
@@ -40,9 +40,7 @@ impl KvApiCommand {
                 let req = UpsertKVReq::update(config.key[0].as_str(), config.value.as_bytes());
 
                 let req = if let Some(expire_after) = config.expire_after {
-                    req.with(KVMeta {
-                        expire_at: Some(SeqV::<()>::now_ms() / 1000 + expire_after),
-                    })
+                    req.with(KVMeta::new_expire(SeqV::<()>::now_sec() + expire_after))
                 } else {
                     req
                 };

--- a/src/meta/api/src/background_api_impl.rs
+++ b/src/meta/api/src/background_api_impl.rs
@@ -243,9 +243,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> BackgroundApi for KV {
                 name_key.to_string_key().as_str(),
                 Any,
                 Operation::Update(serialize_struct(&meta)?),
-                Some(KVMeta {
-                    expire_at: Some(req.expire_at),
-                }),
+                Some(KVMeta::new_expire(req.expire_at)),
             ))
             .await?;
         // confirm a successful update

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -254,9 +254,7 @@ impl kvapi::TestSuite {
             .as_secs();
 
         let _res = kv
-            .upsert_kv(UpsertKVReq::update("k1", b"v1").with(KVMeta {
-                expire_at: Some(now + 2),
-            }))
+            .upsert_kv(UpsertKVReq::update("k1", b"v1").with(KVMeta::new_expire(now + 2)))
             .await?;
         // dbg!("upsert non expired k1", _res);
 
@@ -288,9 +286,7 @@ impl kvapi::TestSuite {
                 .upsert_kv(
                     UpsertKVReq::update("k1", b"v1")
                         .with(MatchSeq::Exact(0))
-                        .with(KVMeta {
-                            expire_at: Some(now - 1),
-                        }),
+                        .with(KVMeta::new_expire(now - 1)),
                 )
                 .await?;
             // dbg!("update expired k1", _res);
@@ -299,9 +295,7 @@ impl kvapi::TestSuite {
                 .upsert_kv(
                     UpsertKVReq::update("k2", b"v2")
                         .with(MatchSeq::Exact(0))
-                        .with(KVMeta {
-                            expire_at: Some(now + 10),
-                        }),
+                        .with(KVMeta::new_expire(now + 10)),
                 )
                 .await?;
             // dbg!("update non expired k2", _res);
@@ -312,9 +306,7 @@ impl kvapi::TestSuite {
                 None,
                 Some(SeqV::with_meta(
                     3,
-                    Some(KVMeta {
-                        expire_at: Some(now + 10)
-                    }),
+                    Some(KVMeta::new_expire(now + 10)),
                     b"v2".to_vec()
                 ))
             ]);
@@ -333,9 +325,7 @@ impl kvapi::TestSuite {
             kv.upsert_kv(
                 UpsertKVReq::update("k2", b"v2")
                     .with(MatchSeq::Exact(3))
-                    .with(KVMeta {
-                        expire_at: Some(now - 1),
-                    }),
+                    .with(KVMeta::new_expire(now - 1)),
             )
             .await?;
 
@@ -368,9 +358,7 @@ impl kvapi::TestSuite {
                 test_key,
                 MatchSeq::Exact(seq + 1),
                 Operation::AsIs,
-                Some(KVMeta {
-                    expire_at: Some(now + 20),
-                }),
+                Some(KVMeta::new_expire(now + 20)),
             ))
             .await?;
         assert_eq!(Some(SeqV::with_meta(1, None, b"v1".to_vec())), r.prev);
@@ -383,18 +371,14 @@ impl kvapi::TestSuite {
                 test_key,
                 MatchSeq::Exact(seq),
                 Operation::AsIs,
-                Some(KVMeta {
-                    expire_at: Some(now + 20),
-                }),
+                Some(KVMeta::new_expire(now + 20)),
             ))
             .await?;
         assert_eq!(Some(SeqV::with_meta(1, None, b"v1".to_vec())), r.prev);
         assert_eq!(
             Some(SeqV::with_meta(
                 2,
-                Some(KVMeta {
-                    expire_at: Some(now + 20)
-                }),
+                Some(KVMeta::new_expire(now + 20)),
                 b"v1".to_vec()
             )),
             r.result
@@ -404,13 +388,7 @@ impl kvapi::TestSuite {
         let key_value = kv.get_kv(test_key).await?;
         assert!(key_value.is_some());
         assert_eq!(
-            SeqV::with_meta(
-                seq + 1,
-                Some(KVMeta {
-                    expire_at: Some(now + 20)
-                }),
-                b"v1".to_vec()
-            ),
+            SeqV::with_meta(seq + 1, Some(KVMeta::new_expire(now + 20)), b"v1".to_vec()),
             key_value.unwrap(),
         );
 

--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -381,9 +381,7 @@ impl<'a> Applier<'a> {
         put: &TxnPutRequest,
         resp: &mut TxnReply,
     ) -> Result<(), io::Error> {
-        let upsert = UpsertKV::update(&put.key, &put.value).with(KVMeta {
-            expire_at: put.expire_at,
-        });
+        let upsert = UpsertKV::update(&put.key, &put.value).with(KVMeta::new(put.expire_at));
 
         let (prev, _result) = self.upsert_kv(&upsert).await?;
 

--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
@@ -379,26 +379,18 @@ async fn build_2_level_with_meta() -> anyhow::Result<LeveledMap> {
 
     // internal_seq: 0
     l.str_map_mut()
-        .set(s("a"), Some((b("a0"), Some(KVMeta { expire_at: Some(1) }))))
+        .set(s("a"), Some((b("a0"), Some(KVMeta::new_expire(1)))))
         .await?;
     l.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
     l.str_map_mut()
-        .set(s("c"), Some((b("c0"), Some(KVMeta { expire_at: Some(2) }))))
+        .set(s("c"), Some((b("c0"), Some(KVMeta::new_expire(2)))))
         .await?;
 
     l.freeze_writable();
 
     // internal_seq: 3
     l.str_map_mut()
-        .set(
-            s("b"),
-            Some((
-                b("b1"),
-                Some(KVMeta {
-                    expire_at: Some(10),
-                }),
-            )),
-        )
+        .set(s("b"), Some((b("b1"), Some(KVMeta::new_expire(10)))))
         .await?;
     l.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
 
@@ -414,17 +406,17 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         let (prev, result) = MapApiExt::upsert_value(&mut l, s("a"), b("a1")).await?;
         assert_eq!(
             prev,
-            Marked::new_with_meta(1, b("a0"), Some(KVMeta { expire_at: Some(1) }))
+            Marked::new_with_meta(1, b("a0"), Some(KVMeta::new_expire(1)))
         );
         assert_eq!(
             result,
-            Marked::new_with_meta(6, b("a1"), Some(KVMeta { expire_at: Some(1) }))
+            Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expire(1)))
         );
 
         let got = l.str_map().get("a").await?;
         assert_eq!(
             got,
-            Marked::new_with_meta(6, b("a1"), Some(KVMeta { expire_at: Some(1) }))
+            Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expire(1)))
         );
     }
 
@@ -435,23 +427,17 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         let (prev, result) = MapApiExt::upsert_value(&mut l, s("b"), b("x1")).await?;
         assert_eq!(
             prev,
-            Marked::new_normal(4, b("b1")).with_meta(Some(KVMeta {
-                expire_at: Some(10)
-            }))
+            Marked::new_normal(4, b("b1")).with_meta(Some(KVMeta::new_expire(10)))
         );
         assert_eq!(
             result,
-            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta {
-                expire_at: Some(10)
-            }))
+            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expire(10)))
         );
 
         let got = l.str_map().get("b").await?;
         assert_eq!(
             got,
-            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta {
-                expire_at: Some(10)
-            }))
+            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expire(10)))
         );
     }
 
@@ -477,20 +463,20 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("a"), Some(KVMeta { expire_at: Some(2) })).await?;
+            MapApiExt::update_meta(&mut l, s("a"), Some(KVMeta::new_expire(2))).await?;
         assert_eq!(
             prev,
-            Marked::new_with_meta(1, b("a0"), Some(KVMeta { expire_at: Some(1) }))
+            Marked::new_with_meta(1, b("a0"), Some(KVMeta::new_expire(1)))
         );
         assert_eq!(
             result,
-            Marked::new_with_meta(6, b("a0"), Some(KVMeta { expire_at: Some(2) }))
+            Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expire(2)))
         );
 
         let got = l.str_map().get("a").await?;
         assert_eq!(
             got,
-            Marked::new_with_meta(6, b("a0"), Some(KVMeta { expire_at: Some(2) }))
+            Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expire(2)))
         );
     }
 
@@ -501,13 +487,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let (prev, result) = MapApiExt::update_meta(&mut l, s("b"), None).await?;
         assert_eq!(
             prev,
-            Marked::new_with_meta(
-                4,
-                b("b1"),
-                Some(KVMeta {
-                    expire_at: Some(10)
-                })
-            )
+            Marked::new_with_meta(4, b("b1"), Some(KVMeta::new_expire(10)))
         );
         assert_eq!(result, Marked::new_with_meta(6, b("b1"), None));
 
@@ -519,28 +499,18 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
     {
         let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::update_meta(
-            &mut l,
-            s("c"),
-            Some(KVMeta {
-                expire_at: Some(20),
-            }),
-        )
-        .await?;
+        let (prev, result) =
+            MapApiExt::update_meta(&mut l, s("c"), Some(KVMeta::new_expire(20))).await?;
         assert_eq!(prev, Marked::new_with_meta(5, b("c1"), None));
         assert_eq!(
             result,
-            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta {
-                expire_at: Some(20)
-            }))
+            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expire(20)))
         );
 
         let got = l.str_map().get("c").await?;
         assert_eq!(
             got,
-            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta {
-                expire_at: Some(20)
-            }))
+            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expire(20)))
         );
     }
 
@@ -549,7 +519,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("d"), Some(KVMeta { expire_at: Some(2) })).await?;
+            MapApiExt::update_meta(&mut l, s("d"), Some(KVMeta::new_expire(2))).await?;
         assert_eq!(prev, Marked::new_tombstone(0));
         assert_eq!(result, Marked::new_tombstone(0));
 

--- a/src/meta/raft-store/src/sm_v002/marked/marked_test.rs
+++ b/src/meta/raft-store/src/sm_v002/marked/marked_test.rs
@@ -22,12 +22,9 @@ use crate::state_machine::ExpireValue;
 
 #[test]
 fn test_from_tuple() -> anyhow::Result<()> {
-    let m = Marked::from((1, 2u64, Some(KVMeta { expire_at: Some(3) })));
+    let m = Marked::from((1, 2u64, Some(KVMeta::new_expire(3))));
 
-    assert_eq!(
-        m,
-        Marked::new_with_meta(1, 2, Some(KVMeta { expire_at: Some(3) }))
-    );
+    assert_eq!(m, Marked::new_with_meta(1, 2, Some(KVMeta::new_expire(3))));
 
     Ok(())
 }
@@ -39,10 +36,10 @@ fn test_impl_trait_seq_value() -> anyhow::Result<()> {
     assert_eq!(m.value(), Some(&2));
     assert_eq!(m.meta(), None);
 
-    let m = Marked::new_with_meta(1, 2, Some(KVMeta { expire_at: Some(3) }));
+    let m = Marked::new_with_meta(1, 2, Some(KVMeta::new_expire(3)));
     assert_eq!(m.seq(), 1);
     assert_eq!(m.value(), Some(&2));
-    assert_eq!(m.meta(), Some(&KVMeta { expire_at: Some(3) }));
+    assert_eq!(m.meta(), Some(&KVMeta::new_expire(3)));
 
     let m: Marked<u64> = Marked::new_tombstone(1);
     assert_eq!(m.seq(), 0, "internal_seq is not returned to application");
@@ -79,11 +76,8 @@ fn test_unpack() -> anyhow::Result<()> {
     let m = Marked::new_with_meta(1, 2, None);
     assert_eq!(m.unpack_ref(), Some((&2, None)));
 
-    let m = Marked::new_with_meta(1, 2, Some(KVMeta { expire_at: Some(3) }));
-    assert_eq!(
-        m.unpack_ref(),
-        Some((&2, Some(&KVMeta { expire_at: Some(3) })))
-    );
+    let m = Marked::new_with_meta(1, 2, Some(KVMeta::new_expire(3)));
+    assert_eq!(m.unpack_ref(), Some((&2, Some(&KVMeta::new_expire(3)))));
 
     let m: Marked<u64> = Marked::new_tombstone(1);
     assert_eq!(m.unpack_ref(), None);
@@ -116,8 +110,8 @@ fn test_from_marked_for_option_seqv() -> anyhow::Result<()> {
     let s: Option<SeqV<u64>> = Some(SeqV::new(1, 2));
     assert_eq!(s, m.into());
 
-    let m = Marked::new_with_meta(1, 2, Some(KVMeta { expire_at: Some(3) }));
-    let s: Option<SeqV<u64>> = Some(SeqV::with_meta(1, Some(KVMeta { expire_at: Some(3) }), 2));
+    let m = Marked::new_with_meta(1, 2, Some(KVMeta::new_expire(3)));
+    let s: Option<SeqV<u64>> = Some(SeqV::with_meta(1, Some(KVMeta::new_expire(3)), 2));
     assert_eq!(s, m.into());
 
     let m: Marked<u64> = Marked::new_tombstone(1);

--- a/src/meta/raft-store/src/sm_v002/marked/mod.rs
+++ b/src/meta/raft-store/src/sm_v002/marked/mod.rs
@@ -256,36 +256,24 @@ mod tests {
             m
         );
 
-        let m = m.with_meta(Some(KVMeta {
-            expire_at: Some(20),
-        }));
+        let m = m.with_meta(Some(KVMeta::new_expire(20)));
 
         assert_eq!(
             Marked::Normal {
                 internal_seq: 1,
                 value: "a",
-                meta: Some(KVMeta {
-                    expire_at: Some(20)
-                })
+                meta: Some(KVMeta::new_expire(20))
             },
             m
         );
 
-        let m = Marked::new_with_meta(
-            2,
-            "b",
-            Some(KVMeta {
-                expire_at: Some(30),
-            }),
-        );
+        let m = Marked::new_with_meta(2, "b", Some(KVMeta::new_expire(30)));
 
         assert_eq!(
             Marked::Normal {
                 internal_seq: 2,
                 value: "b",
-                meta: Some(KVMeta {
-                    expire_at: Some(30)
-                })
+                meta: Some(KVMeta::new_expire(30))
             },
             m
         );

--- a/src/meta/raft-store/src/sm_v002/sm_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002.rs
@@ -447,13 +447,13 @@ impl SMV002 {
 
         // Remove previous expiration index, add a new one.
 
-        if let Some(exp_ms) = removed.expire_at_ms() {
+        if let Some(exp_ms) = removed.get_expire_at_ms() {
             self.levels
                 .set(ExpireKey::new(exp_ms, removed.internal_seq().seq()), None)
                 .await?;
         }
 
-        if let Some(exp_ms) = added.expire_at_ms() {
+        if let Some(exp_ms) = added.get_expire_at_ms() {
             let k = ExpireKey::new(exp_ms, added.internal_seq().seq());
             let v = key.to_string();
             self.levels.set(k, Some((v, None))).await?;

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
@@ -98,27 +98,15 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
         //
         (
             s("a"),
-            Marked::new_with_meta(
-                4,
-                b("a1"),
-                Some(KVMeta {
-                    expire_at: Some(15)
-                })
-            )
+            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expire(15)))
         ),
         (
             s("b"),
-            Marked::new_with_meta(2, b("b0"), Some(KVMeta { expire_at: Some(5) }))
+            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expire(5)))
         ),
         (
             s("c"),
-            Marked::new_with_meta(
-                3,
-                b("c0"),
-                Some(KVMeta {
-                    expire_at: Some(20)
-                })
-            )
+            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expire(20)))
         ),
     ]);
 

--- a/src/meta/raft-store/tests/it/state_machine/expire.rs
+++ b/src/meta/raft-store/tests/it/state_machine/expire.rs
@@ -154,9 +154,7 @@ fn ent(index: u64, key: &str, expire: Option<u64>, time_ms: Option<u64>) -> Entr
         payload: EntryPayload::Normal(LogEntry {
             txid: None,
             time_ms,
-            cmd: Cmd::UpsertKV(
-                UpsertKV::update(key, key.as_bytes()).with(KVMeta { expire_at: expire }),
-            ),
+            cmd: Cmd::UpsertKV(UpsertKV::update(key, key.as_bytes()).with(KVMeta::new(expire))),
         }),
     }
 }

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -58,9 +58,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
 
     info!("--- write a kv expiring in 3 sec");
     {
-        let upsert = UpsertKV::update(key, key.as_bytes()).with(KVMeta {
-            expire_at: Some(now_sec + 3),
-        });
+        let upsert = UpsertKV::update(key, key.as_bytes()).with(KVMeta::new_expire(now_sec + 3));
 
         leader.write(LogEntry::new(Cmd::UpsertKV(upsert))).await?;
         log_index += 1;
@@ -70,12 +68,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     let seq = {
         let resp = leader.get_kv(key).await?;
         let seq_v = resp.unwrap();
-        assert_eq!(
-            Some(KVMeta {
-                expire_at: Some(now_sec + 3)
-            }),
-            seq_v.meta
-        );
+        assert_eq!(Some(KVMeta::new_expire(now_sec + 3)), seq_v.meta);
         seq_v.seq
     };
 
@@ -83,9 +76,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     {
         let upsert = UpsertKV::update(key, value2.as_bytes())
             .with(MatchSeq::Exact(seq))
-            .with(KVMeta {
-                expire_at: Some(now_sec + 1000),
-            });
+            .with(KVMeta::new_expire(now_sec + 1000));
         leader.write(LogEntry::new(Cmd::UpsertKV(upsert))).await?;
         log_index += 1;
     }
@@ -94,12 +85,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     {
         let resp = leader.get_kv(key).await?;
         let seq_v = resp.unwrap();
-        assert_eq!(
-            Some(KVMeta {
-                expire_at: Some(now_sec + 1000),
-            }),
-            seq_v.meta
-        );
+        assert_eq!(Some(KVMeta::new_expire(now_sec + 1000)), seq_v.meta);
         assert_eq!(value2.to_string().into_bytes(), seq_v.data);
     }
 
@@ -125,12 +111,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
         let sm = learner.sto.state_machine.read().await;
         let resp = sm.kv_api().get_kv(key).await.unwrap();
         let seq_v = resp.unwrap();
-        assert_eq!(
-            Some(KVMeta {
-                expire_at: Some(now_sec + 1000),
-            }),
-            seq_v.meta
-        );
+        assert_eq!(Some(KVMeta::new_expire(now_sec + 1000)), seq_v.meta);
         assert_eq!(value2.to_string().into_bytes(), seq_v.data);
     }
 

--- a/src/meta/types/src/cmd.rs
+++ b/src/meta/types/src/cmd.rs
@@ -153,7 +153,7 @@ impl UpsertKV {
 
     pub fn get_expire_at_ms(&self) -> Option<u64> {
         if let Some(meta) = &self.value_meta {
-            meta.expire_at.map(|x| x * 1000)
+            meta.get_expire_at_ms()
         } else {
             None
         }

--- a/src/meta/types/src/proto_ext/seq_v_ext.rs
+++ b/src/meta/types/src/proto_ext/seq_v_ext.rs
@@ -19,7 +19,7 @@ use crate::SeqV;
 impl From<KVMeta> for pb::KvMeta {
     fn from(m: KVMeta) -> Self {
         Self {
-            expire_at: m.expire_at,
+            expire_at: m.get_expire_at_sec(),
         }
     }
 }

--- a/src/query/management/src/cluster/cluster_mgr.rs
+++ b/src/query/management/src/cluster/cluster_mgr.rs
@@ -72,9 +72,7 @@ impl ClusterMgr {
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards");
 
-        KVMeta {
-            expire_at: Some(expire_at.as_secs()),
-        }
+        KVMeta::new_expire(expire_at.as_secs())
     }
 }
 

--- a/src/query/management/tests/it/cluster.rs
+++ b/src/query/management/tests/it/cluster.rs
@@ -43,7 +43,7 @@ async fn test_successfully_add_node() -> Result<()> {
             meta,
             data: value,
         }) => {
-            assert!(meta.unwrap().expire_at.unwrap() - current_time >= 60);
+            assert!(meta.unwrap().get_expire_at_sec().unwrap() - current_time >= 60);
             assert_eq!(value, serde_json::to_vec(&node_info)?);
         }
         catch => panic!("GetKVActionReply{:?}", catch),
@@ -126,7 +126,7 @@ async fn test_successfully_heartbeat_node() -> Result<()> {
         .get_kv("__fd_clusters/test%2dtenant%2did/test%2dcluster%2did/databend_query/test_node")
         .await?;
 
-    assert!(value.unwrap().meta.unwrap().expire_at.unwrap() - current_time >= 60);
+    assert!(value.unwrap().meta.unwrap().get_expire_at_sec().unwrap() - current_time >= 60);
 
     let current_time = current_seconds_time();
     cluster_api.heartbeat(&node_info, MatchSeq::GE(1)).await?;
@@ -135,7 +135,7 @@ async fn test_successfully_heartbeat_node() -> Result<()> {
         .get_kv("__fd_clusters/test%2dtenant%2did/test%2dcluster%2did/databend_query/test_node")
         .await?;
 
-    assert!(value.unwrap().meta.unwrap().expire_at.unwrap() - current_time >= 60);
+    assert!(value.unwrap().meta.unwrap().get_expire_at_sec().unwrap() - current_time >= 60);
     Ok(())
 }
 

--- a/src/query/storages/result_cache/src/meta_manager.rs
+++ b/src/query/storages/result_cache/src/meta_manager.rs
@@ -50,9 +50,7 @@ impl ResultCacheMetaManager {
                 key,
                 seq,
                 value: Operation::Update(value),
-                value_meta: Some(KVMeta {
-                    expire_at: Some(expire_at),
-                }),
+                value_meta: Some(KVMeta::new_expire(expire_at)),
             })
             .await?;
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: access KVMeta with methods instead of field

Make `KVMeta.expire_at` a private field for future refactoring.
Update accessing to it with via methods.

Several methods are added to `KVMeta` and `SeqValue`:

- `eval_expire_at_ms()` evaluate and return a absolute expire time in millisecond. The returned value is set to `u64::MAX` if not expire is set.
- `get_expire_at_ms()` return an `Option` of absolute expire time in millisecond.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14013)
<!-- Reviewable:end -->
