### PR TITLE
refactor: remove from `message::Request`: `Get(r)`, `MGet(r)`, `List(r)` and `StreamGet(r)`.

### DIFF
--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -85,6 +85,11 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2024-01-02: since 1.2.279:
 ///   Meta client: remove `Compatible` for KVAppError and MetaAPIError, added in `2023-02-16: since 0.9.41`
 ///
+/// - 2024-01-07: since TODO
+///   client: remove calling RPC kv_api() with MetaGrpcReq::GetKV/MGetKV/ListKV, kv_api only accept Upsert;
+///   client: remove using MetaGrpcReq::GetKV/MGetKV/ListKV;
+///   client: remove falling back kv_read_v1(Streamed(List)) to kv_api(List), added in `2023-10-20: since 1.2.176`;
+///
 /// Server feature set:
 /// ```yaml
 /// server_features:


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: remove from `message::Request`: `Get(r)`, `MGet(r)`, `List(r)` and `StreamGet(r)`.

For meta-service gRPC client: non stream oriented API `Get(r)`,
`MGet(r)`, `List(r)` are all replaced with stream oriented API.
Stream oriented API `StreamGet(r)` is replaced with `StreamMGet(r)`,
because `mget` is a superset of `get`.

`MetaGrpcClient::kv_api()` now only accepts `Upsert` request;

Remove fallback from `kv_read_v1(Streamed(List))` to `kv_api(List)`,
which added in `2023-10-20: since 1.2.176`, all read requests are called
via stream API.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14258)
<!-- Reviewable:end -->
