### PR TITLE
fix(query): do not check exists for unsetting

### DIFF
--- a/src/query/service/src/interpreters/interpreter_unsetting.rs
+++ b/src/query/service/src/interpreters/interpreter_unsetting.rs
@@ -60,32 +60,35 @@ impl Interpreter for UnSettingInterpreter {
                         .try_drop_global_setting(setting_key)
                         .await?;
 
-                    let default_val = {
-                        if setting_key == "max_memory_usage" {
+                    let default_val = match setting_key {
+                        "max_memory_usage" => {
                             let conf = GlobalConfig::instance();
                             if conf.query.max_server_memory_usage == 0 {
                                 settings
-                                    .check_and_get_default_value(setting_key)?
-                                    .to_string()
+                                    .get_default_value(setting_key)?
+                                    .map(|v| v.to_string())
                             } else {
-                                conf.query.max_server_memory_usage.to_string()
+                                Some(conf.query.max_server_memory_usage.to_string())
                             }
-                        } else if setting_key == "max_threads" {
+                        }
+                        "max_threads" => {
                             let conf = GlobalConfig::instance();
                             if conf.query.num_cpus == 0 {
                                 settings
-                                    .check_and_get_default_value(setting_key)?
-                                    .to_string()
+                                    .get_default_value(setting_key)?
+                                    .map(|v| v.to_string())
                             } else {
-                                conf.query.num_cpus.to_string()
+                                Some(conf.query.num_cpus.to_string())
                             }
-                        } else {
-                            settings
-                                .check_and_get_default_value(setting_key)?
-                                .to_string()
                         }
+                        _ => settings
+                            .get_default_value(setting_key)?
+                            .map(|v| v.to_string()),
                     };
-                    (true, default_val)
+                    match default_val {
+                        Some(val) => (true, val),
+                        None => (false, String::from("")),
+                    }
                 }
             };
             if ok {

--- a/src/query/settings/src/settings.rs
+++ b/src/query/settings/src/settings.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use databend_common_config::GlobalConfig;
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::UserSettingValue;
 use itertools::Itertools;
@@ -86,14 +85,12 @@ impl Settings {
         Ok(DefaultSettings::instance()?.settings.contains_key(key))
     }
 
-    pub fn check_and_get_default_value(&self, key: &str) -> Result<UserSettingValue> {
-        match DefaultSettings::instance()?.settings.get(key) {
-            Some(v) => Ok(v.value.clone()),
-            None => Err(ErrorCode::UnknownVariable(format!(
-                "Unknown variable: {:?}",
-                key
-            ))),
-        }
+    pub fn get_default_value(&self, key: &str) -> Result<Option<UserSettingValue>> {
+        let val = DefaultSettings::instance()?
+            .settings
+            .get(key)
+            .map(|v| v.value.clone());
+        Ok(val)
     }
 
     pub fn unset_setting(&self, k: &str) {

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -745,10 +745,6 @@ impl DefaultSettings {
         Ok(recluster_block_size)
     }
 
-    pub fn has_setting(key: &str) -> Result<bool> {
-        Ok(Self::instance()?.settings.contains_key(key))
-    }
-
     /// Converts and validates a setting value based on its key.
     pub fn convert_value(k: String, v: String) -> Result<(String, UserSettingValue)> {
         // Retrieve the default settings instance

--- a/src/query/settings/src/settings_global.rs
+++ b/src/query/settings/src/settings_global.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::UserSetting;
 use databend_common_meta_app::principal::UserSettingValue;
@@ -42,13 +41,6 @@ impl Settings {
     #[async_backtrace::framed]
     pub async fn try_drop_global_setting(&self, key: &str) -> Result<()> {
         self.changes.remove(key);
-
-        if !DefaultSettings::has_setting(key)? {
-            return Err(ErrorCode::UnknownVariable(format!(
-                "Unknown variable: {:?}",
-                key
-            )));
-        }
 
         UserApiProvider::instance()
             .get_setting_api_client(&self.tenant)?

--- a/tests/sqllogictests/suites/base/05_ddl/05_0026_ddl_unset_settings.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0026_ddl_unset_settings.test
@@ -26,6 +26,9 @@ UNSET (timezone)
 
 onlyif mysql
 statement error 2801
+SET stl_dialect='MySQL'
+
+statement ok
 UNSET stl_dialect
 
 onlyif mysql


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When a deprecated setting is set global to meta service, then we were unable to unset it after upgrading `databend-query`, leaving a warning flood.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14536)
<!-- Reviewable:end -->
