### PR TITLE
fix: fix count rewrite in agg index

### DIFF
--- a/src/query/sql/src/planner/semantic/aggregating_index_visitor.rs
+++ b/src/query/sql/src/planner/semantic/aggregating_index_visitor.rs
@@ -180,11 +180,16 @@ impl AggregatingIndexRewriter {
         }
     }
 
+    // If `arg[0]` data type is *NOT* nullable, the optimizer will rewrite `count(arg)` to `count()`,
+    // this happened in `RuleID::NormalizeAggregate`.
+    // But here we cannot get the arg[0] type, so we provide both `count(arg)` and `count()`.
     pub fn extract_avg(&mut self, args: &[Expr]) {
         let sum = format!("SUM({})", args[0]);
-        let count = "COUNT()".to_string();
+        let count = format!("COUNT({})", args[0]);
+        let count_without_column = "COUNT()".to_string();
         self.extracted_aggs.insert(sum);
         self.extracted_aggs.insert(count);
+        self.extracted_aggs.insert(count_without_column);
     }
 }
 

--- a/src/query/sql/src/planner/semantic/aggregating_index_visitor.rs
+++ b/src/query/sql/src/planner/semantic/aggregating_index_visitor.rs
@@ -72,6 +72,8 @@ impl VisitorMut for AggregatingIndexRewriter {
                 self.has_agg_function = true;
                 if name.name.eq_ignore_ascii_case("avg") {
                     self.extract_avg(args);
+                } else if name.name.eq_ignore_ascii_case("count") {
+                    self.extract_count(args);
                 } else {
                     let agg = format!(
                         "{}({})",
@@ -190,6 +192,15 @@ impl AggregatingIndexRewriter {
         self.extracted_aggs.insert(sum);
         self.extracted_aggs.insert(count);
         self.extracted_aggs.insert(count_without_column);
+    }
+
+    pub fn extract_count(&mut self, args: &[Expr]) {
+        let count_without_column = "COUNT()".to_string();
+        self.extracted_aggs.insert(count_without_column);
+        if !args.is_empty() {
+            let count = format!("COUNT({})", args[0]);
+            self.extracted_aggs.insert(count);
+        }
     }
 }
 

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
@@ -363,6 +363,38 @@ EvalScalar
             └── estimated rows: 0.00
 
 statement ok
+DROP AGGREGATING INDEX idx1
+
+statement ok
+CREATE AGGREGATING INDEX idx1 AS SELECT count(measurement), sum(measurement) from onebrc
+
+query T
+EXPLAIN SELECT count(measurement) from onebrc
+----
+AggregateFinal
+├── output columns: [count(measurement) (#2)]
+├── group by: []
+├── aggregate functions: [count(measurement)]
+├── estimated rows: 1.00
+└── AggregatePartial
+    ├── output columns: [count(measurement) (#2)]
+    ├── group by: []
+    ├── aggregate functions: [count(measurement)]
+    ├── estimated rows: 1.00
+    └── TableScan
+        ├── table: default.test_index_db.onebrc
+        ├── output columns: [measurement (#1)]
+        ├── read rows: 0
+        ├── read bytes: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [], limit: NONE]
+        ├── aggregating index: [SELECT COUNT(), COUNT(measurement), SUM(measurement) FROM test_index_db.onebrc]
+        ├── rewritten query: [selection: [index_col_1 (#1)]]
+        └── estimated rows: 0.00
+
+
+statement ok
 DROP TABLE IF EXISTS onebrc
 
 statement ok

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
@@ -320,9 +320,50 @@ EvalScalar
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
-            ├── aggregating index: [SELECT COUNT(), SUM(a), SUM(b) FROM test_index_db.t1]
-            ├── rewritten query: [selection: [index_col_1 (#1), index_col_0 (#0)]]
+            ├── aggregating index: [SELECT COUNT(), COUNT(a), SUM(a), SUM(b) FROM test_index_db.t1]
+            ├── rewritten query: [selection: [index_col_2 (#2), index_col_0 (#0)]]
             └── estimated rows: 0.00
+
+statement ok
+DROP AGGREGATING INDEX idx1
+
+statement ok
+CREATE TABLE onebrc (station_name VARCHAR NULL, measurement DOUBLE NULL);
+
+statement ok
+CREATE AGGREGATING INDEX idx1 as SELECT station_name, MIN(measurement) AS min_measurement, AVG(measurement) AS mean_measurement, MAX(measurement) AS max_measurement FROM onebrc GROUP BY station_name
+
+query T
+EXPLAIN SELECT station_name, MIN(measurement) AS min_measurement, AVG(measurement) AS mean_measurement, MAX(measurement) AS max_measurement FROM onebrc GROUP BY station_name
+----
+EvalScalar
+├── output columns: [MIN(measurement) (#5), MAX(measurement) (#8), onebrc.station_name (#0), mean_measurement (#9)]
+├── expressions: [sum(measurement) (#6) / CAST(if(CAST(count(measurement) (#7) = 0 AS Boolean NULL), 1, count(measurement) (#7)) AS UInt64 NULL)]
+├── estimated rows: 0.00
+└── AggregateFinal
+    ├── output columns: [MIN(measurement) (#5), sum(measurement) (#6), count(measurement) (#7), MAX(measurement) (#8), onebrc.station_name (#0)]
+    ├── group by: [station_name]
+    ├── aggregate functions: [min(measurement), sum(measurement), count(measurement), max(measurement)]
+    ├── estimated rows: 0.00
+    └── AggregatePartial
+        ├── output columns: [MIN(measurement) (#5), sum(measurement) (#6), count(measurement) (#7), MAX(measurement) (#8), #_group_by_key]
+        ├── group by: [station_name]
+        ├── aggregate functions: [min(measurement), sum(measurement), count(measurement), max(measurement)]
+        ├── estimated rows: 0.00
+        └── TableScan
+            ├── table: default.test_index_db.onebrc
+            ├── output columns: [station_name (#0), measurement (#1)]
+            ├── read rows: 0
+            ├── read bytes: 0
+            ├── partitions total: 0
+            ├── partitions scanned: 0
+            ├── push downs: [filters: [], limit: NONE]
+            ├── aggregating index: [SELECT station_name, COUNT(), COUNT(measurement), MAX(measurement), MIN(measurement), SUM(measurement) FROM test_index_db.onebrc GROUP BY station_name]
+            ├── rewritten query: [selection: [index_col_0 (#0), index_col_4 (#4), index_col_5 (#5), index_col_2 (#2), index_col_3 (#3)]]
+            └── estimated rows: 0.00
+
+statement ok
+DROP TABLE IF EXISTS onebrc
 
 statement ok
 DROP AGGREGATING INDEX idx1
@@ -351,8 +392,8 @@ AggregateFinal
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
-        ├── aggregating index: [SELECT COUNT(), MAX(a), MIN(a), SUM(a), b FROM test_index_db.t1 GROUP BY b]
-        ├── rewritten query: [selection: [index_col_0 (#0), index_col_3 (#3), index_col_2 (#2), index_col_1 (#1)]]
+        ├── aggregating index: [SELECT COUNT(), COUNT(a), MAX(a), MIN(a), SUM(a), b FROM test_index_db.t1 GROUP BY b]
+        ├── rewritten query: [selection: [index_col_0 (#0), index_col_4 (#4), index_col_3 (#3), index_col_1 (#1)]]
         └── estimated rows: 0.00
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`count(col)` will be rewritten to `count()` if col is NOT nullable, as create agg index will rewrite statement and don't know the col's datatype, we will provide both `count(col)` and `count()` for agg index, make query rewrite with agg index happy.

Fixes #14249 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14256)
<!-- Reviewable:end -->
