### PR TITLE
feat: add structlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,6 +3871,7 @@ dependencies = [
  "defer",
  "fern",
  "humantime",
+ "itertools 0.10.5",
  "log",
  "minitrace",
  "minitrace-opentelemetry",

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -78,6 +78,10 @@ format = "text"
 dir = "./.databend/logs_1"
 prefix_filter = ""
 
+[log.structlog]
+on = true
+dir = "./.databend/structlog_1"
+
 [meta]
 # It is a list of `grpc_api_advertise_host:<grpc-api-port>` of databend-meta config
 endpoints = ["0.0.0.0:9191"]

--- a/scripts/ci/deploy/config/databend-query-node-2.toml
+++ b/scripts/ci/deploy/config/databend-query-node-2.toml
@@ -54,6 +54,10 @@ format = "text"
 dir = "./.databend/logs_2"
 prefix_filter = ""
 
+[log.structlog]
+on = true
+dir = "./.databend/structlog_2"
+
 [meta]
 # It is a list of `grpc_api_advertise_host:<grpc-api-port>` of databend-meta config
 endpoints = ["0.0.0.0:9191"]

--- a/scripts/ci/deploy/config/databend-query-node-3.toml
+++ b/scripts/ci/deploy/config/databend-query-node-3.toml
@@ -55,6 +55,10 @@ format = "text"
 dir = "./.databend/logs_3"
 prefix_filter = ""
 
+[log.structlog]
+on = true
+dir = "./.databend/structlog_3"
+
 [meta]
 # It is a list of `grpc_api_advertise_host:<grpc-api-port>` of databend-meta config
 endpoints = ["0.0.0.0:9191"]

--- a/scripts/ci/deploy/config/databend-query-node-hive.toml
+++ b/scripts/ci/deploy/config/databend-query-node-hive.toml
@@ -49,6 +49,10 @@ level = "INFO"
 format = "text"
 dir = "./.databend/logs_hive"
 
+[log.structlog]
+on = true
+dir = "./.databend/structlog_hive"
+
 [meta]
 # It is a list of `grpc_api_advertise_host:<grpc-api-port>` of databend-meta config
 endpoints = ["0.0.0.0:9191"]

--- a/scripts/ci/deploy/config/databend-query-node-native.toml
+++ b/scripts/ci/deploy/config/databend-query-node-native.toml
@@ -67,6 +67,10 @@ level = "INFO"
 format = "text"
 dir = "./.databend/logs_1"
 
+[log.structlog]
+on = true
+dir = "./.databend/structlog_1"
+
 [meta]
 # It is a list of `grpc_api_advertise_host:<grpc-api-port>` of databend-meta config
 endpoints = ["0.0.0.0:9191"]

--- a/scripts/ci/deploy/config/databend-query-node-share-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-share-1.toml
@@ -69,6 +69,10 @@ level = "ERROR"
 format = "text"
 dir = "./.databend/logs_1"
 
+[log.structlog]
+on = true
+dir = "./.databend/structlog_1"
+
 [meta]
 endpoints = ["0.0.0.0:9191"]
 username = "root"

--- a/scripts/ci/deploy/config/databend-query-node-share-2.toml
+++ b/scripts/ci/deploy/config/databend-query-node-share-2.toml
@@ -70,6 +70,10 @@ level = "ERROR"
 format = "text"
 dir = "./.databend/logs_2"
 
+[log.structlog]
+on = true
+dir = "./.databend/structlog_2"
+
 [meta]
 endpoints = ["0.0.0.0:19191"]
 username = "root"

--- a/scripts/ci/deploy/config/databend-query-node-share-3.toml
+++ b/scripts/ci/deploy/config/databend-query-node-share-3.toml
@@ -70,6 +70,10 @@ level = "ERROR"
 format = "text"
 dir = "./.databend/logs_3"
 
+[log.structlog]
+on = true
+dir = "./.databend/structlog_3"
+
 [meta]
 endpoints = ["0.0.0.0:39191"]
 username = "root"

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -20,6 +20,7 @@ databend-common-base = { path = "../base" }
 # Crates.io dependencies
 console-subscriber = { version = "0.2.0", optional = true }
 defer = "0.1"
+itertools = { workspace = true }
 fern = "0.6.2"
 humantime = "2.1.0"
 log = { workspace = true }

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -20,9 +20,9 @@ databend-common-base = { path = "../base" }
 # Crates.io dependencies
 console-subscriber = { version = "0.2.0", optional = true }
 defer = "0.1"
-itertools = { workspace = true }
 fern = "0.6.2"
 humantime = "2.1.0"
+itertools = { workspace = true }
 log = { workspace = true }
 minitrace = { workspace = true }
 minitrace-opentelemetry = "0.6"

--- a/src/common/tracing/src/config.rs
+++ b/src/common/tracing/src/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub otlp: OTLPConfig,
     pub query: QueryLogConfig,
     pub profile: ProfileLogConfig,
+    pub structlog: StructLogConfig,
     pub tracing: TracingConfig,
 }
 
