### PR TITLE
chore: add a setting to enforce broadcast join

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -288,6 +288,12 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: None,
                 }),
+                ("enforce_broadcast_join", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Enforce broadcast join.",
+                    mode: SettingMode::Both,
+                    range: None,
+                }),
                 ("storage_fetch_part_num", DefaultSettingValue {
                     value: UserSettingValue::UInt64(2),
                     desc: "Sets the number of partitions that are fetched in parallel from storage during query execution.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -278,6 +278,10 @@ impl Settings {
         Ok(self.try_get_u64("prefer_broadcast_join")? != 0)
     }
 
+    pub fn get_enforce_broadcast_join(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enforce_broadcast_join")? != 0)
+    }
+
     pub fn get_sql_dialect(&self) -> Result<Dialect> {
         match self.try_get_string("sql_dialect")?.to_lowercase().as_str() {
             "hive" => Ok(Dialect::Hive),

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -538,7 +538,9 @@ impl Operator for Join {
                 // Use a very large value to prevent broadcast join.
                 1000.0
             };
-            if right_stat_info.cardinality * broadcast_join_threshold < left_stat_info.cardinality {
+            if right_stat_info.cardinality * broadcast_join_threshold < left_stat_info.cardinality
+                || ctx.get_settings().get_enforce_broadcast_join()?
+            {
                 if child_index == 1 {
                     required.distribution = Distribution::Broadcast;
                 } else {
@@ -560,13 +562,13 @@ impl Operator for Join {
 
     fn compute_required_prop_children(
         &self,
-        _ctx: Arc<dyn TableContext>,
+        ctx: Arc<dyn TableContext>,
         _rel_expr: &RelExpr,
         _required: &RequiredProperty,
     ) -> Result<Vec<Vec<RequiredProperty>>> {
         let mut children_required = vec![];
 
-        if self.join_type != JoinType::Cross {
+        if self.join_type != JoinType::Cross && !ctx.get_settings().get_enforce_broadcast_join()? {
             // (Hash, Hash)
             children_required.extend(
                 self.left_conditions


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Provide a switch to compare the performance of shuffle join and broadcast join.

Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14361)
<!-- Reviewable:end -->
