### PR TITLE
fix(rbac): revoke privilege

### DIFF
--- a/src/meta/app/src/principal/user_grant.rs
+++ b/src/meta/app/src/principal/user_grant.rs
@@ -267,7 +267,11 @@ impl UserGrantSet {
             .map(|e| {
                 if e.matches_entry(object) {
                     let mut e = e.clone();
-                    e.privileges ^= privileges;
+                    e.privileges = e
+                        .privileges
+                        .into_iter()
+                        .filter(|p| !privileges.contains(*p))
+                        .collect();
                     e
                 } else {
                     e.clone()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixed the revoke logic, in the before it uses `^=` to revoke the provilege, but the semantic of `^=` is "toggle" not "remove". This PR replaces the "^=" with a dump filter logic.

Fixes #14239

## Tests

- [ ] Unit Test
- [x] Logic Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
