### PR TITLE
chore(planner): fix push down filter scan

### DIFF
--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
@@ -72,12 +72,15 @@ impl RulePushDownFilterScan {
         }
     }
 
-    // Using the columns of the source table to replace the columns in the view,
-    // this allows us to perform push-down filtering operations at the storage layer.
-    fn replace_view_column(
+    // Replace columns in a predicate.
+    // If replace_view is true, we will use the columns of the source table to replace the columns in
+    // the view, this allows us to perform push-down filtering operations at the storage layer.
+    // If replace_view is false, we will replace column alias name with original column name.
+    fn replace_predicate_column(
         predicate: &ScalarExpr,
         table_entries: &[TableEntry],
-        column_entries: &[ColumnEntry],
+        column_entries: &[&ColumnEntry],
+        replace_view: bool,
     ) -> Result<ScalarExpr> {
         match predicate {
             ScalarExpr::BoundColumnRef(column) => {
@@ -97,7 +100,7 @@ impl RulePushDownFilterScan {
                         .iter()
                         .find(|table_entry| table_entry.index() == base_column.table_index)
                     {
-                        let column_binding = ColumnBindingBuilder::new(
+                        let mut column_binding_builder = ColumnBindingBuilder::new(
                             base_column.column_name.clone(),
                             base_column.column_index,
                             column.column.data_type.clone(),
@@ -105,12 +108,16 @@ impl RulePushDownFilterScan {
                         )
                         .table_name(Some(table_entry.name().to_string()))
                         .database_name(Some(table_entry.database().to_string()))
-                        .table_index(Some(table_entry.index()))
-                        .virtual_computed_expr(column.column.virtual_computed_expr.clone())
-                        .build();
+                        .table_index(Some(table_entry.index()));
+
+                        if replace_view {
+                            column_binding_builder = column_binding_builder
+                                .virtual_computed_expr(column.column.virtual_computed_expr.clone());
+                        }
+
                         let bound_column_ref = BoundColumnRef {
                             span: column.span,
-                            column: column_binding,
+                            column: column_binding_builder.build(),
                         };
                         return Ok(ScalarExpr::BoundColumnRef(bound_column_ref));
                     }
@@ -124,7 +131,12 @@ impl RulePushDownFilterScan {
                             .args
                             .iter()
                             .map(|arg| {
-                                Self::replace_view_column(arg, table_entries, column_entries)
+                                Self::replace_predicate_column(
+                                    arg,
+                                    table_entries,
+                                    column_entries,
+                                    replace_view,
+                                )
                             })
                             .collect::<Result<Vec<ScalarExpr>>>()?;
 
@@ -138,15 +150,23 @@ impl RulePushDownFilterScan {
                         })
                     }
                     WindowFuncType::LagLead(ll) => {
-                        let new_arg =
-                            Self::replace_view_column(&ll.arg, table_entries, column_entries)?;
-                        let new_default =
-                            match ll.default.clone().map(|d| {
-                                Self::replace_view_column(&d, table_entries, column_entries)
-                            }) {
-                                None => None,
-                                Some(d) => Some(Box::new(d?)),
-                            };
+                        let new_arg = Self::replace_predicate_column(
+                            &ll.arg,
+                            table_entries,
+                            column_entries,
+                            replace_view,
+                        )?;
+                        let new_default = match ll.default.clone().map(|d| {
+                            Self::replace_predicate_column(
+                                &d,
+                                table_entries,
+                                column_entries,
+                                replace_view,
+                            )
+                        }) {
+                            None => None,
+                            Some(d) => Some(Box::new(d?)),
+                        };
                         WindowFuncType::LagLead(LagLeadFunction {
                             is_lag: ll.is_lag,
                             arg: Box::new(new_arg),
@@ -156,8 +176,12 @@ impl RulePushDownFilterScan {
                         })
                     }
                     WindowFuncType::NthValue(func) => {
-                        let new_arg =
-                            Self::replace_view_column(&func.arg, table_entries, column_entries)?;
+                        let new_arg = Self::replace_predicate_column(
+                            &func.arg,
+                            table_entries,
+                            column_entries,
+                            replace_view,
+                        )?;
                         WindowFuncType::NthValue(NthValueFunction {
                             n: func.n,
                             arg: Box::new(new_arg),
@@ -170,15 +194,26 @@ impl RulePushDownFilterScan {
                 let partition_by = window
                     .partition_by
                     .iter()
-                    .map(|arg| Self::replace_view_column(arg, table_entries, column_entries))
+                    .map(|arg| {
+                        Self::replace_predicate_column(
+                            arg,
+                            table_entries,
+                            column_entries,
+                            replace_view,
+                        )
+                    })
                     .collect::<Result<Vec<ScalarExpr>>>()?;
 
                 let order_by = window
                     .order_by
                     .iter()
                     .map(|item| {
-                        let replaced_scalar =
-                            Self::replace_view_column(&item.expr, table_entries, column_entries)?;
+                        let replaced_scalar = Self::replace_predicate_column(
+                            &item.expr,
+                            table_entries,
+                            column_entries,
+                            replace_view,
+                        )?;
                         Ok(WindowOrderBy {
                             expr: replaced_scalar,
                             asc: item.asc,
@@ -200,7 +235,14 @@ impl RulePushDownFilterScan {
                 let args = agg_func
                     .args
                     .iter()
-                    .map(|arg| Self::replace_view_column(arg, table_entries, column_entries))
+                    .map(|arg| {
+                        Self::replace_predicate_column(
+                            arg,
+                            table_entries,
+                            column_entries,
+                            replace_view,
+                        )
+                    })
                     .collect::<Result<Vec<ScalarExpr>>>()?;
 
                 Ok(ScalarExpr::AggregateFunction(AggregateFunction {
@@ -216,7 +258,14 @@ impl RulePushDownFilterScan {
                 let args = lambda_func
                     .args
                     .iter()
-                    .map(|arg| Self::replace_view_column(arg, table_entries, column_entries))
+                    .map(|arg| {
+                        Self::replace_predicate_column(
+                            arg,
+                            table_entries,
+                            column_entries,
+                            replace_view,
+                        )
+                    })
                     .collect::<Result<Vec<ScalarExpr>>>()?;
 
                 Ok(ScalarExpr::LambdaFunction(LambdaFunc {
@@ -232,7 +281,14 @@ impl RulePushDownFilterScan {
                 let arguments = func
                     .arguments
                     .iter()
-                    .map(|arg| Self::replace_view_column(arg, table_entries, column_entries))
+                    .map(|arg| {
+                        Self::replace_predicate_column(
+                            arg,
+                            table_entries,
+                            column_entries,
+                            replace_view,
+                        )
+                    })
                     .collect::<Result<Vec<ScalarExpr>>>()?;
 
                 Ok(ScalarExpr::FunctionCall(FunctionCall {
@@ -243,7 +299,12 @@ impl RulePushDownFilterScan {
                 }))
             }
             ScalarExpr::CastExpr(cast) => {
-                let arg = Self::replace_view_column(&cast.argument, table_entries, column_entries)?;
+                let arg = Self::replace_predicate_column(
+                    &cast.argument,
+                    table_entries,
+                    column_entries,
+                    replace_view,
+                )?;
                 Ok(ScalarExpr::CastExpr(CastExpr {
                     span: cast.span,
                     is_try: cast.is_try,
@@ -255,7 +316,14 @@ impl RulePushDownFilterScan {
                 let arguments = udf
                     .arguments
                     .iter()
-                    .map(|arg| Self::replace_view_column(arg, table_entries, column_entries))
+                    .map(|arg| {
+                        Self::replace_predicate_column(
+                            arg,
+                            table_entries,
+                            column_entries,
+                            replace_view,
+                        )
+                    })
                     .collect::<Result<Vec<ScalarExpr>>>()?;
 
                 Ok(ScalarExpr::UDFServerCall(UDFServerCall {
@@ -273,9 +341,17 @@ impl RulePushDownFilterScan {
         }
     }
 
-    fn find_push_down_predicates(&self, predicates: &[ScalarExpr]) -> Result<Vec<ScalarExpr>> {
+    fn find_push_down_predicates(
+        &self,
+        predicates: &[ScalarExpr],
+        scan: &Scan,
+    ) -> Result<Vec<ScalarExpr>> {
         let metadata = self.metadata.read();
-        let column_entries = metadata.columns();
+        let column_entries = scan
+            .columns
+            .iter()
+            .map(|index| metadata.column(*index))
+            .collect::<Vec<_>>();
         let table_entries = metadata.tables();
         let is_source_of_view = table_entries.iter().any(|t| t.is_source_of_view());
 
@@ -283,7 +359,7 @@ impl RulePushDownFilterScan {
         for predicate in predicates {
             let used_columns = predicate.used_columns();
             let mut contain_derived_column = false;
-            for column_entry in column_entries {
+            for column_entry in column_entries.iter() {
                 if let ColumnEntry::DerivedColumn(column) = column_entry {
                     // Don't push down predicate that contains derived column
                     // Because storage can't know such columns.
@@ -294,13 +370,13 @@ impl RulePushDownFilterScan {
                 }
             }
             if !contain_derived_column {
-                if is_source_of_view {
-                    let new_predicate =
-                        Self::replace_view_column(predicate, table_entries, column_entries)?;
-                    filtered_predicates.push(new_predicate);
-                } else {
-                    filtered_predicates.push(predicate.clone());
-                }
+                let predicate = Self::replace_predicate_column(
+                    predicate,
+                    table_entries,
+                    &column_entries,
+                    is_source_of_view,
+                )?;
+                filtered_predicates.push(predicate);
             }
         }
 
@@ -315,18 +391,18 @@ impl Rule for RulePushDownFilterScan {
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
         let filter: Filter = s_expr.plan().clone().try_into()?;
-        let mut get: Scan = s_expr.child(0)?.plan().clone().try_into()?;
+        let mut scan: Scan = s_expr.child(0)?.plan().clone().try_into()?;
 
-        let add_filters = self.find_push_down_predicates(&filter.predicates)?;
+        let add_filters = self.find_push_down_predicates(&filter.predicates, &scan)?;
 
-        match get.push_down_predicates.as_mut() {
+        match scan.push_down_predicates.as_mut() {
             Some(vs) => vs.extend(add_filters),
-            None => get.push_down_predicates = Some(add_filters),
+            None => scan.push_down_predicates = Some(add_filters),
         }
 
         let mut result = SExpr::create_unary(
             Arc::new(filter.into()),
-            Arc::new(SExpr::create_leaf(Arc::new(get.into()))),
+            Arc::new(SExpr::create_leaf(Arc::new(scan.into()))),
         );
         result.set_applied_rule(&self.id);
         state.add_result(result);

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
@@ -192,7 +192,7 @@ Filter
     │               ├── read bytes: 0
     │               ├── partitions total: 0
     │               ├── partitions scanned: 0
-    │               ├── push downs: [filters: [t.b (#4) > 3], limit: NONE]
+    │               ├── push downs: [filters: [t1.b (#4) > 3], limit: NONE]
     │               ├── aggregating index: [SELECT b, SUM(a) FROM test_index_db.t1 WHERE (b > 3) GROUP BY b]
     │               ├── rewritten query: [selection: [index_col_0 (#0), index_col_1 (#1)]]
     │               └── estimated rows: 0.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -125,7 +125,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_not_null(t1.a (#1))], limit: NONE]
+│       ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -164,7 +164,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_not_null(t1.a (#1))], limit: NONE]
+│       ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -238,7 +238,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_not_null(t1.a (#1))], limit: NONE]
+│       ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
 │       └── estimated rows: 10.00
 └── TableScan(Probe)
     ├── table: default.eliminate_outer_join.t
@@ -273,7 +273,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_not_null(t1.a (#1))], limit: NONE]
+│       ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -312,7 +312,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
-│       ├── push downs: [filters: [is_true(t1.a (#1) = 1)], limit: NONE]
+│       ├── push downs: [filters: [is_true(t.a (#1) = 1)], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -351,7 +351,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_true(t1.a (#1) > 1)], limit: NONE]
+│       ├── push downs: [filters: [is_true(t.a (#1) > 1)], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -390,7 +390,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_true(t1.a (#1) < 1)], limit: NONE]
+│       ├── push downs: [filters: [is_true(t.a (#1) < 1)], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -429,7 +429,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_true(t1.a (#1) <> 1)], limit: NONE]
+│       ├── push downs: [filters: [is_true(t.a (#1) <> 1)], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -468,7 +468,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_true(t1.a (#1) >= 1)], limit: NONE]
+│       ├── push downs: [filters: [is_true(t.a (#1) >= 1)], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -507,7 +507,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_true(t1.a (#1) <= 1)], limit: NONE]
+│       ├── push downs: [filters: [is_true(t.a (#1) <= 1)], limit: NONE]
 │       └── estimated rows: 10.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -586,7 +586,7 @@ Filter
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    │       ├── push downs: [filters: [is_true(t1.a (#1) <= 1 OR t1.a (#1) > 1)], limit: NONE]
+    │       ├── push downs: [filters: [is_true(t.a (#1) <= 1 OR t.a (#1) > 1)], limit: NONE]
     │       └── estimated rows: 10.00
     └── Filter(Probe)
         ├── output columns: [t.a (#0)]
@@ -662,7 +662,7 @@ HashJoin
 │       ├── read bytes: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
-│       ├── push downs: [filters: [is_true(t1.a (#1) > '2001-01-01 00:00:00.000000')], limit: NONE]
+│       ├── push downs: [filters: [is_true(time_table.a (#1) > '2001-01-01 00:00:00.000000')], limit: NONE]
 │       └── estimated rows: 0.00
 └── Filter(Probe)
     ├── output columns: [t.a (#0)]
@@ -675,7 +675,7 @@ HashJoin
         ├── read bytes: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
-        ├── push downs: [filters: [is_true(t.a (#0) > '2001-01-01 00:00:00.000000')], limit: NONE]
+        ├── push downs: [filters: [is_true(time_table.a (#0) > '2001-01-01 00:00:00.000000')], limit: NONE]
         └── estimated rows: 0.00
 
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1264,7 +1264,7 @@ Filter
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    │       ├── push downs: [filters: [is_true(id (#2) = b.id (#2))], limit: NONE]
+    │       ├── push downs: [filters: [is_true(b.id (#2) = b.id (#2))], limit: NONE]
     │       └── estimated rows: 2.00
     └── TableScan(Probe)
         ├── table: default.default.a
@@ -1642,7 +1642,7 @@ Filter
     │                       ├── read bytes: 0
     │                       ├── partitions total: 0
     │                       ├── partitions scanned: 0
-    │                       ├── push downs: [filters: [is_true(t1.a (#3) = a (#3))], limit: NONE]
+    │                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
     │                       └── estimated rows: 0.00
     └── TableScan(Probe)
         ├── table: default.default.t2
@@ -1697,7 +1697,7 @@ Filter
     │                       ├── read bytes: 0
     │                       ├── partitions total: 0
     │                       ├── partitions scanned: 0
-    │                       ├── push downs: [filters: [is_true(t1.a (#3) = a (#3))], limit: NONE]
+    │                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
     │                       └── estimated rows: 0.00
     └── TableScan(Probe)
         ├── table: default.default.t2

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -247,7 +247,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_true(a.x (#0) > 42)], limit: NONE]
+│       ├── push downs: [filters: [is_true(onecolumn.x (#0) > 42)], limit: NONE]
 │       └── estimated rows: 4.00
 └── Filter(Probe)
     ├── output columns: [b.x (#1), b.y (#2)]
@@ -261,7 +261,7 @@ HashJoin
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-        ├── push downs: [filters: [is_true(b.x (#1) > 42)], limit: NONE]
+        ├── push downs: [filters: [is_true(twocolumn.x (#1) > 42)], limit: NONE]
         └── estimated rows: 4.00
 
 query T
@@ -286,7 +286,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [is_true(a.x (#0) > 44 OR a.x (#0) < 43)], limit: NONE]
+│       ├── push downs: [filters: [is_true(onecolumn.x (#0) > 44 OR onecolumn.x (#0) < 43)], limit: NONE]
 │       └── estimated rows: 4.00
 └── Filter(Probe)
     ├── output columns: [b.x (#1), b.y (#2)]
@@ -300,7 +300,7 @@ HashJoin
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-        ├── push downs: [filters: [is_true(b.x (#1) > 44 OR b.x (#1) < 43)], limit: NONE]
+        ├── push downs: [filters: [is_true(twocolumn.x (#1) > 44 OR twocolumn.x (#1) < 43)], limit: NONE]
         └── estimated rows: 4.00
 
 query T
@@ -325,7 +325,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [and_filters(a.x (#0) > 42, a.x (#0) < 45)], limit: NONE]
+│       ├── push downs: [filters: [and_filters(onecolumn.x (#0) > 42, onecolumn.x (#0) < 45)], limit: NONE]
 │       └── estimated rows: 4.00
 └── Filter(Probe)
     ├── output columns: [b.x (#1), b.y (#2)]
@@ -339,7 +339,7 @@ HashJoin
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-        ├── push downs: [filters: [and_filters(b.x (#1) > 42, b.x (#1) < 45)], limit: NONE]
+        ├── push downs: [filters: [and_filters(twocolumn.x (#1) > 42, twocolumn.x (#1) < 45)], limit: NONE]
         └── estimated rows: 4.00
 
 # the following cases won't be converted to inner join
@@ -401,7 +401,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│       ├── push downs: [filters: [and_filters(b.x (#1) > 42, b.x (#1) < 45)], limit: NONE]
+│       ├── push downs: [filters: [and_filters(twocolumn.x (#1) > 42, twocolumn.x (#1) < 45)], limit: NONE]
 │       └── estimated rows: 4.00
 └── TableScan(Probe)
     ├── table: default.default.onecolumn
@@ -746,7 +746,7 @@ HashJoin
 │       ├── partitions total: 2
 │       ├── partitions scanned: 2
 │       ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 2 to 2>]
-│       ├── push downs: [filters: [is_true(t.y (#2) = 53)], limit: NONE]
+│       ├── push downs: [filters: [is_true(twocolumn.y (#2) = 53)], limit: NONE]
 │       └── estimated rows: 8.00
 └── TableScan(Probe)
     ├── table: default.default.onecolumn

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter.test
@@ -244,3 +244,34 @@ drop view v1;
 
 statement ok
 drop view v2;
+
+# push down alias filter scan
+statement ok
+drop table if exists t;
+
+statement ok
+create table t (x INT);
+
+statement ok
+insert into t(x) values (1), (2);
+
+query I
+explain select * from t as a(id) where a.id > 1;
+----
+Filter
+├── output columns: [a.x (#0)]
+├── filters: [is_true(a.id (#0) > 1)]
+├── estimated rows: 0.40
+└── TableScan
+    ├── table: default.default.t
+    ├── output columns: [x (#0)]
+    ├── read rows: 2
+    ├── read bytes: 41
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    ├── push downs: [filters: [is_true(t.x (#0) > 1)], limit: NONE]
+    └── estimated rows: 2.00
+
+statement ok
+drop table t;

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -332,7 +332,7 @@ HashJoin
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── push downs: [filters: [t.number (#0) < 10], limit: NONE]
+        ├── push downs: [filters: [numbers.number (#0) < 10], limit: NONE]
         └── estimated rows: 1.00
 
 query T

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
@@ -231,7 +231,7 @@ HashJoin
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│   ├── push downs: [filters: [is_true(a.x (#0) > 42)], limit: NONE]
+│   ├── push downs: [filters: [is_true(onecolumn.x (#0) > 42)], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.twocolumn
@@ -241,7 +241,7 @@ HashJoin
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    ├── push downs: [filters: [is_true(b.x (#1) > 42)], limit: NONE]
+    ├── push downs: [filters: [is_true(twocolumn.x (#1) > 42)], limit: NONE]
     └── estimated rows: 3.20
 
 query T
@@ -262,7 +262,7 @@ HashJoin
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│   ├── push downs: [filters: [is_true(a.x (#0) > 44 OR a.x (#0) < 43)], limit: NONE]
+│   ├── push downs: [filters: [is_true(onecolumn.x (#0) > 44 OR onecolumn.x (#0) < 43)], limit: NONE]
 │   └── estimated rows: 1.75
 └── TableScan(Probe)
     ├── table: default.default.twocolumn
@@ -272,7 +272,7 @@ HashJoin
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    ├── push downs: [filters: [is_true(b.x (#1) > 44 OR b.x (#1) < 43)], limit: NONE]
+    ├── push downs: [filters: [is_true(twocolumn.x (#1) > 44 OR twocolumn.x (#1) < 43)], limit: NONE]
     └── estimated rows: 2.08
 
 query T
@@ -293,7 +293,7 @@ HashJoin
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│   ├── push downs: [filters: [and_filters(a.x (#0) > 42, a.x (#0) < 45)], limit: NONE]
+│   ├── push downs: [filters: [and_filters(onecolumn.x (#0) > 42, onecolumn.x (#0) < 45)], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.twocolumn
@@ -303,7 +303,7 @@ HashJoin
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    ├── push downs: [filters: [and_filters(b.x (#1) > 42, b.x (#1) < 45)], limit: NONE]
+    ├── push downs: [filters: [and_filters(twocolumn.x (#1) > 42, twocolumn.x (#1) < 45)], limit: NONE]
     └── estimated rows: 3.20
 
 # the following cases won't be converted to inner join
@@ -361,7 +361,7 @@ HashJoin
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-│   ├── push downs: [filters: [and_filters(b.x (#1) > 42, b.x (#1) < 45)], limit: NONE]
+│   ├── push downs: [filters: [and_filters(twocolumn.x (#1) > 42, twocolumn.x (#1) < 45)], limit: NONE]
 │   └── estimated rows: 3.20
 └── TableScan(Probe)
     ├── table: default.default.onecolumn

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter.test
@@ -228,3 +228,34 @@ drop view v1;
 
 statement ok
 drop view v2;
+
+# push down alias filter scan
+statement ok
+drop table if exists t;
+
+statement ok
+create table t (x INT);
+
+statement ok
+insert into t(x) values (1), (2);
+
+query I
+explain select * from t as a(id) where a.id > 1;
+----
+Filter
+├── output columns: [a.x (#0)]
+├── filters: [is_true(a.id (#0) > 1)]
+├── estimated rows: 0.40
+└── TableScan
+    ├── table: default.default.t
+    ├── output columns: [x (#0)]
+    ├── read rows: 2
+    ├── read bytes: 24
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    ├── push downs: [filters: [is_true(t.x (#0) > 1)], limit: NONE]
+    └── estimated rows: 2.00
+
+statement ok
+drop table t;

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
@@ -332,7 +332,7 @@ HashJoin
         ├── read bytes: 8
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── push downs: [filters: [t.number (#0) < 10], limit: NONE]
+        ├── push downs: [filters: [numbers.number (#0) < 10], limit: NONE]
         └── estimated rows: 1.00
 
 query T


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

If `is_source_of_view` is false, we need to replace column alias name with original column name.

- Fixes #14410

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14415)
<!-- Reviewable:end -->
