### PR TITLE
refactor: `common-exception` crate should be independent of `meta-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,8 +2621,6 @@ dependencies = [
  "bincode 2.0.0-rc.3",
  "codespan-reporting 0.11.1 (git+https://github.com/brendanzab/codespan?rev=c84116f5)",
  "databend-common-arrow",
- "databend-common-meta-stoerr",
- "databend-common-meta-types",
  "http",
  "opendal",
  "parquet",
@@ -3077,6 +3075,7 @@ name = "databend-common-meta-stoerr"
 version = "0.1.0"
 dependencies = [
  "anyerror",
+ "databend-common-exception",
  "prost 0.12.1",
  "serde",
  "serde_json",
@@ -3105,6 +3104,7 @@ dependencies = [
  "anyerror",
  "anyhow",
  "databend-common-building",
+ "databend-common-exception",
  "databend-common-meta-stoerr",
  "derive_more",
  "num-derive",

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -12,8 +12,6 @@ test = false
 
 [dependencies] # In alphabetical order
 databend-common-arrow = { path = "../arrow" }
-databend-common-meta-stoerr = { path = "../../meta/stoerr" }
-databend-common-meta-types = { path = "../../meta/types" }
 
 # GitHub dependencies
 # TODO: Use the version from crates.io once

--- a/src/common/exception/src/exception_into.rs
+++ b/src/common/exception/src/exception_into.rs
@@ -18,10 +18,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use databend_common_meta_stoerr::MetaStorageError;
-use databend_common_meta_types::MetaAPIError;
-use databend_common_meta_types::MetaError;
-
 use crate::exception::ErrorCodeBacktrace;
 use crate::exception_backtrace::capture;
 use crate::ErrorCode;
@@ -325,24 +321,6 @@ impl From<tonic::Status> for ErrorCode {
             }
             _ => ErrorCode::Unimplemented(status.to_string()),
         }
-    }
-}
-
-impl From<MetaError> for ErrorCode {
-    fn from(e: MetaError) -> Self {
-        ErrorCode::MetaServiceError(e.to_string())
-    }
-}
-
-impl From<MetaAPIError> for ErrorCode {
-    fn from(e: MetaAPIError) -> Self {
-        ErrorCode::MetaServiceError(e.to_string())
-    }
-}
-
-impl From<MetaStorageError> for ErrorCode {
-    fn from(e: MetaStorageError) -> Self {
-        ErrorCode::MetaServiceError(e.to_string())
     }
 }
 

--- a/src/meta/stoerr/Cargo.toml
+++ b/src/meta/stoerr/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 test = true
 
 [dependencies]
+databend-common-exception = { path = "../../common/exception" }
 
 anyerror = { workspace = true }
 prost = { workspace = true }

--- a/src/meta/stoerr/src/meta_storage_errors.rs
+++ b/src/meta/stoerr/src/meta_storage_errors.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::io;
 
 use anyerror::AnyError;
+use databend_common_exception::ErrorCode;
 use serde::Deserialize;
 use serde::Serialize;
 use sled::transaction::UnabortableTransactionError;
@@ -99,5 +100,11 @@ impl From<UnabortableTransactionError> for MetaStorageError {
 impl From<MetaStorageError> for io::Error {
     fn from(e: MetaStorageError) -> Self {
         io::Error::new(io::ErrorKind::InvalidData, e)
+    }
+}
+
+impl From<MetaStorageError> for ErrorCode {
+    fn from(e: MetaStorageError) -> Self {
+        ErrorCode::MetaServiceError(e.to_string())
     }
 }

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 test = true
 
 [dependencies]
+databend-common-exception = { path = "../../common/exception" }
 databend-common-meta-stoerr = { path = "../stoerr" }
 
 openraft = { workspace = true }

--- a/src/meta/types/src/errors/meta_api_errors.rs
+++ b/src/meta/types/src/errors/meta_api_errors.rs
@@ -15,6 +15,7 @@
 use std::fmt::Display;
 
 use anyerror::AnyError;
+use databend_common_exception::ErrorCode;
 use tonic::Status;
 
 use crate::errors;
@@ -200,5 +201,11 @@ impl From<RaftError<ClientWriteError>> for MetaAPIError {
             }
             RaftError::Fatal(f) => MetaAPIError::DataError(MetaDataError::WriteError(f)),
         }
+    }
+}
+
+impl From<MetaAPIError> for ErrorCode {
+    fn from(e: MetaAPIError) -> Self {
+        ErrorCode::MetaServiceError(e.to_string())
     }
 }

--- a/src/meta/types/src/errors/meta_errors.rs
+++ b/src/meta/types/src/errors/meta_errors.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_exception::ErrorCode;
 use databend_common_meta_stoerr::MetaStorageError;
 use serde::Deserialize;
 use serde::Serialize;
@@ -70,5 +71,11 @@ impl From<errors::IncompleteStream> for MetaError {
         let net_err = MetaNetworkError::from(e);
         let client_err = MetaClientError::from(net_err);
         Self::ClientError(client_err)
+    }
+}
+
+impl From<MetaError> for ErrorCode {
+    fn from(e: MetaError) -> Self {
+        ErrorCode::MetaServiceError(e.to_string())
     }
 }

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -16,7 +16,6 @@ storage-hdfs = ["databend-common-storage/storage-hdfs"]
 ignored = ["strum"]
 
 [dependencies]
-chrono-tz = { workspace = true }
 databend-common-base = { path = "../../common/base" }
 databend-common-exception = { path = "../../common/exception" }
 databend-common-grpc = { path = "../../common/grpc" }
@@ -25,6 +24,7 @@ databend-common-storage = { path = "../../common/storage" }
 databend-common-tracing = { path = "../../common/tracing" }
 databend-common-users = { path = "../users" }
 
+chrono-tz = { workspace = true }
 clap = { workspace = true }
 hex = "0.4.3"
 log = { workspace = true }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: `common-exception` crate should be independent of `meta-types`

The `databend-common-exception` crate, which is a general-purpose
library, should not have a dependency on the business-specific
`databend-common-meta-types` crate.

With this commit, we've relocated the conversion logic for transforming
`Meta**` errors into `ErrorCode`. These conversions are now handled
within the meta-service related crates: `databend-common-meta-types` and
`databend-common-sto-error`.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14275)
<!-- Reviewable:end -->
