### PR TITLE
refactor: move to meta-service handshake into pool

### DIFF
--- a/src/binaries/metactl/grpc.rs
+++ b/src/binaries/metactl/grpc.rs
@@ -32,7 +32,7 @@ pub async fn export_meta(addr: &str, save: String) -> anyhow::Result<()> {
         None,
     )?;
 
-    let (mut grpc_client, _server_version) = client.make_client().await?;
+    let mut grpc_client = client.make_established_client().await?;
 
     let exported = grpc_client.export(tonic::Request::new(Empty {})).await?;
 

--- a/src/meta/client/src/established_client.rs
+++ b/src/meta/client/src/established_client.rs
@@ -1,0 +1,156 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use databend_common_meta_types::protobuf::meta_service_client::MetaServiceClient;
+use databend_common_meta_types::protobuf::ClientInfo;
+use databend_common_meta_types::protobuf::ClusterStatus;
+use databend_common_meta_types::protobuf::Empty;
+use databend_common_meta_types::protobuf::ExportedChunk;
+use databend_common_meta_types::protobuf::MemberListReply;
+use databend_common_meta_types::protobuf::MemberListRequest;
+use databend_common_meta_types::protobuf::RaftReply;
+use databend_common_meta_types::protobuf::RaftRequest;
+use databend_common_meta_types::protobuf::StreamItem;
+use databend_common_meta_types::protobuf::WatchRequest;
+use databend_common_meta_types::protobuf::WatchResponse;
+use databend_common_meta_types::TxnReply;
+use databend_common_meta_types::TxnRequest;
+use tonic::codec::Streaming;
+use tonic::codegen::InterceptedService;
+use tonic::transport::Channel;
+use tonic::Response;
+use tonic::Status;
+
+use crate::grpc_client::AuthInterceptor;
+
+/// A gRPC client that has established a connection to a server and passed handshake.
+#[derive(Debug, Clone)]
+pub struct EstablishedClient {
+    client: MetaServiceClient<InterceptedService<Channel, AuthInterceptor>>,
+
+    server_protocol_version: u64,
+
+    /// The error that occurred when sending an RPC.
+    ///
+    /// The client with error will be dropped by the client pool.
+    error: Arc<Mutex<Option<Status>>>,
+}
+
+impl EstablishedClient {
+    pub(crate) fn new(
+        client: MetaServiceClient<InterceptedService<Channel, AuthInterceptor>>,
+        server_protocol_version: u64,
+    ) -> Self {
+        Self {
+            client,
+            server_protocol_version,
+            error: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn server_protocol_version(&self) -> u64 {
+        self.server_protocol_version
+    }
+
+    pub(crate) fn set_error(&self, error: Status) {
+        *self.error.lock().unwrap() = Some(error);
+    }
+
+    pub(crate) fn take_error(&self) -> Option<Status> {
+        self.error.lock().unwrap().take()
+    }
+
+    pub async fn kv_api(
+        &mut self,
+        request: impl tonic::IntoRequest<RaftRequest>,
+    ) -> Result<Response<RaftReply>, Status> {
+        self.client.kv_api(request).await.map_err(|e| {
+            self.set_error(e.clone());
+            e
+        })
+    }
+
+    pub async fn kv_read_v1(
+        &mut self,
+        request: impl tonic::IntoRequest<RaftRequest>,
+    ) -> Result<Response<Streaming<StreamItem>>, Status> {
+        self.client.kv_read_v1(request).await.map_err(|e| {
+            self.set_error(e.clone());
+            e
+        })
+    }
+
+    pub async fn export(
+        &mut self,
+        request: impl tonic::IntoRequest<Empty>,
+    ) -> Result<Response<Streaming<ExportedChunk>>, Status> {
+        self.client.export(request).await.map_err(|e| {
+            self.set_error(e.clone());
+            e
+        })
+    }
+
+    pub async fn watch(
+        &mut self,
+        request: impl tonic::IntoRequest<WatchRequest>,
+    ) -> Result<Response<Streaming<WatchResponse>>, Status> {
+        self.client.watch(request).await.map_err(|e| {
+            self.set_error(e.clone());
+            e
+        })
+    }
+
+    pub async fn transaction(
+        &mut self,
+        request: impl tonic::IntoRequest<TxnRequest>,
+    ) -> Result<Response<TxnReply>, Status> {
+        self.client.transaction(request).await.map_err(|e| {
+            self.set_error(e.clone());
+            e
+        })
+    }
+
+    pub async fn member_list(
+        &mut self,
+        request: impl tonic::IntoRequest<MemberListRequest>,
+    ) -> Result<Response<MemberListReply>, Status> {
+        self.client.member_list(request).await.map_err(|e| {
+            self.set_error(e.clone());
+            e
+        })
+    }
+
+    pub async fn get_cluster_status(
+        &mut self,
+        request: impl tonic::IntoRequest<Empty>,
+    ) -> Result<Response<ClusterStatus>, Status> {
+        self.client.get_cluster_status(request).await.map_err(|e| {
+            self.set_error(e.clone());
+            e
+        })
+    }
+
+    pub async fn get_client_info(
+        &mut self,
+        request: impl tonic::IntoRequest<Empty>,
+    ) -> Result<Response<ClientInfo>, Status> {
+        self.client.get_client_info(request).await.map_err(|e| {
+            self.set_error(e.clone());
+            e
+        })
+    }
+}

--- a/src/meta/client/src/grpc_action.rs
+++ b/src/meta/client/src/grpc_action.rs
@@ -38,12 +38,12 @@ use log::debug;
 use tonic::codegen::BoxStream;
 use tonic::Request;
 
-use crate::grpc_client::RealClient;
+use crate::established_client::EstablishedClient;
 use crate::message::ExportReq;
 use crate::message::GetClientInfo;
 use crate::message::GetClusterStatus;
 use crate::message::GetEndpoints;
-use crate::message::MakeClient;
+use crate::message::MakeEstablishedClient;
 use crate::message::Streamed;
 
 /// Bind a request type to its corresponding response type.
@@ -204,8 +204,8 @@ impl RequestFor for ExportReq {
     type Reply = tonic::codec::Streaming<WatchResponse>;
 }
 
-impl RequestFor for MakeClient {
-    type Reply = (RealClient, u64);
+impl RequestFor for MakeEstablishedClient {
+    type Reply = EstablishedClient;
 }
 
 impl RequestFor for GetEndpoints {

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -81,7 +81,6 @@ use prost::Message;
 use semver::Version;
 use serde::de::DeserializeOwned;
 use tonic::async_trait;
-use tonic::client::GrpcService;
 use tonic::codegen::BoxStream;
 use tonic::codegen::InterceptedService;
 use tonic::metadata::MetadataValue;
@@ -91,6 +90,7 @@ use tonic::Code;
 use tonic::Request;
 use tonic::Status;
 
+use crate::established_client::EstablishedClient;
 use crate::from_digit_ver;
 use crate::grpc_action::RequestFor;
 use crate::grpc_metrics;
@@ -107,14 +107,59 @@ const AUTH_TOKEN_KEY: &str = "auth-token-bin";
 pub(crate) type RealClient = MetaServiceClient<InterceptedService<Channel, AuthInterceptor>>;
 
 #[derive(Debug)]
-struct MetaChannelManager {
+pub struct MetaChannelManager {
+    username: String,
+    password: String,
     timeout: Option<Duration>,
-    conf: Option<RpcClientTlsConfig>,
+    tls_config: Option<RpcClientTlsConfig>,
 }
 
 impl MetaChannelManager {
+    async fn new_established_client(
+        &self,
+        addr: &String,
+    ) -> Result<EstablishedClient, MetaClientError> {
+        let chan = self.build_channel(addr).await?;
+
+        let (mut real_client, once) = Self::new_real_client(chan);
+
+        let (token, server_version) = MetaGrpcClient::handshake(
+            &mut real_client,
+            &METACLI_COMMIT_SEMVER,
+            &MIN_METASRV_SEMVER,
+            &self.username,
+            &self.password,
+        )
+        .await?;
+
+        // Update the token for the client interceptor.
+        // Safe unwrap(): it is the first time setting it.
+        once.set(token).unwrap();
+
+        Ok(EstablishedClient::new(real_client, server_version))
+    }
+
+    /// Create a MetaServiceClient with authentication interceptor
+    ///
+    /// The returned `OnceCell` is used to fill in a token for the interceptor.
+    pub fn new_real_client(chan: Channel) -> (RealClient, Arc<OnceCell<Vec<u8>>>) {
+        let once = Arc::new(OnceCell::new());
+
+        let interceptor = AuthInterceptor {
+            token: once.clone(),
+        };
+
+        let client = MetaServiceClient::with_interceptor(chan, interceptor)
+            .max_decoding_message_size(GrpcConfig::MAX_DECODING_SIZE)
+            .max_encoding_message_size(GrpcConfig::MAX_ENCODING_SIZE);
+
+        (client, once)
+    }
+
     async fn build_channel(&self, addr: &String) -> Result<Channel, MetaNetworkError> {
-        let ch = ConnectionFactory::create_rpc_channel(addr, self.timeout, self.conf.clone())
+        info!("build channel to {}", addr);
+
+        let ch = ConnectionFactory::create_rpc_channel(addr, self.timeout, self.tls_config.clone())
             .await
             .map_err(|e| match e {
                 GrpcConnectionError::InvalidUri { .. } => MetaNetworkError::BadAddressFormat(
@@ -134,23 +179,24 @@ impl MetaChannelManager {
 #[async_trait]
 impl ItemManager for MetaChannelManager {
     type Key = String;
-    type Item = Channel;
-    type Error = MetaNetworkError;
+    type Item = EstablishedClient;
+    type Error = MetaClientError;
 
     #[logcall::logcall(err = "debug")]
     #[minitrace::trace]
     async fn build(&self, addr: &Self::Key) -> Result<Self::Item, Self::Error> {
-        self.build_channel(addr).await
+        self.new_established_client(addr).await
     }
 
     #[logcall::logcall(err = "debug")]
     #[minitrace::trace]
-    async fn check(&self, mut ch: Self::Item) -> Result<Self::Item, Self::Error> {
-        futures::future::poll_fn(|cx| ch.poll_ready(cx))
-            .await
-            .map_err(|e| {
-                MetaNetworkError::ConnectionError(ConnectionError::new(e, "while check item"))
-            })?;
+    async fn check(&self, ch: Self::Item) -> Result<Self::Item, Self::Error> {
+        // The underlying `tonic::transport::channel::Channel` reconnects when server is down.
+        // But we still need to assert the readiness, e.g., when handshake token expires
+        // If there was an error occurred, the channel will be closed.
+        if let Some(e) = ch.take_error() {
+            return Err(MetaNetworkError::from(e).into());
+        }
         Ok(ch)
     }
 }
@@ -254,8 +300,8 @@ impl ClientHandle {
         self.request(message::GetClientInfo {}).await
     }
 
-    pub async fn make_client(&self) -> Result<(RealClient, u64), MetaClientError> {
-        self.request(message::MakeClient {}).await
+    pub async fn make_established_client(&self) -> Result<EstablishedClient, MetaClientError> {
+        self.request(message::MakeEstablishedClient {}).await
     }
 
     /// Return the endpoints list cached on this client.
@@ -276,8 +322,6 @@ impl ClientHandle {
 pub struct MetaGrpcClient {
     conn_pool: Pool<MetaChannelManager>,
     endpoints: Mutex<Vec<String>>,
-    username: String,
-    password: String,
     current_endpoint: Arc<Mutex<Option<String>>>,
     unhealthy_endpoints: Mutex<TtlHashMap<String, ()>>,
     auto_sync_interval: Option<Duration>,
@@ -334,11 +378,16 @@ impl MetaGrpcClient {
         timeout: Option<Duration>,
         auto_sync_interval: Option<Duration>,
         unhealthy_endpoint_evict_time: Duration,
-        conf: Option<RpcClientTlsConfig>,
+        tls_config: Option<RpcClientTlsConfig>,
     ) -> Result<Arc<ClientHandle>, MetaClientError> {
         Self::endpoints_non_empty(&endpoints)?;
 
-        let mgr = MetaChannelManager { timeout, conf };
+        let mgr = MetaChannelManager {
+            username: username.to_string(),
+            password: password.to_string(),
+            timeout,
+            tls_config,
+        };
 
         let rt =
             Runtime::with_worker_threads(1, Some("meta-client-rt".to_string())).map_err(|e| {
@@ -364,8 +413,6 @@ impl MetaGrpcClient {
             current_endpoint: Arc::new(Mutex::new(None)),
             unhealthy_endpoints: Mutex::new(TtlHashMap::new(unhealthy_endpoint_evict_time)),
             auto_sync_interval,
-            username: username.to_string(),
-            password: password.to_string(),
             rt: rt.clone(),
         });
 
@@ -501,9 +548,9 @@ impl MetaGrpcClient {
                         let resp = self.export(r).await;
                         message::Response::Export(resp)
                     }
-                    message::Request::MakeClient(_) => {
-                        let resp = self.make_client().await;
-                        message::Response::MakeClient(resp)
+                    message::Request::MakeEstablishedClient(_) => {
+                        let resp = self.make_established_client().await;
+                        message::Response::MakeEstablishedClient(resp)
                     }
                     message::Request::GetEndpoints(_) => {
                         unreachable!("handled above");
@@ -589,7 +636,7 @@ impl MetaGrpcClient {
 
     /// Return a client for communication, and a server version in form of `{major:03}.{minor:03}.{patch:03}`.
     #[minitrace::trace]
-    pub async fn make_client(&self) -> Result<(RealClient, u64), MetaClientError> {
+    pub async fn make_established_client(&self) -> Result<EstablishedClient, MetaClientError> {
         let all_endpoints = self.get_cached_endpoints();
         debug!("meta-service all endpoints: {:?}", all_endpoints);
         debug_assert!(!all_endpoints.is_empty());
@@ -616,52 +663,30 @@ impl MetaGrpcClient {
             endpoints
         };
 
-        let mut last_err = None;
+        let mut last_err = None::<MetaClientError>;
 
         for addr in endpoints.iter() {
             self.set_current_endpoint(addr);
 
-            let chan_res = self.make_channel(addr).await;
-            let chan = match chan_res {
-                Ok(chan) => chan,
-                Err(net_err) => {
-                    warn!("{} when make_channel to {}", net_err, addr);
-                    self.mark_current_endpoint_unhealthy();
+            debug!("get or build ReadClient to {}", addr);
 
-                    let cli_err = MetaClientError::NetworkError(net_err);
-                    last_err = Some(cli_err);
+            let res = self.conn_pool.get(addr).await;
+
+            match res {
+                Ok(client) => {
+                    return Ok(client);
+                }
+                Err(client_err) => {
+                    error!(
+                        "Failed to get or build RealClient to {}, err: {:?}",
+                        addr, client_err
+                    );
+                    grpc_metrics::incr_meta_grpc_make_client_fail(addr);
+                    self.mark_current_endpoint_unhealthy();
+                    last_err = Some(client_err);
                     continue;
                 }
-            };
-
-            let (mut client, once) = Self::new_real_client(chan);
-
-            let handshake_res = Self::handshake(
-                &mut client,
-                &METACLI_COMMIT_SEMVER,
-                &MIN_METASRV_SEMVER,
-                &self.username,
-                &self.password,
-            )
-            .await;
-
-            let (token, server_version) = match handshake_res {
-                Ok(x) => x,
-                Err(handshake_err) => {
-                    warn!("handshake error when make client: {:?}", handshake_err);
-                    self.mark_current_endpoint_unhealthy();
-
-                    let cli_err = MetaClientError::HandshakeError(handshake_err);
-                    last_err = Some(cli_err);
-                    continue;
-                }
-            };
-
-            // Update the token for the client interceptor.
-            // Safe unwrap(): it is the first time setting it.
-            once.set(token).unwrap();
-
-            return Ok((client, server_version));
+            }
         }
 
         if let Some(e) = last_err {
@@ -679,23 +704,6 @@ impl MetaGrpcClient {
         Err(MetaClientError::NetworkError(
             MetaNetworkError::ConnectionError(conn_err),
         ))
-    }
-
-    #[minitrace::trace]
-    async fn make_channel(&self, addr: &String) -> Result<Channel, MetaNetworkError> {
-        debug!("make_channel to {}", addr);
-
-        let ch = self.conn_pool.get(addr).await;
-
-        if let Err(ref e) = ch {
-            warn!(
-                "grpc_client create channel with {} failed, err: {:?}",
-                addr, e
-            );
-            grpc_metrics::incr_meta_grpc_make_client_fail(addr);
-        }
-
-        ch
     }
 
     pub fn endpoints_non_empty(endpoints: &[String]) -> Result<(), MetaClientError> {
@@ -737,7 +745,7 @@ impl MetaGrpcClient {
 
     #[minitrace::trace]
     pub async fn sync_endpoints(&self) -> Result<(), MetaError> {
-        let (mut client, _sver) = self.make_client().await?;
+        let mut client = self.make_established_client().await?;
         let result = client
             .member_list(Request::new(MemberListRequest {
                 data: "".to_string(),
@@ -748,7 +756,7 @@ impl MetaGrpcClient {
             Err(s) => {
                 if status_is_retryable(&s) {
                     self.mark_current_endpoint_unhealthy();
-                    let (mut client, _sver) = self.make_client().await?;
+                    let mut client = self.make_established_client().await?;
                     let req = Request::new(MemberListRequest {
                         data: "".to_string(),
                     });
@@ -785,23 +793,6 @@ impl MetaGrpcClient {
                 }
             }
         }
-    }
-
-    /// Create a MetaServiceClient with authentication interceptor
-    ///
-    /// The returned `OnceCell` is used to fill in a token for the interceptor.
-    pub fn new_real_client(chan: Channel) -> (RealClient, Arc<OnceCell<Vec<u8>>>) {
-        let once = Arc::new(OnceCell::new());
-
-        let interceptor = AuthInterceptor {
-            token: once.clone(),
-        };
-
-        let client = MetaServiceClient::with_interceptor(chan, interceptor)
-            .max_decoding_message_size(GrpcConfig::MAX_DECODING_SIZE)
-            .max_encoding_message_size(GrpcConfig::MAX_ENCODING_SIZE);
-
-        (client, once)
     }
 
     /// Handshake with metasrv.
@@ -925,7 +916,7 @@ impl MetaGrpcClient {
             "MetaGrpcClient worker: handle watch request"
         );
 
-        let (mut client, _sver) = self.make_client().await?;
+        let mut client = self.make_established_client().await?;
         let res = client.watch(watch_request).await?;
         Ok(res.into_inner())
     }
@@ -941,7 +932,7 @@ impl MetaGrpcClient {
             "MetaGrpcClient worker: handle export request"
         );
 
-        let (mut client, _sver) = self.make_client().await?;
+        let mut client = self.make_established_client().await?;
         let res = client.export(Empty {}).await?;
         Ok(res.into_inner())
     }
@@ -951,7 +942,7 @@ impl MetaGrpcClient {
     pub(crate) async fn get_cluster_status(&self) -> Result<ClusterStatus, MetaError> {
         debug!("MetaGrpcClient::get_cluster_status");
 
-        let (mut client, _sver) = self.make_client().await?;
+        let mut client = self.make_established_client().await?;
         let res = client.get_cluster_status(Empty {}).await?;
         Ok(res.into_inner())
     }
@@ -961,7 +952,7 @@ impl MetaGrpcClient {
     pub(crate) async fn get_client_info(&self) -> Result<ClientInfo, MetaError> {
         debug!("MetaGrpcClient::get_client_info");
 
-        let (mut client, _sver) = self.make_client().await?;
+        let mut client = self.make_established_client().await?;
         let res = client.get_client_info(Empty {}).await?;
         Ok(res.into_inner())
     }
@@ -985,8 +976,8 @@ impl MetaGrpcClient {
         let mut failures = vec![];
 
         for i in 0..RPC_RETRIES {
-            let (mut client, _server_version) = self
-                .make_client()
+            let mut client = self
+                .make_established_client()
                 .timed_ge(threshold(), info_spent("MetaGrpcClient::make_client"))
                 .await?;
 
@@ -1040,8 +1031,8 @@ impl MetaGrpcClient {
         let mut failures = vec![];
 
         for i in 0..RPC_RETRIES {
-            let (mut client, server_version) = self
-                .make_client()
+            let mut client = self
+                .make_established_client()
                 .timed_ge(threshold(), info_spent("MetaGrpcClient::make_client"))
                 .await?;
 
@@ -1050,13 +1041,13 @@ impl MetaGrpcClient {
             // 1.2.163
             // in 1.2.163, kv_read_v1() API is added
             let kv_read_v1_ver = 1002163;
-            if server_version < kv_read_v1_ver {
+            if client.server_protocol_version() < kv_read_v1_ver {
                 if let MetaGrpcReadReq::ListKV(list_req) = &grpc_req {
                     // Fallback to call non-stream API
 
                     debug!(
                         "meta-service version({} < 0.2.163) is too old, fallback to call non-stream API",
-                        server_version
+                        client.server_protocol_version()
                     );
 
                     let grpc_req = MetaGrpcReq::ListKV(list_req.clone());
@@ -1141,7 +1132,7 @@ impl MetaGrpcClient {
         let req: Request<TxnRequest> = Request::new(txn.clone());
         let req = databend_common_tracing::inject_span_to_tonic_request(req);
 
-        let (mut client, _sver) = self.make_client().await?;
+        let mut client = self.make_established_client().await?;
         let result = client.transaction(req).await;
 
         let result: Result<TxnReply, Status> = match result {
@@ -1149,7 +1140,7 @@ impl MetaGrpcClient {
             Err(s) => {
                 if status_is_retryable(&s) {
                     self.mark_current_endpoint_unhealthy();
-                    let (mut client, _sver) = self.make_client().await?;
+                    let mut client = self.make_established_client().await?;
                     let req: Request<TxnRequest> = Request::new(txn);
                     let req = databend_common_tracing::inject_span_to_tonic_request(req);
                     let ret = client.transaction(req).await?.into_inner();

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::uninlined_format_args)]
 #![feature(lazy_cell)]
 
+pub(crate) mod established_client;
 mod grpc_action;
 mod grpc_client;
 mod grpc_metrics;
@@ -29,6 +30,7 @@ pub use grpc_action::MetaGrpcReadReq;
 pub use grpc_action::MetaGrpcReq;
 pub use grpc_action::RequestFor;
 pub use grpc_client::ClientHandle;
+pub use grpc_client::MetaChannelManager;
 pub use grpc_client::MetaGrpcClient;
 pub use message::ClientWorkerRequest;
 pub use message::Streamed;

--- a/src/meta/client/tests/it/grpc_client.rs
+++ b/src/meta/client/tests/it/grpc_client.rs
@@ -12,63 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use databend_common_base::base::tokio;
 use databend_common_exception::ErrorCode;
 use databend_common_grpc::ConnectionFactory;
-use databend_common_meta_api::SchemaApi;
-use databend_common_meta_app::schema::GetDatabaseReq;
+use databend_common_meta_client::ClientHandle;
+use databend_common_meta_client::MetaChannelManager;
 use databend_common_meta_client::MetaGrpcClient;
+use databend_common_meta_client::Streamed;
 use databend_common_meta_client::MIN_METASRV_SEMVER;
+use databend_common_meta_kvapi::kvapi::GetKVReq;
+use databend_common_meta_types::protobuf::StreamItem;
 use databend_common_meta_types::MetaClientError;
 use databend_common_meta_types::MetaError;
+use futures::StreamExt;
+use log::info;
+use tonic::codegen::BoxStream;
 
+use crate::grpc_server::rand_local_addr;
 use crate::grpc_server::start_grpc_server;
+use crate::grpc_server::start_grpc_server_addr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_grpc_client_action_timeout() {
+async fn test_grpc_client_timeout() -> anyhow::Result<()> {
     // start_grpc_server will sleep 1 second.
-    let srv_addr = start_grpc_server();
+    let (srv_addr, _shutdown, _task_handle) = start_grpc_server();
 
     // use `timeout=3secs` here cause our mock grpc
     // server's handshake impl will sleep 2secs.
     let timeout = Duration::from_secs(3);
+    let client = new_client(&srv_addr, Some(timeout))?;
 
-    let client = MetaGrpcClient::try_create(
-        vec![srv_addr],
-        "",
-        "",
-        Some(timeout),
-        None,
-        Duration::from_secs(10),
-        None,
-    )
-    .unwrap();
+    let res = client.request(GetKVReq::new("foo")).await;
 
-    let res = client
-        .get_database(GetDatabaseReq::new("tenant1", "xx"))
-        .await;
-    let got = res.unwrap_err();
-    let got = ErrorCode::from(got).message();
+    let err = res.unwrap_err();
+    let got = err.to_string();
     let expect = "ConnectionError:  source: tonic::status::Status: status: Cancelled, message: \"Timeout expired\", details: [], metadata: MetadataMap { headers: {} } source: transport error source: Timeout expired";
-    assert_eq!(got, expect);
+    assert_eq!(expect, got);
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_grpc_client_handshake_timeout() {
-    let srv_addr = start_grpc_server();
+    let (srv_addr, _shutdown, _task_handle) = start_grpc_server();
 
     // timeout will happen
     {
         // our mock grpc server's handshake impl will sleep 2secs.
         // see: GrpcServiceForTestImp.handshake
-        let timeout = Duration::from_secs(2);
+        let timeout = Duration::from_secs(1);
         let c = ConnectionFactory::create_rpc_channel(srv_addr.clone(), Some(timeout), None)
             .await
             .unwrap();
 
-        let (mut client, _once) = MetaGrpcClient::new_real_client(c);
+        let (mut client, _once) = MetaChannelManager::new_real_client(c);
 
         let res = MetaGrpcClient::handshake(
             &mut client,
@@ -93,7 +93,7 @@ async fn test_grpc_client_handshake_timeout() {
             .await
             .unwrap();
 
-        let (mut client, _once) = MetaGrpcClient::new_real_client(c);
+        let (mut client, _once) = MetaChannelManager::new_real_client(c);
 
         let res = MetaGrpcClient::handshake(
             &mut client,
@@ -106,4 +106,68 @@ async fn test_grpc_client_handshake_timeout() {
 
         assert!(res.is_ok());
     }
+}
+
+/// When server is down, client should try to reconnect.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_grpc_client_reconnect() -> anyhow::Result<()> {
+    let srv_addr = rand_local_addr();
+    let client = new_client(&srv_addr, Some(Duration::from_secs(3)))?;
+
+    // Send a Get request and return the first item.
+    async fn send_req(client: &Arc<ClientHandle>) -> Result<StreamItem, MetaError> {
+        let res: Result<BoxStream<StreamItem>, MetaError> =
+            client.request(Streamed(GetKVReq::new("foo"))).await;
+
+        let mut strm = res?;
+        let first = strm.next().await.unwrap();
+        let first = first?;
+        Ok(first)
+    }
+
+    info!("--- no server, client does not work");
+    {
+        let res = send_req(&client).await;
+        info!("--- expected error: {:?}", res.unwrap_err());
+    }
+
+    info!("--- start server, client works as expected");
+    let (shutdown, task_handle) = start_grpc_server_addr(&srv_addr);
+    {
+        let got = send_req(&client).await?;
+        info!("--- rpc got: {:?}", got);
+    }
+
+    info!("--- shutdown server, client can not connect");
+    {
+        shutdown.send(()).unwrap();
+        let r = task_handle.await;
+        info!("--- task_handle.await: {:?}", r);
+
+        let res = send_req(&client).await;
+        info!("--- expected error: {:?}", res.unwrap_err());
+    }
+
+    info!("--- restart server, client auto reconnect");
+    let (_shutdown, _task_handle) = start_grpc_server_addr(&srv_addr);
+    {
+        let got = send_req(&client).await?;
+        info!("--- rpc got: {:?}", got);
+    }
+
+    Ok(())
+}
+
+fn new_client(addr: impl ToString, timeout: Option<Duration>) -> anyhow::Result<Arc<ClientHandle>> {
+    let client = MetaGrpcClient::try_create(
+        vec![addr.to_string()],
+        "",
+        "",
+        timeout,
+        None,
+        Duration::from_secs(10),
+        None,
+    )?;
+
+    Ok(client)
 }

--- a/src/meta/client/tests/it/grpc_server.rs
+++ b/src/meta/client/tests/it/grpc_server.rs
@@ -17,6 +17,8 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use databend_common_base::base::tokio;
+use databend_common_base::base::tokio::sync::oneshot;
+use databend_common_base::base::tokio::task::JoinHandle;
 use databend_common_meta_client::to_digit_ver;
 use databend_common_meta_client::MIN_METASRV_SEMVER;
 use databend_common_meta_types::protobuf::meta_service_server::MetaService;
@@ -78,7 +80,9 @@ impl MetaService for GrpcServiceForTestImpl {
         &self,
         _request: Request<RaftRequest>,
     ) -> Result<Response<Self::KvReadV1Stream>, Status> {
-        unimplemented!()
+        let itm = StreamItem::new("kv_read_v1".to_string(), None);
+        let output = futures::stream::once(async { Ok(itm) });
+        Ok(Response::new(Box::pin(output)))
     }
 
     type ExportStream =
@@ -130,25 +134,40 @@ impl MetaService for GrpcServiceForTestImpl {
     }
 }
 
-pub fn start_grpc_server() -> String {
-    let service = GrpcServiceForTestImpl {};
-    start_grpc_server_with_service(service)
+/// Start a grpc server and return its address and task control handle.
+pub fn start_grpc_server() -> (String, oneshot::Sender<()>, JoinHandle<()>) {
+    let addr = rand_local_addr();
+    let (shutdown, task_handle) = start_grpc_server_addr(&addr);
+    (addr, shutdown, task_handle)
 }
 
-pub fn start_grpc_server_with_service(svc: impl MetaService) -> String {
-    let mut rng = rand::thread_rng();
-    let port = rng.gen_range(10000..20000);
-    let addr = format!("127.0.0.1:{}", port).parse().unwrap();
+/// Returns a shutdown tx and a task handle.
+pub fn start_grpc_server_addr(addr: impl ToString) -> (oneshot::Sender<()>, JoinHandle<()>) {
+    let addr = addr.to_string().parse().unwrap();
 
-    let svc = MetaServiceServer::new(svc);
+    let service = GrpcServiceForTestImpl {};
+    let svc = MetaServiceServer::new(service);
 
-    tokio::spawn(async move {
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let h = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve(addr)
+            .serve_with_shutdown(addr, async move {
+                let _ = rx.await;
+            })
             .await
             .unwrap();
     });
+
+    // Wait for server to be ready
     sleep(Duration::from_secs(1));
-    addr.to_string()
+
+    (tx, h)
+}
+
+pub fn rand_local_addr() -> String {
+    let mut rng = rand::thread_rng();
+    let port = rng.gen_range(10000..20000);
+    format!("127.0.0.1:{}", port)
 }

--- a/src/meta/kvapi/src/kvapi/message.rs
+++ b/src/meta/kvapi/src/kvapi/message.rs
@@ -23,14 +23,38 @@ pub struct GetKVReq {
     pub key: String,
 }
 
+impl GetKVReq {
+    pub fn new(key: impl ToString) -> Self {
+        Self {
+            key: key.to_string(),
+        }
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct MGetKVReq {
     pub keys: Vec<String>,
 }
 
+impl MGetKVReq {
+    pub fn new<S: ToString>(keys: impl IntoIterator<Item = S>) -> Self {
+        Self {
+            keys: keys.into_iter().map(|x| x.to_string()).collect(),
+        }
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ListKVReq {
     pub prefix: String,
+}
+
+impl ListKVReq {
+    pub fn new(prefix: impl ToString) -> Self {
+        Self {
+            prefix: prefix.to_string(),
+        }
+    }
 }
 
 pub type UpsertKVReply = Change<Vec<u8>>;

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_export.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_export.rs
@@ -56,7 +56,7 @@ async fn test_export() -> anyhow::Result<()> {
     // Wait for snapshot to be ready
     sleep(Duration::from_secs(2)).await;
 
-    let (mut grpc_client, _server_version) = client.make_client().await?;
+    let mut grpc_client = client.make_established_client().await?;
 
     let exported = grpc_client.export(tonic::Request::new(Empty {})).await?;
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_handshake.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_handshake.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use databend_common_grpc::ConnectionFactory;
 use databend_common_meta_client::from_digit_ver;
 use databend_common_meta_client::to_digit_ver;
+use databend_common_meta_client::MetaChannelManager;
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_client::METACLI_COMMIT_SEMVER;
 use databend_common_meta_client::MIN_METASRV_SEMVER;
@@ -54,7 +55,7 @@ async fn test_metasrv_handshake() -> anyhow::Result<()> {
 
     let c = ConnectionFactory::create_rpc_channel(addr, Some(Duration::from_millis(1000)), None)
         .await?;
-    let (mut client, _once) = MetaGrpcClient::new_real_client(c);
+    let (mut client, _once) = MetaChannelManager::new_real_client(c);
 
     info!("--- client has smaller ver than S.min_cli_ver");
     {

--- a/src/meta/types/src/errors/meta_client_errors.rs
+++ b/src/meta/types/src/errors/meta_client_errors.rs
@@ -27,10 +27,10 @@ pub enum MetaClientError {
     ConfigError(AnyError),
 
     #[error(transparent)]
-    NetworkError(MetaNetworkError),
+    NetworkError(#[from] MetaNetworkError),
 
     #[error(transparent)]
-    HandshakeError(MetaHandshakeError),
+    HandshakeError(#[from] MetaHandshakeError),
 }
 
 impl MetaClientError {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: move to meta-service handshake into poll

Before this commit the connection pool stores raw connections `Channel`.
Before using one, the client handshake with the server everytime using a
channel.

In this commit, the handshake is moved into the connection pool and the
pool stores `MetaServiceClient` that already finished the handshake
phase.

Thus the client no longer needs to send a handshake RPC before using an
in-pool connection.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14161)
<!-- Reviewable:end -->
