### PR TITLE
chore(query): add log on slow http query request

### DIFF
--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -210,6 +210,8 @@ impl<E> HTTPSessionEndpoint<E> {
             node_id,
             deduplicate_label,
             user_agent,
+            req.method().to_string(),
+            req.uri().to_string(),
         ))
     }
 }
@@ -321,10 +323,10 @@ impl<E: Endpoint> Endpoint for MetricsMiddlewareEndpoint<E> {
         let output = self.ep.call(req).await?;
         let resp = output.into_response();
         let status_code = resp.status().to_string();
-        let duration = start_time.elapsed().as_secs_f64();
+        let duration = start_time.elapsed();
         metrics_incr_http_request_count(method.clone(), self.api.clone(), status_code.clone());
         metrics_observe_http_response_duration(method.clone(), self.api.clone(), duration);
-        if duration > 60.0 {
+        if duration.as_secs_f64() > 60.0 {
             // TODO: replace this into histogram
             metrics_incr_http_slow_request_count(method, self.api.clone(), status_code);
         }

--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -22,6 +22,7 @@ use databend_common_exception::Result;
 use databend_common_metrics::http::metrics_incr_http_request_count;
 use databend_common_metrics::http::metrics_incr_http_response_panics_count;
 use databend_common_metrics::http::metrics_incr_http_slow_request_count;
+use databend_common_metrics::http::metrics_observe_http_response_duration;
 use databend_common_storages_fuse::TableContext;
 use headers::authorization::Basic;
 use headers::authorization::Bearer;
@@ -320,8 +321,10 @@ impl<E: Endpoint> Endpoint for MetricsMiddlewareEndpoint<E> {
         let output = self.ep.call(req).await?;
         let resp = output.into_response();
         let status_code = resp.status().to_string();
+        let duration = start_time.elapsed().as_secs_f64();
         metrics_incr_http_request_count(method.clone(), self.api.clone(), status_code.clone());
-        if start_time.elapsed().as_secs() > 20 {
+        metrics_observe_http_response_duration(method.clone(), self.api.clone(), duration);
+        if duration > 60.0 {
             // TODO: replace this into histogram
             metrics_incr_http_slow_request_count(method, self.api.clone(), status_code);
         }

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -19,6 +19,7 @@ use databend_common_metrics::http::metrics_incr_http_response_errors_count;
 use highway::HighwayHash;
 use log::error;
 use log::info;
+use log::warn;
 use minitrace::full_name;
 use minitrace::prelude::*;
 use poem::error::Error as PoemError;
@@ -232,6 +233,7 @@ async fn query_final_handler(
         full_name!(),
         SpanContext::new(trace_id, SpanId(rand::random())),
     );
+    let _t = SlowRequestLogTracker::new(ctx);
 
     async {
         info!("{}: final http query", query_id);
@@ -272,6 +274,7 @@ async fn query_cancel_handler(
         full_name!(),
         SpanContext::new(trace_id, SpanId(rand::random())),
     );
+    let _t = SlowRequestLogTracker::new(ctx);
 
     async {
         info!("{}: http query is killed", query_id);
@@ -335,6 +338,7 @@ async fn query_page_handler(
         full_name!(),
         SpanContext::new(trace_id, SpanId(rand::random())),
     );
+    let _t = SlowRequestLogTracker::new(ctx);
 
     async {
         let http_query_manager = HttpQueryManager::instance();
@@ -366,6 +370,7 @@ pub(crate) async fn query_handler(
 ) -> PoemResult<impl IntoResponse> {
     let trace_id = query_id_to_trace_id(&ctx.query_id);
     let root = Span::root(full_name!(), SpanContext::new(trace_id, SpanId::default()));
+    let _t = SlowRequestLogTracker::new(ctx);
 
     async {
         info!("http query new request: {:}", mask_connection_info(&format!("{:?}", req)));
@@ -446,4 +451,40 @@ fn query_id_not_found_or_removed(
 fn query_id_to_trace_id(query_id: &str) -> TraceId {
     let [hash_high, hash_low] = highway::PortableHash::default().hash128(query_id.as_bytes());
     TraceId(((hash_high as u128) << 64) + (hash_low as u128))
+}
+
+/// The HTTP query endpoints are expected to be responses within 60 seconds.
+/// If it exceeds far of 60 seconds, there might be something wrong, we should
+/// log it.
+struct SlowRequestLogTracker {
+    started_at: std::time::Instant,
+    query_id: String,
+    method: String,
+    uri: String,
+}
+
+impl SlowRequestLogTracker {
+    fn new(ctx: &HttpQueryContext) -> Self {
+        Self {
+            started_at: std::time::Instant::now(),
+            query_id: ctx.query_id.clone(),
+            method: ctx.http_method.clone(),
+            uri: ctx.uri.clone(),
+        }
+    }
+}
+
+impl Drop for SlowRequestLogTracker {
+    fn drop(&mut self) {
+        let elapsed = self.started_at.elapsed();
+        if elapsed.as_secs_f64() > 60.0 {
+            warn!(
+                "{}: slow http query request on {} {}, elapsed: {:.2}s",
+                self.query_id,
+                self.method,
+                self.uri,
+                elapsed.as_secs_f64()
+            );
+        }
+    }
 }

--- a/src/query/service/src/servers/http/v1/query/http_query_context.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_context.rs
@@ -30,6 +30,8 @@ pub struct HttpQueryContext {
     pub node_id: String,
     pub deduplicate_label: Option<String>,
     pub user_agent: Option<String>,
+    pub http_method: String,
+    pub uri: String,
 }
 
 impl HttpQueryContext {
@@ -39,6 +41,8 @@ impl HttpQueryContext {
         node_id: String,
         deduplicate_label: Option<String>,
         user_agent: Option<String>,
+        http_method: String,
+        uri: String,
     ) -> Self {
         HttpQueryContext {
             session,
@@ -46,6 +50,8 @@ impl HttpQueryContext {
             node_id,
             deduplicate_label,
             user_agent,
+            http_method,
+            uri,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

http query request is expected to responded within 60s, but some times we get longer response durations. this PR correlated the slow request log with query id, thus may help diagnosis these timeout issues.

this pr also added a histogram metric `query_http_response_duration_seconds` to track the response duration of individual requests.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - just add logs, not modify any modification.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): add logs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14082)
<!-- Reviewable:end -->
