### PR TITLE
chore(executor): use null as root profile parent id

### DIFF
--- a/src/query/pipeline/core/src/pipeline.rs
+++ b/src/query/pipeline/core/src/pipeline.rs
@@ -139,11 +139,11 @@ impl Pipeline {
     pub fn finalize(mut self) -> Pipeline {
         for pipe in &mut self.pipes {
             if let Some(uninitialized_scope) = &mut pipe.scope {
-                if uninitialized_scope.parent_id == 0 {
+                if uninitialized_scope.parent_id.is_none() {
                     for (index, scope) in self.plans_scope.iter().enumerate() {
                         if scope.id == uninitialized_scope.id && index != 0 {
                             if let Some(parent_scope) = self.plans_scope.get(index - 1) {
-                                uninitialized_scope.parent_id = parent_scope.id;
+                                uninitialized_scope.parent_id = Some(parent_scope.id);
                             }
                         }
                     }
@@ -162,8 +162,8 @@ impl Pipeline {
             // set the parent node in 'add_pipe' helps skip empty plans(no pipeline).
             for pipe in &mut self.pipes {
                 if let Some(children) = &mut pipe.scope {
-                    if children.parent_id == 0 && children.id != scope.id {
-                        children.parent_id = scope.id;
+                    if children.parent_id.is_none() && children.id != scope.id {
+                        children.parent_id = Some(scope.id);
                     }
                 }
             }

--- a/src/query/pipeline/core/src/processors/profile.rs
+++ b/src/query/pipeline/core/src/processors/profile.rs
@@ -44,7 +44,7 @@ impl Profile {
             wait_time: AtomicU64::new(0),
             plan_id: scope.as_ref().map(|x| x.id),
             plan_name: scope.as_ref().map(|x| x.name.clone()),
-            plan_parent_id: scope.as_ref().map(|x| x.parent_id),
+            plan_parent_id: scope.as_ref().and_then(|x| x.parent_id),
         }
     }
 }
@@ -109,14 +109,14 @@ impl Drop for PlanScopeGuard {
 pub struct PlanScope {
     pub id: u32,
     pub name: String,
-    pub parent_id: u32,
+    pub parent_id: Option<u32>,
 }
 
 impl PlanScope {
     pub fn create(id: u32, name: String) -> PlanScope {
         PlanScope {
             id,
-            parent_id: 0,
+            parent_id: None,
             name,
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(executor): use null as root profile parent id
Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14051)
<!-- Reviewable:end -->
