### PR TITLE
fix: disable distributed plan after disabling join reorder

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -306,10 +306,11 @@ pub fn optimize_query(opt_ctx: OptimizerContext, mut s_expr: SExpr) -> Result<SE
         s_expr = cascades.optimize(s_expr)?;
     }
 
-    if !opt_ctx.enable_join_reorder {
-        return RecursiveOptimizer::new(&[RuleID::EliminateEvalScalar], &opt_ctx).run(&s_expr);
-    }
-    s_expr = RecursiveOptimizer::new(&RESIDUAL_RULES, &opt_ctx).run(&s_expr)?;
+    s_expr = if !opt_ctx.enable_join_reorder {
+        RecursiveOptimizer::new(&[RuleID::EliminateEvalScalar], &opt_ctx).run(&s_expr)?
+    } else {
+        RecursiveOptimizer::new(&RESIDUAL_RULES, &opt_ctx).run(&s_expr)?
+    };
 
     // Run distributed query optimization.
     //

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -616,3 +616,48 @@ Exchange
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 1000.00
+
+statement ok
+set disable_join_reorder = 1;
+
+query T
+explain select * from numbers(10) as t1 join numbers(20) as t2 on t1.number = t2.number;
+----
+Exchange
+├── output columns: [t1.number (#0), t2.number (#1)]
+├── exchange type: Merge
+└── HashJoin
+    ├── output columns: [t1.number (#0), t2.number (#1)]
+    ├── join type: INNER
+    ├── build keys: [t2.number (#1)]
+    ├── probe keys: [t1.number (#0)]
+    ├── filters: []
+    ├── estimated rows: 200.00
+    ├── Exchange(Build)
+    │   ├── output columns: [t2.number (#1)]
+    │   ├── exchange type: Hash(t2.number (#1))
+    │   └── TableScan
+    │       ├── table: default.system.numbers
+    │       ├── output columns: [number (#1)]
+    │       ├── read rows: 20
+    │       ├── read bytes: 160
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       ├── push downs: [filters: [], limit: NONE]
+    │       └── estimated rows: 20.00
+    └── Exchange(Probe)
+        ├── output columns: [t1.number (#0)]
+        ├── exchange type: Hash(t1.number (#0))
+        └── TableScan
+            ├── table: default.system.numbers
+            ├── output columns: [number (#0)]
+            ├── read rows: 10
+            ├── read bytes: 80
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 10.00
+
+
+statement ok
+set disable_join_reorder = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

https://github.com/datafuselabs/databend/pull/14163/files#diff-a41c4bd239da9fa211688e4b794d66954fedbcf69449b9a578fefdfaf0af50c2R309


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14218)
<!-- Reviewable:end -->
