### PR TITLE
chore: reduce small block writes (improve merge into write performance)

### DIFF
--- a/src/query/service/src/pipelines/builders/builder_merge_into.rs
+++ b/src/query/service/src/pipelines/builders/builder_merge_into.rs
@@ -30,6 +30,8 @@ use databend_common_pipeline_core::Pipe;
 use databend_common_pipeline_core::PipeItem;
 use databend_common_pipeline_core::TransformPipeBuilder;
 use databend_common_pipeline_transforms::processors::create_dummy_item;
+use databend_common_pipeline_transforms::processors::BlockCompactor;
+use databend_common_pipeline_transforms::processors::TransformCompact;
 use databend_common_sql::binder::MergeIntoType;
 use databend_common_sql::evaluator::BlockOperator;
 use databend_common_sql::evaluator::CompoundBlockOperator;
@@ -228,7 +230,6 @@ impl PipelineBuilder {
             }
 
             // 3. cluster sort
-
             let block_thresholds = table.get_block_thresholds();
             table.cluster_gen_for_append_with_specified_len(
                 self.ctx.clone(),
@@ -238,7 +239,22 @@ impl PipelineBuilder {
                 1,
             )?;
 
-            // 4. serialize block
+            // 4. we should avoid too much little block write, because for s3 write, there are too many
+            // little blocks, it will cause high latency.
+            let mut builder = self.main_pipeline.add_transform_with_specified_len(
+                |transform_input_port, transform_output_port| {
+                    Ok(ProcessorPtr::create(TransformCompact::try_create(
+                        transform_input_port,
+                        transform_output_port,
+                        BlockCompactor::new(block_thresholds),
+                    )?))
+                },
+                1,
+            )?;
+            builder.add_items(vec![create_dummy_item()]);
+            self.main_pipeline.add_pipe(builder.finalize());
+
+            // 5. serialize block
             let cluster_stats_gen =
                 table.get_cluster_stats_gen(self.ctx.clone(), 0, block_thresholds, None)?;
             let serialize_block_transform = TransformSerializeBlock::try_create(
@@ -256,7 +272,7 @@ impl PipelineBuilder {
             ];
             self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
 
-            // 5. serialize segment
+            // 6. serialize segment
             let serialize_segment_transform = TransformSerializeSegment::new(
                 self.ctx.clone(),
                 InputPort::create(),
@@ -770,6 +786,28 @@ impl PipelineBuilder {
             mid_len
         };
         pipe_items.clear();
+
+        // we should avoid too much little block write, because for s3 write, there are too many
+        // little blocks, it will cause high latency.
+        let mut builder = self.main_pipeline.add_transform_with_specified_len(
+            |transform_input_port, transform_output_port| {
+                Ok(ProcessorPtr::create(TransformCompact::try_create(
+                    transform_input_port,
+                    transform_output_port,
+                    BlockCompactor::new(block_thresholds),
+                )?))
+            },
+            serialize_len,
+        )?;
+        if need_match {
+            builder.add_items_prepend(vec![create_dummy_item()]);
+        }
+
+        // need to receive row_number, we should give a dummy item here.
+        if *distributed && need_unmatch && !*change_join_order {
+            builder.add_items(vec![create_dummy_item()]);
+        }
+        self.main_pipeline.add_pipe(builder.finalize());
 
         if need_match {
             // rowid should be accumulated in main node.

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0036_merge_into_without_distributed_enable.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0036_merge_into_without_distributed_enable.test
@@ -1214,5 +1214,127 @@ select * from column_only_optimization_target order by a,b;
 7 a7
 8 a8
 
+## add more tests cases for distributed modes.
+statement ok
+CREATE TABLE IF NOT EXISTS lineitem_target_origin_200_blocks1 (
+    l_orderkey BIGINT not null,
+    l_partkey BIGINT not null,
+    l_suppkey BIGINT not null,
+    l_linenumber BIGINT not null,
+    l_quantity DECIMAL(15, 2) not null,
+    l_extendedprice DECIMAL(15, 2) not null,
+    l_discount DECIMAL(15, 2) not null,
+    l_tax DECIMAL(15, 2) not null,
+    l_returnflag STRING not null,
+    l_linestatus STRING not null,
+    l_shipdate DATE not null,
+    l_commitdate DATE not null,
+    l_receiptdate DATE not null,
+    l_shipinstruct STRING not null,
+    l_shipmode STRING not null,
+    l_comment STRING not null
+) CLUSTER BY(l_shipdate, l_orderkey);
+
+statement ok
+CREATE TABLE IF NOT EXISTS lineitem_target_origin_400_blocks1 (
+    l_orderkey BIGINT not null,
+    l_partkey BIGINT not null,
+    l_suppkey BIGINT not null,
+    l_linenumber BIGINT not null,
+    l_quantity DECIMAL(15, 2) not null,
+    l_extendedprice DECIMAL(15, 2) not null,
+    l_discount DECIMAL(15, 2) not null,
+    l_tax DECIMAL(15, 2) not null,
+    l_returnflag STRING not null,
+    l_linestatus STRING not null,
+    l_shipdate DATE not null,
+    l_commitdate DATE not null,
+    l_receiptdate DATE not null,
+    l_shipinstruct STRING not null,
+    l_shipmode STRING not null,
+    l_comment STRING not null
+) CLUSTER BY(l_shipdate, l_orderkey);
+
+statement ok
+CREATE TABLE IF NOT EXISTS lineitem_random(
+    l_orderkey BIGINT not null,
+    l_partkey BIGINT not null,
+    l_suppkey BIGINT not null,
+    l_linenumber BIGINT not null,
+    l_quantity DECIMAL(15, 2) not null,
+    l_extendedprice DECIMAL(15, 2) not null,
+    l_discount DECIMAL(15, 2) not null,
+    l_tax DECIMAL(15, 2) not null,
+    l_returnflag STRING not null,
+    l_linestatus STRING not null,
+    l_shipdate DATE not null,
+    l_commitdate DATE not null,
+    l_receiptdate DATE not null,
+    l_shipinstruct STRING not null,
+    l_shipmode STRING not null,
+    l_comment STRING not null
+) engine = random;
+
+## add 4w rows
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+query T
+select count(*) from lineitem_target_origin_400_blocks1;
+----
+40000
+
+statement ok
+insert into lineitem_target_origin_200_blocks1 select * from lineitem_target_origin_400_blocks1;
+
+query T
+select count(*) from lineitem_target_origin_200_blocks1;
+----
+40000
+
+statement ok
+insert into lineitem_target_origin_400_blocks1 select * from lineitem_random limit 5000;
+
+query T
+select count(*) from lineitem_target_origin_400_blocks1;
+----
+45000
+
+## it maybe flaky test, but in most times, it's normal.
+query TT
+MERGE INTO lineitem_target_origin_400_blocks1 as t1 using lineitem_target_origin_200_blocks1 as t2 on      
+t1.l_orderkey = t2.l_orderkey and     
+t1.l_partkey = t2.l_partkey  
+and t1.l_suppkey = t2.l_suppkey and     
+t1.l_linenumber = t2.l_linenumber and      
+t1.l_quantity = t2.l_quantity and      
+t1.l_extendedprice = t2.l_extendedprice and     
+t1.l_discount = t2.l_discount     
+when matched then update *     
+when not matched then insert *;
+----
+0 40000
+
 statement ok
 set enable_experimental_merge_into = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
for current merge into implementation, we will write the blocks from join, and the bottom's join result block size depends on the query source block and `65535` threshold control, these will cause too much little block writes which is not good for s3 latency, so we can improve this to improve merge into write s3 performance. 
![FhAyCA43Jg](https://github.com/datafuselabs/databend/assets/60096118/5b66ea4d-a741-4e0b-953b-5584d7342285)


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14637)
<!-- Reviewable:end -->
