### PR TITLE
refactor: Endpoint: add parse(); make fields private

### DIFF
--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -326,7 +326,7 @@ fn build_nodes(initial_cluster: Vec<String>, id: u64) -> anyhow::Result<BTreeMap
         let endpoint = match (url.host_str(), url.port()) {
             (Some(addr), Some(port)) => Endpoint {
                 addr: addr.to_string(),
-                port: port as u32,
+                port,
             },
             _ => {
                 return Err(anyhow::anyhow!("invalid peer raft addr: {}", addrs[0]));

--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -324,10 +324,7 @@ fn build_nodes(initial_cluster: Vec<String>, id: u64) -> anyhow::Result<BTreeMap
         }
         let url = Url::parse(&format!("http://{}", addrs[0]))?;
         let endpoint = match (url.host_str(), url.port()) {
-            (Some(addr), Some(port)) => Endpoint {
-                addr: addr.to_string(),
-                port,
-            },
+            (Some(addr), Some(port)) => Endpoint::new(addr, port),
             _ => {
                 return Err(anyhow::anyhow!("invalid peer raft addr: {}", addrs[0]));
             }

--- a/src/meta/raft-store/src/config.rs
+++ b/src/meta/raft-store/src/config.rs
@@ -164,35 +164,23 @@ impl RaftConfig {
     }
 
     pub fn raft_api_listen_host_endpoint(&self) -> Endpoint {
-        Endpoint {
-            addr: self.raft_listen_host.clone(),
-            port: self.raft_api_port,
-        }
+        Endpoint::new(&self.raft_listen_host, self.raft_api_port)
     }
 
     pub fn raft_api_advertise_host_endpoint(&self) -> Endpoint {
-        Endpoint {
-            addr: self.raft_advertise_host.clone(),
-            port: self.raft_api_port,
-        }
+        Endpoint::new(&self.raft_advertise_host, self.raft_api_port)
     }
 
     /// Support ip address and hostname
     pub async fn raft_api_addr(&self) -> Result<Endpoint> {
         let ipv4_addr = self.raft_advertise_host.as_str().parse::<Ipv4Addr>();
         match ipv4_addr {
-            Ok(addr) => Ok(Endpoint {
-                addr: addr.to_string(),
-                port: self.raft_api_port,
-            }),
+            Ok(addr) => Ok(Endpoint::new(addr, self.raft_api_port)),
             Err(_) => {
                 let _ip_addrs = DNSResolver::instance()?
                     .resolve(self.raft_advertise_host.clone())
                     .await?;
-                Ok(Endpoint {
-                    addr: _ip_addrs[0].to_string(),
-                    port: self.raft_api_port,
-                })
+                Ok(Endpoint::new(_ip_addrs[0], self.raft_api_port))
             }
         }
     }

--- a/src/meta/raft-store/src/config.rs
+++ b/src/meta/raft-store/src/config.rs
@@ -56,7 +56,7 @@ pub struct RaftConfig {
     pub raft_advertise_host: String,
 
     /// The listening port for metadata communication.
-    pub raft_api_port: u32,
+    pub raft_api_port: u16,
 
     /// The dir to store persisted meta state, including raft logs, state machine etc.
     pub raft_dir: String,

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -281,7 +281,7 @@ pub struct ConfigViaEnv {
     pub config_id: String,
     pub kvsrv_listen_host: String,
     pub kvsrv_advertise_host: String,
-    pub kvsrv_api_port: u32,
+    pub kvsrv_api_port: u16,
     pub kvsrv_raft_dir: String,
     pub kvsrv_no_sync: bool,
     pub kvsrv_snapshot_logs_since_last: u64,
@@ -436,7 +436,7 @@ pub struct RaftConfig {
 
     /// The listening port for metadata communication.
     #[clap(long, default_value = "28004")]
-    pub raft_api_port: u32,
+    pub raft_api_port: u16,
 
     /// The dir to store persisted meta state, including raft logs, state machine etc.
     #[clap(long, default_value = "./.databend/meta")]

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -318,7 +318,7 @@ impl MetaNode {
     pub async fn start_grpc(
         mn: Arc<MetaNode>,
         host: &str,
-        port: u32,
+        port: u16,
     ) -> Result<(), MetaNetworkError> {
         let mut rx = mn.running_rx.clone();
 

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -250,7 +250,7 @@ impl MetaNodeBuilder {
 
         info!("about to start raft grpc on endpoint {}", endpoint);
 
-        MetaNode::start_grpc(mn.clone(), &endpoint.addr, endpoint.port).await?;
+        MetaNode::start_grpc(mn.clone(), endpoint.addr(), endpoint.port()).await?;
 
         Ok(mn)
     }

--- a/src/meta/service/tests/it/tests/service.rs
+++ b/src/meta/service/tests/it/tests/service.rs
@@ -90,8 +90,8 @@ pub async fn start_metasrv_cluster(node_ids: &[NodeId]) -> anyhow::Result<Vec<Me
     Ok(res)
 }
 
-pub fn next_port() -> u32 {
-    29000u32 + (GlobalSequence::next() as u32)
+pub fn next_port() -> u16 {
+    29000u16 + (GlobalSequence::next() as u16)
 }
 
 /// It holds a reference to a MetaNode or a GrpcServer, for testing MetaNode or GrpcServer.

--- a/src/meta/types/src/endpoint.rs
+++ b/src/meta/types/src/endpoint.rs
@@ -13,14 +13,16 @@
 // limitations under the License.
 
 use std::fmt;
+use std::net::SocketAddrV4;
 
+use anyerror::AnyError;
 use serde::Deserialize;
 use serde::Serialize;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct Endpoint {
-    pub addr: String,
-    pub port: u16,
+    addr: String,
+    port: u16,
 }
 
 impl Endpoint {
@@ -30,10 +32,42 @@ impl Endpoint {
             port,
         }
     }
+
+    pub fn addr(&self) -> &str {
+        &self.addr
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Parse `1.2.3.4:5555` into `Endpoint`.
+    pub fn parse(address: &str) -> Result<Self, AnyError> {
+        match address.parse::<SocketAddrV4>() {
+            Ok(a) => Ok(Self::new(a.ip().to_string(), a.port())),
+            Err(e) => Err(AnyError::error(format!("Failed to parse address: {}", e))),
+        }
+    }
 }
 
 impl fmt::Display for Endpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.addr, self.port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Endpoint;
+
+    #[test]
+    fn test_endpoint_parse() -> anyhow::Result<()> {
+        assert!(Endpoint::parse("1.2.3.4").is_err());
+        assert!(Endpoint::parse("1.2.3.4:88888").is_err());
+
+        assert_eq!("1.2.3.4", Endpoint::parse("1.2.3.4:1234")?.addr());
+        assert_eq!(1234, Endpoint::parse("1.2.3.4:1234")?.port());
+
+        Ok(())
     }
 }

--- a/src/meta/types/src/endpoint.rs
+++ b/src/meta/types/src/endpoint.rs
@@ -20,11 +20,11 @@ use serde::Serialize;
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct Endpoint {
     pub addr: String,
-    pub port: u32,
+    pub port: u16,
 }
 
 impl Endpoint {
-    pub fn new(addr: impl ToString, port: u32) -> Self {
+    pub fn new(addr: impl ToString, port: u16) -> Self {
         Self {
             addr: addr.to_string(),
             port,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Endpoint: add parse(); make fields private


##### refactor: port should be u16 instead of u32

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14265)
<!-- Reviewable:end -->
