### PR TITLE
chore: fix build tool installation

### DIFF
--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -571,7 +571,8 @@ if [[ "$INSTALL_CHECK_TOOLS" == "true" ]]; then
 	if [[ -f scripts/setup/rust-tools.txt ]]; then
 		export RUSTFLAGS="-C target-feature=-crt-static"
 		while read -r tool; do
-			cargo binstall -y "$tool"
+			# Use cargo install to prevent downloading the tools with incompatible GLIBC
+			cargo install "$tool"
 		done <scripts/setup/rust-tools.txt
 	fi
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`cargo-audit` published a release [v0.18.3](
https://github.com/rustsec/rustsec/releases/tag/cargo-audit%2Fv0.18.3) which has dependency of GLIBC 2.34, while our CI image only have GLIBC 2.31.

To prevent downloading the incompatible tools, we will use `cargo install` for them.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14438)
<!-- Reviewable:end -->
