### PR TITLE
refactor: Add trait FromToProtoEnum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3257,6 +3257,7 @@ dependencies = [
  "minitrace",
  "num",
  "pretty_assertions",
+ "prost 0.12.1",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,6 +2858,7 @@ dependencies = [
  "log",
  "minitrace",
  "mockall",
+ "prost 0.12.1",
  "serde",
  "serde_json",
 ]
@@ -2883,6 +2884,7 @@ dependencies = [
  "logcall",
  "maplit",
  "minitrace",
+ "prost 0.12.1",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -3003,6 +3005,7 @@ dependencies = [
  "databend-common-protos",
  "databend-common-tracing",
  "openraft 0.9.0",
+ "prost 0.12.1",
  "serde",
  "serde_json",
 ]

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -20,7 +20,6 @@ databend-common-meta-kvapi = { path = "../kvapi" }
 databend-common-meta-stoerr = { path = "../stoerr" }
 databend-common-meta-types = { path = "../types" }
 databend-common-proto-conv = { path = "../proto-conv" }
-databend-common-protos = { path = "../protos" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -31,6 +30,7 @@ log = { workspace = true }
 logcall = { workspace = true }
 maplit = "1.0.2"
 minitrace = { workspace = true }
+prost = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/meta/api/src/testing.rs
+++ b/src/meta/api/src/testing.rs
@@ -31,7 +31,6 @@ pub(crate) async fn get_kv_data<T>(
 ) -> Result<T, KVAppError>
 where
     T: FromToProto,
-    T::PB: databend_common_protos::prost::Message + Default,
 {
     let res = kv_api.get_kv(&key.to_string_key()).await?;
     if let Some(res) = res {

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -292,7 +292,7 @@ where T: FromToProto + 'static {
         MetaNetworkError::InvalidArgument(inv)
     })?;
     let mut buf = vec![];
-    databend_common_protos::prost::Message::encode(&p, &mut buf).map_err(|e| {
+    prost::Message::encode(&p, &mut buf).map_err(|e| {
         let inv = InvalidArgument::new(e, "");
         MetaNetworkError::InvalidArgument(inv)
     })?;
@@ -301,7 +301,7 @@ where T: FromToProto + 'static {
 
 pub fn deserialize_struct<T>(buf: &[u8]) -> Result<T, MetaNetworkError>
 where T: FromToProto {
-    let p: T::PB = databend_common_protos::prost::Message::decode(buf).map_err(|e| {
+    let p: T::PB = prost::Message::decode(buf).map_err(|e| {
         let inv = InvalidReply::new("", &e);
         MetaNetworkError::InvalidReply(inv)
     })?;

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -108,7 +108,6 @@ pub fn deserialize_struct_get_response<K, T>(
 where
     K: kvapi::Key,
     T: FromToProto,
-    T::PB: databend_common_protos::prost::Message + Default,
 {
     let key = K::from_str_key(&resp.key).map_err(|e| {
         let inv = InvalidReply::new(
@@ -160,7 +159,6 @@ pub async fn get_pb_value<K, T>(
 where
     K: kvapi::Key,
     T: FromToProto,
-    T::PB: databend_common_protos::prost::Message + Default,
 {
     let res = kv_api.get_kv(&k.to_string_key()).await?;
 
@@ -178,7 +176,6 @@ pub async fn mget_pb_values<T>(
 ) -> Result<Vec<(u64, Option<T>)>, MetaError>
 where
     T: FromToProto,
-    T::PB: databend_common_protos::prost::Message + Default,
 {
     let seq_bytes = kv_api.mget_kv(keys).await?;
     let mut seq_values = Vec::with_capacity(keys.len());
@@ -289,10 +286,7 @@ pub async fn fetch_id<T: kvapi::Key>(
 }
 
 pub fn serialize_struct<T>(value: &T) -> Result<Vec<u8>, MetaNetworkError>
-where
-    T: FromToProto + 'static,
-    T::PB: databend_common_protos::prost::Message,
-{
+where T: FromToProto + 'static {
     let p = value.to_pb().map_err(|e| {
         let inv = InvalidArgument::new(e, "");
         MetaNetworkError::InvalidArgument(inv)
@@ -306,10 +300,7 @@ where
 }
 
 pub fn deserialize_struct<T>(buf: &[u8]) -> Result<T, MetaNetworkError>
-where
-    T: FromToProto,
-    T::PB: databend_common_protos::prost::Message + Default,
-{
+where T: FromToProto {
     let p: T::PB = databend_common_protos::prost::Message::decode(buf).map_err(|e| {
         let inv = InvalidReply::new("", &e);
         MetaNetworkError::InvalidReply(inv)

--- a/src/meta/process/Cargo.toml
+++ b/src/meta/process/Cargo.toml
@@ -22,5 +22,6 @@ databend-common-tracing = { path = "../../common/tracing" }
 anyhow = { workspace = true }
 clap = { workspace = true }
 openraft = { workspace = true }
+prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/meta/process/src/rewrite_kv.rs
+++ b/src/meta/process/src/rewrite_kv.rs
@@ -17,7 +17,7 @@ use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_proto_conv::FromToProto;
 use databend_common_protos::pb;
-use databend_common_protos::prost::Message;
+use prost::Message;
 
 /// Convert old version TableMeta protobuf message to new version.
 ///

--- a/src/meta/proto-conv/Cargo.toml
+++ b/src/meta/proto-conv/Cargo.toml
@@ -20,6 +20,7 @@ chrono-tz = { workspace = true, features = ["serde"] }
 enumflags2 = { workspace = true }
 minitrace = { workspace = true }
 num = "0.4.0"
+prost = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
@@ -26,16 +26,14 @@ use num::FromPrimitive;
 
 use crate::reader_check_msg;
 use crate::FromToProto;
+use crate::FromToProtoEnum;
 use crate::Incompatible;
 use crate::MIN_READER_VER;
 use crate::VER;
 
-impl FromToProto for mt::principal::StageFileFormatType {
-    type PB = pb::StageFileFormatType;
-    fn get_pb_ver(_p: &Self::PB) -> u64 {
-        0
-    }
-    fn from_pb(p: pb::StageFileFormatType) -> Result<Self, Incompatible>
+impl FromToProtoEnum for mt::principal::StageFileFormatType {
+    type PBEnum = pb::StageFileFormatType;
+    fn from_pb_enum(p: pb::StageFileFormatType) -> Result<Self, Incompatible>
     where Self: Sized {
         match p {
             pb::StageFileFormatType::Csv => Ok(mt::principal::StageFileFormatType::Csv),
@@ -49,7 +47,7 @@ impl FromToProto for mt::principal::StageFileFormatType {
         }
     }
 
-    fn to_pb(&self) -> Result<pb::StageFileFormatType, Incompatible> {
+    fn to_pb_enum(&self) -> Result<pb::StageFileFormatType, Incompatible> {
         match *self {
             mt::principal::StageFileFormatType::Csv => Ok(pb::StageFileFormatType::Csv),
             mt::principal::StageFileFormatType::Tsv => Ok(pb::StageFileFormatType::Tsv),
@@ -66,12 +64,9 @@ impl FromToProto for mt::principal::StageFileFormatType {
     }
 }
 
-impl FromToProto for mt::principal::StageFileCompression {
-    type PB = pb::StageFileCompression;
-    fn get_pb_ver(_p: &Self::PB) -> u64 {
-        0
-    }
-    fn from_pb(p: pb::StageFileCompression) -> Result<Self, Incompatible>
+impl FromToProtoEnum for mt::principal::StageFileCompression {
+    type PBEnum = pb::StageFileCompression;
+    fn from_pb_enum(p: pb::StageFileCompression) -> Result<Self, Incompatible>
     where Self: Sized {
         match p {
             pb::StageFileCompression::Auto => Ok(mt::principal::StageFileCompression::Auto),
@@ -90,7 +85,7 @@ impl FromToProto for mt::principal::StageFileCompression {
         }
     }
 
-    fn to_pb(&self) -> Result<pb::StageFileCompression, Incompatible> {
+    fn to_pb_enum(&self) -> Result<pb::StageFileCompression, Incompatible> {
         match *self {
             mt::principal::StageFileCompression::Auto => Ok(pb::StageFileCompression::Auto),
             mt::principal::StageFileCompression::Gzip => Ok(pb::StageFileCompression::Gzip),
@@ -118,13 +113,13 @@ impl FromToProto for mt::principal::FileFormatOptions {
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
-        let format = mt::principal::StageFileFormatType::from_pb(
+        let format = mt::principal::StageFileFormatType::from_pb_enum(
             FromPrimitive::from_i32(p.format).ok_or_else(|| Incompatible {
                 reason: format!("invalid StageFileFormatType: {}", p.format),
             })?,
         )?;
 
-        let compression = mt::principal::StageFileCompression::from_pb(
+        let compression = mt::principal::StageFileCompression::from_pb_enum(
             FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
                 reason: format!("invalid StageFileCompression: {}", p.compression),
             })?,
@@ -151,8 +146,9 @@ impl FromToProto for mt::principal::FileFormatOptions {
     }
 
     fn to_pb(&self) -> Result<pb::FileFormatOptions, Incompatible> {
-        let format = mt::principal::StageFileFormatType::to_pb(&self.format)? as i32;
-        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        let format = mt::principal::StageFileFormatType::to_pb_enum(&self.format)? as i32;
+        let compression =
+            mt::principal::StageFileCompression::to_pb_enum(&self.compression)? as i32;
         Ok(pb::FileFormatOptions {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
@@ -321,7 +317,7 @@ impl FromToProto for mt::principal::NdJsonFileFormatParams {
     fn from_pb(p: pb::NdJsonFileFormatParams) -> Result<Self, Incompatible>
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
-        let compression = mt::principal::StageFileCompression::from_pb(
+        let compression = mt::principal::StageFileCompression::from_pb_enum(
             FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
                 reason: format!("invalid StageFileCompression: {}", p.compression),
             })?,
@@ -338,7 +334,8 @@ impl FromToProto for mt::principal::NdJsonFileFormatParams {
     }
 
     fn to_pb(&self) -> Result<pb::NdJsonFileFormatParams, Incompatible> {
-        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        let compression =
+            mt::principal::StageFileCompression::to_pb_enum(&self.compression)? as i32;
         Ok(pb::NdJsonFileFormatParams {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
@@ -358,7 +355,7 @@ impl FromToProto for mt::principal::JsonFileFormatParams {
     fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
-        let compression = mt::principal::StageFileCompression::from_pb(
+        let compression = mt::principal::StageFileCompression::from_pb_enum(
             FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
                 reason: format!("invalid StageFileCompression: {}", p.compression),
             })?,
@@ -367,7 +364,8 @@ impl FromToProto for mt::principal::JsonFileFormatParams {
     }
 
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
-        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        let compression =
+            mt::principal::StageFileCompression::to_pb_enum(&self.compression)? as i32;
         Ok(Self::PB {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
@@ -385,7 +383,7 @@ impl FromToProto for mt::principal::XmlFileFormatParams {
     fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
-        let compression = mt::principal::StageFileCompression::from_pb(
+        let compression = mt::principal::StageFileCompression::from_pb_enum(
             FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
                 reason: format!("invalid StageFileCompression: {}", p.compression),
             })?,
@@ -397,7 +395,8 @@ impl FromToProto for mt::principal::XmlFileFormatParams {
     }
 
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
-        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        let compression =
+            mt::principal::StageFileCompression::to_pb_enum(&self.compression)? as i32;
         Ok(Self::PB {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
@@ -416,7 +415,7 @@ impl FromToProto for mt::principal::CsvFileFormatParams {
     fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
-        let compression = mt::principal::StageFileCompression::from_pb(
+        let compression = mt::principal::StageFileCompression::from_pb_enum(
             FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
                 reason: format!("invalid StageFileCompression: {}", p.compression),
             })?,
@@ -463,7 +462,8 @@ impl FromToProto for mt::principal::CsvFileFormatParams {
     }
 
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
-        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        let compression =
+            mt::principal::StageFileCompression::to_pb_enum(&self.compression)? as i32;
         Ok(Self::PB {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
@@ -492,7 +492,7 @@ impl FromToProto for mt::principal::TsvFileFormatParams {
     fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
-        let compression = mt::principal::StageFileCompression::from_pb(
+        let compression = mt::principal::StageFileCompression::from_pb_enum(
             FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
                 reason: format!("invalid StageFileCompression: {}", p.compression),
             })?,
@@ -509,7 +509,8 @@ impl FromToProto for mt::principal::TsvFileFormatParams {
     }
 
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
-        let compression = mt::principal::StageFileCompression::to_pb(&self.compression)? as i32;
+        let compression =
+            mt::principal::StageFileCompression::to_pb_enum(&self.compression)? as i32;
         Ok(Self::PB {
             ver: VER,
             min_reader_ver: MIN_READER_VER,

--- a/src/meta/proto-conv/src/from_to_protobuf.rs
+++ b/src/meta/proto-conv/src/from_to_protobuf.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 /// Defines API to convert from/to protobuf meta type.
 pub trait FromToProto {
     /// The corresponding protobuf defined type.
-    type PB;
+    type PB: prost::Message + Default;
 
     /// Get the version encoded in a protobuf message.
     fn get_pb_ver(p: &Self::PB) -> u64;
@@ -28,6 +28,19 @@ pub trait FromToProto {
 
     /// Convert from rust type to protobuf type.
     fn to_pb(&self) -> Result<Self::PB, Incompatible>;
+}
+
+/// Defines API to convert from/to protobuf Enumeration.
+pub trait FromToProtoEnum {
+    /// The corresponding protobuf defined type.
+    type PBEnum;
+
+    /// Convert to rust type from protobuf enum type.
+    fn from_pb_enum(p: Self::PBEnum) -> Result<Self, Incompatible>
+    where Self: Sized;
+
+    /// Convert from rust type to protobuf type.
+    fn to_pb_enum(&self) -> Result<Self::PBEnum, Incompatible>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]

--- a/src/meta/proto-conv/src/lib.rs
+++ b/src/meta/proto-conv/src/lib.rs
@@ -86,6 +86,7 @@ mod util;
 mod virtual_column_from_to_protobuf_impl;
 
 pub use from_to_protobuf::FromToProto;
+pub use from_to_protobuf::FromToProtoEnum;
 pub use from_to_protobuf::Incompatible;
 pub use util::missing;
 pub use util::reader_check_msg;

--- a/src/meta/proto-conv/src/stage_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/stage_from_to_protobuf_impl.rs
@@ -26,6 +26,7 @@ use num::FromPrimitive;
 use crate::reader_check_msg;
 use crate::stage_from_to_protobuf_impl::mt::principal::FileFormatOptionsAst;
 use crate::FromToProto;
+use crate::FromToProtoEnum;
 use crate::Incompatible;
 use crate::MIN_READER_VER;
 use crate::VER;
@@ -198,7 +199,7 @@ impl FromToProto for mt::principal::StageInfo {
         };
         Ok(mt::principal::StageInfo {
             stage_name: p.stage_name.clone(),
-            stage_type: mt::principal::StageType::from_pb(
+            stage_type: mt::principal::StageType::from_pb_enum(
                 FromPrimitive::from_i32(p.stage_type).ok_or_else(|| Incompatible {
                     reason: format!("invalid StageType: {}", p.stage_type),
                 })?,
@@ -233,7 +234,7 @@ impl FromToProto for mt::principal::StageInfo {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
             stage_name: self.stage_name.clone(),
-            stage_type: mt::principal::StageType::to_pb(&self.stage_type)? as i32,
+            stage_type: mt::principal::StageType::to_pb_enum(&self.stage_type)? as i32,
             stage_params: Some(mt::principal::StageParams::to_pb(&self.stage_params)?),
             file_format_params: Some(mt::principal::FileFormatParams::to_pb(
                 &self.file_format_params,
@@ -289,12 +290,9 @@ impl FromToProto for mt::principal::StageFile {
     }
 }
 
-impl FromToProto for mt::principal::StageType {
-    type PB = pb::stage_info::StageType;
-    fn get_pb_ver(_p: &Self::PB) -> u64 {
-        0
-    }
-    fn from_pb(p: pb::stage_info::StageType) -> Result<Self, Incompatible>
+impl FromToProtoEnum for mt::principal::StageType {
+    type PBEnum = pb::stage_info::StageType;
+    fn from_pb_enum(p: pb::stage_info::StageType) -> Result<Self, Incompatible>
     where Self: Sized {
         match p {
             pb::stage_info::StageType::LegacyInternal => {
@@ -306,7 +304,7 @@ impl FromToProto for mt::principal::StageType {
         }
     }
 
-    fn to_pb(&self) -> Result<pb::stage_info::StageType, Incompatible> {
+    fn to_pb_enum(&self) -> Result<pb::stage_info::StageType, Incompatible> {
         match *self {
             mt::principal::StageType::LegacyInternal => {
                 Ok(pb::stage_info::StageType::LegacyInternal)

--- a/src/meta/proto-conv/tests/it/common.rs
+++ b/src/meta/proto-conv/tests/it/common.rs
@@ -23,10 +23,7 @@ use pretty_assertions::assert_eq;
 /// Tests converting rust types from/to protobuf defined types.
 /// It also print out encoded protobuf message as data for backward compatibility test.
 pub(crate) fn test_pb_from_to<MT>(name: impl Display, m: MT) -> anyhow::Result<()>
-where
-    MT: FromToProto + PartialEq + Debug,
-    MT::PB: databend_common_protos::prost::Message,
-{
+where MT: FromToProto + PartialEq + Debug {
     let p = m.to_pb()?;
 
     let n = std::any::type_name::<MT>();
@@ -61,7 +58,6 @@ pub(crate) fn test_load_old<MT>(
 ) -> anyhow::Result<()>
 where
     MT: FromToProto + PartialEq + Debug,
-    MT::PB: databend_common_protos::prost::Message + Default,
 {
     let p: MT::PB = databend_common_protos::prost::Message::decode(buf).map_err(print_err)?;
     assert_eq!(want_msg_ver, MT::get_pb_ver(&p), "loading {}", name);

--- a/src/meta/proto-conv/tests/it/common.rs
+++ b/src/meta/proto-conv/tests/it/common.rs
@@ -29,7 +29,7 @@ where MT: FromToProto + PartialEq + Debug {
     let n = std::any::type_name::<MT>();
 
     let mut buf = vec![];
-    databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+    prost::Message::encode(&p, &mut buf)?;
 
     let var_name = n.split("::").last().unwrap();
     // The encoded data should be saved for compatability test.
@@ -59,7 +59,7 @@ pub(crate) fn test_load_old<MT>(
 where
     MT: FromToProto + PartialEq + Debug,
 {
-    let p: MT::PB = databend_common_protos::prost::Message::decode(buf).map_err(print_err)?;
+    let p: MT::PB = prost::Message::decode(buf).map_err(print_err)?;
     assert_eq!(want_msg_ver, MT::get_pb_ver(&p), "loading {}", name);
 
     let got = MT::from_pb(p).map_err(print_err)?;

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -411,7 +411,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = db_meta.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("db:{:?}", buf);
     }
 
@@ -422,7 +422,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = tbl.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("table:{:?}", buf);
     }
 
@@ -433,7 +433,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = tbl.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("share:{:?}", buf);
     }
 
@@ -444,7 +444,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = share_account_meta.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("share account:{:?}", buf);
     }
 
@@ -454,7 +454,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = index.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("index meta:{buf:?}");
     }
 
@@ -464,7 +464,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = copied_file.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("copied_file:{:?}", buf);
     }
 
@@ -474,7 +474,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = empty_proto.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("empty_proto:{:?}", buf);
     }
 
@@ -484,7 +484,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = table_lock_meta.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
     }
 
     // schema
@@ -493,7 +493,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = schema.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("schema:{:?}", buf);
     }
 
@@ -503,7 +503,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = data_mask_meta.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("data mask:{:?}", buf);
     }
 
@@ -513,7 +513,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = table_statistics.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("table statistics:{:?}", buf);
     }
 
@@ -523,7 +523,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = catalog_meta.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("catalog catalog_meta:{:?}", buf);
     }
 
@@ -533,7 +533,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let p = lvt.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("lvt:{:?}", buf);
     }
 

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -616,7 +616,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let p = user_info.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("user_info: {:?}", buf);
     }
 
@@ -625,7 +625,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let stage_file = test_stage_file();
         let p = stage_file.to_pb()?;
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("stage_file: {:?}", buf);
     }
 
@@ -636,7 +636,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let p = fs_stage_info.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("fs_stage_info: {:?}", buf);
     }
 
@@ -647,7 +647,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let p = s3_stage_info.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("s3_stage_info: {:?}", buf);
     }
 
@@ -658,7 +658,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let p = s3_stage_info.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("s3_stage_info_v16: {:?}", buf);
     }
 
@@ -669,7 +669,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let p = s3_stage_info.to_pb()?;
 
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("s3_stage_info_v14: {:?}", buf);
     }
 
@@ -678,7 +678,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let gcs_stage_info = test_gcs_stage_info();
         let p = gcs_stage_info.to_pb()?;
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("gcs_stage_info: {:?}", buf);
     }
 
@@ -687,7 +687,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let oss_stage_info = test_oss_stage_info();
         let p = oss_stage_info.to_pb()?;
         let mut buf = vec![];
-        databend_common_protos::prost::Message::encode(&p, &mut buf)?;
+        prost::Message::encode(&p, &mut buf)?;
         println!("oss_stage_info: {:?}", buf);
     }
 
@@ -708,9 +708,7 @@ fn test_load_old_user() -> anyhow::Result<()> {
             80, 24, 128, 160, 1, 160, 6, 4, 168, 6, 1, 50, 15, 8, 1, 18, 5, 114, 111, 108, 101, 49,
             160, 6, 4, 168, 6, 1, 160, 6, 4, 168, 6, 1,
         ];
-        let p: pb::UserInfo =
-            databend_common_protos::prost::Message::decode(user_info_v4.as_slice())
-                .map_err(print_err)?;
+        let p: pb::UserInfo = prost::Message::decode(user_info_v4.as_slice()).map_err(print_err)?;
         let got = mt::principal::UserInfo::from_pb(p).map_err(print_err)?;
         let want = test_user_info();
 
@@ -726,9 +724,7 @@ fn test_load_old_user() -> anyhow::Result<()> {
             6, 1, 160, 6, 1, 42, 12, 8, 10, 16, 128, 80, 24, 128, 160, 1, 160, 6, 1, 50, 5, 8, 1,
             160, 6, 1, 160, 6, 1,
         ];
-        let p: pb::UserInfo =
-            databend_common_protos::prost::Message::decode(user_info_v1.as_slice())
-                .map_err(print_err)?;
+        let p: pb::UserInfo = prost::Message::decode(user_info_v1.as_slice()).map_err(print_err)?;
         let got = mt::principal::UserInfo::from_pb(p).map_err(print_err)?;
         assert_eq!(got.name, "test_user".to_string());
         assert_eq!(got.option.default_role().clone(), None);
@@ -743,9 +739,7 @@ fn test_load_old_user() -> anyhow::Result<()> {
             80, 24, 128, 160, 1, 160, 6, 3, 168, 6, 1, 50, 15, 8, 1, 18, 5, 114, 111, 108, 101, 49,
             160, 6, 3, 168, 6, 1, 160, 6, 3, 168, 6, 1,
         ];
-        let p: pb::UserInfo =
-            databend_common_protos::prost::Message::decode(user_info_v3.as_slice())
-                .map_err(print_err)?;
+        let p: pb::UserInfo = prost::Message::decode(user_info_v3.as_slice()).map_err(print_err)?;
         let got = mt::principal::UserInfo::from_pb(p).map_err(print_err)?;
         let want = test_user_info();
         assert_eq!(want, got);
@@ -761,9 +755,7 @@ fn test_load_old_user() -> anyhow::Result<()> {
             80, 24, 128, 160, 1, 160, 6, 3, 168, 6, 1, 50, 15, 8, 2, 18, 5, 114, 111, 108, 101, 49,
             160, 6, 3, 168, 6, 1, 160, 6, 3, 168, 6, 1,
         ];
-        let p: pb::UserInfo =
-            databend_common_protos::prost::Message::decode(user_info_v3.as_slice())
-                .map_err(print_err)?;
+        let p: pb::UserInfo = prost::Message::decode(user_info_v3.as_slice()).map_err(print_err)?;
         let got = mt::principal::UserInfo::from_pb(p).map_err(print_err)?;
         assert!(got.option.flags().is_empty());
     }
@@ -780,9 +772,7 @@ fn test_load_old_user() -> anyhow::Result<()> {
             49, 168, 6, 24,
         ];
 
-        let p: pb::UserInfo =
-            databend_common_protos::prost::Message::decode(user_info_v5.as_slice())
-                .map_err(print_err)?;
+        let p: pb::UserInfo = prost::Message::decode(user_info_v5.as_slice()).map_err(print_err)?;
         let got = mt::principal::UserInfo::from_pb(p).map_err(print_err)?;
         let mut want = test_user_info();
         want.option = want
@@ -807,8 +797,7 @@ fn test_old_stage_file() -> anyhow::Result<()> {
             168, 6, 1, 160, 6, 8, 168, 6, 1,
         ];
         let p: pb::StageFile =
-            databend_common_protos::prost::Message::decode(stage_file_v7.as_slice())
-                .map_err(print_err)?;
+            prost::Message::decode(stage_file_v7.as_slice()).map_err(print_err)?;
         let got = mt::principal::StageFile::from_pb(p).map_err(print_err)?;
 
         let dt = NaiveDateTime::new(

--- a/src/query/management/Cargo.toml
+++ b/src/query/management/Cargo.toml
@@ -22,13 +22,13 @@ databend-common-meta-kvapi = { path = "../../meta/kvapi" }
 databend-common-meta-store = { path = "../../meta/store" }
 databend-common-meta-types = { path = "../../meta/types" }
 databend-common-proto-conv = { path = "../../meta/proto-conv" }
-databend-common-protos = { path = "../../meta/protos" }
 
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 enumflags2 = { workspace = true }
 log = { workspace = true }
 minitrace = { workspace = true }
+prost = { workspace = true }
 serde = "1.0.150"
 serde_json = { workspace = true }
 

--- a/src/query/management/src/serde/pb_serde.rs
+++ b/src/query/management/src/serde/pb_serde.rs
@@ -33,9 +33,9 @@ pub fn serialize_struct<T, ErrFn, CtxFn, D>(
 ) -> Result<Vec<u8>>
 where
     T: FromToProto + 'static,
-    ErrFn: FnOnce(String) -> ErrorCode + std::marker::Copy,
+    ErrFn: FnOnce(String) -> ErrorCode + Copy,
     D: Display,
-    CtxFn: FnOnce() -> D + std::marker::Copy,
+    CtxFn: FnOnce() -> D + Copy,
 {
     let p = value.to_pb().map_err_to_code(err_code_fn, context_fn)?;
     let mut buf = vec![];
@@ -50,9 +50,9 @@ pub fn deserialize_struct<T, ErrFn, CtxFn, D>(
 ) -> Result<T>
 where
     T: FromToProto,
-    ErrFn: FnOnce(String) -> ErrorCode + std::marker::Copy,
+    ErrFn: FnOnce(String) -> ErrorCode + Copy,
     D: Display,
-    CtxFn: FnOnce() -> D + std::marker::Copy,
+    CtxFn: FnOnce() -> D + Copy,
 {
     let p: T::PB = prost::Message::decode(buf).map_err_to_code(err_code_fn, context_fn)?;
     let v: T = FromToProto::from_pb(p).map_err_to_code(err_code_fn, context_fn)?;
@@ -69,9 +69,9 @@ pub async fn check_and_upgrade_to_pb<'a, T, ErrFn, CtxFn, D>(
 ) -> std::result::Result<SeqV<T>, ErrorCode>
 where
     T: FromToProto + serde::de::DeserializeOwned + 'a + 'static,
-    ErrFn: FnOnce(String) -> ErrorCode + std::marker::Copy,
+    ErrFn: FnOnce(String) -> ErrorCode + Copy,
     D: Display,
-    CtxFn: FnOnce() -> D + std::marker::Copy,
+    CtxFn: FnOnce() -> D + Copy,
 {
     let deserialize_result =
         deserialize_struct(&seq_value.data, ErrorCode::IllegalUserInfoFormat, || "");

--- a/src/query/management/src/serde/pb_serde.rs
+++ b/src/query/management/src/serde/pb_serde.rs
@@ -39,8 +39,7 @@ where
 {
     let p = value.to_pb().map_err_to_code(err_code_fn, context_fn)?;
     let mut buf = vec![];
-    databend_common_protos::prost::Message::encode(&p, &mut buf)
-        .map_err_to_code(err_code_fn, context_fn)?;
+    prost::Message::encode(&p, &mut buf).map_err_to_code(err_code_fn, context_fn)?;
     Ok(buf)
 }
 
@@ -55,8 +54,7 @@ where
     D: Display,
     CtxFn: FnOnce() -> D + std::marker::Copy,
 {
-    let p: T::PB = databend_common_protos::prost::Message::decode(buf)
-        .map_err_to_code(err_code_fn, context_fn)?;
+    let p: T::PB = prost::Message::decode(buf).map_err_to_code(err_code_fn, context_fn)?;
     let v: T = FromToProto::from_pb(p).map_err_to_code(err_code_fn, context_fn)?;
 
     Ok(v)
@@ -71,7 +69,6 @@ pub async fn check_and_upgrade_to_pb<'a, T, ErrFn, CtxFn, D>(
 ) -> std::result::Result<SeqV<T>, ErrorCode>
 where
     T: FromToProto + serde::de::DeserializeOwned + 'a + 'static,
-    T::PB: databend_common_protos::prost::Message + Default,
     ErrFn: FnOnce(String) -> ErrorCode + std::marker::Copy,
     D: Display,
     CtxFn: FnOnce() -> D + std::marker::Copy,

--- a/src/query/management/src/serde/pb_serde.rs
+++ b/src/query/management/src/serde/pb_serde.rs
@@ -33,7 +33,6 @@ pub fn serialize_struct<T, ErrFn, CtxFn, D>(
 ) -> Result<Vec<u8>>
 where
     T: FromToProto + 'static,
-    T::PB: databend_common_protos::prost::Message + Default,
     ErrFn: FnOnce(String) -> ErrorCode + std::marker::Copy,
     D: Display,
     CtxFn: FnOnce() -> D + std::marker::Copy,
@@ -52,7 +51,6 @@ pub fn deserialize_struct<T, ErrFn, CtxFn, D>(
 ) -> Result<T>
 where
     T: FromToProto,
-    T::PB: databend_common_protos::prost::Message + Default,
     ErrFn: FnOnce(String) -> ErrorCode + std::marker::Copy,
     D: Display,
     CtxFn: FnOnce() -> D + std::marker::Copy,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Add trait FromToProtoEnum

add trait bound prost::Message+Default to FromToProto::PB;
and add FromToProtoEnum to define behavior converting enum. in protobuf enum is not a Message

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14423)
<!-- Reviewable:end -->
