### PR TITLE
chore: update doc: since 1.2.258 `ttl` is supported by meta-service

### DIFF
--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -78,7 +78,7 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2023-10-20: since 1.2.176:
 ///   Meta client: call stream api: kv_read_v1(), revert to 1.1.32 if server < 1.2.163
 ///
-/// - 2023-12-16: since TODO:
+/// - 2023-12-16: since 1.2.258:
 ///   Meta service: add: ttl to TxnPutRequest and Upsert
 ///
 /// Server feature set:


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### Chore: update doc: since 1.2.258 `ttl` is supported by meta-service

## Changelog



- Documentation



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14058)
<!-- Reviewable:end -->
