### PR TITLE
refactor: get_udf() does not need to specify Seq

### DIFF
--- a/src/meta/api/src/kv_pb_api.rs
+++ b/src/meta/api/src/kv_pb_api.rs
@@ -110,6 +110,7 @@ pub trait KVPbApi: KVApi {
             Ok(v)
         }
     }
+    // TODO: add list
 }
 
 impl<T> KVPbApi for T where T: KVApi + ?Sized {}

--- a/src/query/management/src/udf/udf_api.rs
+++ b/src/query/management/src/udf/udf_api.rs
@@ -27,7 +27,7 @@ pub trait UdfApi: Sync + Send {
     async fn update_udf(&self, udf: UserDefinedFunction, seq: MatchSeq) -> Result<u64>;
 
     // Get UDF by name.
-    async fn get_udf(&self, udf_name: &str, seq: MatchSeq) -> Result<SeqV<UserDefinedFunction>>;
+    async fn get_udf(&self, udf_name: &str) -> Result<SeqV<UserDefinedFunction>>;
 
     // Get all the UDFs for a tenant.
     async fn get_udfs(&self) -> Result<Vec<UserDefinedFunction>>;

--- a/src/query/users/src/user_udf.rs
+++ b/src/query/users/src/user_udf.rs
@@ -49,8 +49,8 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn get_udf(&self, tenant: &str, udf_name: &str) -> Result<UserDefinedFunction> {
         let udf_api_client = self.get_udf_api_client(tenant)?;
-        let get_udf = udf_api_client.get_udf(udf_name, MatchSeq::GE(0));
-        Ok(get_udf.await?.data)
+        let seqv = udf_api_client.get_udf(udf_name).await?;
+        Ok(seqv.data)
     }
 
     #[async_backtrace::framed]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: get_udf() does not need to specify Seq

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14613)
<!-- Reviewable:end -->
