### PR TITLE
refactor: Simplify UdfMgr::add_udf()

### DIFF
--- a/src/meta/api/src/kv_pb_api/codec.rs
+++ b/src/meta/api/src/kv_pb_api/codec.rs
@@ -1,0 +1,58 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_types::Change;
+use databend_common_meta_types::Operation;
+use databend_common_meta_types::SeqV;
+use databend_common_proto_conv::FromToProto;
+
+use crate::kv_pb_api::PbDecodeError;
+use crate::kv_pb_api::PbEncodeError;
+
+/// Encode an upsert Operation of T into protobuf encoded value.
+pub fn encode_operation<T>(value: Operation<T>) -> Result<Operation<Vec<u8>>, PbEncodeError>
+where T: FromToProto + 'static {
+    match value {
+        Operation::Update(t) => {
+            let p = t.to_pb()?;
+            let mut buf = vec![];
+            prost::Message::encode(&p, &mut buf)?;
+            Ok(Operation::Update(buf))
+        }
+        Operation::Delete => Ok(Operation::Delete),
+        Operation::AsIs => Ok(Operation::AsIs),
+    }
+}
+
+/// Decode Change<Vec<u8>> into Change<T>, with FromToProto.
+pub fn decode_transition<T>(seqv: Change<Vec<u8>>) -> Result<Change<T>, PbDecodeError>
+where T: FromToProto {
+    let c = Change {
+        ident: seqv.ident,
+        prev: seqv.prev.map(decode_seqv::<T>).transpose()?,
+        result: seqv.result.map(decode_seqv::<T>).transpose()?,
+    };
+
+    Ok(c)
+}
+
+/// Deserialize SeqV<Vec<u8>> into SeqV<T>, with FromToProto.
+pub fn decode_seqv<T>(seqv: SeqV) -> Result<SeqV<T>, PbDecodeError>
+where T: FromToProto {
+    let buf = &seqv.data;
+    let p: T::PB = prost::Message::decode(buf.as_ref())?;
+    let v: T = FromToProto::from_pb(p)?;
+
+    Ok(SeqV::with_meta(seqv.seq, seqv.meta, v))
+}

--- a/src/meta/api/src/kv_pb_api/codec.rs
+++ b/src/meta/api/src/kv_pb_api/codec.rs
@@ -21,8 +21,8 @@ use crate::kv_pb_api::PbDecodeError;
 use crate::kv_pb_api::PbEncodeError;
 
 /// Encode an upsert Operation of T into protobuf encoded value.
