### PR TITLE
chore: remove `get_table_index` method

### DIFF
--- a/src/query/service/src/pipelines/builders/merge_into_join_optimizations.rs
+++ b/src/query/service/src/pipelines/builders/merge_into_join_optimizations.rs
@@ -24,11 +24,11 @@ impl PipelineBuilder {
     pub(crate) fn merge_into_get_optimization_flag(&self, join: &HashJoin) -> (IndexType, bool) {
         // for merge into target table as build side.
         let (merge_into_build_table_index, merge_into_is_distributed) =
-            if matches!(&*join.build, PhysicalPlan::TableScan(_)) {
+            if let PhysicalPlan::TableScan(scan) = &*join.build {
                 let (need_block_info, is_distributed) =
-                    need_reserve_block_info(self.ctx.clone(), join.build.get_table_index());
+                    need_reserve_block_info(self.ctx.clone(), scan.table_index);
                 if need_block_info {
-                    (join.build.get_table_index(), is_distributed)
+                    (scan.table_index, is_distributed)
                 } else {
                     (DUMMY_TABLE_INDEX, false)
                 }

--- a/src/query/service/src/schedulers/fragments/fragmenter.rs
+++ b/src/query/service/src/schedulers/fragments/fragmenter.rs
@@ -321,8 +321,6 @@ impl PhysicalPlanReplacer for Fragmenter {
         self.state = State::Other;
         let exchange = Self::get_exchange(self.ctx.clone(), &plan)?;
 
-        let table_index = plan.get_table_index();
-
         let mut source_fragment = PlanFragment {
             plan,
             fragment_type,
@@ -348,7 +346,6 @@ impl PhysicalPlanReplacer for Fragmenter {
             query_id: self.query_id.clone(),
 
             source_fragment_id,
-            table_index,
         }))
     }
 }

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -58,7 +58,6 @@ use crate::executor::physical_plans::Udf;
 use crate::executor::physical_plans::UnionAll;
 use crate::executor::physical_plans::UpdateSource;
 use crate::executor::physical_plans::Window;
-use crate::IndexType;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, EnumAsInner)]
 pub enum PhysicalPlan {
@@ -357,49 +356,6 @@ impl PhysicalPlan {
                 self,
                 Self::ExchangeSource(_) | Self::ExchangeSink(_) | Self::Exchange(_)
             )
-    }
-
-    pub fn get_table_index(&self) -> IndexType {
-        match self {
-            PhysicalPlan::TableScan(scan) => scan.table_index,
-            PhysicalPlan::Filter(plan) => plan.input.get_table_index(),
-            PhysicalPlan::Project(plan) => plan.input.get_table_index(),
-            PhysicalPlan::EvalScalar(plan) => plan.input.get_table_index(),
-            PhysicalPlan::ProjectSet(plan) => plan.input.get_table_index(),
-            PhysicalPlan::AggregateExpand(plan) => plan.input.get_table_index(),
-            PhysicalPlan::AggregatePartial(plan) => plan.input.get_table_index(),
-            PhysicalPlan::AggregateFinal(plan) => plan.input.get_table_index(),
-            PhysicalPlan::Window(plan) => plan.input.get_table_index(),
-            PhysicalPlan::Sort(plan) => plan.input.get_table_index(),
-            PhysicalPlan::Limit(plan) => plan.input.get_table_index(),
-            PhysicalPlan::RowFetch(plan) => plan.input.get_table_index(),
-            PhysicalPlan::HashJoin(plan) => plan.probe.get_table_index(),
-            PhysicalPlan::Exchange(plan) => plan.input.get_table_index(),
-            PhysicalPlan::ExchangeSink(plan) => plan.input.get_table_index(),
-            PhysicalPlan::ExchangeSource(plan) => plan.table_index,
-            PhysicalPlan::DistributedInsertSelect(plan) => plan.input.get_table_index(),
-            PhysicalPlan::MaterializedCte(_) |
-            // Todo: support union and range join return valid table index by join probe keys
-            PhysicalPlan::UnionAll(_) |
-            PhysicalPlan::RangeJoin(_) |
-            PhysicalPlan::ConstantTableScan(_)
-            | PhysicalPlan::CteScan(_)
-            | PhysicalPlan::Udf(_)
-            | PhysicalPlan::DeleteSource(_)
-            | PhysicalPlan::CopyIntoTable(_)
-            | PhysicalPlan::ReplaceAsyncSourcer(_)
-            | PhysicalPlan::ReplaceDeduplicate(_)
-            | PhysicalPlan::ReplaceInto(_)
-            | PhysicalPlan::MergeIntoSource(_)
-            | PhysicalPlan::MergeInto(_)
-            | PhysicalPlan::MergeIntoAppendNotMatched(_)
-            | PhysicalPlan::MergeIntoAddRowNumber(_)
-            | PhysicalPlan::CompactSource(_)
-            | PhysicalPlan::CommitSink(_)
-            | PhysicalPlan::ReclusterSource(_)
-            | PhysicalPlan::ReclusterSink(_)
-            | PhysicalPlan::UpdateSource(_) => usize::MAX,
-        }
     }
 
     pub fn get_desc(&self) -> Result<String> {

--- a/src/query/sql/src/executor/physical_plans/physical_exchange_source.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_exchange_source.rs
@@ -15,8 +15,6 @@
 use databend_common_exception::Result;
 use databend_common_expression::DataSchemaRef;
 
-use crate::IndexType;
-
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ExchangeSource {
     // A unique id of operator in a `PhysicalPlan` tree, only used for display.
@@ -28,8 +26,6 @@ pub struct ExchangeSource {
     // Fragment ID of source fragment
     pub source_fragment_id: usize,
     pub query_id: String,
-
-    pub table_index: IndexType,
 }
 
 impl ExchangeSource {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

as the tile

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14557)
<!-- Reviewable:end -->
