### PR TITLE
chore: remove the unused setting:enable_recluster_after_write

### DIFF
--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -69,11 +69,7 @@ async fn do_hook_compact(
         return Ok(());
     }
 
-    // Inorder to compatibility with the old version, we need enable_recluster_after_write, it will deprecated in the future.
-    // use enable_compact_after_write to replace it.
-    if ctx.get_settings().get_enable_recluster_after_write()?
-        && ctx.get_settings().get_enable_compact_after_write()?
-    {
+    if ctx.get_settings().get_enable_compact_after_write()? {
         {
             pipeline.set_on_finished(move |err| {
                     if !ctx.get_need_compact_after_write() {

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -484,13 +484,6 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
-                // Will deprecated in the future, use enable_compact_after_write instead.
-                ("enable_recluster_after_write", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(1),
-                    desc: "Enables re-clustering after write(copy/insert/replace-into/merge-into).",
-                    mode: SettingMode::Both,
-                    range: Some(SettingRange::Numeric(0..=1)),
-                }),
                 ("enable_compact_after_write", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
                     desc: "Enables compact after write(copy/insert/replace-into/merge-into), need more memory.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -427,11 +427,6 @@ impl Settings {
         Ok(self.try_get_u64("enable_aggregating_index_scan")? != 0)
     }
 
-    // Deprecated in the future, use enable_compact_after_write instead.
-    pub fn get_enable_recluster_after_write(&self) -> Result<bool> {
-        Ok(self.try_get_u64("enable_recluster_after_write")? != 0)
-    }
-
     pub fn get_enable_compact_after_write(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_compact_after_write")? != 0)
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* remove the unused setting: `enable_recluster_after_write`

Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - No need test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14146)
<!-- Reviewable:end -->
