### PR TITLE
refactor: delegate backoff handling to Openraft

### DIFF
--- a/src/meta/service/src/network.rs
+++ b/src/meta/service/src/network.rs
@@ -20,12 +20,12 @@ use std::time::Duration;
 use anyerror::AnyError;
 use backon::BackoffBuilder;
 use backon::ExponentialBuilder;
-use databend_common_base::base::tokio::time::sleep;
 use databend_common_base::containers::ItemManager;
 use databend_common_base::containers::Pool;
 use databend_common_base::future::TimingFutureExt;
 use databend_common_meta_sled_store::openraft;
 use databend_common_meta_sled_store::openraft::error::PayloadTooLarge;
+use databend_common_meta_sled_store::openraft::error::Unreachable;
 use databend_common_meta_sled_store::openraft::MessageSummary;
 use databend_common_meta_sled_store::openraft::RaftNetworkFactory;
 use databend_common_meta_types::protobuf::RaftRequest;
@@ -37,7 +37,6 @@ use databend_common_meta_types::InstallSnapshotError;
 use databend_common_meta_types::InstallSnapshotRequest;
 use databend_common_meta_types::InstallSnapshotResponse;
 use databend_common_meta_types::MembershipNode;
-use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::NetworkError;
 use databend_common_meta_types::NodeId;
 use databend_common_meta_types::RPCError;
@@ -54,7 +53,6 @@ use openraft::async_trait::async_trait;
 use openraft::RaftNetwork;
 use tonic::client::GrpcService;
 use tonic::transport::channel::Channel;
-use tonic::Code;
 
 use crate::grpc_helper::GrpcHelper;
 use crate::metrics::raft_metrics;
