### PR TITLE
feat: make Top-N sort can be spilled.

### DIFF
--- a/src/query/service/src/pipelines/builders/builder_sort.rs
+++ b/src/query/service/src/pipelines/builders/builder_sort.rs
@@ -334,6 +334,7 @@ impl SortPipelineBuilder {
                     output,
                     schema.clone(),
                     self.sort_desc.clone(),
+                    self.limit,
                     spiller,
                     output_order_col,
                 );

--- a/tests/suites/0_stateless/20+_others/20_0014_sort_spill.result
+++ b/tests/suites/0_stateless/20+_others/20_0014_sort_spill.result
@@ -1,3 +1,4 @@
+==TEST GLOBAL SORT==
 0
 1
 NULL
@@ -60,3 +61,26 @@ NULL	NULL
 2	5
 2	NULL
 4	8
+==TEST TOP-N SORT==
+===================
+0
+===================
+transform_spill_write_count_total	{"spill":"sort_spill"}	1.0
+transform_spill_write_bytes_total	{"spill":"sort_spill"}	1168.0
+transform_spill_read_count_total	{"spill":"sort_spill"}	1.0
+transform_spill_read_bytes_total	{"spill":"sort_spill"}	1168.0
+===================
+2	NULL
+2	5
+4	8
+2	NULL
+2	5
+4	8
+NULL	6
+NULL	NULL
+2	5
+===================
+transform_spill_write_count_total	{"spill":"sort_spill"}	7.0
+transform_spill_write_bytes_total	{"spill":"sort_spill"}	11968.0
+transform_spill_read_count_total	{"spill":"sort_spill"}	7.0
+transform_spill_read_bytes_total	{"spill":"sort_spill"}	11968.0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Top-N sort can also be spilled now.

Tracking in #13889

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14131)
<!-- Reviewable:end -->
