### PR TITLE
feat: return latest leader addr if request is forwarded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,6 +2944,7 @@ dependencies = [
  "databend-common-tracing",
  "derive_more",
  "futures",
+ "itertools 0.10.5",
  "log",
  "logcall",
  "minitrace",

--- a/src/binaries/metabench/main.rs
+++ b/src/binaries/metabench/main.rs
@@ -18,7 +18,6 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::sync::Arc;
-use std::time::Duration;
 use std::time::Instant;
 
 use chrono::Utc;
@@ -121,15 +120,8 @@ async fn main() {
         let param = cmd_and_param.get(1).unwrap_or(&"").to_string();
 
         let handle = tokio::spawn(async move {
-            let client = MetaGrpcClient::try_create(
-                vec![addr.to_string()],
-                "root",
-                "xxx",
-                None,
-                None,
-                Duration::from_secs(10),
-                None,
-            );
+            let client =
+                MetaGrpcClient::try_create(vec![addr.to_string()], "root", "xxx", None, None, None);
 
             let client = match client {
                 Ok(client) => client,

--- a/src/binaries/metactl/grpc.rs
+++ b/src/binaries/metactl/grpc.rs
@@ -14,7 +14,6 @@
 
 use std::fs::File;
 use std::io::Write;
-use std::time::Duration;
 
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_raft_store::key_spaces::RaftStoreEntry;
@@ -22,15 +21,8 @@ use databend_common_meta_types::protobuf::Empty;
 use tokio_stream::StreamExt;
 
 pub async fn export_meta(addr: &str, save: String) -> anyhow::Result<()> {
-    let client = MetaGrpcClient::try_create(
-        vec![addr.to_string()],
-        "root",
-        "xxx",
-        None,
-        None,
-        Duration::from_secs(10),
-        None,
-    )?;
+    let client =
+        MetaGrpcClient::try_create(vec![addr.to_string()], "root", "xxx", None, None, None)?;
 
     let mut grpc_client = client.make_established_client().await?;
 

--- a/src/binaries/metactl/main.rs
+++ b/src/binaries/metactl/main.rs
@@ -20,7 +20,6 @@ use grpc::export_meta;
 mod snapshot;
 
 use std::collections::BTreeMap;
-use std::time::Duration;
 
 use clap::Parser;
 use databend_common_base::base::tokio;
@@ -207,15 +206,8 @@ async fn bench_client_num_conn(conf: &Config) -> anyhow::Result<()> {
 
     loop {
         i += 1;
-        let client = MetaGrpcClient::try_create(
-            vec![addr.to_string()],
-            "root",
-            "xxx",
-            None,
-            None,
-            Duration::from_secs(10),
-            None,
-        )?;
+        let client =
+            MetaGrpcClient::try_create(vec![addr.to_string()], "root", "xxx", None, None, None)?;
 
         let res = client.get_kv("foo").await;
         println!("{}-th: get_kv(foo): {:?}", i, res);
@@ -227,15 +219,8 @@ async fn bench_client_num_conn(conf: &Config) -> anyhow::Result<()> {
 async fn show_status(conf: &Config) -> anyhow::Result<()> {
     let addr = &conf.grpc_api_address;
 
-    let client = MetaGrpcClient::try_create(
-        vec![addr.to_string()],
-        "root",
-        "xxx",
-        None,
-        None,
-        Duration::from_secs(10),
-        None,
-    )?;
+    let client =
+        MetaGrpcClient::try_create(vec![addr.to_string()], "root", "xxx", None, None, None)?;
 
     let res = client.get_cluster_status().await?;
     println!("BinaryVersion: {}", res.binary_version);

--- a/src/common/base/src/future.rs
+++ b/src/common/base/src/future.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -19,6 +20,7 @@ use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
 
+use log::info;
 use pin_project_lite::pin_project;
 use tokio::time::Instant;
 
@@ -108,6 +110,19 @@ pub trait TimingFutureExt {
             if total >= threshold {
                 f(total, busy)
             }
+        })
+    }
+
+    /// Log elapsed time(total and busy) in info level when the future is ready.
+    fn info_elapsed<'a>(
+        self,
+        ctx: impl fmt::Display + 'a,
+    ) -> TimingFuture<'a, Self, impl Fn(Duration, Duration)>
+    where
+        Self: Future + Sized,
+    {
+        self.timed::<'a>(move |total, busy| {
+            info!("Elapsed: total: {:?}, busy: {:?}; {}", total, busy, ctx);
         })
     }
 }

--- a/src/meta/client/Cargo.toml
+++ b/src/meta/client/Cargo.toml
@@ -28,6 +28,7 @@ databend-common-tracing = { path = "../../common/tracing" }
 
 derive_more = { workspace = true }
 futures = { workspace = true }
+itertools = { workspace = true }
 log = { workspace = true }
 logcall = { workspace = true }
 minitrace = { workspace = true }

--- a/src/meta/client/src/endpoints.rs
+++ b/src/meta/client/src/endpoints.rs
@@ -1,0 +1,215 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use itertools::Itertools;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Status {}
+
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    /// The index of the next node to send a request to, if leader fails.
+    index: usize,
+
+    /// The current leader.
+    ///
+    /// All requests should be sent to the leader in order to minimize latency by avoiding forwarding between meta-service nodes.
+    current: Option<String>,
+
+    /// Nodes of the meta-service cluster.
+    nodes: BTreeMap<String, Status>,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl Endpoints {
+    pub fn new<S>(nodes: impl IntoIterator<Item = S>) -> Self
+    where S: ToString {
+        Self {
+            index: 0,
+            current: None,
+            nodes: nodes
+                .into_iter()
+                .map(|x| (x.to_string(), Status::default()))
+                .collect(),
+        }
+    }
+
+    /// Update `current` to choose the next node to send a request to.
+    ///
+    /// This is used when the `current` node fails.
+    pub fn choose_next(&mut self) -> &str {
+        self.index += 1;
+
+        self.current = self
+            .nodes
+            .keys()
+            .nth(self.index % self.nodes.len())
+            .map(|x| x.to_string());
+
+        self.current.as_deref().unwrap()
+    }
+
+    /// Return the endpoint of the node to connect.
+    ///
+    /// It always return the currently known leader address.
+    /// If it is not known, it will choose a next node.
+    pub fn current_or_next(&mut self) -> &str {
+        if self.current.is_none() {
+            self.choose_next();
+        }
+
+        self.current.as_deref().unwrap()
+    }
+
+    pub fn current(&self) -> Option<&str> {
+        self.current.as_deref()
+    }
+
+    pub fn nodes(&self) -> impl Iterator<Item = &'_ String> + '_ {
+        self.nodes.keys()
+    }
+
+    pub fn set_current(
+        &mut self,
+        current: Option<impl ToString>,
+    ) -> Result<Option<String>, String> {
+        let current = current.map(|x| x.to_string());
+
+        if let Some(c) = current.as_deref() {
+            if !self.nodes.contains_key(c) {
+                return Err(format!("node({}) to set is not in the nodes list", c));
+            }
+        }
+        let prev = std::mem::replace(&mut self.current, current);
+        Ok(prev)
+    }
+
+    /// Replace the nodes of the meta-service cluster.
+    ///
+    /// If the `current` node is not in the new nodes, it will be set to `None`.
+    pub fn replace_nodes(&mut self, nodes: impl IntoIterator<Item = impl ToString>) {
+        self.nodes = nodes
+            .into_iter()
+            .map(|x| (x.to_string(), Status::default()))
+            .collect();
+        if let Some(c) = self.current.as_deref() {
+            if !self.nodes.contains_key(c) {
+                self.current = None;
+            }
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+impl fmt::Display for Endpoints {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let keys = self.nodes.keys().map(|x| x.as_str()).join(", ");
+        write!(
+            f,
+            "current:{:?}, index:{}, all:[{}]",
+            self.current, self.index, keys
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::endpoints::Endpoints;
+
+    #[test]
+    fn test_endpoints_new() -> anyhow::Result<()> {
+        let es = Endpoints::new(["a", "b"]);
+        assert_eq!("current:None, index:0, all:[a, b]", es.to_string());
+        Ok(())
+    }
+
+    #[test]
+    fn test_endpoints_choose_next() -> anyhow::Result<()> {
+        let mut es = Endpoints::new(["a", "b"]);
+        assert_eq!("b", es.choose_next());
+        assert_eq!("a", es.choose_next());
+        assert_eq!("b", es.choose_next());
+        assert_eq!("a", es.choose_next());
+
+        // Update nodes does not reset the index.
+        es.replace_nodes(["c", "d"]);
+        assert_eq!("d", es.choose_next());
+
+        // Reduce nodes list size is ok.
+        let mut es = Endpoints::new(["a", "b", "c"]);
+        assert_eq!("b", es.choose_next());
+        assert_eq!("c", es.choose_next());
+        es.replace_nodes(["d"]);
+        assert_eq!("d", es.choose_next());
+        Ok(())
+    }
+
+    #[test]
+    fn test_endpoints_current_or_next() -> anyhow::Result<()> {
+        let mut es = Endpoints::new(["a", "b"]);
+        assert_eq!("b", es.current_or_next());
+        assert_eq!("b", es.current_or_next());
+        assert_eq!("a", es.choose_next());
+        assert_eq!("a", es.current_or_next());
+
+        // Update nodes does not reset the index, but it will reset the current node.
+        es.replace_nodes(["c", "d"]);
+        assert_eq!("d", es.choose_next());
+
+        // Reduce nodes list size is ok.
+        let mut es = Endpoints::new(["a", "b", "c"]);
+        assert_eq!("b", es.choose_next());
+        assert_eq!("c", es.choose_next());
+        es.replace_nodes(["d"]);
+        assert_eq!("d", es.current_or_next());
+        Ok(())
+    }
+
+    #[test]
+    fn test_endpoints_current() -> anyhow::Result<()> {
+        let mut es = Endpoints::new(["a", "b"]);
+        assert_eq!(None, es.current());
+        assert_eq!("b", es.choose_next());
+        assert_eq!(Some("b"), es.current());
+
+        // Updating nodes will reset the current node.
+        es.replace_nodes(["c", "d"]);
+        assert_eq!(None, es.current());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_endpoints_set_current() -> anyhow::Result<()> {
+        let mut es = Endpoints::new(["a", "b"]);
+        assert_eq!(Ok(None), es.set_current(Some("a")));
+        assert_eq!(Some("a"), es.current());
+
+        assert_eq!(Ok(Some("a".to_string())), es.set_current(Some("a")));
+
+        assert_eq!(Ok(Some("a".to_string())), es.set_current(Some("b")));
+        assert_eq!(Some("b"), es.current());
+
+        assert!(es.set_current(Some("c")).is_err());
+        assert_eq!(Some("b"), es.current());
+
+        Ok(())
+    }
+}

--- a/src/meta/client/src/established_client.rs
+++ b/src/meta/client/src/established_client.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use databend_common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use databend_common_meta_types::protobuf::ClientInfo;
@@ -27,22 +26,84 @@ use databend_common_meta_types::protobuf::RaftRequest;
 use databend_common_meta_types::protobuf::StreamItem;
 use databend_common_meta_types::protobuf::WatchRequest;
 use databend_common_meta_types::protobuf::WatchResponse;
+use databend_common_meta_types::GrpcHelper;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
+use log::error;
+use log::info;
+use parking_lot::Mutex;
 use tonic::codec::Streaming;
 use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 use tonic::Response;
 use tonic::Status;
 
+use crate::endpoints::Endpoints;
 use crate::grpc_client::AuthInterceptor;
+use crate::grpc_client::RealClient;
+
+/// Update the client state according to the result of an RPC.
+trait HandleRPCResult<T> {
+    fn update_client(self, client: &mut EstablishedClient) -> Self;
+}
+
+impl<T> HandleRPCResult<T> for Result<Response<T>, Status> {
+    fn update_client(self, client: &mut EstablishedClient) -> Result<Response<T>, Status> {
+        // - Set the `current` node in endpoints to the leader if the request is forwarded by a follower to a leader.
+        // - Store the error if received an error.
+
+        self.map(|response| {
+            let forwarded_leader = GrpcHelper::get_response_meta_leader(&response);
+
+            // `leader` is set iff the request is forwarded by a follower to a leader
+            if let Some(leader) = forwarded_leader {
+                info!(
+                    "to switch to use leader({}) for further RPC, endpoints: {}",
+                    leader,
+                    &*client.endpoints.lock(),
+                );
+
+                let update_leader_res = {
+                    let mut endpoints = client.endpoints.lock();
+                    let set_res = endpoints.set_current(Some(leader.to_string()));
+
+                    if let Err(ref e) = set_res {
+                        error!("fail to update leader: {:?}; endpoints: {}", e, endpoints);
+                    }
+
+                    set_res
+                };
+
+                info!(
+                    "switch to use leader({}) for further RPC, result: {:?}",
+                    leader, update_leader_res,
+                );
+            }
+
+            response
+        })
+        .map_err(|status| {
+            client.set_error(status.clone());
+            status
+        })
+    }
+}
 
 /// A gRPC client that has established a connection to a server and passed handshake.
 #[derive(Debug, Clone)]
 pub struct EstablishedClient {
-    client: MetaServiceClient<InterceptedService<Channel, AuthInterceptor>>,
+    client: RealClient,
 
     server_protocol_version: u64,
+
+    /// The target endpoint this client connected to.
+    ///
+    /// Note that `target_endpoint` may be different from the `self.endpoints.current()`,
+    /// which is used for in future connections and may have been updated by other thread.
+    target_endpoint: String,
+
+    /// The endpoints shared in a client pool.
+    endpoints: Arc<Mutex<Endpoints>>,
 
     /// The error that occurred when sending an RPC.
     ///
@@ -54,12 +115,20 @@ impl EstablishedClient {
     pub(crate) fn new(
         client: MetaServiceClient<InterceptedService<Channel, AuthInterceptor>>,
         server_protocol_version: u64,
+        target_endpoint: impl ToString,
+        endpoints: Arc<Mutex<Endpoints>>,
     ) -> Self {
         Self {
             client,
             server_protocol_version,
+            target_endpoint: target_endpoint.to_string(),
+            endpoints,
             error: Arc::new(Mutex::new(None)),
         }
+    }
+
+    pub fn target_endpoint(&self) -> &str {
+        &self.target_endpoint
     }
 
     pub fn server_protocol_version(&self) -> u64 {
@@ -67,90 +136,73 @@ impl EstablishedClient {
     }
 
     pub(crate) fn set_error(&self, error: Status) {
-        *self.error.lock().unwrap() = Some(error);
+        *self.error.lock() = Some(error);
     }
 
     pub(crate) fn take_error(&self) -> Option<Status> {
-        self.error.lock().unwrap().take()
+        self.error.lock().take()
     }
 
     pub async fn kv_api(
         &mut self,
         request: impl tonic::IntoRequest<RaftRequest>,
     ) -> Result<Response<RaftReply>, Status> {
-        self.client.kv_api(request).await.map_err(|e| {
-            self.set_error(e.clone());
-            e
-        })
+        self.client.kv_api(request).await.update_client(self)
     }
 
     pub async fn kv_read_v1(
         &mut self,
         request: impl tonic::IntoRequest<RaftRequest>,
     ) -> Result<Response<Streaming<StreamItem>>, Status> {
-        self.client.kv_read_v1(request).await.map_err(|e| {
-            self.set_error(e.clone());
-            e
-        })
+        let resp = self.client.kv_read_v1(request).await;
+        resp.update_client(self)
     }
 
     pub async fn export(
         &mut self,
         request: impl tonic::IntoRequest<Empty>,
     ) -> Result<Response<Streaming<ExportedChunk>>, Status> {
-        self.client.export(request).await.map_err(|e| {
-            self.set_error(e.clone());
-            e
-        })
+        self.client.export(request).await.update_client(self)
     }
 
     pub async fn watch(
         &mut self,
         request: impl tonic::IntoRequest<WatchRequest>,
     ) -> Result<Response<Streaming<WatchResponse>>, Status> {
-        self.client.watch(request).await.map_err(|e| {
-            self.set_error(e.clone());
-            e
-        })
+        self.client.watch(request).await.update_client(self)
     }
 
     pub async fn transaction(
         &mut self,
         request: impl tonic::IntoRequest<TxnRequest>,
     ) -> Result<Response<TxnReply>, Status> {
-        self.client.transaction(request).await.map_err(|e| {
-            self.set_error(e.clone());
-            e
-        })
+        self.client.transaction(request).await.update_client(self)
     }
 
     pub async fn member_list(
         &mut self,
         request: impl tonic::IntoRequest<MemberListRequest>,
     ) -> Result<Response<MemberListReply>, Status> {
-        self.client.member_list(request).await.map_err(|e| {
-            self.set_error(e.clone());
-            e
-        })
+        self.client.member_list(request).await.update_client(self)
     }
 
     pub async fn get_cluster_status(
         &mut self,
         request: impl tonic::IntoRequest<Empty>,
     ) -> Result<Response<ClusterStatus>, Status> {
-        self.client.get_cluster_status(request).await.map_err(|e| {
-            self.set_error(e.clone());
-            e
-        })
+        self.client
+            .get_cluster_status(request)
+            .await
+            .update_client(self)
     }
 
     pub async fn get_client_info(
         &mut self,
         request: impl tonic::IntoRequest<Empty>,
     ) -> Result<Response<ClientInfo>, Status> {
-        self.client.get_client_info(request).await.map_err(|e| {
-            self.set_error(e.clone());
-            e
-        })
+        self.client
+            .get_client_info(request)
+            .await
+            .update_client(self)
     }
 }

--- a/src/meta/client/src/established_client.rs
+++ b/src/meta/client/src/established_client.rs
@@ -131,6 +131,10 @@ impl EstablishedClient {
         &self.target_endpoint
     }
 
+    pub fn endpoints(&self) -> &Arc<Mutex<Endpoints>> {
+        &self.endpoints
+    }
+
     pub fn server_protocol_version(&self) -> u64 {
         self.server_protocol_version
     }

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -15,6 +15,9 @@
 #![allow(clippy::uninlined_format_args)]
 #![feature(lazy_cell)]
 
+extern crate core;
+
+pub mod endpoints;
 pub(crate) mod established_client;
 mod grpc_action;
 mod grpc_client;

--- a/src/meta/client/tests/it/grpc_client.rs
+++ b/src/meta/client/tests/it/grpc_client.rs
@@ -163,15 +163,7 @@ async fn test_grpc_client_reconnect() -> anyhow::Result<()> {
 }
 
 fn new_client(addr: impl ToString, timeout: Option<Duration>) -> anyhow::Result<Arc<ClientHandle>> {
-    let client = MetaGrpcClient::try_create(
-        vec![addr.to_string()],
-        "",
-        "",
-        timeout,
-        None,
-        Duration::from_secs(10),
-        None,
-    )?;
+    let client = MetaGrpcClient::try_create(vec![addr.to_string()], "", "", timeout, None, None)?;
 
     Ok(client)
 }

--- a/src/meta/service/src/meta_service/forwarder.rs
+++ b/src/meta/service/src/meta_service/forwarder.rs
@@ -60,7 +60,7 @@ impl<'a> MetaForwarder<'a> {
 
         let endpoint = self
             .sto
-            .get_node_endpoint(target)
+            .get_node_raft_endpoint(target)
             .await
             .map_err(|e| MetaNetworkError::GetNodeAddrError(e.to_string()))?;
 
@@ -86,7 +86,7 @@ impl<'a> Forwarder<ForwardRequestBody> for MetaForwarder<'a> {
         &self,
         target: NodeId,
         req: ForwardRequest<ForwardRequestBody>,
-    ) -> Result<ForwardResponse, ForwardRPCError> {
+    ) -> Result<(Endpoint, ForwardResponse), ForwardRPCError> {
         debug!("forward ForwardRequest to: {} {:?}", target, req);
 
         let (endpoint, mut client) = self.new_raft_client(&target).await?;
@@ -99,7 +99,8 @@ impl<'a> Forwarder<ForwardRequestBody> for MetaForwarder<'a> {
 
         let res: Result<ForwardResponse, MetaAPIError> = reply_to_api_result(raft_mes);
         let resp = res?;
-        Ok(resp)
+
+        Ok((endpoint, resp))
     }
 }
 
@@ -110,7 +111,7 @@ impl<'a> Forwarder<MetaGrpcReadReq> for MetaForwarder<'a> {
         &self,
         target: NodeId,
         req: ForwardRequest<MetaGrpcReadReq>,
-    ) -> Result<BoxStream<StreamItem>, ForwardRPCError> {
+    ) -> Result<(Endpoint, BoxStream<StreamItem>), ForwardRPCError> {
         debug!("forward ReadRequest to: {} {:?}", target, req);
 
         let (endpoint, mut client) = self.new_raft_client(&target).await?;
@@ -121,6 +122,6 @@ impl<'a> Forwarder<MetaGrpcReadReq> for MetaForwarder<'a> {
         })?;
 
         let strm = strm.into_inner();
-        Ok(Box::pin(strm))
+        Ok((endpoint, Box::pin(strm)))
     }
 }

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -240,7 +240,7 @@ impl MetaNodeBuilder {
         let endpoint = if let Some(a) = self.endpoint.take() {
             a
         } else {
-            sto.get_node_endpoint(&node_id).await.map_err(|e| {
+            sto.get_node_raft_endpoint(&node_id).await.map_err(|e| {
                 MetaStartupError::InvalidConfig(format!(
                     "endpoint of node: {} is not configured and is not in store, error: {}",
                     node_id, e,
@@ -903,7 +903,7 @@ impl MetaNode {
             .get_nodes(|ms| ms.learner_ids().collect::<Vec<_>>())
             .await;
 
-        let endpoint = self.sto.get_node_endpoint(&self.sto.id).await?;
+        let endpoint = self.sto.get_node_raft_endpoint(&self.sto.id).await?;
 
         let db_size = self.sto.db.size_on_disk().map_err(|e| {
             let se = MetaStorageError::SledError(AnyError::new(&e).add_context(|| "get db_size"));
@@ -979,7 +979,7 @@ impl MetaNode {
     pub async fn handle_forwardable_request<Req>(
         &self,
         req: ForwardRequest<Req>,
-    ) -> Result<Req::Reply, MetaAPIError>
+    ) -> Result<(Option<Endpoint>, Req::Reply), MetaAPIError>
     where
         Req: RequestFor,
         for<'a> MetaLeader<'a>: Handler<Req>,
@@ -1001,7 +1001,7 @@ impl MetaNode {
                 Ok(leader) => {
                     let res = leader.handle(req.clone()).await;
                     match res {
-                        Ok(x) => return Ok(x),
+                        Ok(x) => return Ok((None, x)),
                         Err(e) => e,
                     }
                 }
@@ -1026,8 +1026,27 @@ impl MetaNode {
             let res = f.forward(leader_id, req_cloned).await;
 
             let forward_err = match res {
-                Ok(x) => {
-                    return Ok(x);
+                Ok((_leader_raft_endpoint, reply)) => {
+                    let leader_grpc_endpoint = self
+                        .get_node(&leader_id)
+                        .await
+                        .and_then(|node| node.grpc_api_advertise_address)
+                        .and_then(|leader_grpc_address| {
+                            let endpoint_res = Endpoint::parse(&leader_grpc_address);
+
+                            match endpoint_res {
+                                Ok(o) => Some(o),
+                                Err(e) => {
+                                    error!(
+                                        "fail to parse leader_grpc_address: {}; error: {}",
+                                        &leader_grpc_address, e
+                                    );
+                                    None
+                                }
+                            }
+                        });
+
+                    return Ok((leader_grpc_endpoint, reply));
                 }
                 Err(forward_err) => forward_err,
             };
@@ -1111,7 +1130,8 @@ impl MetaNode {
     pub async fn write(&self, req: LogEntry) -> Result<AppliedState, MetaAPIError> {
         debug!("{} req: {:?}", func_name!(), req);
 
-        let res = self
+        // TODO: enable returning endpoint
+        let (_endpoint, res) = self
             .handle_forwardable_request(ForwardRequest::new(
                 1,
                 ForwardRequestBody::Write(req.clone()),

--- a/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
+++ b/src/meta/service/src/meta_service/meta_node_kv_api_impl.rs
@@ -61,13 +61,16 @@ impl kvapi::KVApi for MetaNode {
             keys: keys.to_vec(),
         };
 
-        let strm = self
+        let res = self
             .handle_forwardable_request(ForwardRequest::new(1, MetaGrpcReadReq::MGetKV(req)))
             .await;
 
-        server_metrics::incr_read_result(&strm);
+        server_metrics::incr_read_result(&res);
 
-        let strm = strm?.map_err(MetaAPIError::from);
+        // TODO: enable returning endpoint
+        let (_endpoint, strm) = res?;
+        let strm = strm.map_err(MetaAPIError::from);
+
         Ok(strm.boxed())
     }
 
@@ -77,13 +80,16 @@ impl kvapi::KVApi for MetaNode {
             prefix: prefix.to_string(),
         };
 
-        let strm = self
+        let res = self
             .handle_forwardable_request(ForwardRequest::new(1, MetaGrpcReadReq::ListKV(req)))
             .await;
 
-        server_metrics::incr_read_result(&strm);
+        server_metrics::incr_read_result(&res);
 
-        let strm = strm?.map_err(MetaAPIError::from);
+        // TODO: enable returning endpoint
+        let (_endpoint, strm) = res?;
+
+        let strm = strm.map_err(MetaAPIError::from);
         Ok(strm.boxed())
     }
 

--- a/src/meta/service/src/meta_service/raft_service_impl.rs
+++ b/src/meta/service/src/meta_service/raft_service_impl.rs
@@ -138,6 +138,8 @@ impl RaftService for RaftServiceImpl {
 
             let res = self.meta_node.handle_forwardable_request(forward_req).await;
 
+            let res = res.map(|(_endpoint, forward_resp)| forward_resp);
+
             let raft_reply: RaftReply = res.into();
 
             Ok(Response::new(raft_reply))
@@ -157,13 +159,16 @@ impl RaftService for RaftServiceImpl {
         async {
             let forward_req: ForwardRequest<MetaGrpcReadReq> = GrpcHelper::parse_req(request)?;
 
-            let strm = self
+            let (endpoint, strm) = self
                 .meta_node
                 .handle_forwardable_request(forward_req)
                 .await
                 .map_err(GrpcHelper::internal_err)?;
 
-            Ok(Response::new(strm))
+            let mut resp = Response::new(strm);
+            GrpcHelper::add_response_meta_leader(&mut resp, endpoint.as_ref());
+
+            Ok(resp)
         }
         .in_span(root)
         .await

--- a/src/meta/service/src/network.rs
+++ b/src/meta/service/src/network.rs
@@ -188,7 +188,7 @@ impl NetworkConnection {
 
         let endpoint = self
             .sto
-            .get_node_endpoint(&target)
+            .get_node_raft_endpoint(&target)
             .await
             .map_err(|e| Unreachable::new(&e))?;
 

--- a/src/meta/service/src/request_handling.rs
+++ b/src/meta/service/src/request_handling.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_meta_client::RequestFor;
+use databend_common_meta_types::Endpoint;
 use databend_common_meta_types::ForwardRPCError;
 use databend_common_meta_types::MetaOperationError;
 use databend_common_meta_types::NodeId;
@@ -34,7 +35,7 @@ pub trait Forwarder<Req: RequestFor> {
         &self,
         target: NodeId,
         req: ForwardRequest<Req>,
-    ) -> Result<Req::Reply, ForwardRPCError>;
+    ) -> Result<(Endpoint, Req::Reply), ForwardRPCError>;
 }
 
 impl RequestFor for ForwardRequestBody {

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -541,7 +541,7 @@ impl StoreInner {
         ns
     }
 
-    pub async fn get_node_endpoint(&self, node_id: &NodeId) -> Result<Endpoint, MetaError> {
+    pub async fn get_node_raft_endpoint(&self, node_id: &NodeId) -> Result<Endpoint, MetaError> {
         let endpoint = self
             .get_node(node_id)
             .await

--- a/src/meta/service/tests/it/grpc/metasrv_connection_error.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_connection_error.rs
@@ -151,7 +151,6 @@ fn make_client(addresses: Vec<String>) -> Result<Arc<ClientHandle>, MetaClientEr
         "xxx",
         None,
         Some(Duration::from_secs(10)),
-        Duration::from_secs(10),
         None,
     )?;
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -162,7 +162,6 @@ async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
         "xxx",
         None,
         Some(Duration::from_secs(10)),
-        Duration::from_secs(10),
         None,
     )?;
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
@@ -88,17 +88,22 @@ async fn test_kv_read_v1_follower_responds_leader_endpoint() -> anyhow::Result<(
     let client = make_grpc_client(vec![a1(), a2(), a0()])?;
     {
         let eclient = client.make_established_client().await?;
+        assert_eq!(a0(), eclient.target_endpoint(),);
+
+        // Start using a1(), a follower, for next RPC
+        eclient.endpoints().lock().choose_next();
+    }
+    {
+        let eclient = client.make_established_client().await?;
+        assert_eq!(a1(), eclient.target_endpoint(), "using a1()");
+    }
+    {
+        let eclient = client.make_established_client().await?;
         assert_eq!(
             a1(),
             eclient.target_endpoint(),
-            "Endpoints.index is 0 initially, so the target endpoint is a1"
+            "make client again, still using a1()"
         );
-    }
-
-    // Make client again, still connect to a1.
-    {
-        let eclient = client.make_established_client().await?;
-        assert_eq!(a1(), eclient.target_endpoint(),);
     }
 
     let _strm = client

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_tls.rs
@@ -55,7 +55,6 @@ async fn test_tls_server() -> anyhow::Result<()> {
         "xxx",
         None,
         Some(Duration::from_secs(10)),
-        Duration::from_secs(10),
         Some(tls_conf),
     )?;
 
@@ -94,7 +93,6 @@ async fn test_tls_client_config_failure() -> anyhow::Result<()> {
         "xxx",
         None,
         Some(Duration::from_secs(10)),
-        Duration::from_secs(10),
         Some(tls_conf),
     )
     .unwrap();

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_transaction.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_transaction.rs
@@ -1,0 +1,69 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test special cases of grpc API: transaction().
+
+use databend_common_meta_types::TxnRequest;
+use test_harness::test;
+
+use crate::testing::meta_service_test_harness;
+use crate::tests::service::make_grpc_client;
+
+/// When invoke transaction() on a follower, the leader endpoint is responded in the response header.
+#[test(harness = meta_service_test_harness)]
+#[minitrace::trace]
+async fn test_transaction_follower_responds_leader_endpoint() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let a0 = || addresses[0].clone();
+    let a1 = || addresses[1].clone();
+    let a2 = || addresses[2].clone();
+
+    let client = make_grpc_client(vec![a1(), a2(), a0()])?;
+    {
+        let eclient = client.make_established_client().await?;
+        assert_eq!(
+            a1(),
+            eclient.target_endpoint(),
+            "Endpoints.index is 0 initially, so the target endpoint is a1"
+        );
+    }
+
+    // Make client again, still connect to a1.
+    {
+        let eclient = client.make_established_client().await?;
+        assert_eq!(a1(), eclient.target_endpoint(),);
+    }
+
+    let _res = client
+        .request(TxnRequest {
+            condition: vec![],
+            if_then: vec![],
+            else_then: vec![],
+        })
+        .await?;
+
+    // Current leader endpoint updated, will connect to a0.
+    {
+        let eclient = client.make_established_client().await?;
+        assert_eq!(a0(), eclient.target_endpoint(),);
+    }
+
+    Ok(())
+}

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_transaction.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_transaction.rs
@@ -38,14 +38,13 @@ async fn test_transaction_follower_responds_leader_endpoint() -> anyhow::Result<
     let client = make_grpc_client(vec![a1(), a2(), a0()])?;
     {
         let eclient = client.make_established_client().await?;
-        assert_eq!(
-            a1(),
-            eclient.target_endpoint(),
-            "Endpoints.index is 0 initially, so the target endpoint is a1"
-        );
+        assert_eq!(a0(), eclient.target_endpoint(),);
+
+        // Start using a1(), a follower, for next RPC
+        eclient.endpoints().lock().choose_next();
     }
 
-    // Make client again, still connect to a1.
+    // Make client again, connect to a1.
     {
         let eclient = client.make_established_client().await?;
         assert_eq!(a1(), eclient.target_endpoint(),);

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -543,7 +543,6 @@ fn make_client(addr: impl ToString) -> anyhow::Result<Arc<ClientHandle>> {
         "xxx",
         None,
         Some(Duration::from_secs(10)),
-        Duration::from_secs(10),
         None,
     )?;
 

--- a/src/meta/service/tests/it/grpc/mod.rs
+++ b/src/meta/service/tests/it/grpc/mod.rs
@@ -24,4 +24,5 @@ pub mod metasrv_grpc_schema_api;
 pub mod metasrv_grpc_schema_api_follower_follower;
 pub mod metasrv_grpc_schema_api_leader_follower;
 pub mod metasrv_grpc_tls;
+pub mod metasrv_grpc_transaction;
 pub mod metasrv_grpc_watch;

--- a/src/meta/types/src/endpoint.rs
+++ b/src/meta/types/src/endpoint.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::fmt;
-use std::net::SocketAddrV4;
 
 use anyerror::AnyError;
 use serde::Deserialize;
@@ -43,10 +42,17 @@ impl Endpoint {
 
     /// Parse `1.2.3.4:5555` into `Endpoint`.
     pub fn parse(address: &str) -> Result<Self, AnyError> {
-        match address.parse::<SocketAddrV4>() {
-            Ok(a) => Ok(Self::new(a.ip().to_string(), a.port())),
-            Err(e) => Err(AnyError::error(format!("Failed to parse address: {}", e))),
+        let x = address.splitn(2, ':').collect::<Vec<_>>();
+        if x.len() != 2 {
+            return Err(AnyError::error(format!(
+                "Failed to parse address: {}",
+                address
+            )));
         }
+        let port = x[1].parse::<u16>().map_err(|e| {
+            AnyError::error(format!("Failed to parse port: {}; address: {}", e, address))
+        })?;
+        Ok(Self::new(x[0], port))
     }
 }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feature: return latest leader addr if request is forwarded

New feature, compatible change.

When a meta-service follower receives a request, it forwards it to the
leader. This mechanism introduces additional latency.

In this commit:

- Meta-service responds the leader-address in gRPC
  header(response metadata): "x-databend-meta-leader-grpc-endpoint",
  if the meta-service node is a follower.

- Meta-client that receives such a reponse metadate then updates the
  address for further connection to this perceived leader.

- Leader endpoint response is added to two API: `transaction()` and
  `kv_read_v1()`, which are the most used by `SchemaApi`, and very
  latency sensitive.

  `upsert()` and `kv_read()`(v0 API) are not changed: `upsert()` will be
  replaced with `transaction()`, and `kv_read()` is only used by former
  versions databend-query, which are not capable of parsing leader
  endpoint response.

Detailed Changes

- Add `Endpoints` as a container that stores all of the meta-service
  endpoints for a meta-client.

- Updating leader endpoint is done in `EstablishedClient`, which is a
  wrapper for underlying gRPC client. `HandleRPCResult::update_client()`
  is responsible to update leader endpoint and mark a client as **error**.

- The `endpoints` now is shared between `MetaChannelManager` and
  `EstablishedClient`, `MetaChannelManager` uses `endpoints` for
  connecting, `EstablishedClient` uses it for updating.

- The old health based node choosing algorithm is discarded, because the
  responded leader must be in good healthy state, otherwise it will
  step down.

- Add timing and logging to meta-service API.

---

- Fix: #14224

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14288)
<!-- Reviewable:end -->
