### PR TITLE
docs: replace the wrong links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ Databend thrives on community contributions! Whether it's through ideas, code, o
 
 Here are some resources to help you get started:
 
-- [Building Databend From Source](https://docs.databend.com/doc/contributing/building-from-source)
-- [The First Good Pull Request](https://docs.databend.com/doc/contributing/good-pr)
+- [Building Databend From Source](https://docs.databend.com/doc/overview/community/contributor/building-from-source)
+- [The First Good Pull Request](https://docs.databend.com/doc/overview/community/contributor/good-pr)
 
 
 ## 👥 Community


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

There are two links in README which will lead to 404 NotFound pages.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - fix typo

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14090)
<!-- Reviewable:end -->