@@ -185,14 +183,14 @@ pub struct NetworkConnection {
 impl NetworkConnection {
     #[logcall::logcall(err = "debug")]
     #[minitrace::trace]
-    pub async fn make_client(&self) -> Result<RaftClient, MetaNetworkError> {
+    pub async fn make_client(&self) -> Result<RaftClient, Unreachable> {
         let target = self.target;
 
         let endpoint = self
             .sto
             .get_node_endpoint(&target)
             .await
-            .map_err(|e| MetaNetworkError::GetNodeAddrError(e.to_string()))?;
+            .map_err(|e| Unreachable::new(&e))?;
 
         let addr = format!("http://{}", endpoint);
 
@@ -207,7 +205,7 @@ impl NetworkConnection {
             }
             Err(err) => {
                 raft_metrics::network::incr_connect_failure(&target, &endpoint.to_string());
-                Err(err.into())
+                Err(Unreachable::new(&err))
             }
         }
     }
@@ -226,12 +224,14 @@ impl NetworkConnection {
     /// Create a new RaftRequest for AppendEntriesRequest,
     /// if it is too large, return `PayloadTooLarge` error
     /// to tell Openraft to split it in to smaller chunks.
-    fn new_append_entries_raft_req(
+    fn new_append_entries_raft_req<E>(
         &self,
         rpc: &AppendEntriesRequest,
-    ) -> Result<RaftRequest, PayloadTooLarge> {
-        let raft_req =
-            GrpcHelper::encode_raft_request(rpc).expect("failed to encode append_entries RPC");
+    ) -> Result<RaftRequest, RPCError<E>>
+    where
+        E: std::error::Error,
+    {
+        let raft_req = GrpcHelper::encode_raft_request(rpc).map_err(|e| Unreachable::new(&e))?;
 
         if raft_req.data.len() <= GrpcConfig::advisory_encoding_size() {
             return Ok(raft_req);
@@ -261,7 +261,7 @@ impl NetworkConnection {
                 l,
                 n
             );
-            Err(PayloadTooLarge::new_entries_hint(n as u64))
+            Err(PayloadTooLarge::new_entries_hint(n as u64).into())
         }
     }
 
@@ -276,6 +276,14 @@ impl NetworkConnection {
         // so the longest back off will not be wasted
         let zero = vec![Duration::default()].into_iter();
         policy.chain(zero)
+    }
+
+    /// Convert gRPC status to `RPCError`
+    fn status_to_unreachable<E>(&self, status: tonic::Status) -> RPCError<RaftError<E>>
+    where E: std::error::Error {
+        warn!("target={}, gRPC error: {:?}", self.target, status);
+
+        RPCError::Unreachable(Unreachable::new(&status))
     }
 }
 
@@ -294,49 +302,29 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
             "send_append_entries",
         );
 
-        let mut client = self
-            .make_client()
-            .await
-            .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        let mut client = self.make_client().await?;
 
-        let mut last_err = None;
+        let raft_req = self.new_append_entries_raft_req(&rpc)?;
+        let req = GrpcHelper::traced_req(raft_req);
 
-        for back_off in self.back_off() {
-            let raft_req = self.new_append_entries_raft_req(&rpc)?;
-            let req = GrpcHelper::traced_req(raft_req);
+        let bytes = req.get_ref().data.len() as u64;
+        raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
 
-            let bytes = req.get_ref().data.len() as u64;
-            raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
+        let grpc_res = client
+            .append_entries(req)
+            .timed(observe_append_send_spent(self.target))
+            .await;
+        debug!(
+            "append_entries resp from: target={}: {:?}",
+            self.target, grpc_res
+        );
 
-            let res = client.append_entries(req).await;
-            debug!(
-                "append_entries resp from: target={}: {:?}",
-                self.target, res
-            );
+        let resp = grpc_res.map_err(|e| self.status_to_unreachable(e))?;
 
-            let resp = match res {
-                Ok(x) => x,
-                Err(status) => {
-                    raft_metrics::network::incr_sendto_failure(&self.target);
-                    last_err = Some(new_net_err(&status, || "send_append_entries"));
-                    sleep(back_off).await;
-                    continue;
-                }
-            };
+        let raft_res = GrpcHelper::parse_raft_reply(resp)
+            .map_err(|serde_err| new_net_err(&serde_err, || "parse append_entries reply"))?;
 
-            let rpc_res = GrpcHelper::parse_raft_reply(resp)
-                .map_err(|serde_err| new_net_err(&serde_err, || "parse append_entries reply"))?;
-
-            return rpc_res.map_err(|e| self.to_rpc_err(e));
-        }
-
-        if let Some(net_err) = last_err {
-            Err(RPCError::Network(net_err))
-        } else {
-            Err(RPCError::Network(NetworkError::new(&AnyError::error(
-                "backoff does not send send_append_entries RPC",
-            ))))
-        }
+        return raft_res.map_err(|e| self.to_rpc_err(e));
     }
 
     #[logcall::logcall(err = "debug")]
@@ -353,88 +341,69 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
         );
 
         let _g = snapshot_send_inflight(self.target).counter_guard();
+
+        let mut client = self.make_client().await?;
+
         let bytes = rpc.data.len() as u64;
+        raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
 
