### PR TITLE
chore: make materialized cte scan_progress accurate

### DIFF
--- a/src/query/pipeline/sources/src/async_source.rs
+++ b/src/query/pipeline/sources/src/async_source.rs
@@ -116,7 +116,9 @@ impl<T: 'static + AsyncSource> Processor for AsyncSourcer<T> {
         match self.inner.generate().await? {
             None => self.is_finish = true,
             Some(data_block) => {
-                if !data_block.is_empty() {
+                // Don't need to record the scan progress of `MaterializedCteSource`
+                // Because it reads data from memory.
+                if !data_block.is_empty() && self.name() != "MaterializedCteSource" {
                     let progress_values = ProgressValues {
                         rows: data_block.num_rows(),
                         bytes: data_block.memory_size(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Before:

```
mysql> with t1 as materialized (select number as a from numbers(10)) select t2.a from t1 as t2 where t2.a in (select * from t1 as t3 where t2.a = t3.a);

Read 30 rows, 240.00 B in 0.027 sec., 1.13 thousand rows/sec., 8.80 KiB/sec.
```
Now
```
mysql> with t1 as materialized (select number as a from numbers(10)) select t2.a from t1 as t2 where t2.a in (select * from t1 as t3 where t2.a = t3.a);
Read 10 rows, 80.00 B in 0.012 sec., 801.46 rows/sec., 6.26 KiB/sec.
```
- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14602)
<!-- Reviewable:end -->
