### PR TITLE
refactor(planner): Correct usage of exchange operator

### DIFF
--- a/src/query/service/src/api/rpc/exchange/data_exchange.rs
+++ b/src/query/service/src/api/rpc/exchange/data_exchange.rs
@@ -29,14 +29,6 @@ impl DataExchange {
             DataExchange::ShuffleDataExchange(exchange) => exchange.destination_ids.clone(),
         }
     }
-
-    pub fn from_multiple_nodes(&self) -> bool {
-        match self {
-            DataExchange::Merge(_) => true,
-            DataExchange::ShuffleDataExchange(_) => true,
-            DataExchange::Broadcast(exchange) => exchange.from_multiple_nodes,
-        }
-    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -77,15 +69,11 @@ impl MergeExchange {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BroadcastExchange {
-    pub from_multiple_nodes: bool,
     pub destination_ids: Vec<String>,
 }
 
 impl BroadcastExchange {
-    pub fn create(from_multiple_nodes: bool, destination_ids: Vec<String>) -> DataExchange {
-        DataExchange::Broadcast(BroadcastExchange {
-            from_multiple_nodes,
-            destination_ids,
-        })
+    pub fn create(destination_ids: Vec<String>) -> DataExchange {
+        DataExchange::Broadcast(BroadcastExchange { destination_ids })
     }
 }

--- a/src/query/service/src/api/rpc/exchange/exchange_manager.rs
+++ b/src/query/service/src/api/rpc/exchange/exchange_manager.rs
@@ -660,14 +660,6 @@ impl QueryCoordinator {
             )?;
             let mut build_res = fragment_coordinator.pipeline_build_res.unwrap();
 
-            let data_exchange = fragment_coordinator.data_exchange.as_ref().unwrap();
-
-            if !data_exchange.from_multiple_nodes() {
-                return Err(ErrorCode::Unimplemented(
-                    "Exchange source and no from multiple nodes is unimplemented.",
-                ));
-            }
-
             // Add exchange data transform.
 
             ExchangeTransform::via(

--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -116,6 +116,7 @@ impl CopyIntoTableInterpreter {
         &self,
         plan: &CopyIntoTablePlan,
     ) -> Result<(PhysicalPlan, Vec<StageFileInfo>, Vec<UpdateStreamMetaReq>)> {
+        let mut next_plan_id = 0;
         let to_table = self
             .ctx
             .get_table(
@@ -131,6 +132,7 @@ impl CopyIntoTableInterpreter {
                 self.build_query(query).await?;
             seq = update_stream_meta;
             let plan_query = select_interpreter.build_physical_plan().await?;
+            next_plan_id = plan_query.get_id() + 1;
             let result_columns = select_interpreter.get_result_columns();
             CopyIntoTableSource::Query(Box::new(QuerySource {
                 plan: plan_query,
@@ -159,6 +161,7 @@ impl CopyIntoTableInterpreter {
         };
 
         let mut root = PhysicalPlan::CopyIntoTable(Box::new(CopyIntoTable {
+            plan_id: next_plan_id,
             catalog_info: plan.catalog_info.clone(),
             required_values_schema: plan.required_values_schema.clone(),
             values_consts: plan.values_consts.clone(),
@@ -172,9 +175,10 @@ impl CopyIntoTableInterpreter {
             files: files.clone(),
             source,
         }));
+        next_plan_id += 1;
         if plan.enable_distributed {
             root = PhysicalPlan::Exchange(Exchange {
-                plan_id: 0,
+                plan_id: next_plan_id,
                 input: Box::new(root),
                 kind: FragmentKind::Merge,
                 keys: Vec::new(),

--- a/src/query/service/src/schedulers/fragments/fragmenter.rs
+++ b/src/query/service/src/schedulers/fragments/fragmenter.rs
@@ -25,7 +25,6 @@ use databend_common_sql::executor::physical_plans::ExchangeSink;
 use databend_common_sql::executor::physical_plans::ExchangeSource;
 use databend_common_sql::executor::physical_plans::FragmentKind;
 use databend_common_sql::executor::physical_plans::HashJoin;
-use databend_common_sql::executor::physical_plans::MergeInto;
 use databend_common_sql::executor::physical_plans::QuerySource;
 use databend_common_sql::executor::physical_plans::ReclusterSource;
 use databend_common_sql::executor::physical_plans::ReplaceInto;
@@ -153,15 +152,6 @@ impl PhysicalPlanReplacer for Fragmenter {
         Ok(PhysicalPlan::TableScan(plan.clone()))
     }
 
-    fn replace_merge_into(&mut self, plan: &MergeInto) -> Result<PhysicalPlan> {
-        let input = self.replace(&plan.input)?;
-        self.state = State::SelectLeaf;
-        Ok(PhysicalPlan::MergeInto(Box::new(MergeInto {
-            input: Box::new(input),
-            ..plan.clone()
-        })))
-    }
-
     fn replace_replace_into(&mut self, plan: &ReplaceInto) -> Result<PhysicalPlan> {
         let input = self.replace(&plan.input)?;
         self.state = State::ReplaceInto;
@@ -172,7 +162,7 @@ impl PhysicalPlanReplacer for Fragmenter {
         })))
     }
 
-    //  TODO(Sky): remove rebudant code
+    //  TODO(Sky): remove redundant code
     fn replace_copy_into_table(&mut self, plan: &CopyIntoTable) -> Result<PhysicalPlan> {
         match &plan.source {
             CopyIntoTableSource::Stage(_) => {

--- a/src/query/service/src/schedulers/fragments/fragmenter.rs
+++ b/src/query/service/src/schedulers/fragments/fragmenter.rs
@@ -212,11 +212,11 @@ impl PhysicalPlanReplacer for Fragmenter {
 
     fn replace_hash_join(&mut self, plan: &HashJoin) -> Result<PhysicalPlan> {
         let mut fragments = vec![];
-        let probe_input = self.replace(plan.probe.as_ref())?;
-
-        // Consume current fragments to prevent them being consumed by `build_input`.
-        fragments.append(&mut self.fragments);
         let build_input = self.replace(plan.build.as_ref())?;
+
+        // Consume current fragments to prevent them being consumed by `probe_input`.
+        fragments.append(&mut self.fragments);
+        let probe_input = self.replace(plan.probe.as_ref())?;
 
         fragments.append(&mut self.fragments);
         self.fragments = fragments;

--- a/src/query/service/src/schedulers/fragments/mod.rs
+++ b/src/query/service/src/schedulers/fragments/mod.rs
@@ -19,7 +19,6 @@ mod query_fragment_actions_display;
 
 pub use fragmenter::Fragmenter;
 pub use plan_fragment::PlanFragment;
-pub use plan_fragment::ReplaceReadSource;
 pub use query_fragment_actions::QueryFragmentAction;
 pub use query_fragment_actions::QueryFragmentActions;
 pub use query_fragment_actions::QueryFragmentsActions;

--- a/src/query/sql/src/executor/physical_plans/physical_copy_into.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_copy_into.rs
@@ -29,6 +29,8 @@ use crate::ColumnBinding;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct CopyIntoTable {
+    pub plan_id: u32,
+
     pub catalog_info: CatalogInfo,
     pub required_values_schema: DataSchemaRef,
     pub values_consts: Vec<Scalar>,

--- a/src/query/sql/src/executor/physical_plans/physical_exchange.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_exchange.rs
@@ -63,7 +63,6 @@ impl PhysicalPlanBuilder {
         let mut keys = vec![];
         let mut allow_adjust_parallelism = true;
         let kind = match exchange {
-            crate::plans::Exchange::Random => FragmentKind::Init,
             crate::plans::Exchange::Hash(scalars) => {
                 for scalar in scalars {
                     let expr = scalar

--- a/src/query/sql/src/planner/format/display_rel_operator.rs
+++ b/src/query/sql/src/planner/format/display_rel_operator.rs
@@ -185,9 +185,6 @@ pub fn format_exchange(
     op: &Exchange,
 ) -> std::fmt::Result {
     match op {
-        Exchange::Random => {
-            write!(f, "Exchange(Random)")
-        }
         Exchange::Hash(_) => {
             write!(f, "Exchange(Hash)")
         }

--- a/src/query/sql/src/planner/optimizer/mod.rs
+++ b/src/query/sql/src/planner/optimizer/mod.rs
@@ -51,3 +51,4 @@ pub use rule::DEFAULT_REWRITE_RULES;
 pub use rule::RESIDUAL_RULES;
 pub use s_expr::get_udf_names;
 pub use s_expr::SExpr;
+pub use util::contains_local_table_scan;

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -233,6 +233,7 @@ pub fn optimize(opt_ctx: OptimizerContext, plan: Plan) -> Result<Plan> {
 
             // try to optimize distributed join
             if opt_ctx.enable_distributed_optimization
+                && !contains_local_table_scan(&join_sexpr, &opt_ctx.metadata)
                 && opt_ctx
                     .table_ctx
                     .get_settings()

--- a/src/query/sql/src/planner/optimizer/property/enforcer.rs
+++ b/src/query/sql/src/planner/optimizer/property/enforcer.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 
 use crate::optimizer::property::Distribution;
@@ -22,7 +23,6 @@ use crate::optimizer::RelExpr;
 use crate::optimizer::RequiredProperty;
 use crate::optimizer::SExpr;
 use crate::plans::Exchange;
-use crate::plans::RelOperator;
 
 /// Require and enforce physical property from a physical `SExpr`
 pub fn require_property(
@@ -46,54 +46,10 @@ pub fn require_property(
 
     let rel_expr = RelExpr::with_s_expr(&optimized_expr);
     let mut children = Vec::with_capacity(s_expr.arity());
-    let mut plan = optimized_expr.plan.as_ref().clone();
+    let plan = optimized_expr.plan.as_ref().clone();
     for index in 0..optimized_expr.arity() {
         let required = rel_expr.compute_required_prop_child(ctx.clone(), index, required)?;
         let physical = rel_expr.derive_physical_prop_child(index)?;
-        if let RelOperator::Join(join) = &mut plan {
-            if index == 0 && required.distribution == Distribution::Broadcast {
-                // If the child is join probe side and join type is broadcast join
-                // We should wrap the child with Random exchange to make it repartition to all nodes
-                if optimized_expr
-                    .child(0)?
-                    .children()
-                    .iter()
-                    .any(|v| check_partition(v.as_ref()))
-                {
-                    children.push(Arc::new(optimized_expr.child(index)?.clone()));
-                    continue;
-                }
-                let enforced_child =
-                    enforce_property(optimized_expr.child(index)?, &RequiredProperty {
-                        distribution: Distribution::Any,
-                    })?;
-                children.push(Arc::new(enforced_child));
-                continue;
-            } else if index == 1 && required.distribution == Distribution::Broadcast {
-                join.broadcast = true;
-                // If the child is join build side and join type is broadcast join
-                // We should wrap the child with Broadcast exchange to make it available to all nodes.
-                let enforced_child = enforce_property(optimized_expr.child(index)?, &required)?;
-                children.push(Arc::new(enforced_child));
-                continue;
-            }
-        }
-        if let RelOperator::UnionAll(_) = &plan {
-            // Wrap the child with Random exchange to make it partition to all nodes
-            // Check if exists `Merge` in child, if not exits, wrap it with `Exchange`
-            if optimized_expr
-                .children()
-                .iter()
-                .all(|child| !check_merge(child))
-            {
-                let enforced_child =
-                    enforce_property(optimized_expr.child(index)?, &RequiredProperty {
-                        distribution: Distribution::Any,
-                    })?;
-                children.push(Arc::new(enforced_child));
-                continue;
-            }
-        }
 
         if required.satisfied_by(&physical) {
             children.push(Arc::new(optimized_expr.child(index)?.clone()));
@@ -116,11 +72,6 @@ fn enforce_property(s_expr: &SExpr, required: &RequiredProperty) -> Result<SExpr
 
 pub fn enforce_distribution(distribution: &Distribution, s_expr: &SExpr) -> Result<SExpr> {
     match distribution {
-        Distribution::Random | Distribution::Any => Ok(SExpr::create_unary(
-            Arc::new(Exchange::Random.into()),
-            Arc::new(s_expr.clone()),
-        )),
-
         Distribution::Serial => Ok(SExpr::create_unary(
             Arc::new(Exchange::Merge.into()),
             Arc::new(s_expr.clone()),
@@ -135,37 +86,9 @@ pub fn enforce_distribution(distribution: &Distribution, s_expr: &SExpr) -> Resu
             Arc::new(Exchange::Hash(hash_keys.clone()).into()),
             Arc::new(s_expr.clone()),
         )),
-    }
-}
 
-fn check_merge(s_expr: &SExpr) -> bool {
-    // Todo: support cluster for materialized cte
-    if let RelOperator::CteScan(_) = s_expr.plan.as_ref() {
-        return true;
+        Distribution::Random | Distribution::Any => Err(ErrorCode::Internal(
+            "Cannot enforce random or any distribution",
+        )),
     }
-    if let RelOperator::Exchange(op) = s_expr.plan.as_ref() {
-        if op == &Exchange::Merge {
-            return true;
-        }
-    }
-    for child in s_expr.children() {
-        if check_merge(child) {
-            return true;
-        }
-    }
-    false
-}
-
-fn check_partition(s_expr: &SExpr) -> bool {
-    if let RelOperator::Exchange(op) = s_expr.plan.as_ref() {
-        if matches!(op, Exchange::Random | Exchange::Hash(_)) {
-            return true;
-        }
-    }
-    for child in s_expr.children() {
-        if check_partition(child) {
-            return true;
-        }
-    }
-    false
 }

--- a/src/query/sql/src/planner/plans/exchange.rs
+++ b/src/query/sql/src/planner/plans/exchange.rs
@@ -29,7 +29,6 @@ use crate::plans::ScalarExpr;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Exchange {
-    Random,
     Hash(Vec<ScalarExpr>),
     Broadcast,
     Merge,
@@ -48,7 +47,6 @@ impl Operator for Exchange {
     fn derive_physical_prop(&self, _rel_expr: &RelExpr) -> Result<PhysicalProperty> {
         Ok(PhysicalProperty {
             distribution: match self {
-                Exchange::Random => Distribution::Random,
                 Exchange::Hash(hash_keys) => Distribution::Hash(hash_keys.clone()),
                 Exchange::Broadcast => Distribution::Broadcast,
                 Exchange::Merge => Distribution::Serial,

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -509,7 +509,11 @@ impl Operator for Join {
             // where n is the number of servers in the cluster.
             let broadcast_join_threshold = (ctx.get_cluster().nodes.len() - 1) as f64;
             if right_stat_info.cardinality * broadcast_join_threshold < left_stat_info.cardinality {
-                required.distribution = Distribution::Broadcast;
+                if child_index == 1 {
+                    required.distribution = Distribution::Broadcast;
+                } else {
+                    required.distribution = Distribution::Any;
+                }
                 return Ok(required);
             }
         }

--- a/src/query/sql/src/planner/plans/union_all.rs
+++ b/src/query/sql/src/planner/plans/union_all.rs
@@ -124,17 +124,21 @@ impl Operator for UnionAll {
         _child_index: usize,
         required: &RequiredProperty,
     ) -> Result<RequiredProperty> {
-        let mut required = required.clone();
+        let required = required.clone();
         let left_physical_prop = rel_expr.derive_physical_prop_child(0)?;
         let right_physical_prop = rel_expr.derive_physical_prop_child(1)?;
         if left_physical_prop.distribution == Distribution::Serial
             || right_physical_prop.distribution == Distribution::Serial
+            || required.distribution == Distribution::Serial
         {
-            required.distribution = Distribution::Serial;
-        } else if left_physical_prop.distribution == right_physical_prop.distribution {
-            required.distribution = left_physical_prop.distribution;
+            Ok(RequiredProperty {
+                distribution: Distribution::Serial,
+            })
+        } else {
+            Ok(RequiredProperty {
+                distribution: Distribution::Random,
+            })
         }
-        Ok(required)
     }
 
     fn compute_required_prop_children(

--- a/tests/sqllogictests/suites/crdb/limit.test
+++ b/tests/sqllogictests/suites/crdb/limit.test
@@ -152,7 +152,7 @@ SELECT k, v FROM t ORDER BY k LIMIT 3 OFFSET 3
 6 -36
 
 query I
-SELECT * FROM (select * from numbers(10) a LIMIT 5) OFFSET 3
+SELECT * FROM (select * from numbers(10) a ORDER BY number LIMIT 5) OFFSET 3
 ----
 3
 4

--- a/tests/sqllogictests/suites/mode/cluster/distributed_compact.sql.test
+++ b/tests/sqllogictests/suites/mode/cluster/distributed_compact.sql.test
@@ -25,8 +25,8 @@ statement ok
 alter table t_compact_0 set options(row_per_block=10,block_per_segment=10)
 
 # lazy compact
-# The number of compact segments task is greater than the number of cluster nodes, 
-# so will build compact blocks task during pipeline init. 
+# The number of compact segments task is greater than the number of cluster nodes,
+# so will build compact blocks task during pipeline init.
 # The explain pipeline optimize contain bug (ISSUE-12597), so comment.
 # query T
 # explain pipeline optimize table t_compact_0 compact
@@ -57,7 +57,7 @@ select count(),sum(a) from t_compact_0
 statement ok
 alter table t_compact_0 cluster by(abs(a))
 
-# test compact and recluster 
+# test compact and recluster
 statement ok
 optimize table t_compact_0 compact
 
@@ -91,7 +91,7 @@ statement ok
 alter table t_compact_1 set options(row_per_block=10,block_per_segment=15)
 
 # nolazy compact
-# The number of compact segments task is less than the number of cluster nodes, 
+# The number of compact segments task is less than the number of cluster nodes,
 # so will build compact blocks task before execute pipeline
 # query T
 # explain pipeline optimize table t_compact_1 compact

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -297,3 +297,322 @@ Fragment 4:
 
 statement ok
 set prefer_broadcast_join = 1
+
+query T
+explain
+with
+t1 as (select number as a from numbers(10)),
+t2 as (select number as a from numbers(1000)),
+t3 as (select number as a from numbers(10))
+select sum(a) from (
+select t1.a from t1, t2 where t1.a = t2.a
+union all
+select t1.a from t1, t3 where t1.a = t3.a
+) t
+----
+AggregateFinal
+├── output columns: [sum(a) (#4)]
+├── group by: []
+├── aggregate functions: [sum(number)]
+├── estimated rows: 1.00
+└── Exchange
+    ├── output columns: [sum(a) (#4)]
+    ├── exchange type: Merge
+    └── AggregatePartial
+        ├── output columns: [sum(a) (#4)]
+        ├── group by: []
+        ├── aggregate functions: [sum(number)]
+        ├── estimated rows: 1.00
+        └── UnionAll
+            ├── output columns: [numbers.number (#0)]
+            ├── estimated rows: 10100.00
+            ├── HashJoin
+            │   ├── output columns: [numbers.number (#0)]
+            │   ├── join type: INNER
+            │   ├── build keys: [t1.a (#0)]
+            │   ├── probe keys: [t2.a (#1)]
+            │   ├── filters: []
+            │   ├── estimated rows: 10000.00
+            │   ├── Exchange(Build)
+            │   │   ├── output columns: [numbers.number (#0)]
+            │   │   ├── exchange type: Broadcast
+            │   │   └── TableScan
+            │   │       ├── table: default.system.numbers
+            │   │       ├── output columns: [number (#0)]
+            │   │       ├── read rows: 10
+            │   │       ├── read bytes: 80
+            │   │       ├── partitions total: 1
+            │   │       ├── partitions scanned: 1
+            │   │       ├── push downs: [filters: [], limit: NONE]
+            │   │       └── estimated rows: 10.00
+            │   └── TableScan(Probe)
+            │       ├── table: default.system.numbers
+            │       ├── output columns: [number (#1)]
+            │       ├── read rows: 1000
+            │       ├── read bytes: 8000
+            │       ├── partitions total: 1
+            │       ├── partitions scanned: 1
+            │       ├── push downs: [filters: [], limit: NONE]
+            │       └── estimated rows: 1000.00
+            └── HashJoin
+                ├── output columns: [numbers.number (#2)]
+                ├── join type: INNER
+                ├── build keys: [t3.a (#3)]
+                ├── probe keys: [t1.a (#2)]
+                ├── filters: []
+                ├── estimated rows: 100.00
+                ├── Exchange(Build)
+                │   ├── output columns: [numbers.number (#3)]
+                │   ├── exchange type: Hash(t3.a (#3))
+                │   └── TableScan
+                │       ├── table: default.system.numbers
+                │       ├── output columns: [number (#3)]
+                │       ├── read rows: 10
+                │       ├── read bytes: 80
+                │       ├── partitions total: 1
+                │       ├── partitions scanned: 1
+                │       ├── push downs: [filters: [], limit: NONE]
+                │       └── estimated rows: 10.00
+                └── Exchange(Probe)
+                    ├── output columns: [numbers.number (#2)]
+                    ├── exchange type: Hash(t1.a (#2))
+                    └── TableScan
+                        ├── table: default.system.numbers
+                        ├── output columns: [number (#2)]
+                        ├── read rows: 10
+                        ├── read bytes: 80
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 10.00
+
+
+query T
+explain
+with
+t1 as (select number as a from numbers(10)),
+t2 as (select number as a from numbers(1000)),
+t3 as (select number as a from numbers(10))
+select sum(a) from (
+select t1.a from t1, t2 where t1.a = t2.a
+union all
+select sum(t1.a) from t1, t3 where t1.a = t3.a
+) t
+----
+AggregateFinal
+├── output columns: [sum(a) (#6)]
+├── group by: []
+├── aggregate functions: [sum(a)]
+├── estimated rows: 1.00
+└── AggregatePartial
+    ├── output columns: [sum(a) (#6)]
+    ├── group by: []
+    ├── aggregate functions: [sum(a)]
+    ├── estimated rows: 1.00
+    └── UnionAll
+        ├── output columns: [a (#5)]
+        ├── estimated rows: 10001.00
+        ├── Exchange
+        │   ├── output columns: [a (#5)]
+        │   ├── exchange type: Merge
+        │   └── EvalScalar
+        │       ├── output columns: [a (#5)]
+        │       ├── expressions: [CAST(t1.a (#0) AS UInt64 NULL)]
+        │       ├── estimated rows: 10000.00
+        │       └── HashJoin
+        │           ├── output columns: [numbers.number (#0)]
+        │           ├── join type: INNER
+        │           ├── build keys: [t1.a (#0)]
+        │           ├── probe keys: [t2.a (#1)]
+        │           ├── filters: []
+        │           ├── estimated rows: 10000.00
+        │           ├── Exchange(Build)
+        │           │   ├── output columns: [numbers.number (#0)]
+        │           │   ├── exchange type: Broadcast
+        │           │   └── TableScan
+        │           │       ├── table: default.system.numbers
+        │           │       ├── output columns: [number (#0)]
+        │           │       ├── read rows: 10
+        │           │       ├── read bytes: 80
+        │           │       ├── partitions total: 1
+        │           │       ├── partitions scanned: 1
+        │           │       ├── push downs: [filters: [], limit: NONE]
+        │           │       └── estimated rows: 10.00
+        │           └── TableScan(Probe)
+        │               ├── table: default.system.numbers
+        │               ├── output columns: [number (#1)]
+        │               ├── read rows: 1000
+        │               ├── read bytes: 8000
+        │               ├── partitions total: 1
+        │               ├── partitions scanned: 1
+        │               ├── push downs: [filters: [], limit: NONE]
+        │               └── estimated rows: 1000.00
+        └── AggregateFinal
+            ├── output columns: [sum(t1.a) (#4)]
+            ├── group by: []
+            ├── aggregate functions: [sum(number)]
+            ├── estimated rows: 1.00
+            └── Exchange
+                ├── output columns: [sum(t1.a) (#4)]
+                ├── exchange type: Merge
+                └── AggregatePartial
+                    ├── output columns: [sum(t1.a) (#4)]
+                    ├── group by: []
+                    ├── aggregate functions: [sum(number)]
+                    ├── estimated rows: 1.00
+                    └── HashJoin
+                        ├── output columns: [numbers.number (#2)]
+                        ├── join type: INNER
+                        ├── build keys: [t3.a (#3)]
+                        ├── probe keys: [t1.a (#2)]
+                        ├── filters: []
+                        ├── estimated rows: 100.00
+                        ├── Exchange(Build)
+                        │   ├── output columns: [numbers.number (#3)]
+                        │   ├── exchange type: Hash(t3.a (#3))
+                        │   └── TableScan
+                        │       ├── table: default.system.numbers
+                        │       ├── output columns: [number (#3)]
+                        │       ├── read rows: 10
+                        │       ├── read bytes: 80
+                        │       ├── partitions total: 1
+                        │       ├── partitions scanned: 1
+                        │       ├── push downs: [filters: [], limit: NONE]
+                        │       └── estimated rows: 10.00
+                        └── Exchange(Probe)
+                            ├── output columns: [numbers.number (#2)]
+                            ├── exchange type: Hash(t1.a (#2))
+                            └── TableScan
+                                ├── table: default.system.numbers
+                                ├── output columns: [number (#2)]
+                                ├── read rows: 10
+                                ├── read bytes: 80
+                                ├── partitions total: 1
+                                ├── partitions scanned: 1
+                                ├── push downs: [filters: [], limit: NONE]
+                                └── estimated rows: 10.00
+
+query T
+explain
+with
+t1 as (select number as a from numbers(10)),
+t2 as (select number as a from numbers(1000)),
+t3 as (select number as a from numbers(10))
+select sum(a) from (
+select t1.a from t1, t2 where t1.a = t2.a
+union all
+select t1.a from t1
+) t
+----
+AggregateFinal
+├── output columns: [sum(a) (#3)]
+├── group by: []
+├── aggregate functions: [sum(number)]
+├── estimated rows: 1.00
+└── Exchange
+    ├── output columns: [sum(a) (#3)]
+    ├── exchange type: Merge
+    └── AggregatePartial
+        ├── output columns: [sum(a) (#3)]
+        ├── group by: []
+        ├── aggregate functions: [sum(number)]
+        ├── estimated rows: 1.00
+        └── UnionAll
+            ├── output columns: [numbers.number (#0)]
+            ├── estimated rows: 10010.00
+            ├── HashJoin
+            │   ├── output columns: [numbers.number (#0)]
+            │   ├── join type: INNER
+            │   ├── build keys: [t1.a (#0)]
+            │   ├── probe keys: [t2.a (#1)]
+            │   ├── filters: []
+            │   ├── estimated rows: 10000.00
+            │   ├── Exchange(Build)
+            │   │   ├── output columns: [numbers.number (#0)]
+            │   │   ├── exchange type: Broadcast
+            │   │   └── TableScan
+            │   │       ├── table: default.system.numbers
+            │   │       ├── output columns: [number (#0)]
+            │   │       ├── read rows: 10
+            │   │       ├── read bytes: 80
+            │   │       ├── partitions total: 1
+            │   │       ├── partitions scanned: 1
+            │   │       ├── push downs: [filters: [], limit: NONE]
+            │   │       └── estimated rows: 10.00
+            │   └── TableScan(Probe)
+            │       ├── table: default.system.numbers
+            │       ├── output columns: [number (#1)]
+            │       ├── read rows: 1000
+            │       ├── read bytes: 8000
+            │       ├── partitions total: 1
+            │       ├── partitions scanned: 1
+            │       ├── push downs: [filters: [], limit: NONE]
+            │       └── estimated rows: 1000.00
+            └── TableScan
+                ├── table: default.system.numbers
+                ├── output columns: [number (#2)]
+                ├── read rows: 10
+                ├── read bytes: 80
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                ├── push downs: [filters: [], limit: NONE]
+                └── estimated rows: 10.00
+
+query T
+explain
+with
+t1 as (select number as a from numbers(10)),
+t2 as (select number as a from numbers(1000)),
+t3 as (select number as a from numbers(10))
+select * from t1, t2, t3
+----
+Exchange
+├── output columns: [numbers.number (#1), numbers.number (#0), numbers.number (#2)]
+├── exchange type: Merge
+└── HashJoin
+    ├── output columns: [numbers.number (#1), numbers.number (#0), numbers.number (#2)]
+    ├── join type: CROSS
+    ├── build keys: []
+    ├── probe keys: []
+    ├── filters: []
+    ├── estimated rows: 100000.00
+    ├── Exchange(Build)
+    │   ├── output columns: [numbers.number (#2)]
+    │   ├── exchange type: Broadcast
+    │   └── TableScan
+    │       ├── table: default.system.numbers
+    │       ├── output columns: [number (#2)]
+    │       ├── read rows: 10
+    │       ├── read bytes: 80
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       ├── push downs: [filters: [], limit: NONE]
+    │       └── estimated rows: 10.00
+    └── HashJoin(Probe)
+        ├── output columns: [numbers.number (#1), numbers.number (#0)]
+        ├── join type: CROSS
+        ├── build keys: []
+        ├── probe keys: []
+        ├── filters: []
+        ├── estimated rows: 10000.00
+        ├── Exchange(Build)
+        │   ├── output columns: [numbers.number (#0)]
+        │   ├── exchange type: Broadcast
+        │   └── TableScan
+        │       ├── table: default.system.numbers
+        │       ├── output columns: [number (#0)]
+        │       ├── read rows: 10
+        │       ├── read bytes: 80
+        │       ├── partitions total: 1
+        │       ├── partitions scanned: 1
+        │       ├── push downs: [filters: [], limit: NONE]
+        │       └── estimated rows: 10.00
+        └── TableScan(Probe)
+            ├── table: default.system.numbers
+            ├── output columns: [number (#1)]
+            ├── read rows: 1000
+            ├── read bytes: 8000
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 1000.00

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -220,24 +220,8 @@ explain fragments select * from (select sum(number) as number from numbers(1) gr
 Fragment 0:
   DataExchange: Shuffle
     ExchangeSink
-    ├── output columns: [t1.number (#3)]
-    ├── destination fragment: [3]
-    └── TableScan
-        ├── table: default.system.numbers
-        ├── output columns: [number (#3)]
-        ├── read rows: 2
-        ├── read bytes: 16
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 2.00
-(empty)
-(empty)
-Fragment 1:
-  DataExchange: Shuffle
-    ExchangeSink
     ├── output columns: [sum(number) (#2), #_group_by_key]
-    ├── destination fragment: [2]
+    ├── destination fragment: [1]
     └── AggregatePartial
         ├── output columns: [sum(number) (#2), #_group_by_key]
         ├── group by: [number]
@@ -254,7 +238,7 @@ Fragment 1:
             └── estimated rows: 1.00
 (empty)
 (empty)
-Fragment 2:
+Fragment 1:
   DataExchange: Shuffle
     ExchangeSink
     ├── output columns: [sum(number) (#2), numbers.number (#0)]
@@ -266,7 +250,23 @@ Fragment 2:
         ├── estimated rows: 1.00
         └── ExchangeSource
             ├── output columns: [sum(number) (#2), #_group_by_key]
-            └── source fragment: [1]
+            └── source fragment: [0]
+(empty)
+(empty)
+Fragment 2:
+  DataExchange: Shuffle
+    ExchangeSink
+    ├── output columns: [t1.number (#3)]
+    ├── destination fragment: [3]
+    └── TableScan
+        ├── table: default.system.numbers
+        ├── output columns: [number (#3)]
+        ├── read rows: 2
+        ├── read bytes: 16
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 2.00
 (empty)
 (empty)
 Fragment 3:
@@ -283,10 +283,10 @@ Fragment 3:
         ├── estimated rows: 2.00
         ├── ExchangeSource(Build)
         │   ├── output columns: [sum(number) (#2), numbers.number (#0)]
-        │   └── source fragment: [2]
+        │   └── source fragment: [1]
         └── ExchangeSource(Probe)
             ├── output columns: [t1.number (#3)]
-            └── source fragment: [0]
+            └── source fragment: [2]
 (empty)
 (empty)
 Fragment 4:

--- a/tests/sqllogictests/suites/mode/standalone/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/limit.test
@@ -21,4 +21,3 @@ drop table t1;
 
 statement ok
 drop table t2;
-

--- a/tests/sqllogictests/suites/query/union.test
+++ b/tests/sqllogictests/suites/query/union.test
@@ -184,3 +184,55 @@ select 1 as c union all select 3.3::Double;
 ----
 1.0
 3.3
+
+query I
+with
+t1 as (select number as a from numbers(10)),
+t2 as (select number as a from numbers(1000)),
+t3 as (select number as a from numbers(10))
+select sum(a) from (
+select t1.a from t1, t2 where t1.a = t2.a
+union all
+select t1.a from t1, t3 where t1.a = t3.a
+) t
+----
+90
+
+query I
+with
+t1 as (select number as a from numbers(10)),
+t2 as (select number as a from numbers(1000)),
+t3 as (select number as a from numbers(10))
+select sum(a) from (
+select t1.a from t1, t2 where t1.a = t2.a
+union all
+select t1.a from t1
+) t
+----
+90
+
+query I
+with
+t1 as (select number as a from numbers(10)),
+t2 as (select number as a from numbers(1000)),
+t3 as (select number as a from numbers(10))
+select sum(a) from (
+select t1.a from t1, t2 where t1.a = t2.a
+union all
+select sum(t1.a) from t1, t3 where t1.a = t3.a
+) t
+----
+90
+
+query I
+with
+t1 as (select number as a from numbers(10)),
+t2 as (select number as a from numbers(1000)),
+t3 as (select number as a from numbers(10))
+select sum(a) from (
+select sum(t1.a) as a from t1, t3 where t1.a = t3.a
+union all
+select t1.a from t1, t2 where t1.a = t2.a
+) t
+----
+90


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This pull request involves the restructuring of logic related to the exchange operator and random distribution.

In a cluster environment, where table data is partitioned across query nodes based on a specified scheme, each `TableScan` operator can inherently offer the `Distribution::Random` property. Consequently, there's no longer a necessity for an `Exchange::Random` operator to consistently enforce the `Distribution::Random` property.

Following the implementation of this pull request, the union-all and broadcast join operators will no longer be required to enforce the `Distribution::Random` for their respective children.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14163)
<!-- Reviewable:end -->
