### PR TITLE
feat: meta-service: customize chunk size when export

### DIFF
--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -79,7 +79,6 @@ serde_json = { workspace = true }
 serfig = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
-tonic = { workspace = true }
 
 url = "2.3.1"
 

--- a/src/binaries/metactl/grpc.rs
+++ b/src/binaries/metactl/grpc.rs
@@ -17,16 +17,23 @@ use std::io::Write;
 
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_raft_store::key_spaces::RaftStoreEntry;
-use databend_common_meta_types::protobuf::Empty;
+use databend_common_meta_types::protobuf as pb;
 use tokio_stream::StreamExt;
 
-pub async fn export_meta(addr: &str, save: String) -> anyhow::Result<()> {
+pub async fn export_meta(addr: &str, save: String, chunk_size: Option<u64>) -> anyhow::Result<()> {
     let client =
         MetaGrpcClient::try_create(vec![addr.to_string()], "root", "xxx", None, None, None)?;
 
     let mut grpc_client = client.make_established_client().await?;
 
-    let exported = grpc_client.export(tonic::Request::new(Empty {})).await?;
+    // TODO: since 1.2.315, export_v1() is added, via which chunk size can be specified.
+    let exported = if grpc_client.server_protocol_version() >= 1002315 {
+        grpc_client
+            .export_v1(pb::ExportRequest { chunk_size })
+            .await?
+    } else {
+        grpc_client.export(pb::Empty {}).await?
+    };
 
     let mut stream = exported.into_inner();
 

--- a/src/binaries/metactl/main.rs
+++ b/src/binaries/metactl/main.rs
@@ -55,6 +55,15 @@ pub struct Config {
     #[clap(long)]
     pub export: bool,
 
+    /// The N.O. json strings in a export stream item.
+    ///
+    /// Set this to a smaller value if you get gRPC message body too large error.
+    /// This requires meta-service >= 1.2.315; For older version, this argument is ignored.
+    ///
+    /// By default it is 32.
+    #[clap(long)]
+    pub export_chunk_size: Option<u64>,
+
     #[clap(
         long,
         env = "METASRV_GRPC_API_ADDRESS",

--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -506,7 +506,12 @@ async fn export_from_running_node(config: &Config) -> Result<(), anyhow::Error> 
 
     let grpc_api_addr = get_available_socket_addr(&config.grpc_api_address).await?;
 
-    export_meta(grpc_api_addr.to_string().as_str(), config.db.clone()).await?;
+    export_meta(
+        grpc_api_addr.to_string().as_str(),
+        config.db.clone(),
+        config.export_chunk_size,
+    )
+    .await?;
     Ok(())
 }
 

--- a/src/meta/client/src/established_client.rs
+++ b/src/meta/client/src/established_client.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use databend_common_meta_types::protobuf as pb;
 use databend_common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use databend_common_meta_types::protobuf::ClientInfo;
 use databend_common_meta_types::protobuf::ClusterStatus;
@@ -167,6 +168,13 @@ impl EstablishedClient {
         request: impl tonic::IntoRequest<Empty>,
     ) -> Result<Response<Streaming<ExportedChunk>>, Status> {
         self.client.export(request).await.update_client(self)
+    }
+
+    pub async fn export_v1(
+        &mut self,
+        request: impl tonic::IntoRequest<pb::ExportRequest>,
+    ) -> Result<Response<Streaming<ExportedChunk>>, Status> {
+        self.client.export_v1(request).await.update_client(self)
     }
 
     pub async fn watch(

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -907,7 +907,16 @@ impl MetaGrpcClient {
         );
 
         let mut client = self.make_established_client().await?;
-        let res = client.export(Empty {}).await?;
+        // TODO: since 1.2.315, export_v1() is added, via which chunk size can be specified.
+        let res = if client.server_protocol_version() >= 1002315 {
+            client
+                .export_v1(pb::ExportRequest {
+                    chunk_size: export_request.chunk_size,
+                })
+                .await?
+        } else {
+            client.export(Empty {}).await?
+        };
         Ok(res.into_inner())
     }
 

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -99,6 +99,9 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///           Always return the previous value;
 ///           field index is reserved, no compatibility changes.
 ///
+/// - 2024-01-25: since TODO:
+///   server: add export_v1() to let client specify export chunk size;
+///
 /// Server feature set:
 /// ```yaml
 /// server_features:

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -93,7 +93,7 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///   client: remove using MetaGrpcReq::GetKV/MGetKV/ListKV;
 ///   client: remove falling back kv_read_v1(Streamed(List)) to kv_api(List), added in `2023-10-20: since 1.2.176`;
 ///
-/// - 2024-01-17: since TODO:
+/// - 2024-01-17: since 1.2.304:
 ///   server: do not use TxnPutRequest.prev_value;
 ///   server: do not use TxnDeleteRequest.prev_value;
 ///           Always return the previous value;

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -221,7 +221,12 @@ impl Response {
 
 /// Export all data stored in metasrv
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct ExportReq {}
+pub struct ExportReq {
+    /// Number of json strings contained in a export stream item.
+    ///
+    /// By default meta-service use 32 for this field.
+    pub chunk_size: Option<u64>,
+}
 
 /// Get a grpc-client that is initialized and has passed handshake
 ///

--- a/src/meta/client/tests/it/grpc_server.rs
+++ b/src/meta/client/tests/it/grpc_server.rs
@@ -95,6 +95,16 @@ impl MetaService for GrpcServiceForTestImpl {
         unimplemented!()
     }
 
+    type ExportV1Stream =
+        Pin<Box<dyn Stream<Item = Result<ExportedChunk, tonic::Status>> + Send + 'static>>;
+
+    async fn export_v1(
+        &self,
+        _request: Request<databend_common_meta_types::protobuf::ExportRequest>,
+    ) -> Result<Response<Self::ExportStream>, Status> {
+        unimplemented!()
+    }
+
     type WatchStream =
         Pin<Box<dyn Stream<Item = Result<WatchResponse, tonic::Status>> + Send + 'static>>;
 

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -43,8 +43,18 @@ message HandshakeResponse {
   bytes payload = 2;
 }
 
+// Request meta-service to export all data in a stream.
+message ExportRequest {
+  // The number of lines of json string contained in a stream item.
+  // Note that too many lines in a stream item may cause "gRPC message too large" error.
+  // The default chunk_size is 32.
+  optional uint64 chunk_size = 10;
+}
+
 // Data chunk for export/import meta data
-message ExportedChunk { repeated string data = 10; }
+message ExportedChunk {
+  repeated string data = 10;
+}
 
 message WatchRequest {
   // key is the key to register for watching.
@@ -238,6 +248,19 @@ service MetaService {
   // The exported data is a list of json strings in form of `(tree_name,
   // sub_tree_prefix, key, value)`.
   rpc Export(Empty) returns (stream ExportedChunk);
+
+  // Export all meta data.
+  //
+  // Including raft hard state, logs and state machine.
+  // The exported data is a list of json strings in form of:
+  // `(tree_name, {"<key_space>":{"key":<key>,"value":<value>}})`.
+  //
+  // ```text
+  // ["raft_log",{"Logs":{"key":83,"value":{"log_id":{"leader_id":{"term":1,"node_id":0},"index":83},"payload":{"Normal":{"txid":null,"time_ms":1667290974891,"cmd":{"UpsertKV":{"key":"__fd_clusters/test_tenant/test_cluster/databend_query/KMZ4VvqDFVExlZFThKDzZ1","seq":{"GE":1},"value":"AsIs","value_meta":{"expire_at":1667291034}}}}}}}}]
+  // ["state_machine/0",{"Nodes":{"key":1,"value":{"name":"1","endpoint":{"addr":"localhost","port":28103},"grpc_api_advertise_address":"0.0.0.0:9191"}}}]
+  // ```
+  rpc ExportV1(ExportRequest) returns (stream ExportedChunk);
+
 
   // Add watch key stream.
   // Whenever the watch key data updated, client will be notified across the


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: meta-service: customize chunk size when export

Use `databend-metactl --export --export-chunk-size <n>` to export all meta
data with a stream in which each item contains at most `n` lines.

Specify smaller value for `--export-chunk-size` if got an `gRPC message
body too large error`.

`--export-chunk-size` requries v1.2.315 and will be ignored when
connecting to a older meta-service.


##### chore: update databend version for last meta-service API change

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14467)
<!-- Reviewable:end -->