@@ -217,6 +218,27 @@ impl Default for ProfileLogConfig {
             dir: "".to_string(),
             otlp_endpoint: "".to_string(),
             labels: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct StructLogConfig {
+    pub on: bool,
+    pub dir: String,
+}
+
+impl Display for StructLogConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "enabled={}, dir={}", self.on, self.dir)
+    }
+}
+
+impl Default for StructLogConfig {
+    fn default() -> Self {
+        Self {
+            on: false,
+            dir: "".to_string(),
         }
     }
 }

--- a/src/common/tracing/src/init.rs
+++ b/src/common/tracing/src/init.rs
@@ -14,23 +14,21 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::fmt;
 use std::io::Write;
 use std::time::Duration;
-use std::time::SystemTime;
 
 use databend_common_base::base::tokio;
 use databend_common_base::base::GlobalInstance;
-use fern::FormatCallback;
 use log::LevelFilter;
 use log::Log;
 use minitrace::prelude::*;
 use opentelemetry_otlp::WithExportConfig;
-use serde_json::Map;
 
+use crate::loggers::formatter;
 use crate::loggers::new_file_log_writer;
 use crate::loggers::MinitraceLogger;
 use crate::loggers::OpenTelemetryLogger;
+use crate::structlog::StructLogReporter;
 use crate::Config;
 
 const HEADER_TRACE_PARENT: &str = "traceparent";
