### PR TITLE
fix: fix ranking function out of bounds when calculate partition end

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
@@ -219,9 +219,13 @@ impl<T: Number> TransformWindow<T> {
             // STEP 2: Check each partition column to see if it has changed.
             let mut i = 0;
             while i < partition_by_columns {
-                // Should use `prev_frame_start` because the block at `partition_start` may already be popped out of the buffer queue.
-                let start_column =
-                    self.column_at(&self.prev_frame_start, self.partition_indices[i]);
+                // Should use `prev_frame_start` or `peer_group_start` because the block at `partition_start` may already be popped out of the buffer queue.
+                let index = if self.is_ranking {
+                    &self.peer_group_start
+                } else {
+                    &self.prev_frame_start
+                };
+                let start_column = self.column_at(index, self.partition_indices[i]);
                 let compare_column = self.column_at(&self.partition_end, self.partition_indices[i]);
 
                 if unsafe {

--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -796,5 +796,48 @@ select * from (select b, row_number() over (order by b) from tbpush) where b > 1
 ----
 2 2 
 
+# multiple blocks
+statement ok
+DROP TABLE IF EXISTS customers;
+
+statement ok
+CREATE TABLE customers (
+    customer_id INT UNSIGNED NOT NULL,
+    customer_name VARCHAR NOT NULL,
+    segment VARCHAR NOT NULL,
+    create_timestamp DATE NOT NULL,
+    active BOOLEAN NOT NULL
+) row_per_block=100;
+
+statement ok
+INSERT INTO customers (customer_id, customer_name, segment, create_timestamp, active)
+SELECT
+    number,
+    CONCAT('Customer ', number::String),
+    CASE
+        WHEN number % 3 = 0 THEN 'small'
+        WHEN number % 3 = 1 THEN 'medium'
+        ELSE 'large'
+    END,
+    to_date('2022-01-02'),
+    number % 2 = 0
+FROM numbers(1000000);
+
+
+
+query II
+select c.customer_id, RANK() OVER (PARTITION BY c.segment ORDER BY c.customer_id DESC) AS rank_in_segment from customers c order by c.segment, rank_in_segment, c.customer_id limit 10;
+----
+999998 1
+999995 2
+999992 3
+999989 4
+999986 5
+999983 6
+999980 7
+999977 8
+999974 9
+999971 10
+
 statement ok
 DROP DATABASE test_window_basic;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix ranking function out of bounds when calculate partition end

- Fixes #14534 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14535)
<!-- Reviewable:end -->
