### PR TITLE
refactor: Remove UdfApi, use UdfMgr directly

### DIFF
--- a/src/query/management/src/lib.rs
+++ b/src/query/management/src/lib.rs
@@ -50,7 +50,6 @@ pub use setting::SettingApi;
 pub use setting::SettingMgr;
 pub use stage::StageApi;
 pub use stage::StageMgr;
-pub use udf::UdfApi;
 pub use udf::UdfError;
 pub use udf::UdfMgr;
 pub use user::UserApi;

--- a/src/query/management/src/udf/errors.rs
+++ b/src/query/management/src/udf/errors.rs
@@ -13,11 +13,7 @@
 // limitations under the License.
 
 use databend_common_exception::ErrorCode;
-use databend_common_meta_app::principal::UserDefinedFunction;
-use databend_common_meta_app::schema::CreateOption;
-use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
-use databend_common_meta_types::SeqV;
 
 use crate::errors::TenantError;
 
@@ -42,30 +38,4 @@ impl From<UdfError> for ErrorCode {
             UdfError::MetaError(meta_err) => ErrorCode::from(meta_err),
         }
     }
-}
-
-#[async_trait::async_trait]
-pub trait UdfApi: Sync + Send {
-    // Add a UDF to /tenant/udf-name.
-    async fn add_udf(
-        &self,
-        udf: UserDefinedFunction,
-        create_option: &CreateOption,
-    ) -> Result<(), ErrorCode>;
-
-    // Update a UDF to /tenant/udf-name.
-    async fn update_udf(&self, udf: UserDefinedFunction, seq: MatchSeq) -> Result<u64, ErrorCode>;
-
-    // Get UDF by name.
-    async fn get_udf(&self, udf_name: &str) -> Result<SeqV<UserDefinedFunction>, ErrorCode>;
-
-    // Get all the UDFs for a tenant.
-    async fn get_udfs(&self) -> Result<Vec<UserDefinedFunction>, ErrorCode>;
-
-    /// Drop the tenant's UDF by name, return the dropped one or None if nothing is dropped.
-    async fn drop_udf(
-        &self,
-        udf_name: &str,
-        seq: MatchSeq,
-    ) -> Result<Option<SeqV<UserDefinedFunction>>, MetaError>;
 }

--- a/src/query/management/src/udf/mod.rs
+++ b/src/query/management/src/udf/mod.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod udf_api;
+mod errors;
 mod udf_mgr;
 
-pub use udf_api::UdfApi;
-pub use udf_api::UdfError;
+pub use errors::UdfError;
 pub use udf_mgr::UdfMgr;

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -35,7 +35,6 @@ use databend_common_management::SettingApi;
 use databend_common_management::SettingMgr;
 use databend_common_management::StageApi;
 use databend_common_management::StageMgr;
-use databend_common_management::UdfApi;
 use databend_common_management::UdfMgr;
 use databend_common_management::UserApi;
 use databend_common_management::UserMgr;
@@ -144,8 +143,8 @@ impl UserApiProvider {
         )?))
     }
 
-    pub fn udf_api(&self, tenant: &str) -> std::result::Result<Arc<dyn UdfApi>, TenantError> {
-        Ok(Arc::new(UdfMgr::create(self.client.clone(), tenant)?))
+    pub fn udf_api(&self, tenant: &str) -> std::result::Result<UdfMgr, TenantError> {
+        UdfMgr::create(self.client.clone(), tenant)
     }
 
     pub fn get_tenant_quota_api_client(&self, tenant: &str) -> Result<Arc<dyn QuotaApi>> {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Remove UdfApi, use UdfMgr directly

`UdfApi` has only one implementation `UdfMgr` and the abstraction layer
is the underlying `KVApi`. There is no need to introduce another
abstraction.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14642)
<!-- Reviewable:end -->
