### PR TITLE
chore: make runtime filter for broadcast rework

### DIFF
--- a/src/query/service/tests/it/sql/planner/format/mod.rs
+++ b/src/query/service/tests/it/sql/planner/format/mod.rs
@@ -153,7 +153,6 @@ fn test_format() {
                 marker_index: None,
                 from_correlated_subquery: false,
                 need_hold_hash_table: false,
-                broadcast: false,
                 is_lateral: false,
                 original_join_type: None,
             }

--- a/src/query/sql/src/planner/binder/join.rs
+++ b/src/query/sql/src/planner/binder/join.rs
@@ -241,7 +241,6 @@ impl Binder {
             marker_index: None,
             from_correlated_subquery: false,
             need_hold_hash_table: false,
-            broadcast: false,
             is_lateral,
             original_join_type: None,
         };

--- a/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
@@ -199,7 +199,6 @@ impl SubqueryRewriter {
             marker_index: None,
             from_correlated_subquery: true,
             need_hold_hash_table: false,
-            broadcast: false,
             is_lateral: false,
             original_join_type: None,
         };
@@ -276,7 +275,6 @@ impl SubqueryRewriter {
                     marker_index: None,
                     from_correlated_subquery: true,
                     need_hold_hash_table: false,
-                    broadcast: false,
                     is_lateral: false,
                     original_join_type: None,
                 };
@@ -326,7 +324,6 @@ impl SubqueryRewriter {
                     marker_index: Some(marker_index),
                     from_correlated_subquery: true,
                     need_hold_hash_table: false,
-                    broadcast: false,
                     is_lateral: false,
                     original_join_type: None,
                 };
@@ -391,7 +388,6 @@ impl SubqueryRewriter {
                     marker_index: Some(marker_index),
                     from_correlated_subquery: true,
                     need_hold_hash_table: false,
-                    broadcast: false,
                     is_lateral: false,
                     original_join_type: None,
                 }

--- a/src/query/sql/src/planner/optimizer/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/flatten_plan.rs
@@ -135,7 +135,6 @@ impl SubqueryRewriter {
                 marker_index: None,
                 from_correlated_subquery: false,
                 need_hold_hash_table: false,
-                broadcast: false,
                 is_lateral: false,
                 original_join_type: None,
             }
@@ -469,7 +468,6 @@ impl SubqueryRewriter {
                     marker_index: join.marker_index,
                     from_correlated_subquery: false,
                     need_hold_hash_table: false,
-                    broadcast: false,
                     is_lateral: false,
                     original_join_type: None,
                 }

--- a/src/query/sql/src/planner/optimizer/decorrelate/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/subquery_rewriter.rs
@@ -481,7 +481,6 @@ impl SubqueryRewriter {
                     marker_index: None,
                     from_correlated_subquery: false,
                     need_hold_hash_table: false,
-                    broadcast: false,
                     is_lateral: false,
                     original_join_type: None,
                 }
@@ -552,7 +551,6 @@ impl SubqueryRewriter {
                     marker_index: Some(marker_index),
                     from_correlated_subquery: false,
                     need_hold_hash_table: false,
-                    broadcast: false,
                     is_lateral: false,
                     original_join_type: None,
                 }
@@ -584,7 +582,6 @@ impl SubqueryRewriter {
             marker_index: None,
             from_correlated_subquery: false,
             need_hold_hash_table: false,
-            broadcast: false,
             is_lateral: false,
             original_join_type: None,
         }

--- a/src/query/sql/src/planner/optimizer/distributed/distributed_merge.rs
+++ b/src/query/sql/src/planner/optimizer/distributed/distributed_merge.rs
@@ -68,7 +68,6 @@ impl MergeSourceOptimizer {
 
         let mut join: Join = join_s_expr.plan().clone().try_into()?;
         join.need_hold_hash_table = true;
-        join.broadcast = true;
         let mut join_s_expr = join_s_expr.replace_plan(Arc::new(RelOperator::Join(join)));
         join_s_expr = join_s_expr.replace_children(new_join_children);
         Ok(s_expr.replace_children(vec![Arc::new(join_s_expr)]))

--- a/src/query/sql/src/planner/optimizer/hyper_dp/join_node.rs
+++ b/src/query/sql/src/planner/optimizer/hyper_dp/join_node.rs
@@ -87,7 +87,6 @@ impl JoinNode {
             marker_index: None,
             from_correlated_subquery: false,
             need_hold_hash_table: false,
-            broadcast: false,
             is_lateral: false,
             original_join_type: None,
         });

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -518,8 +518,7 @@ fn try_to_change_as_broadcast_join(
     if let RelOperator::Exchange(Exchange::Merge) = merge_into_join_sexpr.plan.as_ref() {
         let right_exchange = merge_into_join_sexpr.child(0)?.child(1)?;
         if let RelOperator::Exchange(Exchange::Broadcast) = right_exchange.plan.as_ref() {
-            let mut join: Join = merge_into_join_sexpr.child(0)?.plan().clone().try_into()?;
-            join.broadcast = true;
+            let join: Join = merge_into_join_sexpr.child(0)?.plan().clone().try_into()?;
             let join_s_expr = merge_into_join_sexpr
                 .child(0)?
                 .replace_plan(Arc::new(RelOperator::Join(join)));

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -158,8 +158,6 @@ pub struct Join {
     // if we execute distributed merge into, we need to hold the
     // hash table to get not match data from source.
     pub need_hold_hash_table: bool,
-    // Under cluster, mark if the join is broadcast join.
-    pub broadcast: bool,
     pub is_lateral: bool,
     // Original join type. Left/Right single join may be convert to inner join
     // Record the original join type and do some special processing during runtime.
@@ -176,7 +174,6 @@ impl Default for Join {
             marker_index: Default::default(),
             from_correlated_subquery: Default::default(),
             need_hold_hash_table: false,
-            broadcast: false,
             is_lateral: false,
             original_join_type: None,
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

make runtime filter for broadcast rework.

In the [ticket](https://github.com/datafuselabs/databend/pull/14163/files#diff-b78732f8fc0770907b61ae326666380a1941512b5043a6cfca6cb7515b6dae84), the broadcast runtime filter is disabled unexpectedly

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14559)
<!-- Reviewable:end -->
