### PR TITLE
chore(query): virtual columns not pushdown if not created

### DIFF
--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -304,7 +304,7 @@ impl Binder {
         // rewrite variant inner fields as virtual columns
         let mut virtual_column_rewriter =
             VirtualColumnRewriter::new(self.ctx.clone(), self.metadata.clone());
-        s_expr = virtual_column_rewriter.rewrite(&s_expr)?;
+        s_expr = virtual_column_rewriter.rewrite(&s_expr).await?;
 
         // add internal column binding into expr
         s_expr = from_context.add_internal_column_into_expr(s_expr);

--- a/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
@@ -232,7 +232,7 @@ impl VirtualColumnRewriter {
                             }
                         };
                         // If this field name does not have a virtual column created,
-                        // it cannot be rewrited as a virtual column
+                        // it cannot be rewritten as a virtual column
                         match self.virtual_column_names.get(&base_column.table_index) {
                             Some(names) => {
                                 if !names.contains(&name) {

--- a/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use databend_common_catalog::table_context::TableContext;
@@ -22,6 +23,7 @@ use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_license::license::Feature::VirtualColumn;
 use databend_common_license::license_manager::get_license_manager;
+use databend_common_meta_app::schema::ListVirtualColumnsReq;
 use jsonb::keypath::parse_key_paths;
 use jsonb::keypath::KeyPath;
 
@@ -45,6 +47,10 @@ pub(crate) struct VirtualColumnRewriter {
     /// Mapping: (table index) -> (derived virtual column indices)
     /// This is used to add virtual column indices to Scan plan
     table_virtual_columns: HashMap<IndexType, Vec<IndexType>>,
+
+    /// Mapping: (table index) -> (virtual column names)
+    /// This is used to check whether the virtual column has be created
+    virtual_column_names: HashMap<IndexType, HashSet<String>>,
 }
 
 impl VirtualColumnRewriter {
@@ -53,10 +59,12 @@ impl VirtualColumnRewriter {
             ctx,
             metadata,
             table_virtual_columns: Default::default(),
+            virtual_column_names: Default::default(),
         }
     }
 
-    pub(crate) fn rewrite(&mut self, s_expr: &SExpr) -> Result<SExpr> {
+    #[async_backtrace::framed]
+    pub(crate) async fn rewrite(&mut self, s_expr: &SExpr) -> Result<SExpr> {
         let license_manager = get_license_manager();
         if license_manager
             .manager
@@ -66,15 +74,43 @@ impl VirtualColumnRewriter {
             return Ok(s_expr.clone());
         }
 
-        let has_variant_column = self
-            .metadata
-            .read()
-            .columns()
-            .iter()
-            .any(|column| column.data_type().remove_nullable() == DataType::Variant);
-        // If there are no columns of variant type,
-        // no need to check rewrite as virtual columns
-        if !has_variant_column {
+        let metadata = self.metadata.read().clone();
+        for table_entry in metadata.tables() {
+            let table = table_entry.table();
+            // Ignore tables that do not support virtual columns
+            if !table.support_virtual_columns() {
+                continue;
+            }
+
+            let has_variant_column = table
+                .schema()
+                .fields
+                .iter()
+                .any(|field| field.data_type.remove_nullable() == TableDataType::Variant);
+            // Ignore tables that do not have fields of variant type
+            if !has_variant_column {
+                continue;
+            }
+
+            let table_id = table.get_id();
+            let req = ListVirtualColumnsReq {
+                tenant: self.ctx.get_tenant(),
+                table_id: Some(table_id),
+            };
+            let catalog = self.ctx.get_catalog(table_entry.catalog()).await?;
+
+            if let Ok(virtual_column_metas) = catalog.list_virtual_columns(req).await {
+                if !virtual_column_metas.is_empty() {
+                    let virtual_column_name_set =
+                        HashSet::from_iter(virtual_column_metas[0].virtual_columns.iter().cloned());
+                    self.virtual_column_names
+                        .insert(table_entry.index(), virtual_column_name_set);
+                }
+            }
+        }
+        // If all tables do not have virtual columns created,
+        // there is no need to continue checking for rewrites as virtual columns
+        if self.virtual_column_names.is_empty() {
             return Ok(s_expr.clone());
         }
 
@@ -163,14 +199,7 @@ impl VirtualColumnRewriter {
                 {
                     let column_entry = self.metadata.read().column(column_ref.column.index).clone();
                     if let ColumnEntry::BaseTableColumn(base_column) = column_entry {
-                        if !self
-                            .metadata
-                            .read()
-                            .table(base_column.table_index)
-                            .table()
-                            .support_virtual_columns()
-                            || base_column.data_type.remove_nullable() != TableDataType::Variant
-                        {
+                        if base_column.data_type.remove_nullable() != TableDataType::Variant {
                             return Some(());
                         }
                         let name = match constant.value.clone() {
@@ -202,6 +231,18 @@ impl VirtualColumnRewriter {
                                 return Some(());
                             }
                         };
+                        // If this field name does not have a virtual column created,
+                        // it cannot be rewrited as a virtual column
+                        match self.virtual_column_names.get(&base_column.table_index) {
+                            Some(names) => {
+                                if !names.contains(&name) {
+                                    return Some(());
+                                }
+                            }
+                            None => {
+                                return Some(());
+                            }
+                        }
 
                         let mut index = 0;
                         // Check for duplicate virtual columns

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_virtual_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_virtual_column.test
@@ -31,35 +31,63 @@ statement ok
 insert into t1 values(1, parse_json('{"a":[1,2,3],"b":{"c":10}}'))
 
 query T
-explain select a, v['b'] from t1
+explain select a, v['a'][0], v['b'] from t1
+----
+EvalScalar
+├── output columns: [t1.a (#0), v['a'][0] (#2), v['b'] (#3)]
+├── expressions: [get_by_keypath(t1.v (#1), '{"a",0}'), get_by_keypath(t1.v (#1), '{"b"}')]
+├── estimated rows: 1.00
+└── TableScan
+    ├── table: default.test_virtual_db.t1
+    ├── output columns: [a (#0), v (#1)]
+    ├── read rows: 1
+    ├── read bytes: 137
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
+
+query T
+explain select a, v['b'] from t1 where v['a'][0] = 1
+----
+EvalScalar
+├── output columns: [t1.a (#0), v['b'] (#2)]
+├── expressions: [get_by_keypath(t1.v (#1), '{"b"}')]
+├── estimated rows: 0.20
+└── TableScan
+    ├── table: default.test_virtual_db.t1
+    ├── output columns: [a (#0), v (#1)]
+    ├── read rows: 1
+    ├── read bytes: 137
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    ├── push downs: [filters: [is_true(TRY_CAST(get_by_keypath(t1.v (#1), '{"a",0}') AS UInt8 NULL) = 1)], limit: NONE]
+    └── estimated rows: 0.20
+
+statement ok
+create virtual column (v['a'][0], v['b']) for t1
+
+statement ok
+refresh virtual column for t1
+
+query T
+explain select a, v['a'][0], v['b'] from t1
 ----
 TableScan
 ├── table: default.test_virtual_db.t1
-├── output columns: [a (#0), v['b'] (#2)]
+├── output columns: [a (#0), v['a'][0] (#2), v['b'] (#3)]
 ├── read rows: 1
 ├── read bytes: 137
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-├── push downs: [filters: [], limit: NONE, virtual_columns: [v['b']]]
+├── push downs: [filters: [], limit: NONE, virtual_columns: [v['a'][0], v['b']]]
 └── estimated rows: 1.00
 
 query T
-explain select a, v['a'][0] from t1
-----
-TableScan
-├── table: default.test_virtual_db.t1
-├── output columns: [a (#0), v['a'][0] (#2)]
-├── read rows: 1
-├── read bytes: 137
-├── partitions total: 1
-├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-├── push downs: [filters: [], limit: NONE, virtual_columns: [v['a'][0]]]
-└── estimated rows: 1.00
-
-query T
-explain select a, v['b'] from t1 where v['a'][0] = 1;
+explain select a, v['b'] from t1 where v['a'][0] = 1
 ----
 TableScan
 ├── table: default.test_virtual_db.t1
@@ -84,18 +112,65 @@ create table t2 (a int null, v json null) storage_format = 'parquet'
 statement ok
 insert into t2 values(1, parse_json('{"a":[1,2,3],"b":{"c":10}}'))
 
+
 query T
-explain select a, v['b'] from t2
+explain select a, v['a'][0], v['b'] from t2
+----
+EvalScalar
+├── output columns: [t2.a (#0), v['a'][0] (#2), v['b'] (#3)]
+├── expressions: [get_by_keypath(t2.v (#1), '{"a",0}'), get_by_keypath(t2.v (#1), '{"b"}')]
+├── estimated rows: 1.00
+└── TableScan
+    ├── table: default.test_virtual_db.t2
+    ├── output columns: [a (#0), v (#1)]
+    ├── read rows: 1
+    ├── read bytes: 130
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 1.00
+
+query T
+explain select a, v['b'] from t2 where v['a'][0] = 1
+----
+EvalScalar
+├── output columns: [t2.a (#0), v['b'] (#2)]
+├── expressions: [get_by_keypath(t2.v (#1), '{"b"}')]
+├── estimated rows: 0.20
+└── Filter
+    ├── output columns: [t2.a (#0), t2.v (#1)]
+    ├── filters: [is_true(TRY_CAST(get_by_keypath(t2.v (#1), '{"a",0}') AS UInt8 NULL) = 1)]
+    ├── estimated rows: 0.20
+    └── TableScan
+        ├── table: default.test_virtual_db.t2
+        ├── output columns: [a (#0), v (#1)]
+        ├── read rows: 1
+        ├── read bytes: 130
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+        ├── push downs: [filters: [is_true(TRY_CAST(get_by_keypath(t2.v (#1), '{"a",0}') AS UInt8 NULL) = 1)], limit: NONE]
+        └── estimated rows: 1.00
+
+statement ok
+create virtual column (v['a'][0], v['b']) for t2
+
+statement ok
+refresh virtual column for t2
+
+query T
+explain select a, v['a'][0], v['b'] from t2
 ----
 TableScan
 ├── table: default.test_virtual_db.t2
-├── output columns: [a (#0), v['b'] (#2)]
+├── output columns: [a (#0), v['a'][0] (#2), v['b'] (#3)]
 ├── read rows: 1
 ├── read bytes: 130
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-├── push downs: [filters: [], limit: NONE, virtual_columns: [v['b']]]
+├── push downs: [filters: [], limit: NONE, virtual_columns: [v['a'][0], v['b']]]
 └── estimated rows: 1.00
 
 query T


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Only push down user-created virtual columns to avoid incorrect displays that may confuse users.

Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14147)
<!-- Reviewable:end -->
