### PR TITLE
fix(query): http auth query_id should be set into new query ctx

### DIFF
--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -204,6 +204,8 @@ impl<E> HTTPSessionEndpoint<E> {
             .map(|id| id.to_str().unwrap().to_string())
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
+        ctx.set_id(query_id.clone());
+
         Ok(HttpQueryContext::new(
             session,
             query_id,

--- a/src/query/service/src/servers/http/v1/stage.rs
+++ b/src/query/service/src/servers/http/v1/stage.rs
@@ -90,6 +90,8 @@ pub async fn upload_to_stage(
         .create_query_context()
         .await
         .map_err(InternalServerError)?;
+    let query_id = ctx.query_id.clone();
+    context.set_id(query_id.clone());
     let args = UploadToStageArgs::parse(req)?;
 
     let stage = if args.stage_name == "~" {
@@ -127,9 +129,8 @@ pub async fn upload_to_stage(
         files.push(name.clone());
     }
 
-    let mut id = uuid::Uuid::new_v4().to_string();
     Ok(Json(UploadToStageResponse {
-        id,
+        id: query_id,
         stage_name: args.stage_name,
         state: "SUCCESS".to_string(),
         files,

--- a/src/query/service/src/servers/http/v1/suggestions.rs
+++ b/src/query/service/src/servers/http/v1/suggestions.rs
@@ -41,6 +41,7 @@ pub async fn list_suggestions(
         .create_query_context()
         .await
         .map_err(InternalServerError)?;
+    context.set_id(ctx.query_id.clone());
     let suggestions = SuggestedBackgroundTasksSource::all_suggestions(context)
         .await
         .map_err(|err| poem::Error::from_string(err.message(), StatusCode::BAD_REQUEST))?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

http handler will generate a dummy session and query_ctx in auth.

But not reuse this query_id.

Fixes https://github.com/datafuselabs/databend/issues/14172

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14203)
<!-- Reviewable:end -->