-        let mut client = self
-            .make_client()
-            .await
-            .map_err(|e| NetworkError::new(&e))?;
+        // Try send via `v1` API, if the remote peer does not provide `v1` API,
+        // revert to `v0` API.
+        let v1_res = if self.install_snapshot_via_v0 == 0 {
+            // Send via v1 API
 
-        let mut last_err = None;
+            let v1_req = SnapshotChunkRequest::new_v1(rpc.clone());
+            let req = databend_common_tracing::inject_span_to_tonic_request(v1_req);
+            let res = client
+                .install_snapshot_v1(req)
+                .timed(observe_snapshot_send_spent(self.target))
+                .await;
 
-        // It consumes a loop to retry sending install_snapshot via v0 API.
-        // Thus add another backoff of 0.
-        for back_off in [Duration::from_millis(0)]
-            .into_iter()
-            .chain(self.back_off())
-        {
-            raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
-
-            // Try send via `v1` API, if the remote peer does not provide `v1` API,
-            // revert to `v0` API.
-
-            let res = if self.install_snapshot_via_v0 == 0 {
-                // Send via v1 API
-
-                let v1_req = SnapshotChunkRequest::new_v1(rpc.clone());
-                let req = databend_common_tracing::inject_span_to_tonic_request(v1_req);
-                let res = client
-                    .install_snapshot_v1(req)
-                    .timed(observe_snapshot_send_spent(self.target))
-                    .await;
-
-                if let Err(ref status) = res {
-                    if status.code() == Code::Unimplemented {
-                        warn!(
-                            "target={} does not support install_snapshot_v1 API, fallback to v0 API for next 10 times",
-                            self.target
-                        );
-                        // The remote peer may not be upgraded yet, try to send via v0 API for the
-                        // next 10 install_snapshot RPC and retry at once.
-                        self.install_snapshot_via_v0 = 10;
-                        continue;
-                    }
-                }
-                res
+            if is_unimplemented(&res) {
+                warn!(
+                    "target={} does not support install_snapshot_v1 API, fallback to v0 API for next 10 times",
+                    self.target
+                );
+                self.install_snapshot_via_v0 = 10;
+                None
             } else {
-                // Send via v0 API
-
-                self.install_snapshot_via_v0 -= 1;
-
-                let req = databend_common_tracing::inject_span_to_tonic_request(rpc.clone());
-                client
-                    .install_snapshot(req)
-                    .timed(observe_snapshot_send_spent(self.target))
-                    .await
-            };
-
-            info!("install_snapshot resp target={}: {:?}", self.target, res);
-
-            let resp = match res {
-                Ok(x) => x,
-                Err(status) => {
-                    self.report_metrics_snapshot(false);
-                    last_err = Some(new_net_err(&status, || "send_install_snapshot"));
-                    sleep(back_off).await;
-                    continue;
-                }
-            };
-
-            let rpc_res = GrpcHelper::parse_raft_reply(resp)
-                .map_err(|serde_err| new_net_err(&serde_err, || "parse install_snapshot reply"))?;
-
-            self.report_metrics_snapshot(rpc_res.is_ok());
-
-            return rpc_res.map_err(|e| self.to_rpc_err(e));
-        }
-
-        if let Some(net_err) = last_err {
-            Err(RPCError::Network(net_err))
+                Some(res)
+            }
         } else {
-            Err(RPCError::Network(NetworkError::new(&AnyError::error(
-                "backoff does not send send_install_snapshot RPC",
-            ))))
-        }
+            None
+        };
+
+        let grpc_res = if let Some(v1_res) = v1_res {
+            v1_res
+        } else {
+            // Via v1 API is not tried or failed,
+            // Send via v0 API
+
+            self.install_snapshot_via_v0 -= 1;
+
+            let req = databend_common_tracing::inject_span_to_tonic_request(rpc.clone());
+            client
+                .install_snapshot(req)
+                .timed(observe_snapshot_send_spent(self.target))
+                .await
+        };
+
+        info!(
+            "install_snapshot resp target={}: {:?}",
+            self.target, grpc_res
+        );
+
+        let resp = grpc_res.map_err(|e| {
+            self.report_metrics_snapshot(false);
+            self.status_to_unreachable(e)
+        })?;
+
+        let raft_res = GrpcHelper::parse_raft_reply(resp)
+            .map_err(|serde_err| new_net_err(&serde_err, || "parse install_snapshot reply"))?;
+
+        self.report_metrics_snapshot(raft_res.is_ok());
+
+        return raft_res.map_err(|e| self.to_rpc_err(e));
     }
 
     #[logcall::logcall(err = "debug")]
