### PR TITLE
chore: add limit for compact hook

### DIFF
--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -120,7 +120,7 @@ async fn compact_table(
             database: compact_target.database,
             table: compact_target.table,
             action: OptimizeTableAction::CompactBlocks,
-            limit: Some(1000),
+            limit: Some(3),
             need_lock,
         })?;
 

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -120,7 +120,7 @@ async fn compact_table(
             database: compact_target.database,
             table: compact_target.table,
             action: OptimizeTableAction::CompactBlocks,
-            limit: None,
+            limit: Some(1000),
             need_lock,
         })?;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

add limit 3 (segments) for compact hook to prevent out-of-memory (OOM) issues when compaction is triggered on tables with a large volume of uncompacted data.

Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14115)
<!-- Reviewable:end -->