@@ -134,7 +132,12 @@ pub fn init_logging(
         .join()
         .unwrap();
 
-        minitrace::set_reporter(otlp_reporter, minitrace::collector::Config::default());
+        if cfg.structlog.on {
+            let reporter = StructLogReporter::wrap(otlp_reporter);
+            minitrace::set_reporter(reporter, minitrace::collector::Config::default());
+        } else {
+            minitrace::set_reporter(otlp_reporter, minitrace::collector::Config::default());
+        }
 
         guards.push(Box::new(defer::defer(minitrace::flush)));
         guards.push(Box::new(defer::defer(|| {
@@ -142,12 +145,17 @@ pub fn init_logging(
                 .join()
                 .unwrap()
         })));
+    } else if cfg.structlog.on {
+        let reporter = StructLogReporter::new();
+        minitrace::set_reporter(reporter, minitrace::collector::Config::default());
+        guards.push(Box::new(defer::defer(minitrace::flush)));
     }
 
     // Initialize logging
     let mut normal_logger = fern::Dispatch::new();
     let mut query_logger = fern::Dispatch::new();
     let mut profile_logger = fern::Dispatch::new();
+    let mut structlog_logger = fern::Dispatch::new();
 
     // File logger
     if cfg.file.on {
@@ -184,7 +192,7 @@ pub fn init_logging(
     }
 
     // Log to minitrace
-    if cfg.tracing.on {
+    if cfg.tracing.on || cfg.structlog.on {
         let level = cfg
             .tracing
             .capture_log_level
@@ -233,11 +241,23 @@ pub fn init_logging(
         }
     }
 
+    // Error logger
+    if cfg.structlog.on {
+        if !cfg.structlog.dir.is_empty() {
+            let (structlog_log_file, flush_guard) =
+                new_file_log_writer(&cfg.structlog.dir, log_name, cfg.file.limit);
+            guards.push(Box::new(flush_guard));
+            structlog_logger =
+                structlog_logger.chain(Box::new(structlog_log_file) as Box<dyn Write + Send>);
+        }
+    }
+
     let logger = fern::Dispatch::new()
         .chain(
             fern::Dispatch::new()
                 .level_for("databend::log::query", LevelFilter::Off)
                 .level_for("databend::log::profile", LevelFilter::Off)
+                .level_for("databend::log::structlog", LevelFilter::Off)
                 .filter({
                     let prefix_filter = cfg.file.prefix_filter.clone();
                     move |meta| {
@@ -261,6 +281,12 @@ pub fn init_logging(
                 .level(LevelFilter::Off)
                 .level_for("databend::log::profile", LevelFilter::Info)
                 .chain(profile_logger),
+        )
+        .chain(
+            fern::Dispatch::new()
+                .level(LevelFilter::Off)
+                .level_for("databend::log::structlog", LevelFilter::Info)
+                .chain(structlog_logger),
         );
 
     // Set global logger
@@ -282,88 +308,4 @@ fn init_tokio_console() {
     let subscriber = tracing_subscriber::registry::Registry::default();
     let subscriber = subscriber.with(console_subscriber::spawn());
     tracing::subscriber::set_global_default(subscriber).ok();
-}
-
-fn formatter(
-    format: &str,
-) -> fn(out: FormatCallback, message: &fmt::Arguments, record: &log::Record) {
-    match format {
-        "text" => format_text_log,
-        "json" => format_json_log,
-        _ => unreachable!("file logging format {format} is not supported"),
-    }
-}
-
-fn format_text_log(out: FormatCallback, message: &fmt::Arguments, record: &log::Record) {
-    out.finish(format_args!(
-        "{} {:>5} {}: {}:{} {}{}",
-        humantime::format_rfc3339_micros(SystemTime::now()),
-        record.level(),
-        record.module_path().unwrap_or(""),
-        record.file().unwrap_or(""),
-        record.line().unwrap_or(0),
-        message,
-        KvDisplay {
-            kv: record.key_values()
-        }
-    ));
-
-    struct KvDisplay<'kvs> {
-        kv: &'kvs dyn log::kv::Source,
-    }
-
-    impl fmt::Display for KvDisplay<'_> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let mut visitor = KvWriter { writer: f };
-            self.kv.visit(&mut visitor).ok();
-            Ok(())
-        }
-    }
-
-    struct KvWriter<'a, 'kvs> {
-        writer: &'kvs mut fmt::Formatter<'a>,
-    }
-
-    impl<'a, 'kvs> log::kv::Visitor<'kvs> for KvWriter<'a, 'kvs> {
-        fn visit_pair(
-            &mut self,
-            key: log::kv::Key<'kvs>,
-            value: log::kv::Value<'kvs>,
-        ) -> Result<(), log::kv::Error> {
-            write!(self.writer, " {key}={value}")?;
-            Ok(())
-        }
-    }
-}
-
-fn format_json_log(out: FormatCallback, message: &fmt::Arguments, record: &log::Record) {
-    let mut fields = Map::new();
-    fields.insert("message".to_string(), format!("{}", message).into());
-    let mut visitor = KvCollector {
-        fields: &mut fields,
-    };
-    record.key_values().visit(&mut visitor).ok();
-
-    out.finish(format_args!(
-        r#"{{"timestamp":"{}","level":"{}","fields":{}}}"#,
-        humantime::format_rfc3339_micros(SystemTime::now()),
-        record.level(),
-        serde_json::to_string(&fields).unwrap_or_default(),
-    ));
-
-    struct KvCollector<'a> {
-        fields: &'a mut Map<String, serde_json::Value>,
-    }
-
-    impl<'a, 'kvs> log::kv::Visitor<'kvs> for KvCollector<'a> {
-        fn visit_pair(
-            &mut self,
-            key: log::kv::Key<'kvs>,
-            value: log::kv::Value<'kvs>,
-        ) -> Result<(), log::kv::Error> {
-            self.fields
-                .insert(key.as_str().to_string(), value.to_string().into());
-            Ok(())
-        }
-    }
 }

--- a/src/common/tracing/src/init.rs
+++ b/src/common/tracing/src/init.rs
@@ -242,14 +242,12 @@ pub fn init_logging(
     }
 
     // Error logger
-    if cfg.structlog.on {
-        if !cfg.structlog.dir.is_empty() {
-            let (structlog_log_file, flush_guard) =
-                new_file_log_writer(&cfg.structlog.dir, log_name, cfg.file.limit);
-            guards.push(Box::new(flush_guard));
-            structlog_logger =
-                structlog_logger.chain(Box::new(structlog_log_file) as Box<dyn Write + Send>);
-        }
+    if cfg.structlog.on && !cfg.structlog.dir.is_empty() {
+        let (structlog_log_file, flush_guard) =
+            new_file_log_writer(&cfg.structlog.dir, log_name, cfg.file.limit);
+        guards.push(Box::new(flush_guard));
+        structlog_logger =
+            structlog_logger.chain(Box::new(structlog_log_file) as Box<dyn Write + Send>);
     }
 
     let logger = fern::Dispatch::new()

--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -19,6 +19,7 @@ mod config;
 mod init;
 mod loggers;
 mod panic_hook;
+mod structlog;
 
 pub use crate::config::Config;
 pub use crate::config::FileConfig;
@@ -26,6 +27,7 @@ pub use crate::config::OTLPConfig;
 pub use crate::config::ProfileLogConfig;
 pub use crate::config::QueryLogConfig;
 pub use crate::config::StderrConfig;
+pub use crate::config::StructLogConfig;
 pub use crate::config::TracingConfig;
 pub use crate::init::init_logging;
 pub use crate::init::inject_span_to_tonic_request;
@@ -33,6 +35,8 @@ pub use crate::init::start_trace_for_remote_request;
 pub use crate::init::GlobalLogger;
 pub use crate::panic_hook::log_panic;
 pub use crate::panic_hook::set_panic_hook;
+pub use crate::structlog::DummyReporter;
+pub use crate::structlog::StructLogReporter;
 
 pub fn closure_name<F: std::any::Any>() -> &'static str {
     let full_name = std::any::type_name::<F>();

--- a/src/common/tracing/src/loggers.rs
+++ b/src/common/tracing/src/loggers.rs
@@ -73,7 +73,7 @@ impl log::Log for MinitraceLogger {
         );
         if message.contains('\n') {
             // Align multi-line log messages with the first line after `level``.
-            message = message.replace("\n", "\n                                  ");
+            message = message.replace('\n', "\n                                  ");
         }
         minitrace::Event::add_to_local_parent(message, || []);
     }

--- a/src/common/tracing/src/loggers.rs
+++ b/src/common/tracing/src/loggers.rs
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::fmt;
 use std::io::BufWriter;
 use std::time::Duration;
 use std::time::SystemTime;
 
+use fern::FormatCallback;
 use opentelemetry::logs::AnyValue;
 use opentelemetry::logs::Logger;
 use opentelemetry::logs::LoggerProvider;
 use opentelemetry::logs::Severity;
 use opentelemetry_otlp::WithExportConfig;
+use serde_json::Map;
 use tracing_appender::non_blocking::NonBlocking;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
@@ -62,35 +64,18 @@ impl log::Log for MinitraceLogger {
     }
 
     fn log(&self, record: &log::Record<'_>) {
-        if record.key_values().count() == 0 {
-            minitrace::Event::add_to_local_parent(record.level().as_str(), || {
-                [("message".into(), format!("{}", record.args()).into())]
-            });
-        } else {
-            minitrace::Event::add_to_local_parent(record.level().as_str(), || {
-                let mut pairs = Vec::with_capacity(record.key_values().count() + 1);
-                pairs.push(("message".into(), format!("{}", record.args()).into()));
-                let mut visitor = KvCollector { fields: &mut pairs };
-                record.key_values().visit(&mut visitor).ok();
-                pairs
-            });
+        let mut message = format!(
+            "{} {:>5} {}{}",
+            humantime::format_rfc3339_micros(SystemTime::now()),
+            record.level(),
+            record.args(),
+            KvDisplay::new(record.key_values()),
+        );
+        if message.contains('\n') {
+            // Align multi-line log messages with the first line after `level``.
+            message = message.replace("\n", "\n                                  ");
         }
-
-        struct KvCollector<'a> {
-            fields: &'a mut Vec<(Cow<'static, str>, Cow<'static, str>)>,
-        }
-
-        impl<'a, 'kvs> log::kv::Visitor<'kvs> for KvCollector<'a> {
-            fn visit_pair(
-                &mut self,
-                key: log::kv::Key<'kvs>,
-                value: log::kv::Value<'kvs>,
-            ) -> Result<(), log::kv::Error> {
-                self.fields
-                    .push((key.as_str().to_string().into(), value.to_string().into()));
-                Ok(())
-            }
-        }
+        minitrace::Event::add_to_local_parent(message, || []);
     }
 
     fn flush(&self) {}
@@ -159,6 +144,94 @@ impl log::Log for OpenTelemetryLogger {
                 eprintln!("flush log failed: {}", e);
             }
         }
+    }
+}
+
+pub fn formatter(
+    format: &str,
+) -> fn(out: FormatCallback, message: &fmt::Arguments, record: &log::Record) {
+    match format {
+        "text" => format_text_log,
+        "json" => format_json_log,
+        _ => unreachable!("file logging format {format} is not supported"),
+    }
+}
+
+fn format_json_log(out: FormatCallback, message: &fmt::Arguments, record: &log::Record) {
+    let mut fields = Map::new();
+    fields.insert("message".to_string(), format!("{}", message).into());
+    let mut visitor = KvCollector {
+        fields: &mut fields,
+    };
+    record.key_values().visit(&mut visitor).ok();
+
+    out.finish(format_args!(
+        r#"{{"timestamp":"{}","level":"{}","fields":{}}}"#,
+        humantime::format_rfc3339_micros(SystemTime::now()),
+        record.level(),
+        serde_json::to_string(&fields).unwrap_or_default(),
+    ));
+
+    struct KvCollector<'a> {
+        fields: &'a mut Map<String, serde_json::Value>,
+    }
+
+    impl<'a, 'kvs> log::kv::Visitor<'kvs> for KvCollector<'a> {
+        fn visit_pair(
+            &mut self,
+            key: log::kv::Key<'kvs>,
+            value: log::kv::Value<'kvs>,
+        ) -> Result<(), log::kv::Error> {
+            self.fields
+                .insert(key.as_str().to_string(), value.to_string().into());
+            Ok(())
+        }
+    }
+}
+
+fn format_text_log(out: FormatCallback, message: &fmt::Arguments, record: &log::Record) {
+    out.finish(format_args!(
+        "{} {:>5} {}: {}:{} {}{}",
+        humantime::format_rfc3339_micros(SystemTime::now()),
+        record.level(),
+        record.module_path().unwrap_or(""),
+        record.file().unwrap_or(""),
+        record.line().unwrap_or(0),
+        message,
+        KvDisplay::new(record.key_values()),
+    ));
+}
+
+pub struct KvDisplay<'kvs> {
+    kv: &'kvs dyn log::kv::Source,
+}
+
+impl<'kvs> KvDisplay<'kvs> {
+    pub fn new(kv: &'kvs dyn log::kv::Source) -> Self {
+        Self { kv }
+    }
+}
+
+impl fmt::Display for KvDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut visitor = KvWriter { writer: f };
+        self.kv.visit(&mut visitor).ok();
+        Ok(())
+    }
+}
+
+struct KvWriter<'a, 'kvs> {
+    writer: &'kvs mut fmt::Formatter<'a>,
+}
+
+impl<'a, 'kvs> log::kv::Visitor<'kvs> for KvWriter<'a, 'kvs> {
+    fn visit_pair(
+        &mut self,
+        key: log::kv::Key<'kvs>,
+        value: log::kv::Value<'kvs>,
+    ) -> Result<(), log::kv::Error> {
+        write!(self.writer, " {key}={value}")?;
+        Ok(())
     }
 }
 

