### PR TITLE
fix(query):  account_admin should support grant ownership to new role after drop an created role

### DIFF
--- a/src/query/service/src/interpreters/interpreter_privilege_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_grant.rs
@@ -137,7 +137,7 @@ impl GrantPrivilegeInterpreter {
         // if the object's owner is None, it's considered as PUBLIC, everyone could access it
         let owner = user_mgr.get_ownership(tenant, owner_object).await?;
         if let Some(owner) = owner {
-            let can_grant_ownership = available_roles.iter().any(|r| r.name == role);
+            let can_grant_ownership = available_roles.iter().any(|r| r.name == owner.role);
             log_msg = format!(
                 "{}: grant ownership on {:?} from role {} to {}",
                 ctx.get_id(),

--- a/src/query/service/src/interpreters/interpreter_privilege_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_grant.rs
@@ -137,13 +137,6 @@ impl GrantPrivilegeInterpreter {
         // if the object's owner is None, it's considered as PUBLIC, everyone could access it
         let owner = user_mgr.get_ownership(tenant, owner_object).await?;
         if let Some(owner) = owner {
-            // if object has ownership, but the owner role is not exists, set owner role to ACCOUNT_ADMIN,
-            // only account_admin can grant this object.
-            let role = if !user_mgr.exists_role(tenant, owner.role.clone()).await? {
-                BUILTIN_ROLE_ACCOUNT_ADMIN.to_string()
-            } else {
-                owner.role.clone()
-            };
             let can_grant_ownership = available_roles.iter().any(|r| r.name == role);
             log_msg = format!(
                 "{}: grant ownership on {:?} from role {} to {}",

--- a/src/query/service/src/interpreters/interpreter_privilege_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_grant.rs
@@ -24,7 +24,6 @@ use databend_common_meta_app::principal::UserPrivilegeType::Ownership;
 use databend_common_sql::plans::GrantPrivilegePlan;
 use databend_common_users::RoleCacheManager;
 use databend_common_users::UserApiProvider;
-use databend_common_users::BUILTIN_ROLE_ACCOUNT_ADMIN;
 use log::debug;
 use log::error;
 use log::info;

--- a/src/query/service/src/sessions/session_privilege_mgr.rs
+++ b/src/query/service/src/sessions/session_privilege_mgr.rs
@@ -272,7 +272,7 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl {
         let tenant = self.session_ctx.get_current_tenant();
         let owner_role_name = match role_mgr.find_object_owner(&tenant, object).await? {
             Some(owner_role) => owner_role,
-            None => BUILTIN_ROLE_ACCOUNT_ADMIN,
+            None => BUILTIN_ROLE_ACCOUNT_ADMIN.to_string(),
         };
 
         let effective_roles = self.get_all_effective_roles().await?;

--- a/src/query/service/src/sessions/session_privilege_mgr.rs
+++ b/src/query/service/src/sessions/session_privilege_mgr.rs
@@ -275,11 +275,7 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl {
             Some(owner) => match user_mgr.get_role(&tenant, owner.role).await {
                 Ok(owner_role) => owner_role.name,
                 Err(e) => {
-                    if e.code() == ErrorCode::UNKNOWN_ROLE {
-                        BUILTIN_ROLE_ACCOUNT_ADMIN.to_string()
-                    } else {
-                        return Err(e);
-                    }
+                    return Err(e);
                 }
             },
         };

--- a/src/query/users/src/role_cache_mgr.rs
+++ b/src/query/users/src/role_cache_mgr.rs
@@ -116,7 +116,7 @@ impl RoleCacheManager {
         &self,
         tenant: &str,
         object: &OwnershipObject,
-    ) -> Result<Option<RoleInfo>> {
+    ) -> Result<Option<String>> {
         let owner = match self.user_manager.get_ownership(tenant, object).await? {
             None => return Ok(None),
             Some(owner) => owner,
@@ -124,7 +124,7 @@ impl RoleCacheManager {
 
         // cache manager would not look into built-in roles.
         let role = self.user_manager.get_role(tenant, owner.role).await?;
-        Ok(Some(role))
+        Ok(Some(role.name))
     }
 
     // find_related_roles is called on validating an user's privileges.

--- a/src/query/users/src/role_cache_mgr.rs
+++ b/src/query/users/src/role_cache_mgr.rs
@@ -117,14 +117,10 @@ impl RoleCacheManager {
         tenant: &str,
         object: &OwnershipObject,
     ) -> Result<Option<String>> {
-        let owner = match self.user_manager.get_ownership(tenant, object).await? {
+        match self.user_manager.get_ownership(tenant, object).await? {
             None => return Ok(None),
-            Some(owner) => owner,
-        };
-
-        // cache manager would not look into built-in roles.
-        let role = self.user_manager.get_role(tenant, owner.role).await?;
-        Ok(Some(role.name))
+            Some(owner) => Ok(owner.role),
+        }
     }
 
     // find_related_roles is called on validating an user's privileges.

--- a/src/query/users/src/role_cache_mgr.rs
+++ b/src/query/users/src/role_cache_mgr.rs
@@ -119,7 +119,7 @@ impl RoleCacheManager {
     ) -> Result<Option<String>> {
         match self.user_manager.get_ownership(tenant, object).await? {
             None => return Ok(None),
-            Some(owner) => Ok(owner.role),
+            Some(owner) => Ok(Some(owner.role)),
         }
     }
 

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -165,7 +165,20 @@ impl UserApiProvider {
             .get_ownership(object)
             .await
             .map_err(|e| e.add_message_back("(while get ownership)"))?;
-        Ok(ownership)
+        if let Some(owenr) = ownership {
+            // if object has ownership, but the owner role is not exists, set owner role to ACCOUNT_ADMIN,
+            // only account_admin can access this object.
+            let role = if !self.exists_role(tenant, owner.role.clone()).await? {
+                Ok(Some(OwnershipInfo {
+                    role: BUILTIN_ROLE_ACCOUNT_ADMIN.to_string(),
+                    object,
+                }))
+            } else {
+                Ok(Some(owner))
+            };
+        } else {
+            Ok(None)
+        }
     }
 
     #[async_backtrace::framed]

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -168,6 +168,10 @@ impl UserApiProvider {
         if let Some(owner) = ownership {
             // if object has ownership, but the owner role is not exists, set owner role to ACCOUNT_ADMIN,
             // only account_admin can access this object.
+            // Note: get_ownerships no need to do this check.
+            // Because this can cause system.table queries to slow down
+            // The intention is that the account admin can grant ownership.
+            // So system.tables will display dropped role. It's by design.
             if !self.exists_role(tenant, owner.role.clone()).await? {
                 Ok(Some(OwnershipInfo {
                     role: BUILTIN_ROLE_ACCOUNT_ADMIN.to_string(),

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -168,10 +168,10 @@ impl UserApiProvider {
         if let Some(owenr) = ownership {
             // if object has ownership, but the owner role is not exists, set owner role to ACCOUNT_ADMIN,
             // only account_admin can access this object.
-            let role = if !self.exists_role(tenant, owner.role.clone()).await? {
+            if !self.exists_role(tenant, owner.role.clone()).await? {
                 Ok(Some(OwnershipInfo {
                     role: BUILTIN_ROLE_ACCOUNT_ADMIN.to_string(),
-                    object,
+                    object: *object,
                 }))
             } else {
                 Ok(Some(owner))

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -165,17 +165,17 @@ impl UserApiProvider {
             .get_ownership(object)
             .await
             .map_err(|e| e.add_message_back("(while get ownership)"))?;
-        if let Some(owenr) = ownership {
+        if let Some(owner) = ownership {
             // if object has ownership, but the owner role is not exists, set owner role to ACCOUNT_ADMIN,
             // only account_admin can access this object.
             if !self.exists_role(tenant, owner.role.clone()).await? {
                 Ok(Some(OwnershipInfo {
                     role: BUILTIN_ROLE_ACCOUNT_ADMIN.to_string(),
-                    object: *object,
+                    object: object.clone(),
                 }))
             } else {
                 Ok(Some(owner))
-            };
+            }
         } else {
             Ok(None)
         }

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
@@ -39,6 +39,10 @@ t
 t1
 === fix_issue_14572: test drop role; grant ownership ===
 a	drop_role
+t	drop_role
 a	account_admin
+t	drop_role
 a	drop_role1
+t	drop_role1
 GRANT OWNERSHIP ON 'default'.'a'.* TO ROLE `drop_role1`
+GRANT OWNERSHIP ON 'default'.'a'.'t' TO ROLE `drop_role1`

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
@@ -39,6 +39,6 @@ t
 t1
 === fix_issue_14572: test drop role; grant ownership ===
 a	drop_role
-a	drop_role
+a	account_admin
 a	drop_role1
 GRANT OWNERSHIP ON 'default'.'a'.* TO ROLE `drop_role1`

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
@@ -37,3 +37,8 @@ t1
 Error: APIError: ResponseError with 1063: Permission denied: User 'a'@'%' does not have the required privileges for database 'db_a'
 t
 t1
+=== fix_issue_14572: test drop role; grant ownership ===
+a	drop_role
+a	drop_role
+a	drop_role1
+GRANT OWNERSHIP ON 'default'.'a'.* TO ROLE `drop_role1`

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
@@ -140,11 +140,16 @@ echo "grant create on *.* to u1;" | $BENDSQL_CLIENT_CONNECT
 export USER_U1_CONNECT="bendsql --user=u1 --password=123 --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
 
 echo "create database a" | $USER_U1_CONNECT
+echo "create table a.t(id int)" | $USER_U1_CONNECT
 echo "select name, owner from system.databases where name='a'" | $USER_U1_CONNECT
+echo "select name, owner from system.tables where database='a'" | $USER_U1_CONNECT
 echo "drop role drop_role;" | $BENDSQL_CLIENT_CONNECT
 echo "select name, owner from system.databases where name='a'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.tables where database='a'" | $USER_U1_CONNECT
 echo "grant ownership on a.* to role drop_role1;" | $BENDSQL_CLIENT_CONNECT
+echo "grant ownership on a.t to role drop_role1;" | $BENDSQL_CLIENT_CONNECT
 echo "select name, owner from system.databases where name='a'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.tables where database='a'" | $USER_U1_CONNECT
 echo "show grants for role drop_role1" | $BENDSQL_CLIENT_CONNECT
 echo "drop role drop_role1" | $BENDSQL_CLIENT_CONNECT
 echo "drop user u1" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
@@ -126,3 +126,26 @@ echo "drop database db_a;" | $BENDSQL_CLIENT_CONNECT
 echo "drop role if exists role1;" | $BENDSQL_CLIENT_CONNECT
 echo "drop user if exists a;" | $BENDSQL_CLIENT_CONNECT
 echo "drop user if exists b;" | $BENDSQL_CLIENT_CONNECT
+
+echo "=== fix_issue_14572: test drop role; grant ownership ==="
+echo "drop role if exists drop_role;" | $BENDSQL_CLIENT_CONNECT
+echo "drop role if exists drop_role1;" | $BENDSQL_CLIENT_CONNECT
+echo "drop user if exists u1;" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists a;" | $BENDSQL_CLIENT_CONNECT
+echo "create role drop_role;" | $BENDSQL_CLIENT_CONNECT
+echo "create role drop_role1;" | $BENDSQL_CLIENT_CONNECT
+echo "create user u1 identified by '123' with DEFAULT_ROLE='drop_role'" | $BENDSQL_CLIENT_CONNECT
+echo "grant role drop_role to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "grant create on *.* to u1;" | $BENDSQL_CLIENT_CONNECT
+export USER_U1_CONNECT="bendsql --user=u1 --password=123 --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
+
+echo "create database a" | $USER_U1_CONNECT
+echo "select name, owner from system.databases where name='a'" | $USER_U1_CONNECT
+echo "drop role drop_role;" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.databases where name='a'" | $BENDSQL_CLIENT_CONNECT
+echo "grant ownership on a.* to role drop_role1;" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.databases where name='a'" | $BENDSQL_CLIENT_CONNECT
+echo "show grants for role drop_role1" | $BENDSQL_CLIENT_CONNECT
+echo "drop role drop_role1" | $BENDSQL_CLIENT_CONNECT
+echo "drop user u1" | $BENDSQL_CLIENT_CONNECT
+echo "drop database a" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. if has ownership but owner role not exists, the owner role will be set to account_admin

2. has_ownership should get ownership and role from meta


- Fixes #14572

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14597)
<!-- Reviewable:end -->
