### PR TITLE
chore: move KVPbApi impl to seperate files

### DIFF
--- a/src/meta/api/src/kv_pb_api/errors/decode_error.rs
+++ b/src/meta/api/src/kv_pb_api/errors/decode_error.rs
@@ -1,0 +1,48 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_types::InvalidReply;
+use databend_common_meta_types::MetaError;
+use databend_common_proto_conv::Incompatible;
+
+/// An error occurred when decoding protobuf encoded value.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[error("PbDecodeError: {0}")]
+pub enum PbDecodeError {
+    DecodeError(#[from] prost::DecodeError),
+    Incompatible(#[from] Incompatible),
+}
+
+impl From<PbDecodeError> for MetaError {
+    fn from(value: PbDecodeError) -> Self {
+        match value {
+            PbDecodeError::DecodeError(e) => MetaError::from(InvalidReply::new("", &e)),
+            PbDecodeError::Incompatible(e) => MetaError::from(InvalidReply::new("", &e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kv_pb_api::errors::PbDecodeError;
+
+    #[test]
+    fn test_error_message() {
+        let e = PbDecodeError::DecodeError(prost::DecodeError::new("decode error"));
+        assert_eq!(
+            "PbDecodeError: failed to decode Protobuf message: decode error",
+            e.to_string()
+        );
+    }
+}

--- a/src/meta/api/src/kv_pb_api/errors/encode_error.rs
+++ b/src/meta/api/src/kv_pb_api/errors/encode_error.rs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Defines errors used by protobuf based API.
-
 use databend_common_meta_types::InvalidArgument;
 use databend_common_meta_types::MetaError;
 use databend_common_proto_conv::Incompatible;
-
-use crate::kv_pb_api::PbDecodeError;
 
 /// An error occurred when encoding with FromToProto.
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]
@@ -33,28 +29,6 @@ impl From<PbEncodeError> for MetaError {
         match value {
             PbEncodeError::EncodeError(e) => MetaError::from(InvalidArgument::new(e, "")),
             PbEncodeError::Incompatible(e) => MetaError::from(InvalidArgument::new(e, "")),
-        }
-    }
-}
-
-/// An error occurs when writing protobuf encoded value to kv store.
-#[derive(Clone, Debug, PartialEq, thiserror::Error)]
-#[error("PbApiWriteError: {0}")]
-pub enum PbApiWriteError<E> {
-    PbEncodeError(#[from] PbEncodeError),
-    /// upsert reads the state transition after the operation.
-    PbDecodeError(#[from] PbDecodeError),
-    /// Error returned from KVApi.
-    KvApiError(E),
-}
-
-impl From<PbApiWriteError<MetaError>> for MetaError {
-    /// For KVApi that returns MetaError, convert protobuf related error to MetaError directly.
-    fn from(value: PbApiWriteError<MetaError>) -> Self {
-        match value {
-            PbApiWriteError::PbEncodeError(e) => MetaError::from(e),
-            PbApiWriteError::PbDecodeError(e) => MetaError::from(e),
-            PbApiWriteError::KvApiError(e) => e,
         }
     }
 }

--- a/src/meta/api/src/kv_pb_api/errors/mod.rs
+++ b/src/meta/api/src/kv_pb_api/errors/mod.rs
@@ -1,0 +1,26 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines errors used by protobuf based API.
+
+mod decode_error;
+mod encode_error;
+mod read_error;
+mod write_error;
+
+pub use self::decode_error::PbDecodeError;
+pub use self::encode_error::PbEncodeError;
+pub use self::read_error::NoneValue;
+pub use self::read_error::PbApiReadError;
+pub use self::write_error::PbApiWriteError;

--- a/src/meta/api/src/kv_pb_api/errors/read_error.rs
+++ b/src/meta/api/src/kv_pb_api/errors/read_error.rs
@@ -1,0 +1,60 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_kvapi::kvapi;
+use databend_common_meta_types::InvalidReply;
+use databend_common_meta_types::MetaError;
+
+use crate::kv_pb_api::errors::PbDecodeError;
+
+/// An error occurs when found an unexpected None value.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[error("NoneValue: unexpected None value of key: '{key}'")]
+pub struct NoneValue {
+    key: String,
+}
+
+impl NoneValue {
+    pub fn new(key: impl ToString) -> Self {
+        NoneValue {
+            key: key.to_string(),
+        }
+    }
+}
+
+/// An error occurs when reading protobuf encoded value from kv store.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[error("PbApiReadError: {0}")]
+pub enum PbApiReadError<E> {
+    PbDecodeError(#[from] PbDecodeError),
+    KeyError(#[from] kvapi::KeyError),
+    NoneValue(#[from] NoneValue),
+    /// Error returned from KVApi.
+    KvApiError(E),
+}
+
+impl From<PbApiReadError<MetaError>> for MetaError {
+    /// For KVApi that returns MetaError, convert protobuf related error to MetaError directly.
+    ///
+    /// Because MetaError contains network protocol level error variant.
+    /// If there is a decoding error, consider it as network level error.
+    fn from(value: PbApiReadError<MetaError>) -> Self {
+        match value {
+            PbApiReadError::PbDecodeError(e) => MetaError::from(e),
+            PbApiReadError::KeyError(e) => MetaError::from(InvalidReply::new("", &e)),
+            PbApiReadError::NoneValue(e) => MetaError::from(InvalidReply::new("", &e)),
+            PbApiReadError::KvApiError(e) => e,
+        }
+    }
+}

--- a/src/meta/api/src/kv_pb_api/errors/write_error.rs
+++ b/src/meta/api/src/kv_pb_api/errors/write_error.rs
@@ -1,0 +1,40 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_types::MetaError;
+
+use crate::kv_pb_api::errors::PbDecodeError;
+use crate::kv_pb_api::errors::PbEncodeError;
+
+/// An error occurs when writing protobuf encoded value to kv store.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[error("PbApiWriteError: {0}")]
+pub enum PbApiWriteError<E> {
+    PbEncodeError(#[from] PbEncodeError),
+    /// upsert reads the state transition after the operation.
+    PbDecodeError(#[from] PbDecodeError),
+    /// Error returned from KVApi.
+    KvApiError(E),
+}
+
+impl From<PbApiWriteError<MetaError>> for MetaError {
+    /// For KVApi that returns MetaError, convert protobuf related error to MetaError directly.
+    fn from(value: PbApiWriteError<MetaError>) -> Self {
+        match value {
+            PbApiWriteError::PbEncodeError(e) => MetaError::from(e),
+            PbApiWriteError::PbDecodeError(e) => MetaError::from(e),
+            PbApiWriteError::KvApiError(e) => e,
+        }
+    }
+}

--- a/src/meta/api/src/kv_pb_api/mod.rs
+++ b/src/meta/api/src/kv_pb_api/mod.rs
@@ -14,8 +14,9 @@
 
 //! Kv API with `kvapi::Key` type key and protobuf encoded value.
 
+pub mod errors;
+
 mod codec;
-mod errors;
 mod upsert_pb;
 
 use std::future::Future;
@@ -25,115 +26,23 @@ use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_kvapi::kvapi::NonEmptyItem;
-use databend_common_meta_types::protobuf::StreamItem;
 use databend_common_meta_types::Change;
-use databend_common_meta_types::InvalidReply;
-use databend_common_meta_types::MetaError;
-use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::SeqV;
 use databend_common_meta_types::UpsertKV;
 use databend_common_proto_conv::FromToProto;
-use databend_common_proto_conv::Incompatible;
 use futures::future::FutureExt;
 use futures::future::TryFutureExt;
 use futures::stream::BoxStream;
 use futures::stream::StreamExt;
 use futures::TryStreamExt;
-use PbApiReadError::KvApiError;
 
+pub(crate) use self::codec::decode_non_empty_item;
 pub(crate) use self::codec::decode_seqv;
 pub(crate) use self::codec::decode_transition;
 pub(crate) use self::codec::encode_operation;
-pub use self::errors::PbApiWriteError;
-pub use self::errors::PbEncodeError;
 pub use self::upsert_pb::UpsertPB;
-
-// TODO: move error to separate file
-
-/// An error occurred when decoding protobuf encoded value.
-#[derive(Clone, Debug, PartialEq, thiserror::Error)]
-#[error("PbDecodeError: {0}")]
-pub enum PbDecodeError {
-    DecodeError(#[from] prost::DecodeError),
-    Incompatible(#[from] Incompatible),
-}
-
-impl From<PbDecodeError> for MetaError {
-    fn from(value: PbDecodeError) -> Self {
-        match value {
-            PbDecodeError::DecodeError(e) => MetaError::from(InvalidReply::new("", &e)),
-            PbDecodeError::Incompatible(e) => MetaError::from(InvalidReply::new("", &e)),
-        }
-    }
-}
-
-/// An error occurs when found an unexpected None value.
-#[derive(Clone, Debug, PartialEq, thiserror::Error)]
-#[error("NoneValue: unexpected None value of key: '{key}'")]
-pub struct NoneValue {
-    key: String,
-}
-
-impl NoneValue {
-    pub fn new(key: impl ToString) -> Self {
-        NoneValue {
-            key: key.to_string(),
-        }
-    }
-}
-
-/// An error occurs when reading protobuf encoded value from kv store.
-#[derive(Clone, Debug, PartialEq, thiserror::Error)]
-#[error("PbApiReadError: {0}")]
-pub enum PbApiReadError<E> {
-    DecodeError(#[from] prost::DecodeError),
-    Incompatible(#[from] Incompatible),
-    KeyError(#[from] kvapi::KeyError),
-    NoneValue(#[from] NoneValue),
-    /// Error returned from KVApi.
-    KvApiError(E),
-}
-
-impl<E> From<PbDecodeError> for PbApiReadError<E> {
-    fn from(e: PbDecodeError) -> Self {
-        match e {
-            PbDecodeError::DecodeError(e) => PbApiReadError::DecodeError(e),
-            PbDecodeError::Incompatible(e) => PbApiReadError::Incompatible(e),
-        }
-    }
-}
-
-impl From<PbApiReadError<MetaError>> for MetaError {
-    /// For KVApi that returns MetaError, convert protobuf related error to MetaError directly.
-    ///
-    /// Because MetaError contains network protocol level error variant.
-    /// If there is a decoding error, consider it as network level error.
-    fn from(value: PbApiReadError<MetaError>) -> Self {
-        match value {
-            PbApiReadError::DecodeError(e) => {
-                let inv = InvalidReply::new("", &e);
-                let net_err = MetaNetworkError::InvalidReply(inv);
-                MetaError::NetworkError(net_err)
-            }
-            PbApiReadError::Incompatible(e) => {
-                let inv = InvalidReply::new("", &e);
-                let net_err = MetaNetworkError::InvalidReply(inv);
-                MetaError::NetworkError(net_err)
-            }
-            PbApiReadError::KeyError(e) => {
-                let inv = InvalidReply::new("", &e);
-                let net_err = MetaNetworkError::InvalidReply(inv);
-                MetaError::NetworkError(net_err)
-            }
-            PbApiReadError::NoneValue(e) => {
-                let inv = InvalidReply::new("", &e);
-                let net_err = MetaNetworkError::InvalidReply(inv);
-                MetaError::NetworkError(net_err)
-            }
-            KvApiError(e) => e,
-        }
-    }
-}
+use crate::kv_pb_api::errors::PbApiReadError;
+use crate::kv_pb_api::errors::PbApiWriteError;
 
 /// This trait provides a way to access a kv store with `kvapi::Key` type key and protobuf encoded value.
 pub trait KVPbApi: KVApi {
@@ -209,7 +118,10 @@ pub trait KVPbApi: KVApi {
     {
         let key = key.to_string_key();
         async move {
-            let raw_seqv = self.get_kv(&key).await.map_err(KvApiError)?;
+            let raw_seqv = self
+                .get_kv(&key)
+                .await
+                .map_err(PbApiReadError::KvApiError)?;
             let v = raw_seqv.map(decode_seqv::<K::ValueType>).transpose()?;
             Ok(v)
         }
@@ -269,7 +181,10 @@ pub trait KVPbApi: KVApi {
     {
         let prefix = prefix.to_string_key();
         async move {
-            let strm = self.list_kv(&prefix).await.map_err(KvApiError)?;
+            let strm = self
+                .list_kv(&prefix)
+                .await
+                .map_err(PbApiReadError::KvApiError)?;
             let strm = strm.map(decode_non_empty_item::<K, Self::Error>);
             Ok(strm.boxed())
         }
@@ -277,40 +192,3 @@ pub trait KVPbApi: KVApi {
 }
 
 impl<T> KVPbApi for T where T: KVApi + ?Sized {}
-
-/// Decode key and protobuf encoded value from `StreamItem`.
-///
-/// It requires K to be static because it is used in a static stream map()
-fn decode_non_empty_item<K, E>(
-    r: Result<StreamItem, E>,
-) -> Result<NonEmptyItem<K>, PbApiReadError<E>>
-where
-    K: kvapi::Key + 'static,
-    K::ValueType: FromToProto,
-{
-    match r {
-        Ok(item) => {
-            let k = K::from_str_key(&item.key)?;
-
-            let raw = item.value.ok_or_else(|| NoneValue::new(item.key))?;
-            let v = decode_seqv::<K::ValueType>(SeqV::from(raw))?;
-
-            Ok(NonEmptyItem::new(k, v))
-        }
-        Err(e) => Err(KvApiError(e)),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::kv_pb_api::PbDecodeError;
-
-    #[test]
-    fn test_error_message() {
-        let e = PbDecodeError::DecodeError(prost::DecodeError::new("decode error"));
-        assert_eq!(
-            "PbDecodeError: failed to decode Protobuf message: decode error",
-            e.to_string()
-        );
-    }
-}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: move KVPbApi impl to seperate files


##### refacot: extract ensure_non_builtin()

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14634)
<!-- Reviewable:end -->
