### PR TITLE
chore(query): better handling of nullable columns during filter execution

### DIFF
--- a/src/query/expression/src/filter/select.rs
+++ b/src/query/expression/src/filter/select.rs
@@ -92,7 +92,7 @@ impl<'a> Selector<'a> {
             op.clone()
         };
 
-        match left_data_type {
+        match left_data_type.remove_nullable() {
             DataType::Number(ty) => {
                 with_number_mapped_type!(|T| match ty {
                     NumberDataType::T => self.select_type_values::<NumberType<T>>(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Solve the problem in https://github.com/datafuselabs/databend/pull/14190

## Benchmark TPC-H SF100 External Parquet:
| query | main      | pr        | 
| ----- | --------- | --------- |
| Q1    | 12.7  | 11.8 |
| Q3   | 5.1  | 4.2  |
| Q4    | 3.6  | 3.2  |
| Q6    | 5.3  | 4.2  |
| Q7    | 5.6   | 4.6  |
| Q10   | 7.9  | 6.2  |
| Q12    | 7.9  | 6.3  |
| Q14    | 4.1   | 3.5  |
| Q15   | 7.0  | 5.9  |
| Q19   | 11.3 | 9.6 |
| Q20   | 17.3  | 15.5  |
| Q21   | 8.2  | 6.7  |

**TPC-H SF100 External Parquet Q19 FlameGraph before:**
<img width="1726" alt="截屏2024-01-02 13 53 09" src="https://github.com/datafuselabs/databend/assets/54522439/b6ebe78a-0f8f-4f70-a55e-5c106db09380">
**TPC-H SF100 External Parquet Q19 FlameGraph after:**
<img width="1726" alt="截屏2024-01-02 13 53 42" src="https://github.com/datafuselabs/databend/assets/54522439/146f6096-342b-4675-9bfb-6f4c72fbbe25">




## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Covered by existing tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14197)
<!-- Reviewable:end -->
