### PR TITLE
chore(ci): only publish deb & python binding on stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,6 +575,7 @@ jobs:
 
   deb:
     runs-on: ubuntu-latest
+    if: inputs.stable
     needs: [create_release, distribution]
     steps:
       - uses: actions/checkout@v4
@@ -661,6 +662,7 @@ jobs:
           name: test-sqlsmith
 
   bindings_python:
+    if: inputs.stable
     needs: create_release
     uses: ./.github/workflows/bindings.python.yml
     secrets: inherit
@@ -676,7 +678,6 @@ jobs:
       - docker_combined
       - docker_separate
       - distribution
-      - deb
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Summary about this PR

- Closes #issue

## Tests
- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14015)
<!-- Reviewable:end -->
