### PR TITLE
fix: aggregate and window function as the argument of unnest return unable to get field named

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1399,6 +1399,15 @@ impl<'a> TypeChecker<'a> {
             )
             .set_span(span));
         }
+        if matches!(
+            self.bind_context.expr_context,
+            ExprContext::InSetReturningFunction
+        ) {
+            return Err(ErrorCode::SemanticError(
+                "window functions can not be used in set-returning function".to_string(),
+            )
+            .set_span(span));
+        }
         // try to resolve window function without arguments first
         if let Ok(window_func) = WindowFuncType::from_name(func_name) {
             return Ok(window_func);
@@ -1630,6 +1639,15 @@ impl<'a> TypeChecker<'a> {
         ) {
             return Err(ErrorCode::SemanticError(
                 "aggregate functions can not be used in lambda function".to_string(),
+            )
+            .set_span(span));
+        }
+        if matches!(
+            self.bind_context.expr_context,
+            ExprContext::InSetReturningFunction
+        ) {
+            return Err(ErrorCode::SemanticError(
+                "aggregate functions can not be used in set-returning function".to_string(),
             )
             .set_span(span));
         }

--- a/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest.test
+++ b/tests/sqllogictests/suites/query/02_function/02_0062_function_unnest.test
@@ -479,6 +479,15 @@ query T
 select unnest(parse_json('"a"'))
 ----
 
+statement error 1065
+select unnest(max(11))
+
+statement error 1065
+select unnest(min(11),max(12))
+
+statement error 1065
+select unnest(first_value('aa') OVER (PARTITION BY 'bb'))
+
 statement ok
 set max_block_size = 65535;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

_Unnest cannot contain aggregate or window functions; otherwise, an error should be returned._

### example:
```
select unnest(max(1));
error: APIError: ResponseError with 1065: error:
  --> SQL:1:15
  |
1 | select unnest(max(1))
  |               ^^^^^^ aggregate functions can not be used in set-returning function
```

Fixes #[#13057]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14233)
<!-- Reviewable:end -->