-pub fn encode_operation<T>(value: Operation<T>) -> Result<Operation<Vec<u8>>, PbEncodeError>
-where T: FromToProto + 'static {
+pub fn encode_operation<T>(value: &Operation<T>) -> Result<Operation<Vec<u8>>, PbEncodeError>
+where T: FromToProto {
     match value {
         Operation::Update(t) => {
             let p = t.to_pb()?;

--- a/src/meta/api/src/kv_pb_api/errors.rs
+++ b/src/meta/api/src/kv_pb_api/errors.rs
@@ -1,0 +1,56 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines errors used by protobuf based API.
+
+use databend_common_meta_types::InvalidArgument;
+use databend_common_meta_types::MetaError;
+use databend_common_proto_conv::Incompatible;
+
+use crate::kv_pb_api::PbApiReadError;
+
+/// An error occurred when encoding protobuf message.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[error("PbEncodeError: {0}")]
+pub enum PbEncodeError {
+    EncodeError(#[from] prost::EncodeError),
+    Incompatible(#[from] Incompatible),
+}
+
+/// An error occurs when writing protobuf encoded value to kv store.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[error("PbApiWriteError: {0}")]
+pub enum PbApiWriteError<E> {
+    EncodeError(#[from] prost::EncodeError),
+    Incompatible(#[from] Incompatible),
+    /// upsert reads the state transition after the operation.
+    ReadError(#[from] PbApiReadError<E>),
+    /// Error returned from KVApi.
+    KvApiError(E),
+}
+
+impl From<PbApiWriteError<MetaError>> for MetaError {
+    /// For KVApi that returns MetaError, convert protobuf related error to MetaError directly.
+    ///
+    /// Because MetaError contains network protocol level error variant.
+    /// If there is a encoding error, consider it as network level error.
+    fn from(value: PbApiWriteError<MetaError>) -> Self {
+        match value {
+            PbApiWriteError::EncodeError(e) => MetaError::from(InvalidArgument::new(&e, "")),
+            PbApiWriteError::Incompatible(e) => MetaError::from(InvalidArgument::new(&e, "")),
+            PbApiWriteError::ReadError(e) => MetaError::from(e),
+            PbApiWriteError::KvApiError(e) => e,
+        }
+    }
+}

--- a/src/meta/api/src/kv_pb_api/upsert_pb.rs
+++ b/src/meta/api/src/kv_pb_api/upsert_pb.rs
@@ -19,7 +19,6 @@ use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaSpec;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::With;
-use futures::SinkExt;
 
 #[derive(Clone, Debug)]
 pub struct UpsertPB<K: kvapi::Key> {

--- a/src/meta/api/src/kv_pb_api/upsert_pb.rs
+++ b/src/meta/api/src/kv_pb_api/upsert_pb.rs
@@ -1,0 +1,106 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use databend_common_meta_kvapi::kvapi;
+use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::MetaSpec;
+use databend_common_meta_types::Operation;
+use databend_common_meta_types::With;
+use futures::SinkExt;
+
+#[derive(Clone, Debug)]
+pub struct UpsertPB<K: kvapi::Key> {
+    pub key: K,
+
+    /// Since a sequence number is always positive, using Exact(0) to perform an add-if-absent operation.
+    /// - GE(1) to perform an update-any operation.
+    /// - Exact(n) to perform an update on some specified version.
+    /// - Any to perform an update or insert that always takes effect.
+    pub seq: MatchSeq,
+
+    /// The value to set. A `None` indicates to delete it.
+    pub value: Operation<K::ValueType>,
+
+    /// Meta data of a value.
+    pub value_meta: Option<MetaSpec>,
+}
+
+impl<K: kvapi::Key> UpsertPB<K> {
+    pub fn new(
+        key: K,
+        seq: MatchSeq,
+        value: Operation<K::ValueType>,
+        value_meta: Option<MetaSpec>,
+    ) -> Self {
+        Self {
+            key,
+            seq,
+            value,
+            value_meta,
+        }
+    }
+
+    pub fn insert(key: K, value: K::ValueType) -> Self {
+        Self {
+            key,
+            seq: MatchSeq::Exact(0),
+            value: Operation::Update(value),
+            value_meta: None,
+        }
+    }
+
+    pub fn update(key: K, value: K::ValueType) -> Self {
+        Self {
+            key,
+            seq: MatchSeq::GE(0),
+            value: Operation::Update(value),
+            value_meta: None,
+        }
+    }
+
+    pub fn delete(key: K) -> Self {
+        Self {
+            key,
+            seq: MatchSeq::GE(0),
+            value: Operation::Delete,
+            value_meta: None,
+        }
+    }
+
+    pub fn with_expire_sec(self, expire_at_sec: u64) -> Self {
+        self.with(MetaSpec::new_expire(expire_at_sec))
+    }
+
+    /// Set the time to last for the value.
+    /// When the ttl is passed, the value is deleted.
+    pub fn with_ttl(self, ttl: Duration) -> Self {
+        self.with(MetaSpec::new_ttl(ttl))
+    }
+}
+
+impl<K: kvapi::Key> With<MatchSeq> for UpsertPB<K> {
+    fn with(mut self, seq: MatchSeq) -> Self {
+        self.seq = seq;
+        self
+    }
+}
+
+impl<K: kvapi::Key> With<MetaSpec> for UpsertPB<K> {
+    fn with(mut self, meta: MetaSpec) -> Self {
+        self.value_meta = Some(meta);
+        self
+    }
+}

--- a/src/meta/types/src/change.rs
+++ b/src/meta/types/src/change.rs
@@ -29,9 +29,7 @@ use crate::SeqValue;
 /// the `result` could also be possible to be None.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, derive_more::From)]
 pub struct Change<T, ID = u64>
-where
-    ID: Clone + PartialEq,
-    T: Clone + PartialEq,
+where ID: Clone + PartialEq
 {
     /// identity of the resource that is changed.
     pub ident: Option<ID>,
@@ -42,7 +40,7 @@ where
 impl<T, ID> Change<T, ID>
 where
     ID: Clone + PartialEq + Debug,
-    T: Clone + PartialEq + Debug,
+    T: PartialEq + Debug,
 {
     pub fn new(prev: Option<SeqV<T>>, result: Option<SeqV<T>>) -> Self {
         Change {

--- a/src/meta/types/src/cmd/mod.rs
+++ b/src/meta/types/src/cmd/mod.rs
@@ -111,7 +111,7 @@ impl fmt::Display for UpsertKV {
 
 impl UpsertKV {
     pub fn new(
-        key: &str,
+        key: impl ToString,
         seq: MatchSeq,
         value: Operation<Vec<u8>>,
         value_meta: Option<MetaSpec>,

--- a/src/meta/types/src/errors/meta_api_errors.rs
+++ b/src/meta/types/src/errors/meta_api_errors.rs
@@ -23,6 +23,7 @@ use crate::raft_types::ChangeMembershipError;
 use crate::raft_types::Fatal;
 use crate::raft_types::ForwardToLeader;
 use crate::ClientWriteError;
+use crate::InvalidArgument;
 use crate::InvalidReply;
 use crate::MetaNetworkError;
 use crate::RaftError;
@@ -169,6 +170,13 @@ impl From<MetaDataReadError> for MetaOperationError {
 impl From<Status> for MetaAPIError {
     fn from(status: Status) -> Self {
         let net_err = MetaNetworkError::from(status);
+        Self::NetworkError(net_err)
+    }
+}
+
+impl From<InvalidArgument> for MetaAPIError {
+    fn from(e: InvalidArgument) -> Self {
+        let net_err = MetaNetworkError::from(e);
         Self::NetworkError(net_err)
     }
 }

--- a/src/meta/types/src/errors/meta_errors.rs
+++ b/src/meta/types/src/errors/meta_errors.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::errors;
+use crate::InvalidArgument;
 use crate::InvalidReply;
 use crate::MetaAPIError;
 use crate::MetaClientError;
@@ -59,6 +60,12 @@ impl From<tonic::Status> for MetaError {
     }
 }
 
+impl From<InvalidArgument> for MetaError {
+    fn from(e: InvalidArgument) -> Self {
+        let api_err = MetaAPIError::from(e);
+        Self::APIError(api_err)
+    }
+}
 impl From<InvalidReply> for MetaError {
     fn from(e: InvalidReply) -> Self {
         let api_err = MetaAPIError::from(e);

--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -144,8 +144,7 @@ impl UdfApi for UdfMgr {
     #[minitrace::trace]
     async fn get_udfs(&self) -> Result<Vec<UserDefinedFunction>> {
         let key = DirName::new(UdfName::new(&self.tenant, ""));
-        let strm = self.kv_api.list_pb(&key).await?;
-        let strm = strm.map_ok(|item| item.seqv.data);
+        let strm = self.kv_api.list_pb_values(&key).await?;
         let udfs = strm.try_collect().await?;
         Ok(udfs)
     }

--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -24,16 +24,12 @@ use databend_common_meta_app::principal::UserDefinedFunction;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::DirName;
-use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_types::MatchSeq;
-use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::SeqV;
-use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::With;
 use futures::stream::TryStreamExt;
 
-use crate::serde::serialize_struct;
 use crate::udf::UdfApi;
 
 pub struct UdfMgr {
@@ -71,8 +67,8 @@ impl UdfApi for UdfMgr {
         let seq = MatchSeq::from(*create_option);
 
         let key = UdfName::new(&self.tenant, &info.name);
-        let req = UpsertPB::insert(key, info).with(seq);
-        let res = self.kv_api.upsert_pb(req).await?;
+        let req = UpsertPB::insert(key, info.clone()).with(seq);
+        let res = self.kv_api.upsert_pb(&req).await?;
 
         if let CreateOption::CreateIfNotExists(false) = create_option {
             if res.prev.is_some() {
@@ -89,6 +85,7 @@ impl UdfApi for UdfMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn update_udf(&self, info: UserDefinedFunction, seq: MatchSeq) -> Result<u64> {
+        // TODO: add ensure_not_builtin_function()
         if is_builtin_function(info.name.as_str()) {
             return Err(ErrorCode::UdfAlreadyExists(format!(
                 "Cannot add UDF '{}': name conflicts with a built-in function.",
@@ -96,33 +93,16 @@ impl UdfApi for UdfMgr {
             )));
         }
 
-        // TODO: remove get_udf(), check if the UDF exists after upsert_kv()
-        // Check if UDF is defined
-        let seqv = self.get_udf(info.name.as_str()).await?;
-
-        match seq.match_seq(&seqv) {
-            Ok(_) => {}
-            Err(_) => {
-                return Err(ErrorCode::UnknownUDF(format!(
-                    "UDF '{}' does not exist.",
-                    &info.name
-                )));
-            }
-        }
-
         let key = UdfName::new(&self.tenant, &info.name);
-        // TODO: these logic are reppeated several times, consider to extract them.
-        // TODO: add a new trait PBKVApi for the common logic that saves pb values in kvapi.
-        let value = serialize_struct(&info, ErrorCode::IllegalUDFFormat, || "")?;
-        let req = UpsertKV::update(key.to_string_key(), &value).with(seq);
-        let res = self.kv_api.upsert_kv(req).await?;
-
-        match res.result {
-            Some(SeqV { seq: s, .. }) => Ok(s),
-            None => Err(ErrorCode::UnknownUDF(format!(
+        let req = UpsertPB::update(key, info.clone()).with(seq);
+        let res = self.kv_api.upsert_pb(&req).await?;
+        if res.is_changed() {
+            Ok(res.result.unwrap().seq)
+        } else {
+            Err(ErrorCode::UnknownUDF(format!(
                 "UDF '{}' does not exist.",
-                info.name.clone()
-            ))),
+                info.name
+            )))
         }
     }
 
@@ -153,10 +133,10 @@ impl UdfApi for UdfMgr {
     #[minitrace::trace]
     async fn drop_udf(&self, udf_name: &str, seq: MatchSeq) -> Result<()> {
         let key = UdfName::new(&self.tenant, udf_name);
-        let req = UpsertKV::delete(key.to_string_key()).with(seq);
-        let res = self.kv_api.upsert_kv(req).await?;
+        let req = UpsertPB::delete(key).with(seq);
+        let res = self.kv_api.upsert_pb(&req).await?;
 
-        if res.prev.is_some() && res.result.is_none() {
+        if res.is_changed() {
             Ok(())
         } else {
             Err(ErrorCode::UnknownUDF(format!(


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Simplify UdfMgr::add_udf()


##### refactor: add KVPbApi::upsert_pb() to update or insert


##### refactor: Add KVPbApi::list_pb_values() returns values without keys

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14631)
<!-- Reviewable:end -->
