### PR TITLE
feat(query): support session setting scope `LOCAL`

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -30,6 +30,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::AuthInfo;
 use databend_common_meta_app::principal::AuthType;
+use databend_common_meta_app::principal::UserSettingValue;
 use databend_common_meta_app::storage::StorageAzblobConfig as InnerStorageAzblobConfig;
 use databend_common_meta_app::storage::StorageCosConfig as InnerStorageCosConfig;
 use databend_common_meta_app::storage::StorageFsConfig as InnerStorageFsConfig;
@@ -1583,6 +1584,9 @@ pub struct QueryConfig {
 
     #[clap(long)]
     pub cloud_control_grpc_server_address: Option<String>,
+
+    #[clap(skip)]
+    pub settings: HashMap<String, UserSettingValue>,
 }
 
 impl Default for QueryConfig {
@@ -1661,6 +1665,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
             enable_udf_server: self.enable_udf_server,
             udf_server_allow_list: self.udf_server_allow_list,
             cloud_control_grpc_server_address: self.cloud_control_grpc_server_address,
+            settings: self.settings,
         })
     }
 }
@@ -1751,6 +1756,7 @@ impl From<InnerQueryConfig> for QueryConfig {
             enable_udf_server: inner.enable_udf_server,
             udf_server_allow_list: inner.udf_server_allow_list,
             cloud_control_grpc_server_address: inner.cloud_control_grpc_server_address,
+            settings: HashMap::new(),
         }
     }
 }

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -26,6 +26,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_grpc::RpcClientConf;
 use databend_common_grpc::RpcClientTlsConfig;
+use databend_common_meta_app::principal::UserSettingValue;
 use databend_common_meta_app::tenant::TenantQuota;
 use databend_common_storage::StorageConfig;
 use databend_common_tracing::Config as LogConfig;
