### PR TITLE
fix(sqlsmith): fix generate nested not null types caused panic

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -685,9 +685,25 @@ fn convert_to_type_name(ty: &DataType) -> TypeName {
         DataType::String => TypeName::String,
         DataType::Bitmap => TypeName::Bitmap,
         DataType::Variant => TypeName::Variant,
+        DataType::Binary => TypeName::Binary,
         DataType::Nullable(box inner_ty) => {
             TypeName::Nullable(Box::new(convert_to_type_name(inner_ty)))
         }
-        _ => unreachable!(),
+        DataType::Array(box inner_ty) => TypeName::Array(Box::new(convert_to_type_name(inner_ty))),
+        DataType::Map(box inner_ty) => match inner_ty {
+            DataType::Tuple(inner_tys) => TypeName::Map {
+                key_type: Box::new(convert_to_type_name(&inner_tys[0])),
+                val_type: Box::new(convert_to_type_name(&inner_tys[1])),
+            },
+            _ => unreachable!(),
+        },
+        DataType::Tuple(inner_tys) => TypeName::Tuple {
+            fields_name: None,
+            fields_type: inner_tys
+                .iter()
+                .map(convert_to_type_name)
+                .collect::<Vec<_>>(),
+        },
+        _ => TypeName::String,
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix generate nested not null types caused panic

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - test is not needed for sqlsmith

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14392)
<!-- Reviewable:end -->
