### PR TITLE
feat: system table add query_log.log_type_name and cluster.cluster_id

### DIFF
--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -138,9 +138,11 @@ impl InterpreterQueryLog {
         // Error
         let (log_type, exception_code, exception_text, stack_trace) =
             error_fields(LogType::Start, err);
+        let log_type_name = log_type.as_string();
 
         Self::write_log(QueryLogElement {
             log_type,
+            log_type_name,
             handler_type,
             tenant_id,
             cluster_id,
@@ -284,9 +286,11 @@ impl InterpreterQueryLog {
         // Error
         let (log_type, exception_code, exception_text, stack_trace) =
             error_fields(LogType::Finish, err);
+        let log_type_name = log_type.as_string();
 
         Self::write_log(QueryLogElement {
             log_type,
+            log_type_name,
             handler_type,
             tenant_id,
             cluster_id,

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -32,6 +32,7 @@ use databend_common_sql::Planner;
 use futures::StreamExt;
 use log::error;
 use log::info;
+use log::warn;
 use serde::Deserialize;
 use serde::Serialize;
 use ExecuteState::*;
@@ -203,7 +204,7 @@ impl Executor {
     pub async fn stop(this: &Arc<RwLock<Executor>>, reason: Result<()>, kill: bool) {
         {
             let guard = this.read().await;
-            info!(
+            warn!(
                 "{}: http query change state to Stopped, reason {:?}",
                 &guard.query_id, reason
             );
@@ -252,7 +253,7 @@ impl Executor {
                 }))
             }
             Stopped(s) => {
-                info!(
+                warn!(
                     "{}: http query already stopped, reason {:?}, new reason {:?}",
                     &guard.query_id, s.reason, reason
                 );

--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -138,7 +138,7 @@ async fn test_clusters_table() -> Result<()> {
     let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
-    assert_eq!(block.num_columns(), 4);
+    assert_eq!(block.num_columns(), 5);
 
     Ok(())
 }

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -35,6 +35,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'check_option'                    | 'information_schema' | 'views'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'client_address'                  | 'system'             | 'query_log'           | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'client_info'                     | 'system'             | 'query_log'           | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'cluster'                         | 'system'             | 'clusters'            | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'cluster_by'                      | 'system'             | 'tables'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'cluster_by'                      | 'system'             | 'tables_with_history' | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'cluster_id'                      | 'system'             | 'query_log'           | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
@@ -203,6 +204,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'license'                         | 'system'             | 'credits'             | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'location'                        | 'system'             | 'query_cache'         | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'log_type'                        | 'system'             | 'query_log'           | 'Int8'                | 'TINYINT'           | ''       | ''       | 'NO'     | ''       |
+| 'log_type_name'                   | 'system'             | 'query_log'           | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'memory_usage'                    | 'system'             | 'processes'           | 'Int64'               | 'BIGINT'            | ''       | ''       | 'NO'     | ''       |
 | 'memory_usage'                    | 'system'             | 'query_log'           | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'message'                         | 'system'             | 'background_jobs'     | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/storages/system/src/clusters_table.rs
+++ b/src/query/storages/system/src/clusters_table.rs
@@ -70,6 +70,7 @@ impl SyncSystemTable for ClustersTable {
 
         Ok(DataBlock::new_from_columns(vec![
             names.build(),
+            clusters.build(),
             addresses.build(),
             addresses_port.build(),
             versions.build(),

--- a/src/query/storages/system/src/clusters_table.rs
+++ b/src/query/storages/system/src/clusters_table.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
 use databend_common_expression::types::number::NumberScalar;
 use databend_common_expression::types::DataType;
@@ -48,6 +49,7 @@ impl SyncSystemTable for ClustersTable {
         let cluster_nodes = ctx.get_cluster().nodes.clone();
 
         let mut names = ColumnBuilder::with_capacity(&DataType::String, cluster_nodes.len());
+        let mut clusters = ColumnBuilder::with_capacity(&DataType::String, cluster_nodes.len());
         let mut addresses = ColumnBuilder::with_capacity(&DataType::String, cluster_nodes.len());
         let mut addresses_port = ColumnBuilder::with_capacity(
             &DataType::Number(NumberDataType::UInt16),
@@ -55,10 +57,12 @@ impl SyncSystemTable for ClustersTable {
         );
         let mut versions = ColumnBuilder::with_capacity(&DataType::String, cluster_nodes.len());
 
+        let cluster_id = GlobalConfig::instance().query.cluster_id.clone();
         for cluster_node in &cluster_nodes {
             let (ip, port) = cluster_node.ip_port()?;
 
             names.push(Scalar::String(cluster_node.id.clone()).as_ref());
+            clusters.push(Scalar::String(cluster_id.clone()).as_ref());
             addresses.push(Scalar::String(ip).as_ref());
             addresses_port.push(Scalar::Number(NumberScalar::UInt16(port)).as_ref());
             versions.push(Scalar::String(cluster_node.binary_version.clone()).as_ref());
@@ -77,6 +81,7 @@ impl ClustersTable {
     pub fn create(table_id: u64) -> Arc<dyn Table> {
         let schema = TableSchemaRefExt::create(vec![
             TableField::new("name", TableDataType::String),
+            TableField::new("cluster", TableDataType::String),
             TableField::new("host", TableDataType::String),
             TableField::new("port", TableDataType::Number(NumberDataType::UInt16)),
             TableField::new("version", TableDataType::String),

--- a/src/query/storages/system/src/query_log_table.rs
+++ b/src/query/storages/system/src/query_log_table.rs
@@ -39,14 +39,20 @@ pub enum LogType {
     Aborted = 4,
 }
 
+impl LogType {
+    pub fn as_string(&self) -> String {
+        match self {
+            LogType::Start => "Start".to_string(),
+            LogType::Finish => "Finish".to_string(),
+            LogType::Error => "Error".to_string(),
+            LogType::Aborted => "Aborted".to_string(),
+        }
+    }
+}
+
 impl std::fmt::Debug for LogType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LogType::Start => write!(f, "Start"),
-            LogType::Finish => write!(f, "Finish"),
-            LogType::Error => write!(f, "Error"),
-            LogType::Aborted => write!(f, "Aborted"),
-        }
+        write!(f, "{}", self.as_string())
     }
 }
 
@@ -71,6 +77,7 @@ where S: Serializer {
 pub struct QueryLogElement {
     // Type.
     pub log_type: LogType,
+    pub log_type_name: String,
     pub handler_type: String,
 
     // User.
@@ -159,6 +166,7 @@ impl SystemLogElement for QueryLogElement {
         TableSchemaRefExt::create(vec![
             // Type.
             TableField::new("log_type", TableDataType::Number(NumberDataType::Int8)),
+            TableField::new("log_type_name", TableDataType::String),
             TableField::new("handler_type", TableDataType::String),
             // User.
             TableField::new("tenant_id", TableDataType::String),
@@ -292,6 +300,10 @@ impl SystemLogElement for QueryLogElement {
             .next()
             .unwrap()
             .push(Scalar::Number(NumberScalar::Int8(self.log_type as i8)).as_ref());
+        columns
+            .next()
+            .unwrap()
+            .push(Scalar::String(self.log_type_name.clone()).as_ref());
         columns
             .next()
             .unwrap()

--- a/tests/suites/1_stateful/02_query/02_0006_system_table_query_speed.py
+++ b/tests/suites/1_stateful/02_query/02_0006_system_table_query_speed.py
@@ -6,28 +6,36 @@ from datetime import datetime
 import mysql.connector
 
 
-db = mysql.connector.connect(host="127.0.0.1", user="root", passwd="root", port="3307", buffered=True)
+db = mysql.connector.connect(
+    host="127.0.0.1", user="root", passwd="root", port="3307", buffered=True
+)
 cursor = db.cursor()
 cursor.execute("drop database if exists test;")
 cursor.execute("create database test;")
 for i in range(100):
-    sql = "CREATE TABLE test.table_name_{i}(id int(5) comment 't\est', c1 int comment 'sss') comment='test'".format(i=i)
+    sql = "CREATE TABLE test.table_name_{i}(id int(5) comment 't\est', c1 int comment 'sss') comment='test'".format(
+        i=i
+    )
     cursor.execute(sql)
 db.commit()
 
+
 def test_speed(cursor, name):
-    sql = "select count() from system."+ name +" where database='test'"
+    sql = "select count() from system." + name + " where database='test'"
     cursor.execute(sql)
     start = datetime.now()
     cursor.execute(sql)
-    execute = (datetime.now()-start)
+    execute = datetime.now() - start
     # In ci 0.068s, in local debug build cost 0.03s
     # But of ci is vary, we set the exception value to 0.1s
     # if not modify system table but the test failed, we should up the value again.
     if execute.total_seconds() > 0.1:
-        print("Err: query system.%s in one db cost exception, cost: %s"%(name, execute))
+        print(
+            "Err: query system.%s in one db cost exception, cost: %s" % (name, execute)
+        )
     else:
         print("normal")
+
 
 test_speed(cursor, "tables")
 test_speed(cursor, "columns")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* add `log_type_name` to system.log_query table, make the query log type more readable
* add `cluster` to system.cluster, make the node belongs to which cluster more readable
* change http handler `execute_steate.rs` stop log level from **info** to **warn** @youngsofun 

Fixes #14542

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14545)
<!-- Reviewable:end -->
