### PR TITLE
chore(query): improve agg index range comparison

### DIFF
--- a/src/query/expression/src/types/number.rs
+++ b/src/query/expression/src/types/number.rs
@@ -531,6 +531,28 @@ impl NumberScalar {
             NumberScalar::NUM_TYPE(_) => NumberDataType::NUM_TYPE,
         })
     }
+
+    pub fn is_integer(&self) -> bool {
+        crate::with_integer_mapped_type!(|NUM_TYPE| match self {
+            NumberScalar::NUM_TYPE(_) => true,
+            _ => false,
+        })
+    }
+
+    pub fn integer_to_i128(&self) -> Option<i128> {
+        crate::with_integer_mapped_type!(|NUM_TYPE| match self {
+            NumberScalar::NUM_TYPE(x) => Some(*x as i128),
+            _ => None,
+        })
+    }
+
+    pub fn float_to_f64(&self) -> Option<f64> {
+        match self {
+            NumberScalar::Float32(value) => Some(value.into_inner() as f64),
+            NumberScalar::Float64(value) => Some(value.into_inner()),
+            _ => None,
+        }
+    }
 }
 
 impl<T> From<T> for NumberScalar


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When we compare the `Range` of agg index, we need to compare the internal value of the `Scalar` instead of comparing `Scalar` directly, for example, both `NumberScalar(UInt8(1)) == NumberScalar(UInt32(1))` and `NumberScalar(UInt8(2)) > NumberScalar(UInt32(1))` should return `true`.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Covered by existing tests

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14378)
<!-- Reviewable:end -->
