### PR TITLE
refactor: Implement exponential backoff in meta-service txn retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,9 +2901,11 @@ dependencies = [
  "logcall",
  "maplit",
  "minitrace",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
  "tonic 0.10.2",
 ]
 

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -31,7 +31,9 @@ log = { workspace = true }
 logcall = { workspace = true }
 maplit = "1.0.2"
 minitrace = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tonic = { workspace = true }

--- a/src/meta/api/src/lib.rs
+++ b/src/meta/api/src/lib.rs
@@ -14,6 +14,8 @@
 
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::diverging_sub_expression)]
+#![feature(const_fn_floating_point_arithmetic)]
+
 extern crate databend_common_meta_types;
 
 mod background_api;
@@ -37,6 +39,7 @@ mod share_api_impl;
 mod share_api_keys;
 mod share_api_test_suite;
 pub(crate) mod testing;
+pub mod txn_backoff;
 pub(crate) mod util;
 
 pub use background_api::BackgroundApi;
@@ -76,4 +79,3 @@ pub use util::txn_op_del;
 pub use util::txn_op_put;
 pub use util::txn_op_put_with_expire;
 pub use util::DEFAULT_MGET_SIZE;
-pub use util::TXN_MAX_RETRY_TIMES;

--- a/src/meta/api/src/txn_backoff.rs
+++ b/src/meta/api/src/txn_backoff.rs
@@ -1,0 +1,147 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Display;
+use std::time::Duration;
+
+use databend_common_meta_app::app_error::AppError;
+use databend_common_meta_app::app_error::TxnRetryMaxTimes;
+use rand::Rng;
+use tokio::time::Sleep;
+
+const TXN_MAX_RETRY_TIMES: u32 = 60;
+
+/// Creates an iterator providing a series of backoff durations for transaction retries,
+/// followed by an error upon reaching the maximum number of retries.
+///
+/// The iterator yields `n` `Ok` items, each containing a `Sleep` future representing
+/// the backoff duration to wait before the next transaction attempt. After `n` successful
+/// yields, the iterator will produce an `Err` containing an `AppError` to signify that
+/// the maximum number of retries has been exceeded.
+///
+/// The backoff strategy is determined by a predefined list of durations, and the backoff
+/// time for each subsequent retry increases up to the last value in this list, after which
+/// it remains constant for any further retries. Additionally, a random jitter is applied
+/// to each backoff duration to prevent synchronization issues in distributed systems.
+///
+/// # Examples
+///
+/// ```
+/// fn update_table() -> Result<(), AppError> {
+///     let mut trials = txn_trials(3, "update_table");
+///     loop {
+///         trials.next().unwrap()?.await;
+///         // do something
+///     }
+/// }
+/// ```
+pub fn txn_backoff<'a>(
+    n: Option<u32>,
+    ctx: impl Display + 'a,
+) -> impl Iterator<Item = Result<Sleep, AppError>> + 'a {
+    let n = n.unwrap_or(TXN_MAX_RETRY_TIMES);
+
+    let mut rnd = rand::thread_rng();
+    let scale = 1.0 + rnd.gen_range(-0.2..0.2);
+
+    (1..=(n + 1)).map(move |i| {
+        if i <= n {
+            let backoff = ith_backoff(i as usize);
+            let fu = tokio::time::sleep(Duration::from_secs_f64(backoff * scale));
+            Ok(fu)
+        } else {
+            let err = TxnRetryMaxTimes::new(&ctx.to_string(), n);
+            Err(AppError::from(err))
+        }
+    })
+}
+
+/// Return ith backoff in seconds
+fn ith_backoff(i: usize) -> f64 {
+    let len = BACKOFF.len();
+
+    if i < len {
+        BACKOFF[i]
+    } else {
+        BACKOFF[len - 1]
+    }
+}
+
+const fn from_millis(millis: u64) -> f64 {
+    (millis as f64) / 1000.0
+}
+
+// backoff time in ms
+// 0-th item is not used.
+// 1-th item for the first attempt should always 0.
+const BACKOFF: &[f64] = &[
+    from_millis(0),
+    from_millis(0),
+    from_millis(10),
+    from_millis(14),
+    from_millis(20),
+    from_millis(29),
+    from_millis(42),
+    from_millis(61),
+    from_millis(89),
+    from_millis(128),
+    from_millis(184),
+    from_millis(266),
+    from_millis(383),
+    from_millis(552),
+    from_millis(794),
+];
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn test_backoff_first() {
+        let mut trials = super::txn_backoff(Some(4), "test");
+
+        let now = std::time::Instant::now();
+        let _ = trials.next().unwrap().unwrap().await;
+        let elapsed = now.elapsed().as_secs_f64();
+
+        assert!(elapsed < 0.010, "{} is expected to be 0", elapsed);
+    }
+
+    #[tokio::test]
+    async fn test_backoff() {
+        let now = std::time::Instant::now();
+        let mut trials = super::txn_backoff(Some(4), "test");
+        for _ in 0..4 {
+            let _ = trials.next().unwrap().unwrap().await;
+        }
+
+        let elapsed = now.elapsed().as_secs_f64();
+        assert!(
+            (0.034..0.060).contains(&elapsed)
+            "{} is expected to be 10 + 14 + 20 milliseconds",
+            elapsed
+        );
+
+        let _err = trials.next().unwrap().unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn test_backoff_many() {
+        let mut trials = super::txn_backoff(Some(100), "test");
+        for _ in 0..100 {
+            #[allow(clippy::let_underscore_future)]
+            let _ = trials.next().unwrap().unwrap();
+        }
+
+        let _err = trials.next().unwrap().unwrap_err();
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Implement exponential backoff in meta-service txn retries

Introduce an exponential backoff strategy for meta-service transaction
retries to mitigate race conditions. Upon a transaction failure, the
system now initiates a delay before the next attempt, reducing the
likelihood of concurrent transaction conflicts.

The backoff intervals follow an exponential pattern, calculated as
`1.4^i * 10 milliseconds`, where `i` is the current retry count:
```
0ms, 10ms, 14ms, 20ms, 29ms, 42ms, 61ms, 89ms, 128ms, 184ms, 266ms, 383ms, 552ms, 794ms, 794ms, 794ms, ...
```

This change aims to improve the robustness of the transaction handling
by spacing out retries in the face of transient failures.

The number of attempt to retry is increased from 10 to 60.


## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14196)
<!-- Reviewable:end -->
