### PR TITLE
chore(query): Rename table not allow modify catalog or database

### DIFF
--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -998,9 +998,9 @@ impl Binder {
         let (new_catalog, new_database, new_table) =
             self.normalize_object_identifier_triple(new_catalog, new_database, new_table);
 
-        if new_catalog != catalog {
+        if new_catalog != catalog || new_database != database {
             return Err(ErrorCode::BadArguments(
-                "alter catalog not allowed while rename table",
+                "Rename table not allow modify catalog or database",
             ));
         }
 

--- a/tests/sqllogictests/suites/base/05_ddl/05_0003_ddl_rename_table.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0003_ddl_rename_table.test
@@ -22,7 +22,7 @@ DROP TABLE t0
 statement ok
 SELECT * FROM t1
 
-statement error 1002
+statement error 1006
 RENAME TABLE t1 to system.t1
 
 statement ok
@@ -56,7 +56,7 @@ SELECT * FROM t1
 ----
 1
 
-statement error 1002
+statement error 1006
 RENAME TABLE t1 to system.t1
 
 statement ok
@@ -90,7 +90,7 @@ SELECT * FROM t1
 ----
 1
 
-statement error 1002
+statement error 1006
 RENAME TABLE t1 to system.t1
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Rename table not allow modify catalog or database

It's no use to support this, It will cause other questions.

```sql
rename table db1.t1 to db2.t2
```

BTW alter table can also rename table, it also not support modify database.


Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14098)
<!-- Reviewable:end -->
