### PR TITLE
refactor: replace `OneTable` with `DummyTableScan`

### DIFF
--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -100,6 +100,7 @@ use crate::optimizer::SExpr;
 use crate::planner::semantic::normalize_identifier;
 use crate::planner::semantic::TypeChecker;
 use crate::plans::CteScan;
+use crate::plans::DummyTableScan;
 use crate::plans::EvalScalar;
 use crate::plans::FunctionCall;
 use crate::plans::RelOperator;
@@ -135,24 +136,11 @@ impl Binder {
                 }
             }
         }
-        let catalog = CATALOG_DEFAULT;
-        let database = "system";
-        let tenant = self.ctx.get_tenant();
-        let table_meta = self
-            .resolve_data_source(tenant.as_str(), catalog, database, "one", &None)
-            .await?;
-        let table_index = self.metadata.write().add_table(
-            CATALOG_DEFAULT.to_owned(),
-            database.to_string(),
-            table_meta,
-            None,
-            false,
-            false,
-            false,
-        );
-
-        self.bind_base_table(bind_context, database, table_index, None)
-            .await
+        let bind_context = BindContext::with_parent(Box::new(bind_context.clone()));
+        Ok((
+            SExpr::create_leaf(Arc::new(DummyTableScan.into())),
+            bind_context,
+        ))
     }
 
     fn check_view_dep(bind_context: &BindContext, database: &str, view_name: &str) -> Result<()> {

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
@@ -81,76 +81,68 @@ FROM
     t2;
 ----
 EvalScalar
-├── output columns: [(select if(exists (select 1 from t1 where (t1.a = t2.c)), '1', '0')) (#7)]
-├── expressions: [scalar_subquery_6 (#6)]
+├── output columns: [(select if(exists (select 1 from t1 where (t1.a = t2.c)), '1', '0')) (#6)]
+├── expressions: [scalar_subquery_5 (#5)]
 ├── estimated rows: 4.00
 └── HashJoin
-    ├── output columns: [if(exists (select 1 from t1 where (t1.a = t2.c)), '1', '0') (#6)]
+    ├── output columns: [if(exists (select 1 from t1 where (t1.a = t2.c)), '1', '0') (#5)]
     ├── join type: LEFT SINGLE
-    ├── build keys: [c (#9)]
+    ├── build keys: [c (#8)]
     ├── probe keys: [c (#0)]
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)
-    │   ├── output columns: [c (#9), if(exists (select 1 from t1 where (t1.a = t2.c)), '1', '0') (#6)]
-    │   ├── expressions: [if(8 (#8), '1', '0')]
+    │   ├── output columns: [c (#8), if(exists (select 1 from t1 where (t1.a = t2.c)), '1', '0') (#5)]
+    │   ├── expressions: [if(7 (#7), '1', '0')]
     │   ├── estimated rows: 0.00
     │   └── HashJoin
-    │       ├── output columns: [c (#9), marker (#8)]
+    │       ├── output columns: [c (#8), marker (#7)]
     │       ├── join type: LEFT MARK
-    │       ├── build keys: [c (#9)]
-    │       ├── probe keys: [a (#3)]
+    │       ├── build keys: [c (#8)]
+    │       ├── probe keys: [a (#2)]
     │       ├── filters: []
     │       ├── estimated rows: 0.00
     │       ├── HashJoin(Build)
-    │       │   ├── output columns: [c (#9)]
+    │       │   ├── output columns: [c (#8)]
     │       │   ├── join type: CROSS
     │       │   ├── build keys: []
     │       │   ├── probe keys: []
     │       │   ├── filters: []
     │       │   ├── estimated rows: 0.00
-    │       │   ├── TableScan(Build)
-    │       │   │   ├── table: default.system.one
-    │       │   │   ├── output columns: []
-    │       │   │   ├── read rows: 1
-    │       │   │   ├── read bytes: 1
-    │       │   │   ├── partitions total: 1
-    │       │   │   ├── partitions scanned: 1
-    │       │   │   ├── push downs: [filters: [], limit: NONE]
-    │       │   │   └── estimated rows: 0.00
-    │       │   └── AggregateFinal(Probe)
-    │       │       ├── output columns: [c (#9)]
-    │       │       ├── group by: [c]
-    │       │       ├── aggregate functions: []
-    │       │       ├── estimated rows: 0.00
-    │       │       └── AggregatePartial
-    │       │           ├── output columns: [#_group_by_key]
-    │       │           ├── group by: [c]
-    │       │           ├── aggregate functions: []
-    │       │           ├── estimated rows: 0.00
-    │       │           └── TableScan
-    │       │               ├── table: default.default.t2
-    │       │               ├── output columns: [c (#9)]
-    │       │               ├── read rows: 4
-    │       │               ├── read bytes: 49
-    │       │               ├── partitions total: 1
-    │       │               ├── partitions scanned: 1
-    │       │               ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    │       │               ├── push downs: [filters: [], limit: NONE]
-    │       │               └── estimated rows: 0.00
+    │       │   ├── AggregateFinal(Build)
+    │       │   │   ├── output columns: [c (#8)]
+    │       │   │   ├── group by: [c]
+    │       │   │   ├── aggregate functions: []
+    │       │   │   ├── estimated rows: 0.00
+    │       │   │   └── AggregatePartial
+    │       │   │       ├── output columns: [#_group_by_key]
+    │       │   │       ├── group by: [c]
+    │       │   │       ├── aggregate functions: []
+    │       │   │       ├── estimated rows: 0.00
+    │       │   │       └── TableScan
+    │       │   │           ├── table: default.default.t2
+    │       │   │           ├── output columns: [c (#8)]
+    │       │   │           ├── read rows: 4
+    │       │   │           ├── read bytes: 49
+    │       │   │           ├── partitions total: 1
+    │       │   │           ├── partitions scanned: 1
+    │       │   │           ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
+    │       │   │           ├── push downs: [filters: [], limit: NONE]
+    │       │   │           └── estimated rows: 0.00
+    │       │   └── DummyTableScan(Probe)
     │       └── Filter(Probe)
-    │           ├── output columns: [t1.a (#3)]
-    │           ├── filters: [is_true(t1.a (#3) = a (#3))]
+    │           ├── output columns: [t1.a (#2)]
+    │           ├── filters: [is_true(t1.a (#2) = a (#2))]
     │           ├── estimated rows: 0.60
     │           └── TableScan
     │               ├── table: default.default.t1
-    │               ├── output columns: [a (#3)]
+    │               ├── output columns: [a (#2)]
     │               ├── read rows: 3
     │               ├── read bytes: 45
     │               ├── partitions total: 1
     │               ├── partitions scanned: 1
     │               ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
-    │               ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
+    │               ├── push downs: [filters: [is_true(t1.a (#2) = t1.a (#2))], limit: NONE]
     │               └── estimated rows: 3.00
     └── TableScan(Probe)
         ├── table: default.default.t2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`DummyTableScan` has statistics and reduce code.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - covered by current tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14461)
<!-- Reviewable:end -->