@@ -226,6 +227,8 @@ pub struct QueryConfig {
     pub udf_server_allow_list: Vec<String>,
 
     pub cloud_control_grpc_server_address: Option<String>,
+
+    pub settings: HashMap<String, UserSettingValue>,
 }
 
 impl Default for QueryConfig {
@@ -294,6 +297,7 @@ impl Default for QueryConfig {
             udf_server_allow_list: Vec::new(),
             cloud_control_grpc_server_address: None,
             data_retention_time_in_days_max: 90,
+            settings: HashMap::new(),
         }
     }
 }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -137,7 +137,7 @@ impl QueryContext {
         let query_settings = Settings::create(tenant);
         Arc::new(QueryContext {
             partition_queue: Arc::new(RwLock::new(VecDeque::new())),
-            version: format!("DatabendQuery {}", *DATABEND_COMMIT_VERSION),
+            version: format!("Databend Query {}", *DATABEND_COMMIT_VERSION),
             mysql_version: format!("{}-{}", MYSQL_VERSION, *DATABEND_COMMIT_VERSION),
             clickhouse_version: CLICKHOUSE_VERSION.to_string(),
             shared,

--- a/src/query/settings/src/settings.rs
+++ b/src/query/settings/src/settings.rs
@@ -18,6 +18,7 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 use dashmap::DashMap;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::UserSettingValue;
@@ -30,15 +31,23 @@ use crate::SettingMode;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub enum ScopeLevel {
+    Default,
     Global,
+    Local,
     Session,
 }
 
 impl Debug for ScopeLevel {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
+            ScopeLevel::Default => {
+                write!(f, "DEFAULT")
+            }
             ScopeLevel::Global => {
                 write!(f, "GLOBAL")
+            }
+            ScopeLevel::Local => {
+                write!(f, "LOCAL")
             }
             ScopeLevel::Session => {
                 write!(f, "SESSION")
@@ -57,13 +66,19 @@ pub struct ChangeValue {
 pub struct Settings {
     pub(crate) tenant: String,
     pub(crate) changes: DashMap<String, ChangeValue>,
+    pub(crate) configs: HashMap<String, UserSettingValue>,
 }
 
 impl Settings {
     pub fn create(tenant: String) -> Arc<Settings> {
+        let configs = match GlobalConfig::try_get_instance() {
+            Some(conf) => conf.query.settings.clone(),
+            None => HashMap::new(),
+        };
         Arc::new(Settings {
             tenant,
             changes: DashMap::new(),
+            configs,
         })
     }
 
@@ -151,14 +166,6 @@ impl<'a> Iterator for SettingsIter<'a> {
                     continue;
                 }
                 Some((key, default_value)) => Some(match self.settings.changes.get(&key) {
-                    None => SettingsItem {
-                        name: key,
-                        level: ScopeLevel::Session,
-                        desc: default_value.desc,
-                        user_value: default_value.value.clone(),
-                        default_value: default_value.value,
-                        range: default_value.range,
-                    },
                     Some(change_value) => SettingsItem {
                         name: key,
                         level: change_value.level.clone(),
@@ -166,6 +173,24 @@ impl<'a> Iterator for SettingsIter<'a> {
                         user_value: change_value.value.clone(),
                         default_value: default_value.value,
                         range: default_value.range,
+                    },
+                    None => match self.settings.configs.get(&key) {
+                        Some(local_value) => SettingsItem {
+                            name: key,
+                            level: ScopeLevel::Local,
+                            desc: default_value.desc,
+                            user_value: local_value.clone(),
+                            default_value: default_value.value,
+                            range: default_value.range,
+                        },
+                        None => SettingsItem {
+                            name: key,
+                            level: ScopeLevel::Default,
+                            desc: default_value.desc,
+                            user_value: default_value.value.clone(),
+                            default_value: default_value.value,
+                            range: default_value.range,
+                        },
                     },
                 }),
             };

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -43,7 +43,10 @@ impl Settings {
     unsafe fn unchecked_try_get_u64(&self, key: &str) -> Result<u64> {
         match self.changes.get(key) {
             Some(v) => v.value.as_u64(),
-            None => DefaultSettings::try_get_u64(key),
+            None => match self.configs.get(key) {
+                Some(v) => v.as_u64(),
+                None => DefaultSettings::try_get_u64(key),
+            },
         }
     }
 
@@ -56,7 +59,10 @@ impl Settings {
     unsafe fn unchecked_try_get_string(&self, key: &str) -> Result<String, ErrorCode> {
         match self.changes.get(key) {
             Some(v) => Ok(v.value.as_string()),
-            None => DefaultSettings::try_get_string(key),
+            None => match self.configs.get(key) {
+                Some(v) => Ok(v.as_string()),
+                None => DefaultSettings::try_get_string(key),
+            },
         }
     }
 

--- a/tests/sqllogictests/suites/base/05_ddl/05_0026_ddl_unset_settings.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0026_ddl_unset_settings.test
@@ -2,8 +2,8 @@ onlyif mysql
 query TTTT
 SELECT name, value, default, level from system.settings where name in ('sql_dialect', 'timezone')
 ----
-sql_dialect PostgreSQL PostgreSQL SESSION
-timezone UTC UTC SESSION
+sql_dialect PostgreSQL PostgreSQL DEFAULT
+timezone UTC UTC DEFAULT
 
 onlyif mysql
 statement ok
@@ -36,5 +36,5 @@ onlyif mysql
 query TTTT
 SELECT name, value, default, level from system.settings where name in ('sql_dialect', 'timezone')
 ----
-sql_dialect PostgreSQL PostgreSQL SESSION
-timezone                       UTC         UTC         SESSION
+sql_dialect PostgreSQL PostgreSQL DEFAULT
+timezone UTC UTC DEFAULT

--- a/tests/sqllogictests/suites/base/06_show/06_0003_show_settings.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0003_show_settings.test
@@ -13,8 +13,8 @@ select value=default from system.settings where name in ('max_threads', 'max_mem
 query TTT
 select name, level, description from system.settings where name in ('max_threads', 'max_memory_usage') order by name
 ----
-max_memory_usage  SESSION  Sets the maximum memory usage in bytes for processing a single query.
-max_threads       SESSION  Sets the maximum number of threads to execute a request.
+max_memory_usage  DEFAULT  Sets the maximum memory usage in bytes for processing a single query.
+max_threads       DEFAULT  Sets the maximum number of threads to execute a request.
 
 statement ok
 SET max_threads=11
@@ -31,12 +31,12 @@ SHOW SETTINGS LIKE 'enable%'
 query TT
 SHOW SETTINGS LIKE 'max%' LIMIT 1
 ----
-max_block_size 65536 65536 None SESSION Sets the maximum byte size of a single data block that can be read. UInt64
+max_block_size 65536 65536 None DEFAULT Sets the maximum byte size of a single data block that can be read. UInt64
 
 query TT
 SHOW SETTINGS WHERE name='max_block_size' LIMIT 1
 ----
-max_block_size 65536 65536 None SESSION Sets the maximum byte size of a single data block that can be read. UInt64
+max_block_size 65536 65536 None DEFAULT Sets the maximum byte size of a single data block that can be read. UInt64
 
 statement error
 SHOW SETTINGS ilike 'ff%' LIMIT 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Support loading query settings from config as scope `LOCAL`.
Then we do not need to add every user setting to config struct.

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14441)
<!-- Reviewable:end -->
