### PR TITLE
refactor: port should be u16 instead of u32

### DIFF
--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -326,7 +326,7 @@ fn build_nodes(initial_cluster: Vec<String>, id: u64) -> anyhow::Result<BTreeMap
         let endpoint = match (url.host_str(), url.port()) {
             (Some(addr), Some(port)) => Endpoint {
                 addr: addr.to_string(),
-                port: port as u32,
+                port,
             },
             _ => {
                 return Err(anyhow::anyhow!("invalid peer raft addr: {}", addrs[0]));

--- a/src/meta/raft-store/src/config.rs
+++ b/src/meta/raft-store/src/config.rs
@@ -56,7 +56,7 @@ pub struct RaftConfig {
     pub raft_advertise_host: String,
 
     /// The listening port for metadata communication.
-    pub raft_api_port: u32,
+    pub raft_api_port: u16,
 
     /// The dir to store persisted meta state, including raft logs, state machine etc.
     pub raft_dir: String,

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -281,7 +281,7 @@ pub struct ConfigViaEnv {
     pub config_id: String,
     pub kvsrv_listen_host: String,
     pub kvsrv_advertise_host: String,
-    pub kvsrv_api_port: u32,
+    pub kvsrv_api_port: u16,
     pub kvsrv_raft_dir: String,
     pub kvsrv_no_sync: bool,
     pub kvsrv_snapshot_logs_since_last: u64,
@@ -436,7 +436,7 @@ pub struct RaftConfig {
 
     /// The listening port for metadata communication.
     #[clap(long, default_value = "28004")]
-    pub raft_api_port: u32,
+    pub raft_api_port: u16,
 
     /// The dir to store persisted meta state, including raft logs, state machine etc.
     #[clap(long, default_value = "./.databend/meta")]

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -318,7 +318,7 @@ impl MetaNode {
     pub async fn start_grpc(
         mn: Arc<MetaNode>,
         host: &str,
-        port: u32,
+        port: u16,
     ) -> Result<(), MetaNetworkError> {
         let mut rx = mn.running_rx.clone();
 

--- a/src/meta/service/tests/it/tests/service.rs
+++ b/src/meta/service/tests/it/tests/service.rs
@@ -90,8 +90,8 @@ pub async fn start_metasrv_cluster(node_ids: &[NodeId]) -> anyhow::Result<Vec<Me
     Ok(res)
 }
 
-pub fn next_port() -> u32 {
-    29000u32 + (GlobalSequence::next() as u32)
+pub fn next_port() -> u16 {
+    29000u16 + (GlobalSequence::next() as u16)
 }
 
 /// It holds a reference to a MetaNode or a GrpcServer, for testing MetaNode or GrpcServer.

--- a/src/meta/types/src/endpoint.rs
+++ b/src/meta/types/src/endpoint.rs
@@ -20,11 +20,11 @@ use serde::Serialize;
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct Endpoint {
     pub addr: String,
-    pub port: u32,
+    pub port: u16,
 }
 
 impl Endpoint {
-    pub fn new(addr: impl ToString, port: u32) -> Self {
+    pub fn new(addr: impl ToString, port: u16) -> Self {
         Self {
             addr: addr.to_string(),
             port,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: port should be u16 instead of u32

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14263)
<!-- Reviewable:end -->
