### PR TITLE
refactor: meta-service: purge log in another task

### DIFF
--- a/src/meta/raft-store/src/log/raft_log.rs
+++ b/src/meta/raft-store/src/log/raft_log.rs
@@ -34,6 +34,7 @@ pub const TREE_RAFT_LOG: &str = "raft_log";
 
 /// RaftLog stores the logs of a raft node.
 /// It is part of MetaStore.
+#[derive(Clone)]
 pub struct RaftLog {
     pub inner: SledTree,
 }

--- a/src/meta/service/src/metrics/meta_metrics.rs
+++ b/src/meta/service/src/metrics/meta_metrics.rs
@@ -511,6 +511,28 @@ pub mod raft_metrics {
 
         static STORAGE_METRICS: LazyLock<StorageMetrics> = LazyLock::new(StorageMetrics::init);
 
+        pub fn incr_raft_storage_write_result<T, E>(func: &str, result: &Result<T, E>) {
+            match result {
+                Ok(_) => {
+                    // Do not update metrics for success.
+                }
+                Err(_) => {
+                    incr_raft_storage_fail(func, true);
+                }
+            }
+        }
+
+        pub fn incr_raft_storage_read_result<T, E>(func: &str, result: &Result<T, E>) {
+            match result {
+                Ok(_) => {
+                    // Do not update metrics for success.
+                }
+                Err(_) => {
+                    incr_raft_storage_fail(func, false);
+                }
+            }
+        }
+
         pub fn incr_raft_storage_fail(func: &str, write: bool) {
             let labels = FuncLabels {
                 func: func.to_string(),


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: meta-service: purge log in another task

In this commit, `purge_logs_upto()` returns at once upon the
`last_purged_log_id` is updated, and spawn another tokio task to do the
actuall log puge.

This avoid the blocking caused by purging large amount of log.

Purge can be done in another task safely, because:

- Next time when raft starts, it will read last_purged_log_id without examining the actual first log.
  And junk can be removed next time purge_logs_upto() is called.

- Purging operates the start of the logs, and only committed logs are purged;
  while append and truncate operates on the end of the logs,
  it is safe to run purge and (append or truncate) concurrently.

## Changelog




- Improvement


## Related Issues