### PR TITLE
fix: Split config load and check to make sure logger init first

### DIFF
--- a/src/bendpy/src/lib.rs
+++ b/src/bendpy/src/lib.rs
@@ -54,7 +54,7 @@ fn databend(_py: Python, m: &PyModule) -> PyResult<()> {
         MetaEmbedded::init_global_meta_store(meta_dir.to_string_lossy().to_string())
             .await
             .unwrap();
-        GlobalServices::init(&conf).await.unwrap();
+        GlobalServices::init(conf.clone()).await.unwrap();
 
         // init oss license manager
         OssLicenseManager::init(conf.query.tenant_id.clone()).unwrap();

--- a/src/binaries/query/ee_main.rs
+++ b/src/binaries/query/ee_main.rs
@@ -51,7 +51,7 @@ pub async fn main_entrypoint() -> Result<()> {
         return Ok(());
     }
 
-    init_services(&conf).await?;
-    EnterpriseServices::init(conf.clone()).await?;
-    start_services(&conf).await
+    init_services(conf).await?;
+    EnterpriseServices::init().await?;
+    start_services().await
 }

--- a/src/binaries/query/oss_main.rs
+++ b/src/binaries/query/oss_main.rs
@@ -52,8 +52,8 @@ async fn main_entrypoint() -> Result<()> {
         return Ok(());
     }
 
-    init_services(&conf).await?;
+    init_services(conf.clone()).await?;
     // init oss license manager
     OssLicenseManager::init(conf.query.tenant_id.clone())?;
-    start_services(&conf).await
+    start_services().await
 }

--- a/src/binaries/tool/table_meta_inspector.rs
+++ b/src/binaries/tool/table_meta_inspector.rs
@@ -87,7 +87,7 @@ async fn parse_input_data(config: &InspectorConfig) -> Result<Vec<u8>> {
                     builder = builder.collect(from_file(Toml, config_file));
                     let read_config = builder.build()?;
                     let inner_config: InnerConfig = read_config.clone().try_into()?;
-                    GlobalServices::init(&inner_config).await?;
+                    GlobalServices::init(inner_config).await?;
                     let storage_config: StorageConfig = read_config.storage.try_into()?;
                     init_operator(&storage_config.params)?
                 }

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -76,15 +76,19 @@ impl InnerConfig {
 
         // Handle the node_id for query node.
         cfg.query.node_id = GlobalUniqName::unique();
+        Ok(cfg)
+    }
 
+    /// Check if current config is valid.
+    pub async fn check(mut self) -> Result<Self> {
         // Handle auto detect for storage params.
-        cfg.storage.params = cfg.storage.params.auto_detect().await?;
+        self.storage.params = self.storage.params.auto_detect().await?;
 
         // Only check meta config when cmd is empty.
-        if cfg.subcommand.is_none() {
-            cfg.meta.check_valid()?;
+        if self.subcommand.is_none() {
+            self.meta.check_valid()?;
         }
-        Ok(cfg)
+        Ok(self)
     }
 
     /// # NOTE

--- a/src/query/ee/src/enterprise_services.rs
+++ b/src/query/ee/src/enterprise_services.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_config::InnerConfig;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
 use databend_common_license::license_manager::LicenseManager;
 
@@ -28,7 +28,9 @@ use crate::virtual_column::RealVirtualColumnHandler;
 pub struct EnterpriseServices;
 impl EnterpriseServices {
     #[async_backtrace::framed]
-    pub async fn init(cfg: InnerConfig) -> Result<()> {
+    pub async fn init() -> Result<()> {
+        let cfg = GlobalConfig::instance();
+
         RealLicenseManager::init(cfg.query.tenant_id.clone())?;
         RealStorageEncryptionHandler::init(&cfg)?;
         RealVacuumHandler::init()?;

--- a/src/query/ee/src/test_kits/setup.rs
+++ b/src/query/ee/src/test_kits/setup.rs
@@ -34,7 +34,7 @@ impl TestFixture {
             databend_common_base::base::GlobalInstance::init_testing(&thread_name);
         }
 
-        GlobalServices::init_with(config).await?;
+        GlobalServices::init_with(config.clone()).await?;
         MockServices::init(config, public_key).await?;
 
         // Cluster register.

--- a/src/query/service/src/api/rpc_service.rs
+++ b/src/query/service/src/api/rpc_service.rs
@@ -37,9 +37,9 @@ pub struct RpcService {
 }
 
 impl RpcService {
-    pub fn create(config: InnerConfig) -> Result<Box<dyn DatabendQueryServer>> {
+    pub fn create(config: &InnerConfig) -> Result<Box<dyn DatabendQueryServer>> {
         Ok(Box::new(Self {
-            config,
+            config: config.clone(),
             abort_notify: Arc::new(Notify::new()),
         }))
     }

--- a/src/query/service/src/local/mod.rs
+++ b/src/query/service/src/local/mod.rs
@@ -54,7 +54,7 @@ pub async fn query_local(query_sql: &str, output_format: &str) -> Result<()> {
         .await
         .unwrap();
 
-    GlobalServices::init(&conf).await?;
+    GlobalServices::init(conf.clone()).await?;
     // init oss license manager
     OssLicenseManager::init(conf.query.tenant_id.clone()).unwrap();
 

--- a/src/query/service/src/servers/flight_sql/flight_sql_server.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_server.rs
@@ -37,9 +37,9 @@ pub struct FlightSQLServer {
 }
 
 impl FlightSQLServer {
-    pub fn create(config: InnerConfig) -> Result<Box<dyn DatabendQueryServer>> {
+    pub fn create(config: &InnerConfig) -> Result<Box<dyn DatabendQueryServer>> {
         Ok(Box::new(Self {
-            config,
+            config: config.clone(),
             abort_notify: Arc::new(Notify::new()),
         }))
     }

--- a/src/query/service/src/test_kits/fixture.rs
+++ b/src/query/service/src/test_kits/fixture.rs
@@ -204,7 +204,7 @@ impl TestFixture {
             databend_common_base::base::GlobalInstance::init_testing(&thread_name);
         }
 
-        GlobalServices::init_with(config).await?;
+        GlobalServices::init_with(config.clone()).await?;
         OssLicenseManager::init(config.query.tenant_id.clone())?;
 
         // Cluster register.

--- a/src/query/service/tests/it/api/rpc_service.rs
+++ b/src/query/service/tests/it/api/rpc_service.rs
@@ -36,7 +36,7 @@ use crate::tests::tls_constants::TEST_SERVER_KEY;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_tls_rpc_server() -> Result<()> {
     let mut rpc_service = RpcService::create(
-        ConfigBuilder::create()
+        &ConfigBuilder::create()
             .rpc_tls_server_key(TEST_SERVER_KEY)
             .rpc_tls_server_cert(TEST_SERVER_CERT)
             .build(),

--- a/src/query/service/tests/it/distributed/cluster.rs
+++ b/src/query/service/tests/it/distributed/cluster.rs
@@ -57,7 +57,7 @@ fn test_simple_cluster() -> Result<()> {
                 let inner_async = async move {
                     let fixture = TestFixture::setup_with_config(&conf_clone).await?;
 
-                    let mut srv = RpcService::create(conf_clone.clone())?;
+                    let mut srv = RpcService::create(&conf_clone)?;
                     srv.start(conf_clone.query.flight_api_address.parse()?)
                         .await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix: Split config load and check to make sure logger init first

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14568)
<!-- Reviewable:end -->