@@ -442,47 +411,31 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     async fn send_vote(&mut self, rpc: VoteRequest) -> Result<VoteResponse, RPCError<RaftError>> {
         info!(id = self.id, target = self.target, rpc = rpc.summary(); "send_vote");
 
-        let mut client = self
-            .make_client()
-            .await
-            .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        let mut client = self.make_client().await?;
 
-        let mut last_err = None;
+        let raft_req = GrpcHelper::encode_raft_request(&rpc).map_err(|e| Unreachable::new(&e))?;
 
-        for back_off in self.back_off() {
-            let raft_req =
-                GrpcHelper::encode_raft_request(&rpc).expect("failed to encode vote RPC");
-            let req = GrpcHelper::traced_req(raft_req);
+        let req = GrpcHelper::traced_req(raft_req);
 
-            let bytes = req.get_ref().data.len() as u64;
-            raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
+        let bytes = req.get_ref().data.len() as u64;
+        raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
 
-            let res = client.vote(req).await;
-            info!("vote: resp from target={} {:?}", self.target, res);
+        let grpc_res = client.vote(req).await;
+        info!("vote: resp from target={} {:?}", self.target, grpc_res);
 
-            let resp = match res {
-                Ok(x) => x,
-                Err(status) => {
-                    raft_metrics::network::incr_sendto_failure(&self.target);
-                    last_err = Some(new_net_err(&status, || "send_vote"));
-                    sleep(back_off).await;
-                    continue;
-                }
-            };
+        let resp = grpc_res.map_err(|e| self.status_to_unreachable(e))?;
 
-            let rpc_res = GrpcHelper::parse_raft_reply(resp)
-                .map_err(|serde_err| new_net_err(&serde_err, || "parse vote reply"))?;
+        let raft_res = GrpcHelper::parse_raft_reply(resp)
+            .map_err(|serde_err| new_net_err(&serde_err, || "parse vote reply"))?;
 
-            return rpc_res.map_err(|e| self.to_rpc_err(e));
-        }
+        return raft_res.map_err(|e| self.to_rpc_err(e));
+    }
 
-        if let Some(net_err) = last_err {
-            Err(RPCError::Network(net_err))
-        } else {
-            Err(RPCError::Network(NetworkError::new(&AnyError::error(
-                "backoff does not send send_vote RPC",
-            ))))
-        }
+    /// When a `Unreachable` error is returned from the `Network`,
+    /// Openraft will call this method to build a backoff instance.
+    fn backoff(&self) -> openraft::network::Backoff {
+        warn!("backoff is required: target={}", self.target);
+        openraft::network::Backoff::new(self.back_off())
     }
 }
 
@@ -520,6 +473,13 @@ fn new_net_err<D: Display>(
 }
 
 /// Create a function record the time cost of snapshot sending.
+fn observe_append_send_spent(target: NodeId) -> impl Fn(Duration, Duration) {
+    move |t, _b| {
+        raft_metrics::network::observe_append_sendto_spent(&target, t.as_secs() as f64);
+    }
+}
+
+/// Create a function record the time cost of snapshot sending.
 fn observe_snapshot_send_spent(target: NodeId) -> impl Fn(Duration, Duration) {
     move |t, _b| {
         raft_metrics::network::observe_snapshot_sendto_spent(&target, t.as_secs() as f64);
@@ -529,4 +489,15 @@ fn observe_snapshot_send_spent(target: NodeId) -> impl Fn(Duration, Duration) {
 /// Create a function that increases metric value of inflight snapshot sending.
 fn snapshot_send_inflight(target: NodeId) -> impl FnMut(i64) {
     move |i: i64| raft_metrics::network::incr_snapshot_sendto_inflight(&target, i)
+}
+
+/// Return true if it IS an error and the error code is Unimplemented.
+///
+/// Return false if it is NOT an error or the error code is NOT Unimplemented.
+fn is_unimplemented<T>(res: &Result<T, tonic::Status>) -> bool {
+    if let Err(status) = res {
+        status.code() == tonic::Code::Unimplemented
+    } else {
+        false
+    }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: delegate backoff handling to Openraft

Remove the manually implemented backoff logic from meta-service internal
`Network` module.

Add a new metric `append_sent_seconds` to observe time spent on sending
append-entries RPC between meta-service node.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14154)
<!-- Reviewable:end -->
