### PR TITLE
fix(query): fix json cast to string with quote

### DIFF
--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -99,6 +99,7 @@ use jsonb::type_of;
 
 pub fn register(registry: &mut FunctionRegistry) {
     registry.register_aliases("json_object_keys", &["object_keys"]);
+    registry.register_aliases("to_string", &["json_to_string"]);
 
     registry.register_passthrough_nullable_1_arg::<VariantType, VariantType, _, _>(
         "parse_json",
@@ -397,7 +398,10 @@ pub fn register(registry: &mut FunctionRegistry) {
                 match std::str::from_utf8(name) {
                     Ok(name) => match get_by_name(val, name, false) {
                         Some(v) => {
-                            output.push(to_string(&v).as_bytes());
+                            let json_str = cast_to_string(&v);
+                            output.builder.put_str(&json_str);
+                            output.builder.commit_row();
+                            output.validity.push(true);
                         }
                         None => output.push_null(),
                     },
@@ -433,7 +437,10 @@ pub fn register(registry: &mut FunctionRegistry) {
                 } else {
                     match get_by_index(val, idx as usize) {
                         Some(v) => {
-                            output.push(to_string(&v).as_bytes());
+                            let json_str = cast_to_string(&v);
+                            output.builder.put_str(&json_str);
+                            output.builder.commit_row();
+                            output.validity.push(true);
                         }
                         None => {
                             output.push_null();
@@ -626,8 +633,8 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 if out_offsets.is_empty() {
                                     output.push_null();
                                 } else {
-                                    let json_str = to_string(&out_buf);
-                                    output.builder.put(json_str.as_bytes());
+                                    let json_str = cast_to_string(&out_buf);
+                                    output.builder.put_str(&json_str);
                                     output.builder.commit_row();
                                     output.validity.push(true);
                                 }
@@ -840,7 +847,7 @@ pub fn register(registry: &mut FunctionRegistry) {
 
     registry.register_passthrough_nullable_1_arg::<VariantType, StringType, _, _>(
         "to_string",
-        |_, _| FunctionDomain::MayThrow,
+        |_, _| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<VariantType, StringType>(|val, output, ctx| {
             if let Some(validity) = &ctx.validity {
                 if !validity.get_bit(output.len()) {
@@ -848,12 +855,8 @@ pub fn register(registry: &mut FunctionRegistry) {
                     return;
                 }
             }
-            match to_str(val) {
-                Ok(value) => output.put_slice(value.as_bytes()),
-                Err(err) => {
-                    ctx.set_error(output.len(), err.to_string());
-                }
-            }
+            let json_str = cast_to_string(val);
+            output.put_str(&json_str);
             output.commit_row();
         }),
     );
@@ -869,14 +872,10 @@ pub fn register(registry: &mut FunctionRegistry) {
                         return;
                     }
                 }
-                match to_str(val) {
-                    Ok(value) => {
-                        output.validity.push(true);
-                        output.builder.put_slice(value.as_bytes());
-                        output.builder.commit_row();
-                    }
-                    Err(_) => output.push_null(),
-                }
+                let json_str = cast_to_string(val);
+                output.builder.put_str(&json_str);
+                output.builder.commit_row();
+                output.validity.push(true);
             },
         ),
     );
@@ -1058,22 +1057,6 @@ pub fn register(registry: &mut FunctionRegistry) {
             }
         });
     }
-
-    registry.register_passthrough_nullable_1_arg::<VariantType, StringType, _, _>(
-        "json_to_string",
-        |_, _| FunctionDomain::Full,
-        vectorize_with_builder_1_arg::<VariantType, StringType>(|val, output, ctx| {
-            if let Some(validity) = &ctx.validity {
-                if !validity.get_bit(output.len()) {
-                    output.commit_row();
-                    return;
-                }
-            }
-            let s = to_string(val);
-            output.put_slice(s.as_bytes());
-            output.commit_row();
-        }),
-    );
 
     registry.register_passthrough_nullable_1_arg::<VariantType, StringType, _, _>(
         "json_pretty",
@@ -1472,7 +1455,8 @@ fn get_by_keypath_fn(
                             Some(res) => {
                                 match &mut builder {
                                     ColumnBuilder::String(builder) => {
-                                        builder.put_str(&to_string(&res));
+                                        let json_str = cast_to_string(&res);
+                                        builder.put_str(&json_str);
                                     }
                                     ColumnBuilder::Variant(builder) => {
                                         builder.put_slice(&res);
@@ -1604,5 +1588,13 @@ where
                 Value::Scalar(Scalar::Boolean(output.get(0)))
             }
         }
+    }
+}
+
+// Extract string for string type, other types convert to JSON string.
+fn cast_to_string(v: &[u8]) -> String {
+    match to_str(v) {
+        Ok(v) => v,
+        Err(_) => to_string(v),
     }
 }

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -14,6 +14,7 @@ hex -> to_hex
 intdiv -> div
 ipv4_num_to_string -> inet_ntoa
 ipv4_string_to_num -> inet_aton
+json_to_string -> to_string
 lcase -> lower
 length_utf8 -> char_length
 mid -> substr
@@ -1888,8 +1889,6 @@ Functions overloads:
 1 json_pretty(Variant NULL) :: String NULL
 0 json_strip_nulls(Variant) :: Variant
 1 json_strip_nulls(Variant NULL) :: Variant NULL
-0 json_to_string(Variant) :: String
-1 json_to_string(Variant NULL) :: String NULL
 0 json_typeof(Variant) :: String
 1 json_typeof(Variant NULL) :: String NULL
 0 l2_distance(Array(Float32), Array(Float32)) :: Float32

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -935,7 +935,7 @@ evaluation:
 | Row 0  | 'true'                      | '[0]'        | NULL        |
 | Row 1  | '{"k":1}'                   | '["k"]'      | '1'         |
 | Row 2  | NULL                        | ''           | NULL        |
-| Row 3  | '["a","b"]'                 | '[0]'        | '"a"'       |
+| Row 3  | '["a","b"]'                 | '[0]'        | 'a'         |
 +--------+-----------------------------+--------------+-------------+
 evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -943,7 +943,7 @@ evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 | s      | NullableColumn { column: StringColumn { data: 0x747275657b226b223a317d5b2261222c2262225d, offsets: [0, 4, 11, 11, 20] }, validity: [0b____1011] } |
 | k      | StringColumn { data: 0x5b305d5b226b225d5b305d, offsets: [0, 3, 8, 8, 11] }                                                                        |
-| Output | NullableColumn { column: StringColumn { data: 0x31226122, offsets: [0, 0, 1, 1, 4] }, validity: [0b____1010] }                                    |
+| Output | NullableColumn { column: StringColumn { data: 0x3161, offsets: [0, 0, 1, 1, 2] }, validity: [0b____1010] }                                        |
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
@@ -2468,7 +2468,7 @@ evaluation (internal):
 
 ast            : json_to_string(parse_json('true'))
 raw expr       : json_to_string(parse_json('true'))
-checked expr   : json_to_string<Variant>(parse_json<String>("true"))
+checked expr   : to_string<Variant>(parse_json<String>("true"))
 optimized expr : "true"
 output type    : String
 output domain  : {"true"..="true"}
@@ -2477,7 +2477,7 @@ output         : 'true'
 
 ast            : json_to_string(parse_json('123456'))
 raw expr       : json_to_string(parse_json('123456'))
-checked expr   : json_to_string<Variant>(parse_json<String>("123456"))
+checked expr   : to_string<Variant>(parse_json<String>("123456"))
 optimized expr : "123456"
 output type    : String
 output domain  : {"123456"..="123456"}
@@ -2486,16 +2486,16 @@ output         : '123456'
 
 ast            : json_to_string(parse_json('"abcd"'))
 raw expr       : json_to_string(parse_json('"abcd"'))
-checked expr   : json_to_string<Variant>(parse_json<String>("\"abcd\""))
-optimized expr : "\"abcd\""
+checked expr   : to_string<Variant>(parse_json<String>("\"abcd\""))
+optimized expr : "abcd"
 output type    : String
-output domain  : {"\"abcd\""..="\"abcd\""}
-output         : '"abcd"'
+output domain  : {"abcd"..="abcd"}
+output         : 'abcd'
 
 
 ast            : json_to_string(parse_json('[1, 2, 3, 4, 5, 6]'))
 raw expr       : json_to_string(parse_json('[1, 2, 3, 4, 5, 6]'))
-checked expr   : json_to_string<Variant>(parse_json<String>("[1, 2, 3, 4, 5, 6]"))
+checked expr   : to_string<Variant>(parse_json<String>("[1, 2, 3, 4, 5, 6]"))
 optimized expr : "[1,2,3,4,5,6]"
 output type    : String
 output domain  : {"[1,2,3,4,5,6]"..="[1,2,3,4,5,6]"}
@@ -2504,7 +2504,7 @@ output         : '[1,2,3,4,5,6]'
 
 ast            : json_to_string(parse_json('{"k1":123, "k2":"abc"}'))
 raw expr       : json_to_string(parse_json('{"k1":123, "k2":"abc"}'))
-checked expr   : json_to_string<Variant>(parse_json<String>("{\"k1\":123, \"k2\":\"abc\"}"))
+checked expr   : to_string<Variant>(parse_json<String>("{\"k1\":123, \"k2\":\"abc\"}"))
 optimized expr : "{\"k1\":123,\"k2\":\"abc\"}"
 output type    : String
 output domain  : {"{\"k1\":123,\"k2\":\"abc\"}"..="{\"k1\":123,\"k2\":\"abc\"}"}
@@ -3014,10 +3014,10 @@ output         : NULL
 ast            : parse_json('{"k":"v"}')->>'k'
 raw expr       : get_string(parse_json('{"k":"v"}'), 'k')
 checked expr   : get_string<Variant, String>(parse_json<String>("{\"k\":\"v\"}"), "k")
-optimized expr : "\"v\""
+optimized expr : "v"
 output type    : String NULL
-output domain  : {"\"v\""..="\"v\""}
-output         : '"v"'
+output domain  : {"v"..="v"}
+output         : 'v'
 
 
 ast            : parse_json('{"k":"v"}')->>'x'
@@ -3032,10 +3032,10 @@ output         : NULL
 ast            : CAST(('a', 'b') AS VARIANT)->>'2'
 raw expr       : get_string(CAST(tuple('a', 'b') AS Variant), '2')
 checked expr   : get_string<Variant, String>(to_variant<T0=Tuple(String, String)><T0>(tuple<String, String>("a", "b")), "2")
-optimized expr : "\"b\""
+optimized expr : "b"
 output type    : String NULL
-output domain  : {"\"b\""..="\"b\""}
-output         : '"b"'
+output domain  : {"b"..="b"}
+output         : 'b'
 
 
 ast            : parse_json(s)->>i
@@ -3049,16 +3049,16 @@ evaluation:
 | Domain | {"[\"a\",\"b\",\"c\"]"..="true"} | {0..=1} | Unknown     |
 | Row 0  | 'true'                           | 0       | NULL        |
 | Row 1  | '[1,2,3,4]'                      | 0       | '1'         |
-| Row 2  | '["a","b","c"]'                  | 1       | '"b"'       |
+| Row 2  | '["a","b","c"]'                  | 1       | 'b'         |
 +--------+----------------------------------+---------+-------------+
 evaluation (internal):
-+--------+-------------------------------------------------------------------------------------------------------------+
-| Column | Data                                                                                                        |
-+--------+-------------------------------------------------------------------------------------------------------------+
-| s      | StringColumn { data: 0x747275655b312c322c332c345d5b2261222c2262222c2263225d, offsets: [0, 4, 13, 26] }      |
-| i      | UInt64([0, 0, 1])                                                                                           |
-| Output | NullableColumn { column: StringColumn { data: 0x31226222, offsets: [0, 0, 1, 4] }, validity: [0b_____110] } |
-+--------+-------------------------------------------------------------------------------------------------------------+
++--------+---------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                    |
++--------+---------------------------------------------------------------------------------------------------------+
+| s      | StringColumn { data: 0x747275655b312c322c332c345d5b2261222c2262222c2263225d, offsets: [0, 4, 13, 26] }  |
+| i      | UInt64([0, 0, 1])                                                                                       |
+| Output | NullableColumn { column: StringColumn { data: 0x3162, offsets: [0, 0, 1, 2] }, validity: [0b_____110] } |
++--------+---------------------------------------------------------------------------------------------------------+
 
 
 ast            : parse_json(s)->>i
@@ -3073,7 +3073,7 @@ evaluation:
 | Row 0  | 'true'                 | NULL             | NULL        |
 | Row 1  | '[1,2,3,4]'            | 2                | '3'         |
 | Row 2  | NULL                   | NULL             | NULL        |
-| Row 3  | '["a","b","c"]'        | 1                | '"b"'       |
+| Row 3  | '["a","b","c"]'        | 1                | 'b'         |
 +--------+------------------------+------------------+-------------+
 evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -3081,7 +3081,7 @@ evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | s      | NullableColumn { column: StringColumn { data: 0x747275655b312c322c332c345d5b2261222c2262222c2263225d, offsets: [0, 4, 13, 13, 26] }, validity: [0b____1011] } |
 | i      | NullableColumn { column: UInt64([0, 2, 0, 1]), validity: [0b____1010] }                                                                                       |
-| Output | NullableColumn { column: StringColumn { data: 0x33226222, offsets: [0, 0, 1, 1, 4] }, validity: [0b____1010] }                                                |
+| Output | NullableColumn { column: StringColumn { data: 0x3362, offsets: [0, 0, 1, 1, 2] }, validity: [0b____1010] }                                                    |
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
@@ -3120,7 +3120,7 @@ evaluation:
 | Row 0  | 'true'                      | ''         | NULL        |
 | Row 1  | '{"k":1}'                   | 'k'        | '1'         |
 | Row 2  | NULL                        | ''         | NULL        |
-| Row 3  | '{"a":"b"}'                 | 'a'        | '"b"'       |
+| Row 3  | '{"a":"b"}'                 | 'a'        | 'b'         |
 +--------+-----------------------------+------------+-------------+
 evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -3128,7 +3128,7 @@ evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 | s      | NullableColumn { column: StringColumn { data: 0x747275657b226b223a317d7b2261223a2262227d, offsets: [0, 4, 11, 11, 20] }, validity: [0b____1011] } |
 | k      | StringColumn { data: 0x6b61, offsets: [0, 0, 1, 1, 2] }                                                                                           |
-| Output | NullableColumn { column: StringColumn { data: 0x31226222, offsets: [0, 0, 1, 1, 4] }, validity: [0b____1010] }                                    |
+| Output | NullableColumn { column: StringColumn { data: 0x3162, offsets: [0, 0, 1, 1, 2] }, validity: [0b____1010] }                                        |
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
@@ -3393,7 +3393,7 @@ evaluation:
 | Row 0  | 'true'                      | '{1}'                 | NULL        |
 | Row 1  | '{"k":1}'                   | '{k}'                 | '1'         |
 | Row 2  | NULL                        | NULL                  | NULL        |
-| Row 3  | '{"a":"b"}'                 | '{a}'                 | '"b"'       |
+| Row 3  | '{"a":"b"}'                 | '{a}'                 | 'b'         |
 +--------+-----------------------------+-----------------------+-------------+
 evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -3401,7 +3401,7 @@ evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 | s      | NullableColumn { column: StringColumn { data: 0x747275657b226b223a317d7b2261223a2262227d, offsets: [0, 4, 11, 11, 20] }, validity: [0b____1011] } |
 | k      | NullableColumn { column: StringColumn { data: 0x7b317d7b6b7d7b617d, offsets: [0, 3, 6, 6, 9] }, validity: [0b____1011] }                          |
-| Output | NullableColumn { column: StringColumn { data: 0x31226222, offsets: [0, 0, 1, 1, 4] }, validity: [0b____1010] }                                    |
+| Output | NullableColumn { column: StringColumn { data: 0x3162, offsets: [0, 0, 1, 1, 2] }, validity: [0b____1010] }                                        |
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 
 

--- a/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get.test
+++ b/tests/sqllogictests/suites/query/02_function/02_0051_function_semi_structureds_get.test
@@ -77,7 +77,7 @@ NULL
 query T
 select parse_json('{"aa": 1, "aA": "text", "Aa": 3}')->>'aA'
 ----
-"text"
+text
 
 query T
 select parse_json('{"aa": 1, "aA": "text", "Aa": {"a":1}}')->>'Aa'
@@ -179,12 +179,12 @@ select json_extract_path_text('{"customer":{"id": 1, "name":"databend", "extras"
 query T
 select json_extract_path_text('{"customer":{"id": 1, "name":"databend", "extras":["ext", "test"]}}', 'customer.name')
 ----
-"databend"
+databend
 
 query T
 select json_extract_path_text('{"customer":{"id": 1, "name":"databend", "extras":["ext", "test"]}}', 'customer["extras"][0]')
 ----
-"ext"
+ext
 
 query T
 select json_extract_path_text('{"customer":{"id": 1, "name":"databend", "extras":["ext", "test"]}}', 'customer["extras"][2]')
@@ -460,7 +460,7 @@ select id, json_extract_path_text(str, '[0]') from t3
 query IT
 select id, json_extract_path_text(str, '[3][0]') from t3
 ----
-1 "a"
+1 a
 2 NULL
 
 query IT
@@ -700,7 +700,7 @@ SELECT arr #>> '{3}' FROM t1;
 query T
 SELECT arr #>> '{3,1}' FROM t1;
 ----
-"b"
+b
 
 query I
 SELECT obj #>> '{a}' FROM t2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fix `json_extract_path_text`, `to_string`, `get_string` extract string for JSON string type, remove redundant quotes
- make `json_to_string` as alias of `to_string`

Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14389)
<!-- Reviewable:end -->
