### PR TITLE
refactor: use `Binaryfuse16` and disable feature `uniform-random`

### DIFF
--- a/src/query/catalog/Cargo.toml
+++ b/src/query/catalog/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = { workspace = true }
 sha2 = "0.10.6"
 thrift = "0.17.0"
 typetag = { workspace = true }
-xorf = "0.11.0"
+xorf = { version = "0.11.0", default-features = false, features = ["binary-fuse"] }
 
 [dev-dependencies]
 goldenfile = "1.4"

--- a/src/query/catalog/src/runtime_filter_info.rs
+++ b/src/query/catalog/src/runtime_filter_info.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use databend_common_expression::Expr;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 
 #[derive(Clone, Debug, Default)]
 pub struct RuntimeFilterInfo {
     inlist: Vec<Expr<String>>,
     min_max: Vec<Expr<String>>,
-    bloom: Vec<(String, BinaryFuse8)>,
+    bloom: Vec<(String, BinaryFuse16)>,
 }
 
 impl RuntimeFilterInfo {
@@ -27,7 +27,7 @@ impl RuntimeFilterInfo {
         self.inlist.push(expr);
     }
 
-    pub fn add_bloom(&mut self, bloom: (String, BinaryFuse8)) {
+    pub fn add_bloom(&mut self, bloom: (String, BinaryFuse16)) {
         self.bloom.push(bloom);
     }
 
@@ -39,7 +39,7 @@ impl RuntimeFilterInfo {
         &self.inlist
     }
 
-    pub fn get_bloom(&self) -> &Vec<(String, BinaryFuse8)> {
+    pub fn get_bloom(&self) -> &Vec<(String, BinaryFuse16)> {
         &self.bloom
     }
 
@@ -47,7 +47,7 @@ impl RuntimeFilterInfo {
         &self.min_max
     }
 
-    pub fn blooms(self) -> Vec<(String, BinaryFuse8)> {
+    pub fn blooms(self) -> Vec<(String, BinaryFuse16)> {
         self.bloom
     }
 

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -48,7 +48,7 @@ use databend_common_storage::StorageMetrics;
 use databend_common_users::GrantObjectVisibilityChecker;
 use databend_storages_common_table_meta::meta::Location;
 use parking_lot::RwLock;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 
 use crate::catalog::Catalog;
 use crate::cluster_info::Cluster;
@@ -243,7 +243,7 @@ pub trait TableContext: Send + Sync {
 
     fn set_runtime_filter(&self, filters: (usize, RuntimeFilterInfo));
 
-    fn get_bloom_runtime_filter_with_id(&self, id: usize) -> Vec<(String, BinaryFuse8)>;
+    fn get_bloom_runtime_filter_with_id(&self, id: usize) -> Vec<(String, BinaryFuse16)>;
 
     fn get_inlist_runtime_filter_with_id(&self, id: usize) -> Vec<Expr<String>>;
 

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -164,7 +164,7 @@ typetag = { workspace = true }
 unicode-segmentation = "1.10.1"
 uuid = { workspace = true }
 walkdir = { workspace = true }
-xorf = "0.11.0"
+xorf = { version = "0.11.0", default-features = false, features = ["binary-fuse"] }
 
 [dev-dependencies]
 arrow-cast = { workspace = true }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -58,7 +58,7 @@ use itertools::Itertools;
 use log::info;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 
 use crate::pipelines::processors::transforms::hash_join::common::wrap_true_validity;
 use crate::pipelines::processors::transforms::hash_join::desc::MARKER_KIND_FALSE;
@@ -833,7 +833,7 @@ impl HashJoinBuildState {
                 hashes.into_iter().for_each(|hash| {
                     hashes_vec.push(hash);
                 });
-                let filter = BinaryFuse8::try_from(&hashes_vec)?;
+                let filter = BinaryFuse16::try_from(&hashes_vec)?;
                 runtime_filter.add_bloom((id.to_string(), filter));
             }
         }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -91,7 +91,7 @@ use databend_storages_common_table_meta::meta::Location;
 use log::debug;
 use log::info;
 use parking_lot::RwLock;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 
 use crate::api::DataExchangeManager;
 use crate::catalogs::Catalog;
@@ -930,7 +930,7 @@ impl TableContext for QueryContext {
         }
     }
 
-    fn get_bloom_runtime_filter_with_id(&self, id: IndexType) -> Vec<(String, BinaryFuse8)> {
+    fn get_bloom_runtime_filter_with_id(&self, id: IndexType) -> Vec<(String, BinaryFuse16)> {
         let runtime_filters = self.shared.runtime_filters.read();
         match runtime_filters.get(&id) {
             Some(v) => (v.get_bloom()).clone(),

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -123,7 +123,7 @@ use databend_query::test_kits::*;
 use databend_storages_common_table_meta::meta::Location;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 
 type MetaType = (String, String, String);
 
@@ -753,7 +753,7 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn get_bloom_runtime_filter_with_id(&self, _id: usize) -> Vec<(String, BinaryFuse8)> {
+    fn get_bloom_runtime_filter_with_id(&self, _id: usize) -> Vec<(String, BinaryFuse16)> {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -129,7 +129,7 @@ use futures::TryStreamExt;
 use parking_lot::RwLock;
 use uuid::Uuid;
 use walkdir::WalkDir;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fuse_occ_retry() -> Result<()> {
@@ -703,7 +703,7 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn get_bloom_runtime_filter_with_id(&self, _id: usize) -> Vec<(String, BinaryFuse8)> {
+    fn get_bloom_runtime_filter_with_id(&self, _id: usize) -> Vec<(String, BinaryFuse16)> {
         todo!()
     }
 

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -65,4 +65,4 @@ streaming-decompression = "0.1.2"
 sys-info = "0.9"
 typetag = { workspace = true }
 uuid = { workspace = true }
-xorf = "0.11.0"
+xorf = { version = "0.11.0", default-features = false, features = ["binary-fuse"] }

--- a/src/query/storages/fuse/src/operations/read/native_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/native_data_source_deserializer.rs
@@ -59,7 +59,7 @@ use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::Processor;
 use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_sql::IndexType;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 
 use super::fuse_source::fill_internal_column_meta;
 use super::native_data_source::NativeDataSource;
@@ -122,7 +122,7 @@ pub struct NativeDeserializeDataTransform {
 
     base_block_ids: Option<Scalar>,
 
-    cached_bloom_runtime_filter: Option<Vec<(FieldIndex, BinaryFuse8)>>,
+    cached_bloom_runtime_filter: Option<Vec<(FieldIndex, BinaryFuse16)>>,
 }
 
 impl NativeDeserializeDataTransform {
@@ -537,7 +537,7 @@ impl NativeDeserializeDataTransform {
                         .ok()
                         .map(|idx| (idx, filter.1.clone()))
                 })
-                .collect::<Vec<(FieldIndex, BinaryFuse8)>>();
+                .collect::<Vec<(FieldIndex, BinaryFuse16)>>();
             if bloom_filters.is_empty() {
                 return Ok((None, false));
             }

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -40,7 +40,7 @@ use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::Processor;
 use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_sql::IndexType;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 
 use super::fuse_source::fill_internal_column_meta;
 use super::parquet_data_source::ParquetDataSource;
@@ -71,7 +71,7 @@ pub struct DeserializeDataTransform {
     virtual_reader: Arc<Option<VirtualColumnReader>>,
 
     base_block_ids: Option<Scalar>,
-    cached_runtime_filter: Option<Vec<(FieldIndex, BinaryFuse8)>>,
+    cached_runtime_filter: Option<Vec<(FieldIndex, BinaryFuse16)>>,
 }
 
 unsafe impl Send for DeserializeDataTransform {}
@@ -140,7 +140,7 @@ impl DeserializeDataTransform {
                         .ok()
                         .map(|idx| (idx, filter.1.clone()))
                 })
-                .collect::<Vec<(FieldIndex, BinaryFuse8)>>();
+                .collect::<Vec<(FieldIndex, BinaryFuse16)>>();
             if bloom_filters.is_empty() {
                 return Ok(None);
             }

--- a/src/query/storages/fuse/src/operations/read/runtime_filter_prunner.rs
+++ b/src/query/storages/fuse/src/operations/read/runtime_filter_prunner.rs
@@ -35,7 +35,7 @@ use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_hashtable::FastHash;
 use databend_storages_common_index::statistics_to_domain;
 use log::info;
-use xorf::BinaryFuse8;
+use xorf::BinaryFuse16;
 use xorf::Filter;
 
 use crate::FusePartInfo;
@@ -97,7 +97,7 @@ pub fn runtime_filter_pruner(
 
 pub(crate) fn update_bitmap_with_bloom_filter(
     column: Column,
-    filter: &BinaryFuse8,
+    filter: &BinaryFuse16,
     bitmap: &mut MutableBitmap,
 ) -> Result<()> {
     let data_type = column.data_type();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- `Binaryfuse16` will reduce fp rate

- disabling feature `uniform-random` can reduce the cost of building bloom filter: https://github.com/ayazhafiz/xorf?tab=readme-ov-file#uniform-random


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14187)
<!-- Reviewable:end -->
