### PR TITLE
refactor: UdfApi::drop_udf() return the dropped record instead of returning ErrorCode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ dependencies = [
  "prost 0.12.1",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/src/query/management/Cargo.toml
+++ b/src/query/management/Cargo.toml
@@ -32,6 +32,7 @@ minitrace = { workspace = true }
 prost = { workspace = true }
 serde = "1.0.150"
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 databend-common-expression = { path = "../../query/expression" }

--- a/src/query/management/src/errors.rs
+++ b/src/query/management/src/errors.rs
@@ -12,9 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod udf_api;
-mod udf_mgr;
+use databend_common_exception::ErrorCode;
 
-pub use udf_api::UdfApi;
-pub use udf_api::UdfError;
-pub use udf_mgr::UdfMgr;
+/// Error related to tenant operation
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum TenantError {
+    #[error("tenant can not be empty string, while {context}")]
+    CanNotBeEmpty { context: String },
+}
+
+impl From<TenantError> for ErrorCode {
+    fn from(value: TenantError) -> Self {
+        let s = value.to_string();
+        match value {
+            TenantError::CanNotBeEmpty { .. } => ErrorCode::TenantIsEmpty(s),
+        }
+    }
+}

--- a/src/query/management/src/lib.rs
+++ b/src/query/management/src/lib.rs
@@ -27,6 +27,8 @@ mod stage;
 mod udf;
 mod user;
 
+pub mod errors;
+
 pub use cluster::ClusterApi;
 pub use cluster::ClusterMgr;
 pub use connection::ConnectionApi;
@@ -49,6 +51,7 @@ pub use setting::SettingMgr;
 pub use stage::StageApi;
 pub use stage::StageMgr;
 pub use udf::UdfApi;
+pub use udf::UdfError;
 pub use udf::UdfMgr;
 pub use user::UserApi;
 pub use user::UserMgr;

--- a/src/query/management/src/udf/udf_api.rs
+++ b/src/query/management/src/udf/udf_api.rs
@@ -12,26 +12,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_exception::Result;
+use databend_common_exception::ErrorCode;
 use databend_common_meta_app::principal::UserDefinedFunction;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::MetaError;
 use databend_common_meta_types::SeqV;
+
+use crate::errors::TenantError;
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum UdfError {
+    #[error("TenantError: '{0}'")]
+    TenantError(#[from] TenantError),
+
+    #[error("UDF not found: '{tenant}/{name}'")]
+    NotFound { tenant: String, name: String },
+
+    #[error("MetaService error: {0}")]
+    MetaError(#[from] MetaError),
+}
+
+impl From<UdfError> for ErrorCode {
+    fn from(value: UdfError) -> Self {
+        let s = value.to_string();
+        match value {
+            UdfError::TenantError(e) => ErrorCode::from(e),
+            UdfError::NotFound { .. } => ErrorCode::UnknownUDF(s),
+            UdfError::MetaError(meta_err) => ErrorCode::from(meta_err),
+        }
+    }
+}
 
 #[async_trait::async_trait]
 pub trait UdfApi: Sync + Send {
     // Add a UDF to /tenant/udf-name.
-    async fn add_udf(&self, udf: UserDefinedFunction, create_option: &CreateOption) -> Result<()>;
+    async fn add_udf(
+        &self,
+        udf: UserDefinedFunction,
+        create_option: &CreateOption,
+    ) -> Result<(), ErrorCode>;
 
     // Update a UDF to /tenant/udf-name.
-    async fn update_udf(&self, udf: UserDefinedFunction, seq: MatchSeq) -> Result<u64>;
+    async fn update_udf(&self, udf: UserDefinedFunction, seq: MatchSeq) -> Result<u64, ErrorCode>;
 
     // Get UDF by name.
-    async fn get_udf(&self, udf_name: &str) -> Result<SeqV<UserDefinedFunction>>;
+    async fn get_udf(&self, udf_name: &str) -> Result<SeqV<UserDefinedFunction>, ErrorCode>;
 
     // Get all the UDFs for a tenant.
-    async fn get_udfs(&self) -> Result<Vec<UserDefinedFunction>>;
+    async fn get_udfs(&self) -> Result<Vec<UserDefinedFunction>, ErrorCode>;
 
-    // Drop the tenant's UDF by name.
-    async fn drop_udf(&self, udf_name: &str, seq: MatchSeq) -> Result<()>;
+    /// Drop the tenant's UDF by name, return the dropped one or None if nothing is dropped.
+    async fn drop_udf(
+        &self,
+        udf_name: &str,
+        seq: MatchSeq,
+    ) -> Result<Option<SeqV<UserDefinedFunction>>, MetaError>;
 }

--- a/src/query/management/tests/it/udf.rs
+++ b/src/query/management/tests/it/udf.rs
@@ -163,10 +163,8 @@ async fn test_successfully_drop_udf() -> Result<()> {
 async fn test_unknown_udf_drop_udf() -> Result<()> {
     let (_, udf_api) = new_udf_api().await?;
 
-    match udf_api.drop_udf("UNKNOWN_NAME", MatchSeq::GE(1)).await {
-        Ok(_) => panic!("Unknown Function drop must be return Err."),
-        Err(cause) => assert_eq!(cause.code(), 2602),
-    }
+    let res = udf_api.drop_udf("UNKNOWN_NAME", MatchSeq::GE(1)).await;
+    assert_eq!(Ok(None), res);
 
     Ok(())
 }

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use databend_common_base::base::GlobalInstance;
 use databend_common_exception::Result;
 use databend_common_grpc::RpcClientConf;
+use databend_common_management::errors::TenantError;
 use databend_common_management::ConnectionApi;
 use databend_common_management::ConnectionMgr;
 use databend_common_management::FileFormatApi;
@@ -143,7 +144,7 @@ impl UserApiProvider {
         )?))
     }
 
-    pub fn get_udf_api_client(&self, tenant: &str) -> Result<Arc<dyn UdfApi>> {
+    pub fn udf_api(&self, tenant: &str) -> std::result::Result<Arc<dyn UdfApi>, TenantError> {
         Ok(Arc::new(UdfMgr::create(self.client.clone(), tenant)?))
     }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: UdfApi::drop_udf() return the dropped record instead of returning ErrorCode

This way the caller can distinguish between a logic error and a backend
meta-service error.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14640)
<!-- Reviewable:end -->
