### PR TITLE
chore: fix openraft version: use v0.9.0-alpha.5 instead of v0.9.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8334,7 +8334,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.4#25d448a8f03efac5a0cdec7a1921fbe23bb00f34"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.5#3f834771c42c4c9a18df25fde25cc5d71e7b09f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9211,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.4#25d448a8f03efac5a0cdec7a1921fbe23bb00f34"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.5#3f834771c42c4c9a18df25fde25cc5d71e7b09f8"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ opendal = { version = "0.44.2", features = [
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 # openraft for debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.4", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.5", features = [
     "compat-07",
     "tracing-log",
     "loosen-follower-log-revert", # allows removing all data from a follower and restoring from the leader.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: fix openraft version: use v0.9.0-alpha.5 instead of v0.9.0-alpha.4

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14538)
<!-- Reviewable:end -->
