### PR TITLE
fix: treat change$* as internal columns

### DIFF
--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -102,6 +102,9 @@ pub fn is_internal_column(column_name: &str) -> bool {
             | BASE_BLOCK_IDS_COL_NAME
             | ROW_NUMBER_COL_NAME
             | PREDICATE_COLUMN_NAME
+            | CHANGE_ACTION_COL_NAME
+            | CHANGE_IS_UPDATE_COL_NAME
+            | CHANGE_ROW_ID_COL_NAME
     )
 }
 

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -105,6 +105,10 @@ pub fn is_internal_column(column_name: &str) -> bool {
             | CHANGE_ACTION_COL_NAME
             | CHANGE_IS_UPDATE_COL_NAME
             | CHANGE_ROW_ID_COL_NAME
+            // change$row_id might be expended 
+            // to the computation of the two following internal columns
+            | ORIGIN_BLOCK_ROW_NUM_COL_NAME
+            | BASE_ROW_ID_COL_NAME
     )
 }
 

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0003_stream.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0003_stream.test
@@ -223,5 +223,37 @@ drop table s2
 statement ok
 drop stream s2
 
+# issue 14062
+statement ok
+drop stream s
+
+statement ok
+drop stream t
+
+statement ok
+create table t (c int);
+
+statement ok
+create stream s on table t ;
+
+statement ok
+insert into t values(1);
+
+query T
+select * from s where change$action = 'INSERT';
+----
+1
+
+query T
+select * from s where change$is_update = false;
+----
+1
+
+query T
+select * from s where change$row_id = '1';
+----
+
+# end of issue 14062
+
 statement ok
 DROP DATABASE IF EXISTS test_stream

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0003_stream.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0003_stream.test
@@ -223,37 +223,36 @@ drop table s2
 statement ok
 drop stream s2
 
-# issue 14062
-statement ok
-drop stream s
+###############
+# issue 14062 #
+###############
 
 statement ok
-drop stream t
+create table t_14062 (c int);
 
 statement ok
-create table t (c int);
+create stream s_14062 on table t_14062 ;
 
 statement ok
-create stream s on table t ;
-
-statement ok
-insert into t values(1);
+insert into t_14062 values(1);
 
 query T
-select * from s where change$action = 'INSERT';
+select * from s_14062 where change$action = 'INSERT';
 ----
 1
 
 query T
-select * from s where change$is_update = false;
+select * from s_14062 where change$is_update = false;
 ----
 1
 
 query T
-select * from s where change$row_id = '1';
+select * from s_14062 where change$row_id = '1';
 ----
 
-# end of issue 14062
+######################
+# end of issue 14062 #
+######################
 
 statement ok
 DROP DATABASE IF EXISTS test_stream


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

mark  stream meta columns `change$action`, `change$is_update`, and `change$row_id` as Internal Columns,

so that test scenario of issue #14062 passes

~~~
mysql> create table t (c int);
Query OK, 0 rows affected (0.12 sec)

mysql> create stream s on table t ;
Query OK, 0 rows affected (0.12 sec)

mysql>
mysql> insert into t values(1);
Query OK, 1 row affected (0.14 sec)

mysql>
mysql> select * from s where change$action = 'INSERT';
+------+
| c    |
+------+
|    1 |
+------+
1 row in set (0.09 sec)
Read 1 rows, 133.00 B in 0.038 sec., 26.02 rows/sec., 3.38 KiB/sec.

mysql>
mysql> select * from s where change$is_update = false;
+------+
| c    |
+------+
|    1 |
+------+
1 row in set (0.09 sec)
Read 1 rows, 133.00 B in 0.039 sec., 25.72 rows/sec., 3.34 KiB/sec.

mysql>
mysql> select * from s where change$row_id = '1';
Empty set (0.13 sec)
Read 1 rows, 197.00 B in 0.043 sec., 23.39 rows/sec., 4.50 KiB/sec.

mysql> select *, change$row_id from s
    -> ;
+------+----------------------------------------+
| c    | change$row_id                          |
+------+----------------------------------------+
|    1 | 21cf143922c14704883f5264d09cc84b000000 |
+------+----------------------------------------+
1 row in set (0.12 sec)
Read 1 rows, 197.00 B in 0.037 sec., 26.86 rows/sec., 5.17 KiB/sec.

mysql> select * from s where change$row_id = '21cf143922c14704883f5264d09cc84b000000';
+------+
| c    |
+------+
|    1 |
+------+
1 row in set (0.14 sec)
Read 1 rows, 197.00 B in 0.042 sec., 23.85 rows/sec., 4.59 KiB/sec.
~~~

Fixes https://github.com/datafuselabs/databend/issues/14062

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14061)
<!-- Reviewable:end -->
