### PR TITLE
chore: use raw sql as task SQL instead of pretty one

### DIFF
--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -129,9 +129,7 @@ pub fn statement(i: Input) -> IResult<StatementWithFormat> {
             _,
             sql,
         )| {
-            let sql = pretty_statement(sql.stmt, 10)
-                .map_err(|_| ErrorKind::Other("invalid statement"))
-                .unwrap();
+            let sql = format!("{}", sql.stmt);
             Statement::CreateTask(CreateTaskStmt {
                 if_not_exists: opt_if_not_exists.is_some(),
                 name: task.to_string(),

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -511,6 +511,7 @@ fn test_statement() {
         r#"CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = 'MyWarehouse' SCHEDULE = 1215 SECOND SUSPEND_TASK_AFTER_NUM_FAILURES = 3 COMMENT = 'This is test task 1' AS SELECT * FROM MyTable1"#,
         r#"CREATE TASK IF NOT EXISTS MyTask1 SCHEDULE = USING CRON '0 6 * * *' 'America/Los_Angeles' COMMENT = 'serverless + cron' AS insert into t (c1, c2) values (1, 2), (3, 4)"#,
         r#"CREATE TASK IF NOT EXISTS MyTask1 SCHEDULE = USING CRON '0 12 * * *' AS VACUUM TABLE t"#,
+        r#"CREATE TASK IF NOT EXISTS MyTask1 SCHEDULE = USING CRON '0 13 * * *' AS COPY INTO @my_internal_stage FROM canadian_city_population FILE_FORMAT = (TYPE = PARQUET)"#,
         r#"CREATE TASK IF NOT EXISTS MyTask1 AFTER 'task2', 'task3' WHEN SYSTEM$GET_PREDECESSOR_RETURN_VALUE('task_name') != 'VALIDATION' AS VACUUM TABLE t"#,
         r#"ALTER TASK MyTask1 RESUME"#,
         r#"ALTER TASK MyTask1 SUSPEND"#,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -13842,9 +13842,7 @@ AlterNetworkPolicy(
 ---------- Input ----------
 CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = 'MyWarehouse' SCHEDULE = 15 MINUTE SUSPEND_TASK_AFTER_NUM_FAILURES = 3 COMMENT = 'This is test task 1' AS SELECT * FROM MyTable1
 ---------- Output ---------
-CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = MyWarehouse SCHEDULE 900 SECOND SUSPEND TASK AFTER 3 FAILURES COMMENTS = 'This is test task 1' AS SELECT *
-FROM
-    MyTable1
+CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = MyWarehouse SCHEDULE 900 SECOND SUSPEND TASK AFTER 3 FAILURES COMMENTS = 'This is test task 1' AS SELECT * FROM MyTable1
 ---------- AST ------------
 CreateTask(
     CreateTaskStmt {
@@ -13866,7 +13864,7 @@ CreateTask(
         comments: "This is test task 1",
         after: [],
         when_condition: None,
-        sql: "SELECT *\nFROM\n    MyTable1",
+        sql: "SELECT * FROM MyTable1",
     },
 )
 
@@ -13874,9 +13872,7 @@ CreateTask(
 ---------- Input ----------
 CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = 'MyWarehouse' SCHEDULE = 15 SECOND SUSPEND_TASK_AFTER_NUM_FAILURES = 3 COMMENT = 'This is test task 1' AS SELECT * FROM MyTable1
 ---------- Output ---------
-CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = MyWarehouse SCHEDULE 15 SECOND SUSPEND TASK AFTER 3 FAILURES COMMENTS = 'This is test task 1' AS SELECT *
-FROM
-    MyTable1
+CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = MyWarehouse SCHEDULE 15 SECOND SUSPEND TASK AFTER 3 FAILURES COMMENTS = 'This is test task 1' AS SELECT * FROM MyTable1
 ---------- AST ------------
 CreateTask(
     CreateTaskStmt {
@@ -13898,7 +13894,7 @@ CreateTask(
         comments: "This is test task 1",
         after: [],
         when_condition: None,
-        sql: "SELECT *\nFROM\n    MyTable1",
+        sql: "SELECT * FROM MyTable1",
     },
 )
 
@@ -13906,9 +13902,7 @@ CreateTask(
 ---------- Input ----------
 CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = 'MyWarehouse' SCHEDULE = 1215 SECOND SUSPEND_TASK_AFTER_NUM_FAILURES = 3 COMMENT = 'This is test task 1' AS SELECT * FROM MyTable1
 ---------- Output ---------
-CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = MyWarehouse SCHEDULE 1215 SECOND SUSPEND TASK AFTER 3 FAILURES COMMENTS = 'This is test task 1' AS SELECT *
-FROM
-    MyTable1
+CREATE TASK IF NOT EXISTS MyTask1 WAREHOUSE = MyWarehouse SCHEDULE 1215 SECOND SUSPEND TASK AFTER 3 FAILURES COMMENTS = 'This is test task 1' AS SELECT * FROM MyTable1
 ---------- AST ------------
 CreateTask(
     CreateTaskStmt {
@@ -13930,7 +13924,7 @@ CreateTask(
         comments: "This is test task 1",
         after: [],
         when_condition: None,
-        sql: "SELECT *\nFROM\n    MyTable1",
+        sql: "SELECT * FROM MyTable1",
     },
 )
 
@@ -13938,10 +13932,7 @@ CreateTask(
 ---------- Input ----------
 CREATE TASK IF NOT EXISTS MyTask1 SCHEDULE = USING CRON '0 6 * * *' 'America/Los_Angeles' COMMENT = 'serverless + cron' AS insert into t (c1, c2) values (1, 2), (3, 4)
 ---------- Output ---------
-CREATE TASK IF NOT EXISTS MyTask1 SCHEDULE CRON '0 6 * * *' TIMEZONE 'America/Los_Angeles' COMMENTS = 'serverless + cron' AS INSERT INTO
-    t (c1, c2)
-VALUES
-    (1, 2), (3, 4)
+CREATE TASK IF NOT EXISTS MyTask1 SCHEDULE CRON '0 6 * * *' TIMEZONE 'America/Los_Angeles' COMMENTS = 'serverless + cron' AS INSERT INTO t (c1, c2) VALUES (1, 2), (3, 4)
 ---------- AST ------------
 CreateTask(
     CreateTaskStmt {
@@ -13962,7 +13953,7 @@ CreateTask(
         comments: "serverless + cron",
         after: [],
         when_condition: None,
-        sql: "INSERT INTO\n    t (c1, c2)\nVALUES\n    (1, 2), (3, 4)",
+        sql: "INSERT INTO t (c1, c2) VALUES (1, 2), (3, 4)",
     },
 )
 
@@ -13990,6 +13981,33 @@ CreateTask(
         after: [],
         when_condition: None,
         sql: "VACUUM TABLE t ",
+    },
+)
+
+
+---------- Input ----------
+CREATE TASK IF NOT EXISTS MyTask1 SCHEDULE = USING CRON '0 13 * * *' AS COPY INTO @my_internal_stage FROM canadian_city_population FILE_FORMAT = (TYPE = PARQUET)
+---------- Output ---------
+CREATE TASK IF NOT EXISTS MyTask1 SCHEDULE CRON '0 13 * * *' AS COPY INTO @my_internal_stage FROM canadian_city_population FILE_FORMAT = (type = 'PARQUET') SINGLE = false MAX_FILE_SIZE= 0
+---------- AST ------------
+CreateTask(
+    CreateTaskStmt {
+        if_not_exists: true,
+        name: "MyTask1",
+        warehouse_opts: WarehouseOptions {
+            warehouse: None,
+        },
+        schedule_opts: Some(
+            CronExpression(
+                "0 13 * * *",
+                None,
+            ),
+        ),
+        suspend_task_after_num_failures: None,
+        comments: "",
+        after: [],
+        when_condition: None,
+        sql: "COPY INTO @my_internal_stage FROM canadian_city_population FILE_FORMAT = (type = 'PARQUET') SINGLE = false MAX_FILE_SIZE= 0",
     },
 )
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

Use raw formatted SQL instead of prettied one.
Previous, task SQL used the pretty_statement function and generate prettified SQL for further cloud service execution, but it seems like there are some SQL may parse in different way and unable to execute anymore. for example
```sql
copy into @stream_stage from (
        SELECT
            CASE
                WHEN (RAND() * 10)::INT % 4 = 0 THEN 'a'
                WHEN (RAND() * 10)::INT % 4 = 1 THEN 'b'
                WHEN (RAND() * 10)::INT % 4 = 2 THEN 'c'
                ELSE 'd'
            END AS level
        FROM numbers(500000)
    ) FILE_FORMAT = (
        TYPE = PARQUET
    );
```

its pretty formatted string is 
```sql
COPY INTO Stage("stream_stage")
FROM (
    SELECT CASE
        WHEN (((RAND() * 10)::Int32 % 4) = 0) THEN 'a',
        WHEN (((RAND() * 10)::Int32 % 4) = 1) THEN 'b',
        WHEN (((RAND() * 10)::Int32 % 4) = 2) THEN 'c',
        ELSE 'd'
    END AS level
    FROM numbers(500000)
)
FILE_FORMAT = (
    type = "PARQUET"
)
SINGLE = false;

```

which is unable to execute

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14281)
<!-- Reviewable:end -->
