### PR TITLE
feat: more constrain for file format string options.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,6 +2925,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "opendal",
+ "paste",
  "serde",
  "serde_json",
  "sha1",

--- a/src/meta/app/Cargo.toml
+++ b/src/meta/app/Cargo.toml
@@ -31,6 +31,7 @@ maplit = "1.0.2"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 opendal = { workspace = true }
+paste = "1.0.9"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha1 = "0.10.5"

--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -205,7 +205,7 @@ impl FromStr for StageFileFormatType {
 
 impl ToString for StageFileFormatType {
     fn to_string(&self) -> String {
-        format!("{:?}", *self)
+        format!("{:?}", *self).to_uppercase()
     }
 }
 

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_delimiter.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_delimiter.test
@@ -4,6 +4,12 @@ drop table if exists tit
 statement ok
 create table tit(a string not null, b int not null, c string not null)
 
+query error Invalid CSV option value: FIELD_DELIMITER is currently set to 'x'. Expecting a single one-byte, non-alphanumeric character.
+copy into tit from @data/csv/ file_format = (type = CSV field_delimiter = 'x')
+
+query error Invalid CSV option value: RECORD_DELIMITER is currently set to 'x'. Expecting a single one-byte, non-alphanumeric character or '\\r\\n'.
+copy into tit from @data/csv/ file_format = (type = CSV record_delimiter = 'x')
+
 query TIITI
 copy into tit from @data/csv/x01_field_x02_record.csv file_format = (type = CSV skip_header = 0 field_delimiter = '\x01' record_delimiter = '\x02')
 ----

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_option_escape.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_option_escape.test
@@ -4,6 +4,9 @@ drop table if exists v
 statement ok
 create table v (a variant not null)
 
+query error Invalid CSV option value: ESCAPE is currently set to 'x'. The valid values are '\\\\', ''.
+copy into v from @data/csv/ file_format = (type = CSV escape = 'x')
+
 query TIITI
 copy into v from @data/csv/escape_default.csv file_format = (type = CSV)
 ----

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_types.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_types.test
@@ -90,7 +90,7 @@ statement ok
 drop file format if exists csv_raw
 
 statement ok
-create file format csv_raw type = 'csv' field_delimiter='#' quote= '&'
+create file format csv_raw type = 'csv' field_delimiter='#' quote= '`'
 
 
 query

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_null_and_missing.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_null_and_missing.test
@@ -4,7 +4,7 @@ drop table if exists t
 statement ok
 create table t(id string, a int default 2, b int not null default 2)
 
-query error 2004.*NULL_FIELD_AS cannot be ERROR
+query error 2004.*Invalid option value: NULL_FIELD_AS is set to ERROR. The valid values are NULL | FIELD_DEFAULT.
 copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, null_field_as = ERROR) on_error = continue
 
 # default:  null_field_as = NULL missing_field_as = ERROR


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

I see no reason to allow any values.
less choice is good for:

1. avoid users to use what not intended (typo, or mistake when involving escaping). 
2. avoid users to use what is no recommended (e.g. avoid alphanumeric for delimiter)
3. may make the parser a little faster.
4. avoid some ambiguity when parsing (e.g. avoid alphanumeric for delimiter)

we can add to the whitelist when something is really needed.

- quote: ["\'", "\"", "`"]
- escape:  ["\\", ""]
- field_delimiter/record_delimiter:  one-byte, non-alphanumeric

and unify related error messages.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14374)
<!-- Reviewable:end -->
