### PR TITLE
feat: add data_retention_time_in_days_max config and data_retention_time_in_days setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "async-backtrace",
  "dashmap",
  "databend-common-ast",
+ "databend-common-base",
  "databend-common-config",
  "databend-common-exception",
  "databend-common-meta-app",

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1493,6 +1493,10 @@ pub struct QueryConfig {
     #[clap(long, value_name = "VALUE")]
     pub internal_merge_on_read_mutation: bool,
 
+    /// Max retention time in days for data, default is 90 days.
+    #[clap(long, value_name = "VALUE", default_value = "90")]
+    pub(crate) data_retention_time_in_days_max: u64,
+
     // ----- the following options/args are all deprecated               ----
     // ----- and turned into Option<T>, to help user migrate the configs ----
     /// OBSOLETED: Table disk cache size (mb).
@@ -1657,6 +1661,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             tenant_quota: self.quota,
             internal_enable_sandbox_tenant: self.internal_enable_sandbox_tenant,
             internal_merge_on_read_mutation: self.internal_merge_on_read_mutation,
+            data_retention_time_in_days_max: self.data_retention_time_in_days_max,
             disable_system_table_load: self.disable_system_table_load,
             openai_api_chat_base_url: self.openai_api_chat_base_url,
             openai_api_embedding_base_url: self.openai_api_embedding_base_url,
@@ -1732,6 +1737,8 @@ impl From<InnerQueryConfig> for QueryConfig {
             quota: inner.tenant_quota,
             internal_enable_sandbox_tenant: inner.internal_enable_sandbox_tenant,
             internal_merge_on_read_mutation: false,
+            data_retention_time_in_days_max: 90,
+
             // obsoleted config entries
             table_disk_cache_mb_size: None,
             table_meta_cache_enabled: None,
@@ -1744,6 +1751,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             table_cache_bloom_index_meta_count: None,
             table_cache_bloom_index_filter_count: None,
             table_cache_bloom_index_data_bytes: None,
+            //
             disable_system_table_load: inner.disable_system_table_load,
             openai_api_chat_base_url: inner.openai_api_chat_base_url,
             openai_api_embedding_base_url: inner.openai_api_embedding_base_url,

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -211,6 +211,9 @@ pub struct QueryConfig {
     /// Disable some system load(For example system.configs) for cloud security.
     pub disable_system_table_load: bool,
 
+    /// Max data retention time in days.
+    pub data_retention_time_in_days_max: u64,
+
     /// (azure) openai
     pub openai_api_key: String,
     pub openai_api_version: String,
@@ -290,6 +293,7 @@ impl Default for QueryConfig {
             enable_udf_server: false,
             udf_server_allow_list: Vec::new(),
             cloud_control_grpc_server_address: None,
+            data_retention_time_in_days_max: 90,
         }
     }
 }

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -69,6 +69,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | 'query'   | 'clickhouse_http_handler_port'             | '8124'                                                         | ''       |
 | 'query'   | 'cloud_control_grpc_server_address'        | 'null'                                                         | ''       |
 | 'query'   | 'cluster_id'                               | ''                                                             | ''       |
+| 'query'   | 'data_retention_time_in_days_max'          | '90'                                                           | ''       |
 | 'query'   | 'databend_enterprise_license'              | 'null'                                                         | ''       |
 | 'query'   | 'default_compression'                      | 'auto'                                                         | ''       |
 | 'query'   | 'default_storage_format'                   | 'auto'                                                         | ''       |

--- a/src/query/settings/Cargo.toml
+++ b/src/query/settings/Cargo.toml
@@ -26,4 +26,5 @@ once_cell = { workspace = true }
 sys-info = "0.9"
 
 [dev-dependencies]
+databend-common-base = { path = "../../common/base" }
 tokio = { workspace = true }

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -183,6 +183,14 @@ impl Settings {
         self.try_get_u64("retention_period")
     }
 
+    pub fn set_data_retention_time_in_days(&self, days: u64) -> Result<()> {
+        self.try_set_u64("data_retention_time_in_days", days)
+    }
+
+    pub fn get_data_retention_time_in_days(&self) -> Result<u64> {
+        self.try_get_u64("data_retention_time_in_days")
+    }
+
     pub fn get_max_storage_io_requests(&self) -> Result<u64> {
         self.try_get_u64("max_storage_io_requests")
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- add new settings `data_retention_time_in_days` and new config `data_retention_time_in_days_max `
   * Setting `data_retention_time_in_days` default value is `1` days
   * Config `data_retention_time_in_days_max` default is `90` days
   * Setting range is `[0, config.query.data_retention_time_in_days_max]`


Like:
```
set data_retention_time_in_days=91;
WrongValueForVariable. Code: 2803, Text = Value 91 is not within the range [0, 90].
```

Config `config.query.data_retention_time_in_days_max=33`:
```
set data_retention_time_in_days=34;
WrongValueForVariable. Code: 2803, Text = Value 34 is not within the range [0, 33].
```


- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14388)
<!-- Reviewable:end -->
