### PR TITLE
chore: remove the compact hook warn message and rename auto_compaction_threshold to auto_compaction_imperfect_blocks_threshold

### DIFF
--- a/src/query/ee/tests/it/aggregating_index/index_refresh.rs
+++ b/src/query/ee/tests/it/aggregating_index/index_refresh.rs
@@ -538,7 +538,7 @@ async fn test_sync_agg_index_after_copy_into() -> Result<()> {
     let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
     let settings = fixture.default_session().get_settings();
     settings.set_enable_refresh_aggregating_index_after_write(true)?;
-    settings.set_auto_compaction_threshold(1)?;
+    settings.set_auto_compaction_imperfect_blocks_threshold(1)?;
 
     // Create table
     fixture.execute_command(

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -22,7 +22,6 @@ use databend_common_pipeline_core::Pipeline;
 use databend_common_sql::plans::OptimizeTableAction;
 use databend_common_sql::plans::OptimizeTablePlan;
 use log::info;
-use log::warn;
 
 use crate::interpreters::common::metrics_inc_compact_hook_compact_time_ms;
 use crate::interpreters::common::metrics_inc_compact_hook_main_operation_time_ms;
@@ -73,9 +72,6 @@ async fn do_hook_compact(
     // Inorder to compatibility with the old version, we need enable_recluster_after_write, it will deprecated in the future.
     // use enable_compact_after_write to replace it.
     if ctx.get_settings().get_enable_recluster_after_write()? {
-        warn!(
-            "setting: `enable_recluster_after_write` will be deprecated in the future, please use `enable_compact_after_write` instead."
-        );
         if ctx.get_settings().get_enable_compact_after_write()? {
             {
                 pipeline.set_on_finished(move |err| {

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -71,10 +71,11 @@ async fn do_hook_compact(
 
     // Inorder to compatibility with the old version, we need enable_recluster_after_write, it will deprecated in the future.
     // use enable_compact_after_write to replace it.
-    if ctx.get_settings().get_enable_recluster_after_write()? {
-        if ctx.get_settings().get_enable_compact_after_write()? {
-            {
-                pipeline.set_on_finished(move |err| {
+    if ctx.get_settings().get_enable_recluster_after_write()?
+        && ctx.get_settings().get_enable_compact_after_write()?
+    {
+        {
+            pipeline.set_on_finished(move |err| {
                     if !ctx.get_need_compact_after_write() {
                         return Ok(());
                     }
@@ -98,7 +99,6 @@ async fn do_hook_compact(
 
                     Ok(())
                 });
-            }
         }
     }
     Ok(())

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -497,9 +497,9 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
-                ("auto_compaction_threshold", DefaultSettingValue {
+                ("auto_compaction_imperfect_blocks_threshold", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1000),
-                    desc: "Threshold for triggering auto compaction. This occurs when the number of imperfect blocks in a snapshot exceeds this value after write (copy/insert) operations.",
+                    desc: "Threshold for triggering auto compaction. This occurs when the number of imperfect blocks in a snapshot exceeds this value after write operations.",
                     mode: SettingMode::Both,
                     range: None,
                 }),

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -436,12 +436,12 @@ impl Settings {
         Ok(self.try_get_u64("enable_compact_after_write")? != 0)
     }
 
-    pub fn get_auto_compaction_threshold(&self) -> Result<u64> {
-        self.try_get_u64("auto_compaction_threshold")
+    pub fn get_auto_compaction_imperfect_blocks_threshold(&self) -> Result<u64> {
+        self.try_get_u64("auto_compaction_imperfect_blocks_threshold")
     }
 
-    pub fn set_auto_compaction_threshold(&self, val: u64) -> Result<()> {
-        self.try_set_u64("auto_compaction_threshold", val)
+    pub fn set_auto_compaction_imperfect_blocks_threshold(&self, val: u64) -> Result<()> {
+        self.try_set_u64("auto_compaction_imperfect_blocks_threshold", val)
     }
 
     pub fn get_use_parquet2(&self) -> Result<bool> {

--- a/src/query/storages/fuse/src/operations/common/snapshot_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/snapshot_generator.rs
@@ -425,7 +425,10 @@ impl SnapshotGenerator for AppendGenerator {
         // the algorithm is: if the number of imperfect blocks is greater than the threshold, then auto compact.
         // the threshold is set by the setting `auto_compaction_threshold`, default is 1000.
         let imperfect_count = new_summary.block_count - new_summary.perfect_block_count;
-        let auto_compaction_threshold = self.ctx.get_settings().get_auto_compaction_threshold()?;
+        let auto_compaction_threshold = self
+            .ctx
+            .get_settings()
+            .get_auto_compaction_imperfect_blocks_threshold()?;
         let auto_compact = imperfect_count >= auto_compaction_threshold;
         self.ctx.set_need_compact_after_write(auto_compact);
 

--- a/src/query/storages/fuse/src/operations/common/snapshot_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/snapshot_generator.rs
@@ -423,13 +423,13 @@ impl SnapshotGenerator for AppendGenerator {
 
         // check if need to auto compact
         // the algorithm is: if the number of imperfect blocks is greater than the threshold, then auto compact.
-        // the threshold is set by the setting `auto_compaction_threshold`, default is 1000.
+        // the threshold is set by the setting `auto_compaction_imperfect_blocks_threshold`, default is 1000.
         let imperfect_count = new_summary.block_count - new_summary.perfect_block_count;
-        let auto_compaction_threshold = self
+        let auto_compaction_imperfect_blocks_threshold = self
             .ctx
             .get_settings()
             .get_auto_compaction_imperfect_blocks_threshold()?;
-        let auto_compact = imperfect_count >= auto_compaction_threshold;
+        let auto_compact = imperfect_count >= auto_compaction_imperfect_blocks_threshold;
         self.ctx.set_need_compact_after_write(auto_compact);
 
         Ok(TableSnapshot::new(

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert.test
@@ -83,7 +83,7 @@ SELECT segment_count, block_count, row_count from FUSE_SNAPSHOT('db1', 't3') lim
 4 4 3002
 
 statement ok
-SET auto_compaction_threshold = 3;
+SET auto_compaction_imperfect_blocks_threshold = 3;
 
 statement ok
 create table t4(number String);
@@ -109,7 +109,7 @@ SELECT segment_count, block_count, row_count from FUSE_SNAPSHOT('db1', 't4') lim
 3 3 300
 
 statement ok
-SET auto_compaction_threshold = 1000;
+SET auto_compaction_imperfect_blocks_threshold = 1000;
 
 statement ok
 DROP TABLE t1

--- a/tests/sqllogictests/suites/mode/cluster/distributed_copy_into_table2.test
+++ b/tests/sqllogictests/suites/mode/cluster/distributed_copy_into_table2.test
@@ -5,7 +5,7 @@ statement ok
 set global max_threads = 1;
 
 statement ok
-set auto_compaction_threshold = 3;
+set auto_compaction_imperfect_blocks_threshold = 3;
 
 statement ok
 drop table if exists products;
@@ -55,4 +55,4 @@ statement ok
 set enable_distributed_copy_into = 0;
 
 statement ok
-set auto_compaction_threshold = 1000;
+set auto_compaction_imperfect_blocks_threshold = 1000;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* remove warn log from hook_compact, this maybe flood
*  `auto_compaction_threshold` -> `auto_compaction_imperfect_blocks_threshold`, make it more meaningful
*  collapsed hook_compact setting checks


Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14117)
<!-- Reviewable:end -->
