### PR TITLE
fix(query): fix cast domain values did not perform rounding operation

### DIFF
--- a/src/query/functions/src/scalars/arithmetic.rs
+++ b/src/query/functions/src/scalars/arithmetic.rs
@@ -589,8 +589,20 @@ pub fn register_number_to_number(registry: &mut FunctionRegistry) {
                         } else if src_type.need_round_cast_to(*dest_type) {
                             registry.register_passthrough_nullable_1_arg::<NumberType<SRC_TYPE>, NumberType<DEST_TYPE>, _, _>(
                                 &name,
-                                |_, domain| {
-                                    let (domain, overflowing) = domain.overflow_cast();
+                                |func_ctx, domain| {
+                                    let (domain, overflowing) = if func_ctx.rounding_mode {
+                                        // Perform round on domain to keep the result of domain
+                                        // matches the result of function
+                                        let min = AsPrimitive::<f64>::as_(domain.min);
+                                        let max = AsPrimitive::<f64>::as_(domain.max);
+                                        let round_domain = SimpleDomain::<F64>{
+                                            min: min.round().into(),
+                                            max: max.round().into(),
+                                        };
+                                        round_domain.overflow_cast()
+                                    } else {
+                                        domain.overflow_cast()
+                                    };
                                     if overflowing {
                                         FunctionDomain::MayThrow
                                     } else {
@@ -659,8 +671,20 @@ pub fn register_number_to_number(registry: &mut FunctionRegistry) {
                         } else if src_type.need_round_cast_to(*dest_type) {
                             registry.register_combine_nullable_1_arg::<NumberType<SRC_TYPE>, NumberType<DEST_TYPE>, _, _>(
                                 &name,
-                                |_, domain| {
-                                    let (domain, overflowing) = domain.overflow_cast();
+                                |func_ctx, domain| {
+                                    let (domain, overflowing) = if func_ctx.rounding_mode {
+                                        // Perform round on domain to keep the result of domain
+                                        // matches the result of function
+                                        let min = AsPrimitive::<f64>::as_(domain.min);
+                                        let max = AsPrimitive::<f64>::as_(domain.max);
+                                        let round_domain = SimpleDomain::<F64>{
+                                            min: min.round().into(),
+                                            max: max.round().into(),
+                                        };
+                                        round_domain.overflow_cast()
+                                    } else {
+                                        domain.overflow_cast()
+                                    };
                                     FunctionDomain::Domain(NullableDomain {
                                         has_null: overflowing,
                                         value: Some(Box::new(

--- a/tests/sqllogictests/suites/query/functions/cast.test
+++ b/tests/sqllogictests/suites/query/functions/cast.test
@@ -81,3 +81,31 @@ drop table cast_array
 
 statement ok
 drop table t1
+
+# for issue #14156 https://github.com/datafuselabs/databend/issues/14156
+
+statement ok
+set numeric_cast_option = 'truncating'
+
+query T
+select CAST(10249.5500000000000000 * POW(10, 2) AS UNSIGNED)
+----
+1024954
+
+query T
+select to_uint64(1024954.98046875::double)
+----
+1024954
+
+statement ok
+set numeric_cast_option = 'rounding'
+
+query T
+select CAST(10249.5500000000000000 * POW(10, 2) AS UNSIGNED)
+----
+1024955
+
+query T
+select to_uint64(1024954.98046875::double)
+----
+1024955


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix the issue where cast domain values did not perform rounding operation resulting in incorrect cast results

Fixes #14156

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14158)
<!-- Reviewable:end -->
