### PR TITLE
chore: remove flaky test(cluster) in 01_0013_system_metrics.test

### DIFF
--- a/tests/sqllogictests/suites/base/01_system/01_0013_system_metrics.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0013_system_metrics.test
@@ -47,9 +47,3 @@ SELECT sum(to_int32(to_float32(value) > 5)) > 1 FROM system.metrics where metric
 onlyif mysql
 statement ok
 truncate table system.metrics
-
-onlyif mysql
-query I
-SELECT sum(to_int32(to_float32(value) > 5)) FROM system.metrics where metric = 'query_success_total'
-----
-0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
remove this flaky test:
```

onlyif mysql
query I
SELECT sum(to_int32(to_float32(value) > 5)) FROM system.metrics where metric = 'query_success_total'
----
0
```

Fixes #14120
Fixes #14103

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  -  No need new tests.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14123)
<!-- Reviewable:end -->
