### PR TITLE
refactor: do not use `TxnPutRequest|TxnDeleteRequest.prev_value`, always return previous value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-io",
  "databend-common-meta-app",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "ethnum 1.5.0",
  "fast-float",
  "goldenfile",
@@ -2606,7 +2606,7 @@ dependencies = [
 name = "databend-common-datavalues"
 version = "0.1.0"
 dependencies = [
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "enum_dispatch",
  "serde",
  "serde_json",
@@ -2657,7 +2657,7 @@ dependencies = [
  "databend-common-hashtable",
  "databend-common-io",
  "educe",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "ethnum 1.5.0",
  "futures",
  "goldenfile",
@@ -2781,7 +2781,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tonic 0.10.2",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.22.0",
 ]
 
 [[package]]
@@ -3370,7 +3370,7 @@ dependencies = [
  "databend-enterprise-data-mask-feature",
  "databend-storages-common-table-meta",
  "educe",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "globiter",
  "indexmap 2.0.0",
  "itertools 0.10.5",
@@ -3513,7 +3513,7 @@ dependencies = [
  "databend-storages-common-index",
  "databend-storages-common-pruner",
  "databend-storages-common-table-meta",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "futures",
  "futures-util",
  "indexmap 2.0.0",
@@ -4488,7 +4488,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-io",
  "databend-common-storages-fuse",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "futures",
  "futures-util",
  "pot",
@@ -4906,6 +4906,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -7032,9 +7044,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -7042,7 +7054,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.2",
+ "indexmap 2.0.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -7530,6 +7542,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -10381,7 +10403,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.0",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "pyo3-build-config 0.19.1",
  "pyo3-ffi",
  "pyo3-macros",
@@ -10822,9 +10844,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.19"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b9b67e2ca7dd9e9f9285b759de30ff538aab981abaaf7bc9bd90b84a0126c3"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -10850,11 +10872,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.23.2",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -12307,6 +12330,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12907,13 +12951,38 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "futures-channel",
  "futures-io",
  "futures-util",
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
+ "rand 0.8.5",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner 0.6.0",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
  "rand 0.8.5",
  "smallvec",
  "thiserror",
@@ -12940,7 +13009,28 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "trust-dns-proto",
+ "trust-dns-proto 0.22.0",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trust-dns-proto 0.23.2",
 ]
 
 [[package]]
@@ -12956,7 +13046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -93,6 +93,12 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///   client: remove using MetaGrpcReq::GetKV/MGetKV/ListKV;
 ///   client: remove falling back kv_read_v1(Streamed(List)) to kv_api(List), added in `2023-10-20: since 1.2.176`;
 ///
+/// - 2024-01-17: since TODO:
+///   server: do not use TxnPutRequest.prev_value;
+///   server: do not use TxnDeleteRequest.prev_value;
+///           Always return the previous value;
+///           field index is reserved, no compatibility changes.
+///
 /// Server feature set:
 /// ```yaml
 /// server_features:

--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -394,11 +394,7 @@ impl<'a> Applier<'a> {
 
         let put_resp = TxnPutResponse {
             key: put.key.clone(),
-            prev_value: if put.prev_value {
-                prev.map(pb::SeqV::from)
-            } else {
-                None
-            },
+            prev_value: prev.map(pb::SeqV::from),
         };
 
         resp.responses.push(TxnOpResponse {
@@ -428,11 +424,7 @@ impl<'a> Applier<'a> {
         let del_resp = TxnDeleteResponse {
             key: delete.key.clone(),
             success: is_deleted,
-            prev_value: if delete.prev_value {
-                prev.map(pb::SeqV::from)
-            } else {
-                None
-            },
+            prev_value: prev.map(pb::SeqV::from),
         };
 
         resp.responses.push(TxnOpResponse {

--- a/src/meta/raft-store/src/state_machine/sm.rs
+++ b/src/meta/raft-store/src/state_machine/sm.rs
@@ -549,11 +549,7 @@ impl StateMachine {
 
         let put_resp = TxnPutResponse {
             key: put.key.clone(),
-            prev_value: if put.prev_value {
-                prev.map(pb::SeqV::from)
-            } else {
-                None
-            },
+            prev_value: prev.map(pb::SeqV::from),
         };
 
         resp.responses.push(TxnOpResponse {
@@ -590,11 +586,7 @@ impl StateMachine {
         let del_resp = TxnDeleteResponse {
             key: delete.key.clone(),
             success: is_deleted,
-            prev_value: if delete.prev_value {
-                prev.map(pb::SeqV::from)
-            } else {
-                None
-            },
+            prev_value: prev.map(pb::SeqV::from),
         };
 
         resp.responses.push(TxnOpResponse {

--- a/src/meta/types/proto/request.proto
+++ b/src/meta/types/proto/request.proto
@@ -44,6 +44,7 @@ message TxnPutRequest {
   bytes value = 2;
 
   // Whether or not to return the prev value
+  // Not used anymore
   bool prev_value = 3;
 
   // Absolute expire time
@@ -64,7 +65,9 @@ message TxnPutResponse {
 // Delete request and response
 message TxnDeleteRequest {
   string key = 1;
+
   // if or not return the prev value
+  // Not used anymore
   bool prev_value = 2;
 
   // Delete only if the `seq` matches the specified value.

--- a/src/meta/types/src/proto_display.rs
+++ b/src/meta/types/src/proto_display.rs
@@ -14,6 +14,8 @@
 
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::time::Duration;
+use std::time::SystemTime;
 
 use num_traits::FromPrimitive;
 
@@ -144,13 +146,13 @@ impl Display for TxnGetRequest {
 
 impl Display for TxnPutRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Put key={}, need prev_value: {}",
-            self.key, self.prev_value
-        )?;
+        write!(f, "Put key={}", self.key)?;
         if let Some(expire_at) = self.expire_at {
-            write!(f, " expire at: {}", expire_at)?;
+            let t = SystemTime::UNIX_EPOCH + Duration::from_millis(expire_at);
+            write!(f, " expire_at: {:?}", t)?;
+        }
+        if let Some(ttl_ms) = self.ttl_ms {
+            write!(f, "  ttl: {:?}", Duration::from_millis(ttl_ms))?;
         }
         Ok(())
     }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: do not use `TxnPutRequest|TxnDeleteRequest.prev_value`, always return previous value

Meta-service does not check `TxnPutRequest.prev_value` and
`TxnDeleteRequest.prev_value` any more, and always assumes it is true.
When a `Put` or `Delete` request is executed, the previous value before
`Put` will always be responded.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14371)
<!-- Reviewable:end -->
