### PR TITLE
feat: add stream_status http api

### DIFF
--- a/src/query/service/src/api/http/v1/mod.rs
+++ b/src/query/service/src/api/http/v1/mod.rs
@@ -18,4 +18,5 @@ pub mod config;
 pub mod instance_status;
 pub mod logs;
 pub mod processes;
+pub mod stream_status;
 pub mod tenant_tables;

--- a/src/query/service/src/api/http/v1/stream_status.rs
+++ b/src/query/service/src/api/http/v1/stream_status.rs
@@ -1,0 +1,75 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_catalog::catalog::CatalogManager;
+use databend_common_exception::Result;
+use databend_common_storages_fuse::TableContext;
+use databend_common_storages_stream::stream_table::StreamTable;
+use log::debug;
+use poem::web::Json;
+use poem::web::Path;
+use poem::web::Query;
+use poem::IntoResponse;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StreamStatusQuery {
+    pub database: Option<String>,
+    pub stream_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StreamStatusResponse {
+    has_data: bool,
+    params: StreamStatusQuery,
+}
+
+#[async_backtrace::framed]
+async fn check_stream_status(
+    tenant: &str,
+    params: Query<StreamStatusQuery>,
+) -> Result<StreamStatusResponse> {
+    let catalog = CatalogManager::instance().get_default_catalog()?;
+    let db_name = params.database.clone().unwrap_or("default".to_string());
+    let tbl = catalog
+        .get_table(tenant, &db_name, &params.stream_name)
+        .await?;
+    let stream = StreamTable::try_from_table(tbl.as_ref())?;
+    let (base_table_ident, _) = catalog
+        .get_table_meta_by_id(stream.source_table_id())
+        .await?;
+    Ok(StreamStatusResponse {
+        has_data: base_table_ident.seq != stream.offset(),
+        params: params.0,
+    })
+}
+
+// This handler returns the status of a stream. It's only enabled in management mode.
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn stream_status_handler(
+    Path(tenant): Path<String>,
+    params: Query<StreamStatusQuery>,
+) -> poem::Result<impl IntoResponse> {
+    debug!(
+        "check_stream_stauts: tenant: {}, params: {:?}",
+        tenant, params
+    );
+
+    let resp = check_stream_status(&tenant, params)
+        .await
+        .map_err(poem::error::InternalServerError)?;
+    Ok(Json(resp))
+}

--- a/src/query/service/src/api/http/v1/stream_status.rs
+++ b/src/query/service/src/api/http/v1/stream_status.rs
@@ -14,7 +14,6 @@
 
 use databend_common_catalog::catalog::CatalogManager;
 use databend_common_exception::Result;
-use databend_common_storages_fuse::TableContext;
 use databend_common_storages_stream::stream_table::StreamTable;
 use log::debug;
 use poem::web::Json;

--- a/src/query/service/src/api/http_service.rs
+++ b/src/query/service/src/api/http_service.rs
@@ -80,10 +80,15 @@ impl HttpService {
                 get(super::http::v1::background_tasks::list_background_tasks),
             );
         if self.config.query.management_mode {
-            route = route.at(
-                "/v1/tenants/:tenant/tables",
-                get(super::http::v1::tenant_tables::list_tenant_tables_handler),
-            );
+            route = route
+                .at(
+                    "/v1/tenants/:tenant/tables",
+                    get(super::http::v1::tenant_tables::list_tenant_tables_handler),
+                )
+                .at(
+                    "v1/tenants/:tenant/stream_status",
+                    get(super::http::v1::stream_status::stream_status_handler),
+                );
         }
 
         #[cfg(feature = "memory-profiling")]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```shell
✗ curl -sL -u root:  http://127.0.0.1:8081/v1/tenants/system/stream_status?stream_name=s&database=default
{"has_data":false,"params":{"database":"default","stream_name":"s"}}                                                             
✗ curl -sL -u root:  http://127.0.0.1:8081/v1/tenants/system/stream_status?stream_name=s1
UnknownTable. Code: 1025, Text = Unknown table 's1'.
✗ curl -sL -u root:  http://127.0.0.1:8081/v1/tenants/test_tenant/stream_status?stream_name=s
{"has_data":true,"params":{"database":null,"stream_name":"s"}}
```

Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14185)
<!-- Reviewable:end -->
