### PR TITLE
chore: refine enable_compact_after_write, enable_recluster_after_write need deprecated

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -141,8 +141,8 @@ pub trait TableContext: Send + Sync {
     fn set_cacheable(&self, cacheable: bool);
     fn get_can_scan_from_agg_index(&self) -> bool;
     fn set_can_scan_from_agg_index(&self, enable: bool);
-    fn set_auto_compact_after_write(&self, enable: bool);
-    fn get_auto_compact_after_write(&self) -> bool;
+    fn set_need_compact_after_write(&self, enable: bool);
+    fn get_need_compact_after_write(&self) -> bool;
 
     fn attach_query_str(&self, kind: QueryKind, query: String);
     fn get_query_str(&self) -> String;

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -22,6 +22,7 @@ use databend_common_pipeline_core::Pipeline;
 use databend_common_sql::plans::OptimizeTableAction;
 use databend_common_sql::plans::OptimizeTablePlan;
 use log::info;
+use log::warn;
 
 use crate::interpreters::common::metrics_inc_compact_hook_compact_time_ms;
 use crate::interpreters::common::metrics_inc_compact_hook_main_operation_time_ms;
@@ -69,31 +70,40 @@ async fn do_hook_compact(
         return Ok(());
     }
 
-    if !pipeline.is_empty() && ctx.get_settings().get_enable_recluster_after_write()? {
-        pipeline.set_on_finished(move |err| {
-            if !ctx.get_auto_compact_after_write() {
-                return Ok(());
-            }
-
-            let op_name = &trace_ctx.operation_name;
-            metrics_inc_compact_hook_main_operation_time_ms(op_name, trace_ctx.start.elapsed().as_millis() as u64);
-
-            let compact_start_at = Instant::now();
-            if err.is_ok() {
-                info!("execute {op_name} finished successfully. running table optimization job.");
-                match GlobalIORuntime::instance().block_on({
-                    compact_table(ctx, compact_target, need_lock)
-                }) {
-                    Ok(_) => {
-                        info!("execute {op_name} finished successfully. table optimization job finished.");
+    // Inorder to compatibility with the old version, we need enable_recluster_after_write, it will deprecated in the future.
+    // use enable_compact_after_write to replace it.
+    if ctx.get_settings().get_enable_recluster_after_write()? {
+        warn!(
+            "setting: `enable_recluster_after_write` will be deprecated in the future, please use `enable_compact_after_write` instead."
+        );
+        if ctx.get_settings().get_enable_compact_after_write()? {
+            {
+                pipeline.set_on_finished(move |err| {
+                    if !ctx.get_need_compact_after_write() {
+                        return Ok(());
                     }
-                    Err(e) => { info!("execute {op_name} finished successfully. table optimization job failed. {:?}", e)}
-                }
-            }
-            metrics_inc_compact_hook_compact_time_ms(&trace_ctx.operation_name, compact_start_at.elapsed().as_millis() as u64);
 
-            Ok(())
-        });
+                    let op_name = &trace_ctx.operation_name;
+                    metrics_inc_compact_hook_main_operation_time_ms(op_name, trace_ctx.start.elapsed().as_millis() as u64);
+
+                    let compact_start_at = Instant::now();
+                    if err.is_ok() {
+                        info!("execute {op_name} finished successfully. running table optimization job.");
+                        match GlobalIORuntime::instance().block_on({
+                            compact_table(ctx, compact_target, need_lock)
+                        }) {
+                            Ok(_) => {
+                                info!("execute {op_name} finished successfully. table optimization job finished.");
+                            }
+                            Err(e) => { info!("execute {op_name} finished successfully. table optimization job failed. {:?}", e) }
+                        }
+                    }
+                    metrics_inc_compact_hook_compact_time_ms(&trace_ctx.operation_name, compact_start_at.elapsed().as_millis() as u64);
+
+                    Ok(())
+                });
+            }
+        }
     }
     Ok(())
 }

--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -358,7 +358,7 @@ impl Interpreter for CopyIntoTableInterpreter {
             .await?;
         }
 
-        // Compact if 'enable_recluster_after_write' on.
+        // Compact if 'enable_compact_after_write' is on.
         {
             let compact_target = CompactTargetTableDescription {
                 catalog: self.plan.catalog_info.name_ident.catalog_name.clone(),

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -252,7 +252,7 @@ impl Interpreter for InsertInterpreter {
                     None,
                 )?;
 
-                // Compact if 'enable_recluster_after_write' on.
+                // Compact if 'enable_compact_after_write' on.
                 {
                     let compact_target = CompactTargetTableDescription {
                         catalog: self.plan.catalog.clone(),
@@ -304,7 +304,7 @@ impl Interpreter for InsertInterpreter {
             append_mode,
         )?;
 
-        // Compact if 'enable_recluster_after_write' on.
+        // Compact if 'enable_compact_after_write' on.
         {
             let compact_target = CompactTargetTableDescription {
                 catalog: self.plan.catalog.clone(),

--- a/src/query/service/src/interpreters/interpreter_merge_into.rs
+++ b/src/query/service/src/interpreters/interpreter_merge_into.rs
@@ -102,7 +102,7 @@ impl Interpreter for MergeIntoInterpreter {
         // let lock_guard = table_lock.try_lock(self.ctx.clone()).await?;
         // build_res.main_pipeline.add_lock_guard(lock_guard);
 
-        // Compact if 'enable_recluster_after_write' on.
+        // Compact if 'enable_compact_after_write' is on.
         {
             let compact_target = CompactTargetTableDescription {
                 catalog: self.plan.catalog.clone(),

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -106,7 +106,7 @@ impl Interpreter for ReplaceInterpreter {
             )?;
         }
 
-        // Compact if 'enable_recluster_after_write' on.
+        // Compact if 'enable_compact_after_write' is on.
         {
             let compact_target = CompactTargetTableDescription {
                 catalog: self.plan.catalog.clone(),

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -464,11 +464,12 @@ impl TableContext for QueryContext {
             .store(enable, Ordering::Release);
     }
 
-    fn get_auto_compact_after_write(&self) -> bool {
+    // Need compact after write, over the threshold.
+    fn get_need_compact_after_write(&self) -> bool {
         self.shared.auto_compact_after_write.load(Ordering::Acquire)
     }
 
-    fn set_auto_compact_after_write(&self, enable: bool) {
+    fn set_need_compact_after_write(&self, enable: bool) {
         self.shared
             .auto_compact_after_write
             .store(enable, Ordering::Release);

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -709,11 +709,11 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn set_auto_compact_after_write(&self, _enable: bool) {
+    fn set_need_compact_after_write(&self, _enable: bool) {
         todo!()
     }
 
-    fn get_auto_compact_after_write(&self) -> bool {
+    fn get_need_compact_after_write(&self) -> bool {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -658,11 +658,11 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn set_auto_compact_after_write(&self, _enable: bool) {
+    fn set_need_compact_after_write(&self, _enable: bool) {
         todo!()
     }
 
-    fn get_auto_compact_after_write(&self) -> bool {
+    fn get_need_compact_after_write(&self) -> bool {
         todo!()
     }
 

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -484,11 +484,18 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                // Will deprecated in the future, use enable_compact_after_write instead.
                 ("enable_recluster_after_write", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
-                    desc: "Enables re-clustering after write(copy/replace-into).",
+                    desc: "Enables re-clustering after write(copy/insert/replace-into/merge-into).",
                     mode: SettingMode::Both,
-                    range: None,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
+                ("enable_compact_after_write", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1),
+                    desc: "Enables compact after write(copy/insert/replace-into/merge-into), need more memory.",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
                 }),
                 ("auto_compaction_threshold", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1000),

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -427,8 +427,13 @@ impl Settings {
         Ok(self.try_get_u64("enable_aggregating_index_scan")? != 0)
     }
 
+    // Deprecated in the future, use enable_compact_after_write instead.
     pub fn get_enable_recluster_after_write(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_recluster_after_write")? != 0)
+    }
+
+    pub fn get_enable_compact_after_write(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_compact_after_write")? != 0)
     }
 
     pub fn get_auto_compaction_threshold(&self) -> Result<u64> {

--- a/src/query/storages/fuse/src/operations/common/snapshot_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/snapshot_generator.rs
@@ -427,7 +427,7 @@ impl SnapshotGenerator for AppendGenerator {
         let imperfect_count = new_summary.block_count - new_summary.perfect_block_count;
         let auto_compaction_threshold = self.ctx.get_settings().get_auto_compaction_threshold()?;
         let auto_compact = imperfect_count >= auto_compaction_threshold;
-        self.ctx.set_auto_compact_after_write(auto_compact);
+        self.ctx.set_need_compact_after_write(auto_compact);
 
         Ok(TableSnapshot::new(
             Uuid::new_v4(),

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
@@ -375,7 +375,7 @@ insert into test values(2, 2), (3, 2)
 
 # disable the auto re-clustering
 statement ok
-set enable_recluster_after_write = 0;
+set enable_compact_after_write = 0;
 
 statement ok
 replace into test on(a) values(3, 3), (4, 4)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* use `enable_recluster_after_write` to control compact is not meaningful, plan to deprecated it in the future
* add `enable_compact_after_write` to control the compact after COPY/REPLACEINTO, this including recluster
* `*_auto_compact_after_write` to `*_need_compact_after_write`

Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Covered by exists tests.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14114)
<!-- Reviewable:end -->
