### PR TITLE
chore: rename `CompactOptions::limit` to `num_segment_limit`

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -219,7 +219,7 @@ async fn test_safety() -> Result<()> {
         let compact_params = CompactOptions {
             base_snapshot: Arc::new(snapshot),
             block_per_seg: 10,
-            limit: Some(limit),
+            num_segment_limit: Some(limit),
         };
 
         eprintln!("running target select");

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -261,7 +261,7 @@ async fn build_mutator(
     let compact_params = CompactOptions {
         base_snapshot,
         block_per_seg,
-        limit,
+        num_segment_limit: limit,
     };
 
     let table_lock = LockManager::create_table_lock(tbl.get_table_info().clone())?;

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -47,7 +47,7 @@ pub struct CompactOptions {
     // the snapshot that compactor working on, it never changed during phases compaction.
     pub base_snapshot: Arc<TableSnapshot>,
     pub block_per_seg: usize,
-    pub limit: Option<usize>,
+    pub num_segment_limit: Option<usize>,
 }
 
 impl FuseTable {
@@ -246,7 +246,7 @@ impl FuseTable {
         Ok(Some(CompactOptions {
             base_snapshot,
             block_per_seg,
-            limit,
+            num_segment_limit: limit,
         }))
     }
 }

--- a/src/query/storages/fuse/src/operations/mutation/compact/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/block_compact_mutator.rs
@@ -82,7 +82,10 @@ impl BlockCompactMutator {
         let snapshot = self.compact_params.base_snapshot.clone();
         let segment_locations = &snapshot.segments;
         let number_segments = segment_locations.len();
-        let limit = self.compact_params.limit.unwrap_or(number_segments);
+        let limit = self
+            .compact_params
+            .num_segment_limit
+            .unwrap_or(number_segments);
 
         // Status.
         self.ctx

--- a/src/query/storages/fuse/src/operations/mutation/compact/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/compact/segment_compact_mutator.rs
@@ -95,7 +95,12 @@ impl SegmentCompactMutator {
 
         // need at lease 2 segments to make sense
         let num_segments = base_segment_locations.len();
-        let limit = std::cmp::max(2, self.compact_params.limit.unwrap_or(num_segments));
+        let limit = std::cmp::max(
+            2,
+            self.compact_params
+                .num_segment_limit
+                .unwrap_or(num_segments),
+        );
 
         // prepare compactor
         let schema = Arc::new(self.compact_params.base_snapshot.schema.clone());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`CompactOptions::limit` is used by both compact segment and compact block, as the threshold of the number of segments to be compacted.

It is a little bit confusing, so rename it to `num_segment_limit`.



Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Pure renaming, no functionality changed

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14116)
<!-- Reviewable:end -->