--- a/src/common/tracing/src/structlog.rs
+++ b/src/common/tracing/src/structlog.rs
@@ -80,7 +80,11 @@ impl<R: Reporter> Reporter for StructLogReporter<R> {
 pub fn pretty_print_trace(spans: &[&SpanRecord]) {
     debug_assert!(spans.iter().map(|span| span.trace_id).all_equal());
 
-    let mut tree = build_tree(spans).unwrap();
+    let mut tree = if let Some(tree) = build_tree(spans) {
+        tree
+    } else {
+        return;
+    };
     let has_event = remove_no_event(&mut tree);
     if !has_event {
         return;

--- a/src/common/tracing/src/structlog.rs
+++ b/src/common/tracing/src/structlog.rs
@@ -33,6 +33,12 @@ pub struct StructLogReporter<R: Reporter> {
     inner: R,
 }
 
+impl Default for StructLogReporter<DummyReporter> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StructLogReporter<DummyReporter> {
     pub fn new() -> Self {
         Self {
@@ -172,7 +178,7 @@ fn remove_no_event(node: &mut TreeNode) -> bool {
     if node.record.is_event() {
         return true;
     }
-    node.children.retain_mut(|child| remove_no_event(child));
+    node.children.retain_mut(remove_no_event);
     !node.children.is_empty()
 }
 
@@ -230,7 +236,7 @@ fn write_tree(
     } else {
         write!(buf, " ")?; // Single line, continue on the same line
     }
-    write_properties(buf, &node.record.properties())?;
+    write_properties(buf, node.record.properties())?;
     writeln!(buf)?;
 
     // Process children

--- a/src/common/tracing/src/structlog.rs
+++ b/src/common/tracing/src/structlog.rs
@@ -1,0 +1,263 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fmt::Write;
+
+use itertools::Itertools;
+use log::info;
+use minitrace::collector::EventRecord;
+use minitrace::collector::Reporter;
+use minitrace::collector::SpanId;
+use minitrace::collector::SpanRecord;
+pub struct DummyReporter;
+
+impl Reporter for DummyReporter {
+    fn report(&mut self, _spans: &[SpanRecord]) {}
+}
+
+pub struct StructLogReporter<R: Reporter> {
+    inner: R,
+}
+
+impl StructLogReporter<DummyReporter> {
+    pub fn new() -> Self {
+        Self {
+            inner: DummyReporter,
+        }
+    }
+}
+
+impl<R: Reporter> StructLogReporter<R> {
+    pub fn wrap(inner: R) -> Self {
+        Self { inner }
+    }
+}
+
+impl<R: Reporter> Reporter for StructLogReporter<R> {
+    fn report(&mut self, spans: &[SpanRecord]) {
+        self.inner.report(spans);
+
+        let mut traces_contain_event = HashSet::new();
+
+        // Find all traces that contain event.
+        for span in spans {
+            if !span.events.is_empty() {
+                traces_contain_event.insert(span.trace_id);
+            }
+        }
+
+        // Print all traces that contain event.
+        for trace_id in traces_contain_event {
+            let spans: Vec<&SpanRecord> = spans
+                .iter()
+                .filter(|span| span.trace_id == trace_id)
+                .collect();
+            pretty_print_trace(&spans);
+        }
+    }
+}
+
+pub fn pretty_print_trace(spans: &[&SpanRecord]) {
+    debug_assert!(spans.iter().map(|span| span.trace_id).all_equal());
+
+    let mut tree = build_tree(spans).unwrap();
+    let has_event = remove_no_event(&mut tree);
+    if !has_event {
+        return;
+    }
+    sort_tree(&mut tree);
+    let mut buf = String::new();
+    write_tree(&mut buf, &tree, "".to_string(), true, true).unwrap();
+
+    info!(target: "databend::log::structlog", "{buf}");
+}
+
+#[derive(Debug, Clone)]
+struct TreeNode {
+    record: TreeRecord,
+    children: Vec<TreeNode>,
+}
+
+#[derive(Debug, Clone)]
+enum TreeRecord {
+    Span(SpanRecord),
+    Event(EventRecord),
+}
+
+impl TreeRecord {
+    fn is_event(&self) -> bool {
+        match self {
+            TreeRecord::Span(_) => false,
+            TreeRecord::Event(_) => true,
+        }
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            TreeRecord::Span(span) => &span.name,
+            TreeRecord::Event(event) => &event.name,
+        }
+    }
+
+    fn start_timestamp(&self) -> u64 {
+        match self {
+            TreeRecord::Span(span) => span.begin_time_unix_ns,
+            TreeRecord::Event(event) => event.timestamp_unix_ns,
+        }
+    }
+
+    fn properties(&self) -> &[(Cow<'static, str>, Cow<'static, str>)] {
+        match self {
+            TreeRecord::Span(span) => &span.properties,
+            TreeRecord::Event(event) => &event.properties,
+        }
+    }
+}
+
+impl TreeNode {
+    fn from_span(span: SpanRecord) -> Self {
+        TreeNode {
+            record: TreeRecord::Span(span),
+            children: Vec::new(),
+        }
+    }
+
+    fn from_event(event: EventRecord) -> Self {
+        TreeNode {
+            record: TreeRecord::Event(event),
+            children: Vec::new(),
+        }
+    }
+}
+
+fn build_tree(spans: &[&SpanRecord]) -> Option<TreeNode> {
+    let mut raw = HashMap::new();
+    for span in spans {
+        raw.entry(span.parent_id)
+            .or_insert_with(Vec::new)
+            .push(*span);
+    }
+    build_sub_tree(SpanId::default(), &raw).pop()
+}
+
+fn build_sub_tree(parent_id: SpanId, raw: &HashMap<SpanId, Vec<&SpanRecord>>) -> Vec<TreeNode> {
+    let mut trees = Vec::new();
+    if let Some(records) = raw.get(&parent_id) {
+        for record in records {
+            let mut tree = TreeNode::from_span((*record).clone());
+            tree.children = build_sub_tree(record.span_id, raw);
+            tree.children
+                .extend(record.events.iter().cloned().map(TreeNode::from_event));
+            trees.push(tree);
+        }
+    }
+    trees
+}
+
+fn remove_no_event(node: &mut TreeNode) -> bool {
+    if node.record.is_event() {
+        return true;
+    }
+    node.children.retain_mut(|child| remove_no_event(child));
+    !node.children.is_empty()
+}
+
+fn sort_tree(node: &mut TreeNode) {
+    node.children
+        .sort_by_key(|child| child.record.start_timestamp());
+    for child in &mut node.children {
+        sort_tree(child);
+    }
+}
+
+fn write_tree(
+    buf: &mut impl Write,
+    node: &TreeNode,
+    prefix: String,
+    is_last: bool,
+    is_root: bool,
+) -> std::fmt::Result {
+    let connector = if is_root {
+        ""
+    } else if is_last {
+        "╰─ "
+    } else {
+        "├─ "
+    };
+
+    let lines = node.record.name().lines().collect::<Vec<_>>();
+    let is_multiline = lines.len() > 1;
+
+    // Update prefix for children
+    let new_prefix = if is_root {
+        ""
+    } else if is_last {
+        "   "
+    } else {
+        "│  "
+    };
+    let children_prefix = prefix.clone() + new_prefix;
+
+    // Process span name
+    for (i, line) in lines.iter().enumerate() {
+        if i == 0 {
+            write!(buf, "{}{}{}", prefix, connector, line)?;
+        } else {
+            write!(buf, "{}{}", children_prefix, line)?;
+        }
+        if i < lines.len() - 1 {
+            writeln!(buf)?;
+        }
+    }
+
+    // Process properties
+    if is_multiline {
+        write!(buf, "\n{}", children_prefix)?;
+    } else {
+        write!(buf, " ")?; // Single line, continue on the same line
+    }
+    write_properties(buf, &node.record.properties())?;
+    writeln!(buf)?;
+
+    // Process children
+    let count = node.children.len();
+    for (i, child) in node.children.iter().enumerate() {
+        write_tree(buf, child, children_prefix.clone(), i + 1 == count, false)?;
+    }
+
+    Ok(())
+}
+
+fn write_properties(
+    buf: &mut impl Write,
+    properties: &[(Cow<'static, str>, Cow<'static, str>)],
+) -> std::fmt::Result {
+    if properties.is_empty() {
+        return Ok(());
+    }
+
+    write!(buf, "{{ ")?;
+    for (i, (k, v)) in properties.iter().enumerate() {
+        if i > 0 {
+            write!(buf, ", ")?;
+        }
+        write!(buf, r#""{}": "{}""#, k, v)?;
+    }
+    write!(buf, " }}")?;
+
+    Ok(())
+}

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -26,6 +26,7 @@ use databend_common_tracing::OTLPConfig;
 use databend_common_tracing::ProfileLogConfig;
 use databend_common_tracing::QueryLogConfig;
 use databend_common_tracing::StderrConfig as InnerStderrLogConfig;
+use databend_common_tracing::StructLogConfig;
 use databend_common_tracing::TracingConfig;
 use serde::Deserialize;
 use serde::Serialize;
@@ -598,6 +599,7 @@ impl Into<InnerLogConfig> for LogConfig {
             otlp: OTLPConfig::default(),
             query: QueryLogConfig::default(),
             profile: ProfileLogConfig::default(),
+            structlog: StructLogConfig::default(),
             tracing: TracingConfig::default(),
         }
     }

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -232,7 +232,8 @@ async fn query_final_handler(
     let root = Span::root(
         full_name!(),
         SpanContext::new(trace_id, SpanId(rand::random())),
-    );
+    )
+    .with_properties(|| ctx.to_minitrace_properties());
     let _t = SlowRequestLogTracker::new(ctx);
 
     async {
@@ -273,7 +274,8 @@ async fn query_cancel_handler(
     let root = Span::root(
         full_name!(),
         SpanContext::new(trace_id, SpanId(rand::random())),
-    );
+    )
+    .with_properties(|| ctx.to_minitrace_properties());
     let _t = SlowRequestLogTracker::new(ctx);
 
     async {
@@ -308,7 +310,8 @@ async fn query_state_handler(
     let root = Span::root(
         full_name!(),
         SpanContext::new(trace_id, SpanId(rand::random())),
-    );
+    )
+    .with_properties(|| ctx.to_minitrace_properties());
 
     async {
         let http_query_manager = HttpQueryManager::instance();
@@ -337,7 +340,8 @@ async fn query_page_handler(
     let root = Span::root(
         full_name!(),
         SpanContext::new(trace_id, SpanId(rand::random())),
-    );
+    )
+    .with_properties(|| ctx.to_minitrace_properties());
     let _t = SlowRequestLogTracker::new(ctx);
 
     async {
@@ -369,7 +373,8 @@ pub(crate) async fn query_handler(
     Json(req): Json<HttpQueryRequest>,
 ) -> PoemResult<impl IntoResponse> {
     let trace_id = query_id_to_trace_id(&ctx.query_id);
-    let root = Span::root(full_name!(), SpanContext::new(trace_id, SpanId::default()));
+    let root = Span::root(full_name!(), SpanContext::new(trace_id, SpanId::default()))
+        .with_properties(|| ctx.to_minitrace_properties());
     let _t = SlowRequestLogTracker::new(ctx);
 
     async {

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -290,6 +290,7 @@ impl HttpQuery {
         let deduplicate_label = &ctx.deduplicate_label;
         let user_agent = &ctx.user_agent;
         let query_id = ctx.query_id.clone();
+        let http_ctx = ctx;
         let ctx = session.create_query_context().await?;
 
         // Deduplicate label is used on the DML queries which may be retried by the client.
@@ -346,6 +347,7 @@ impl HttpQuery {
 
         let span = if let Some(parent) = SpanContext::current_local_parent() {
             Span::root(std::any::type_name::<ExecuteState>(), parent)
+                .with_properties(|| http_ctx.to_minitrace_properties())
         } else {
             Span::noop()
         };

--- a/src/query/service/src/servers/http/v1/query/http_query_context.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_context.rs
@@ -63,6 +63,22 @@ impl HttpQueryContext {
             })?;
         Ok(self.session.clone())
     }
+
+    pub fn to_minitrace_properties(&self) -> Vec<(&'static str, String)> {
+        let mut properties = self.session.to_minitrace_properties();
+        properties.extend([
+            ("query_id", self.query_id.clone()),
+            ("node_id", self.node_id.clone()),
+            (
+                "deduplicate_label",
+                self.deduplicate_label.clone().unwrap_or_default(),
+            ),
+            ("user_agent", self.user_agent.clone().unwrap_or_default()),
+            ("http_method", self.http_method.clone()),
+            ("uri", self.uri.clone()),
+        ]);
+        properties
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -187,7 +187,8 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for InteractiveWorke
         query: &'a str,
         writer: QueryResultWriter<'a, W>,
     ) -> Result<()> {
-        let root = Span::root(full_name!(), SpanContext::random());
+        let root = Span::root(full_name!(), SpanContext::random())
+            .with_properties(|| self.base.session.to_minitrace_properties());
 
         async {
             if self.base.session.is_aborting() {

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -70,6 +70,21 @@ impl Session {
         }))
     }
 
+    pub fn to_minitrace_properties(self: &Arc<Self>) -> Vec<(&'static str, String)> {
+        let mut properties = vec![
+            ("session_id", self.id.clone()),
+            ("session_database", self.get_current_database()),
+            ("session_tenant", self.get_current_tenant()),
+        ];
+        if let Some(query_id) = self.get_current_query_id() {
+            properties.push(("query_id", query_id));
+        }
+        if let Some(connection_id) = self.get_mysql_conn_id() {
+            properties.push(("connection_id", connection_id.to_string()));
+        }
+        properties
+    }
+
     pub fn get_mysql_conn_id(self: &Arc<Self>) -> Option<u32> {
         self.mysql_connection_id
     }

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -43,6 +43,8 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | 'log'     | 'stderr.format'                            | 'text'                                                         | ''       |
 | 'log'     | 'stderr.level'                             | 'WARN'                                                         | ''       |
 | 'log'     | 'stderr.on'                                | 'true'                                                         | ''       |
+| 'log'     | 'structlog.dir'                            | ''                                                             | ''       |
+| 'log'     | 'structlog.on'                             | 'false'                                                        | ''       |
 | 'log'     | 'tracing.capture_log_level'                | 'INFO'                                                         | ''       |
 | 'log'     | 'tracing.on'                               | 'false'                                                        | ''       |
 | 'log'     | 'tracing.otlp_endpoint'                    | 'http://127.0.0.1:4317'                                        | ''       |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Group logs by request and arrange by the call stack. 

To enable, set in config:
```toml
[log.structlog]
on = true
dir = "./.databend/structlog"
```

Normal log will not be affected.

Before:
<img width="1330" alt="Screenshot 2024-01-27 at 18 12 58" src="https://github.com/datafuselabs/databend/assets/9637710/9c70fe44-4831-4db1-abf4-d95aa443cab8">

After:
<img width="1178" alt="Screenshot 2024-01-27 at 18 12 04" src="https://github.com/datafuselabs/databend/assets/9637710/25ca15c4-9a2a-4ee2-b2bf-a6754d17734e">

# Need discussion

1. What is the proper name for this feature? The term [structured log](https://www.loggly.com/use-cases/what-is-structured-logging-and-how-to-use-it/) has been used to refer well-formatted and machine-friendly log format.
2. Can we improve the output format for optimizing clarity and conciseness?

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14495)
<!-- Reviewable:end -->
