### PR TITLE
chore: set auto_compaction_imperfect_blocks_threshold to 50

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -499,7 +499,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
                 ("auto_compaction_imperfect_blocks_threshold", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(1000),
+                    value: UserSettingValue::UInt64(50),
                     desc: "Threshold for triggering auto compaction. This occurs when the number of imperfect blocks in a snapshot exceeds this value after write operations.",
                     mode: SettingMode::Both,
                     range: None,

--- a/src/query/storages/fuse/src/operations/common/snapshot_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/snapshot_generator.rs
@@ -424,7 +424,7 @@ impl SnapshotGenerator for AppendGenerator {
 
         // check if need to auto compact
         // the algorithm is: if the number of imperfect blocks is greater than the threshold, then auto compact.
-        // the threshold is set by the setting `auto_compaction_imperfect_blocks_threshold`, default is 1000.
+        // the threshold is set by the setting `auto_compaction_imperfect_blocks_threshold`, default is 50.
         let imperfect_count = new_summary.block_count - new_summary.perfect_block_count;
         let auto_compaction_imperfect_blocks_threshold = self
             .ctx

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert.test
@@ -109,7 +109,7 @@ SELECT segment_count, block_count, row_count from FUSE_SNAPSHOT('db1', 't4') lim
 3 3 300
 
 statement ok
-SET auto_compaction_imperfect_blocks_threshold = 1000;
+SET auto_compaction_imperfect_blocks_threshold = 50;
 
 statement ok
 DROP TABLE t1

--- a/tests/sqllogictests/suites/mode/cluster/distributed_copy_into_table2.test
+++ b/tests/sqllogictests/suites/mode/cluster/distributed_copy_into_table2.test
@@ -55,4 +55,4 @@ statement ok
 set enable_distributed_copy_into = 0;
 
 statement ok
-set auto_compaction_imperfect_blocks_threshold = 1000;
+set auto_compaction_imperfect_blocks_threshold = 50;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 set the default value of `auto_compaction_imperfect_blocks_threshold default value` to 50,  because now the hook compact has added a limit of 3, which has a minimal impact on writing.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14390)
<!-- Reviewable:end -->
