### PR TITLE
fix: should use `is_nested` while populating in-memory cache

### DIFF
--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -130,7 +130,6 @@ data_path = "./.databend/stateless_test_data"
 # default is "none", which disable table data cache
 # use "disk" to enabled disk cache
 data_cache_storage = "none"
-table_data_deserialized_data_bytes = 102400
 
 [cache.disk]
 # cache path

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -130,6 +130,7 @@ data_path = "./.databend/stateless_test_data"
 # default is "none", which disable table data cache
 # use "disk" to enabled disk cache
 data_cache_storage = "none"
+table_data_deserialized_data_bytes = 102400
 
 [cache.disk]
 # cache path

--- a/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
@@ -247,7 +247,7 @@ impl BlockReader {
         let uncompressed_buffer = deserialization_context.uncompressed_buffer;
         // column passed in may be a compound field (with sub leaves),
         // or a leaf column of compound field
-        let is_nested = column.has_children();
+        let is_nested = column.is_nested;
         let estimated_cap = indices.len();
         let mut field_column_metas = Vec::with_capacity(estimated_cap);
         let mut field_column_data = Vec::with_capacity(estimated_cap);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Use `is_nested` rather than `has_children` to determine if populating the in-memory cache is necessary

- Fixes #14502

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14503)
<!-- Reviewable:end -->
