### PR TITLE
fix: keys in stage_attachment.file_format_options should be case-insensitive

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -320,7 +320,11 @@ impl HttpQuery {
         match &request.stage_attachment {
             Some(attachment) => ctx.attach_stage(StageAttachment {
                 location: attachment.location.clone(),
-                file_format_options: attachment.file_format_options.clone(),
+                file_format_options: attachment.file_format_options.as_ref().map(|v| {
+                    v.iter()
+                        .map(|(k, v)| (k.to_lowercase(), v.to_owned()))
+                        .collect::<BTreeMap<_, _>>()
+                }),
                 copy_options: attachment.copy_options.clone(),
             }),
             None => {}

--- a/tests/suites/1_stateful/07_stage_attachment/07_0003_insert_with_stage_file_format.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0003_insert_with_stage_file_format.result
@@ -1,0 +1,16 @@
+>>>> drop table if exists t1
+>>>> create table t1 (a string, b string)
+>>>> drop stage if exists s1
+>>>> create stage s1
+>>>> copy into @s1 from (select 'Null', 'NULL') file_format = (type = csv)
+1	14	14
+<<<<
+Succeeded
+14
+38
+null
+>>>> select a is null, b is null from t1
+true	false
+<<<<
+>>>> drop table if exists t1
+>>>> drop stage if exists s1

--- a/tests/suites/1_stateful/07_stage_attachment/07_0003_insert_with_stage_file_format.sh
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0003_insert_with_stage_file_format.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+stmt "drop table if exists t1"
+stmt "create table t1 (a string, b string)"
+
+stmt "drop stage if exists s1"
+stmt "create stage s1"
+
+query "copy into @s1 from (select 'Null', 'NULL') file_format = (type = csv)"
+
+curl -s -u root: -XPOST "http://localhost:8000/v1/query" --header 'Content-Type: application/json' -d '{"sql": "insert into t1 (a, b) values", "stage_attachment": {"location": "@s1/", "copy_options": {"purge": "true"},  "file_format_options":{"Type": "csv","Binary_Format":"hex", "null_display": "Null"}}, "pagination": { "wait_time_secs": 8}}' | jq -r '.state, .stats.scan_progress.bytes, .stats.write_progress.bytes, .error'
+
+query "select a is null, b is null from t1"
+
+stmt "drop table if exists t1"
+stmt "drop stage if exists s1"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

consist with that in SQL:
keys are case-insensitive, but values depend (enum is insensitive, but string is sensetive).

Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14357)
<!-- Reviewable:end -->
