### PR TITLE
chore(query): forbiden udf except select clause

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -2920,6 +2920,13 @@ impl<'a> TypeChecker<'a> {
             return Ok(None);
         }
 
+        if !matches!(self.bind_context.expr_context, ExprContext::SelectClause) {
+            return Err(ErrorCode::SemanticError(
+                "User Defined functions can only be used in Select Clause".to_string(),
+            )
+            .set_span(span));
+        }
+
         let udf = UserApiProvider::instance()
             .get_udf(self.ctx.get_tenant().as_str(), udf_name)
             .await;

--- a/src/query/sql/src/planner/semantic/udf_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/udf_rewriter.rs
@@ -86,14 +86,6 @@ impl UdfRewriter {
                 let new_expr = SExpr::create_unary(Arc::new(plan.into()), child_expr);
                 Ok(new_expr)
             }
-            RelOperator::Filter(mut plan) => {
-                for scalar in &mut plan.predicates {
-                    self.visit(scalar)?;
-                }
-                let child_expr = self.create_udf_expr(s_expr.children[0].clone());
-                let new_expr = SExpr::create_unary(Arc::new(plan.into()), child_expr);
-                Ok(new_expr)
-            }
             _ => Ok(s_expr),
         }
     }

--- a/tests/sqllogictests/suites/base/03_common/03_0013_select_udf.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0013_select_udf.test
@@ -23,6 +23,9 @@ SELECT cal(1, 2, 3, 4, 6)
 ----
 6.0
 
+statement error 1065
+select 1 from system.one where cal(1,2,3,4,5)
+
 statement ok
 DROP FUNCTION cal
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

forbiden udf except select clause.

In insert, udf will be convert to string, can not check privilege in insert query. So we limit only select clause can use udf.

- Fixes https://github.com/datafuselabs/databend/issues/13739

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14650)
<!-- Reviewable:end -->
