### PR TITLE
chore: turn off static filter when source is complex

### DIFF
--- a/src/query/sql/src/planner/optimizer/s_expr.rs
+++ b/src/query/sql/src/planner/optimizer/s_expr.rs
@@ -416,6 +416,13 @@ impl SExpr {
 
         add_internal_column_index_into_child(expr, column_index, table_index)
     }
+
+    pub fn is_distributed_plan(&self) -> bool {
+        self.children()
+            .iter()
+            .any(|child| child.is_distributed_plan())
+            || matches!(self.plan.as_ref(), RelOperator::Exchange(_))
+    }
 }
 
 fn find_subquery(rel_op: &RelOperator) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
After the optimizer optimization, performing query rewriting again can easily lead to bugs. In the subsequent PR, I will rewrite the 'merge into' filter functionality.

Summary about this PR

- Closes #14014

## Tests
- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14018)
<!-- Reviewable:end -->
