### PR TITLE
chore: add error message on refresh table info

### DIFF
--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -77,7 +77,7 @@ impl DefaultDatabase {
             refreshed.push(
                 self.ctx
                     .storage_factory
-                    .refresh_table_info(table_info)
+                    .refresh_table_info(table_info.clone())
                     .await
                     .map_err(|err| {
                         err.add_message_back(format!(

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -78,7 +78,13 @@ impl DefaultDatabase {
                 self.ctx
                     .storage_factory
                     .refresh_table_info(table_info)
-                    .await?,
+                    .await
+                    .map_err(|err| {
+                        err.add_message_back(format!(
+                            "(while refresh table info on {})",
+                            table_info.name
+                        ))
+                    })?,
             );
         }
         Ok(refreshed)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`list_table_infos` might access table's s3 storage on `refresh_table_info`. On the case of the external tables, one bad external table will break ALL the `list_table_infos` on the db.

This PR add a small error message on `list_table_infos`, we can find out the bad table with this additional infomation.

This PR 

## Tests

- [x] No Test: just add a small error message

## Type of change

- [x] Other (please describe): add a small error message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14606)
<!-- Reviewable:end -->
