### PR TITLE
chore: move interpreter/*_hook.rs to hook/

### DIFF
--- a/src/query/service/src/interpreters/common/util.rs
+++ b/src/query/service/src/interpreters/common/util.rs
@@ -48,6 +48,7 @@ pub async fn check_deduplicate_label(ctx: Arc<dyn TableContext>) -> Result<bool>
     }
 }
 
+/// create push down filters
 pub fn create_push_down_filters(scalar: &ScalarExpr) -> Result<Filters> {
     let filter = cast_expr_to_non_null_boolean(
         scalar

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -42,10 +42,9 @@ pub struct CompactHookTraceCtx {
     pub operation_name: String,
 }
 
-// only if target table have cluster keys defined, and auto-reclustering is enabled,
-// we will hook the compact action with a on-finished callback.
-//
-// errors (if any) are ignored
+/// Hook compact action with a on-finished callback.
+/// only if target table have cluster keys defined, and auto-reclustering is enabled,
+/// errors (if any) are ignored.
 pub async fn hook_compact(
     ctx: Arc<QueryContext>,
     pipeline: &mut Pipeline,
@@ -59,6 +58,9 @@ pub async fn hook_compact(
     }
 }
 
+/// hook the compact action with a on-finished callback.
+/// only if target table have cluster keys defined, and auto-reclustering is enabled,
+/// errors (if any) are ignored
 async fn do_hook_compact(
     ctx: Arc<QueryContext>,
     pipeline: &mut Pipeline,
@@ -96,6 +98,9 @@ async fn do_hook_compact(
     Ok(())
 }
 
+/// compact the target table
+/// only if target table have cluster keys defined, and auto-reclustering is enabled,
+/// errors (if any) are ignored
 async fn compact_table(
     ctx: Arc<QueryContext>,
     compact_target: CompactTargetTableDescription,

--- a/src/query/service/src/interpreters/hook/mod.rs
+++ b/src/query/service/src/interpreters/hook/mod.rs
@@ -12,22 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod grant;
-mod metrics;
-mod query_log;
-mod stream;
-mod table;
-mod task;
-mod util;
+mod compact_hook;
+mod refresh_hook;
 
-pub use grant::validate_grant_object_exists;
-pub use query_log::InterpreterQueryLog;
-pub use stream::build_update_stream_meta_seq;
-pub use table::check_referenced_computed_columns;
-pub use task::get_client_config;
-pub use task::make_schedule_options;
-pub use task::make_warehouse_options;
-pub use util::check_deduplicate_label;
-pub use util::create_push_down_filters;
-
-pub use self::metrics::*;
+pub use compact_hook::*;
+pub use refresh_hook::hook_refresh;
+pub use refresh_hook::RefreshDesc;

--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -42,11 +42,11 @@ use log::info;
 
 use crate::interpreters::common::build_update_stream_meta_seq;
 use crate::interpreters::common::check_deduplicate_label;
-use crate::interpreters::common::hook_compact;
-use crate::interpreters::common::hook_refresh;
-use crate::interpreters::common::CompactHookTraceCtx;
-use crate::interpreters::common::CompactTargetTableDescription;
-use crate::interpreters::common::RefreshDesc;
+use crate::interpreters::hook::hook_compact;
+use crate::interpreters::hook::hook_refresh;
+use crate::interpreters::hook::CompactHookTraceCtx;
+use crate::interpreters::hook::CompactTargetTableDescription;
+use crate::interpreters::hook::RefreshDesc;
 use crate::interpreters::Interpreter;
 use crate::interpreters::SelectInterpreter;
 use crate::pipelines::PipelineBuildResult;

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -32,8 +32,8 @@ use common_sql::NameResolutionContext;
 
 use crate::interpreters::common::build_update_stream_meta_seq;
 use crate::interpreters::common::check_deduplicate_label;
-use crate::interpreters::common::hook_refresh;
-use crate::interpreters::common::RefreshDesc;
+use crate::interpreters::hook::hook_refresh;
+use crate::interpreters::hook::RefreshDesc;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::pipelines::processors::transforms::TransformRuntimeCastSchema;

--- a/src/query/service/src/interpreters/interpreter_merge_into.rs
+++ b/src/query/service/src/interpreters/interpreter_merge_into.rs
@@ -56,11 +56,11 @@ use itertools::Itertools;
 use storages_common_table_meta::meta::TableSnapshot;
 
 use crate::interpreters::common::build_update_stream_meta_seq;
-use crate::interpreters::common::hook_compact;
-use crate::interpreters::common::hook_refresh;
-use crate::interpreters::common::CompactHookTraceCtx;
-use crate::interpreters::common::CompactTargetTableDescription;
-use crate::interpreters::common::RefreshDesc;
+use crate::interpreters::hook::hook_compact;
+use crate::interpreters::hook::hook_refresh;
+use crate::interpreters::hook::CompactHookTraceCtx;
+use crate::interpreters::hook::CompactTargetTableDescription;
+use crate::interpreters::hook::RefreshDesc;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::pipelines::PipelineBuildResult;

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -49,11 +49,11 @@ use storages_common_table_meta::meta::TableSnapshot;
 
 use crate::interpreters::common::build_update_stream_meta_seq;
 use crate::interpreters::common::check_deduplicate_label;
-use crate::interpreters::common::hook_compact;
-use crate::interpreters::common::hook_refresh;
-use crate::interpreters::common::CompactHookTraceCtx;
-use crate::interpreters::common::CompactTargetTableDescription;
-use crate::interpreters::common::RefreshDesc;
+use crate::interpreters::hook::hook_compact;
+use crate::interpreters::hook::hook_refresh;
+use crate::interpreters::hook::CompactHookTraceCtx;
+use crate::interpreters::hook::CompactTargetTableDescription;
+use crate::interpreters::hook::RefreshDesc;
 use crate::interpreters::interpreter_copy_into_table::CopyIntoTableInterpreter;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -45,8 +45,8 @@ use storages_common_table_meta::meta::TableSnapshot;
 
 use crate::interpreters::common::check_deduplicate_label;
 use crate::interpreters::common::create_push_down_filters;
-use crate::interpreters::common::hook_refresh;
-use crate::interpreters::common::RefreshDesc;
+use crate::interpreters::hook::hook_refresh;
+use crate::interpreters::hook::RefreshDesc;
 use crate::interpreters::interpreter_delete::replace_subquery;
 use crate::interpreters::interpreter_delete::subquery_filter;
 use crate::interpreters::Interpreter;

--- a/src/query/service/src/interpreters/mod.rs
+++ b/src/query/service/src/interpreters/mod.rs
@@ -14,6 +14,7 @@
 
 mod access;
 mod common;
+mod hook;
 mod interpreter;
 mod interpreter_catalog_create;
 mod interpreter_catalog_drop;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* move the functional ` interpreters/*_hook.rs` to `interpreters/hook/*`
* add more comments for funcs

- Closes #issue

## Tests
- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14044)
<!-- Reviewable:end -->
