### PR TITLE
refactor: enables the bloom runtime filter to be turned on adaptively

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/desc.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/desc.rs
@@ -47,6 +47,8 @@ pub struct HashJoinDesc {
     pub(crate) probe_keys_rt: Vec<Option<(Expr<String>, IndexType)>>,
     // Under cluster, mark if the join is broadcast join.
     pub broadcast: bool,
+    // If enable bloom runtime filter
+    pub enable_bloom_runtime_filter: bool,
 }
 
 impl HashJoinDesc {
@@ -87,6 +89,7 @@ impl HashJoinDesc {
             probe_keys_rt,
             broadcast: join.broadcast,
             original_join_type: join.original_join_type.clone(),
+            enable_bloom_runtime_filter: join.enable_bloom_runtime_filter,
         })
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -152,7 +152,9 @@ impl HashJoinBuildState {
             if !is_cluster || is_broadcast_join {
                 enable_inlist_runtime_filter = true;
                 enable_min_max_runtime_filter = true;
-                if ctx.get_settings().get_runtime_filter()? {
+                if ctx.get_settings().get_runtime_filter()?
+                    && hash_join_state.hash_join_desc.enable_bloom_runtime_filter
+                {
                     enable_bloom_runtime_filter = true;
                 }
             }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -152,7 +152,7 @@ impl HashJoinBuildState {
             if !is_cluster || is_broadcast_join {
                 enable_inlist_runtime_filter = true;
                 enable_min_max_runtime_filter = true;
-                if ctx.get_settings().get_runtime_filter()?
+                if ctx.get_settings().get_bloom_runtime_filter()?
                     && hash_join_state.hash_join_desc.enable_bloom_runtime_filter
                 {
                     enable_bloom_runtime_filter = true;

--- a/src/query/service/src/schedulers/fragments/fragmenter.rs
+++ b/src/query/service/src/schedulers/fragments/fragmenter.rs
@@ -251,6 +251,7 @@ impl PhysicalPlanReplacer for Fragmenter {
             need_hold_hash_table: plan.need_hold_hash_table,
             stat_info: plan.stat_info.clone(),
             probe_keys_rt: plan.probe_keys_rt.clone(),
+            enable_bloom_runtime_filter: plan.enable_bloom_runtime_filter,
             broadcast: plan.broadcast,
             original_join_type: plan.original_join_type.clone(),
         }))

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -265,7 +265,7 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: None,
                 }),
-                ("enable_runtime_filter", DefaultSettingValue {
+                ("enable_bloom_runtime_filter", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
                     desc: "Enables runtime filter optimization for JOIN.",
                     mode: SettingMode::Both,

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -266,7 +266,7 @@ impl DefaultSettings {
                     range: None,
                 }),
                 ("enable_runtime_filter", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
+                    value: UserSettingValue::UInt64(1),
                     desc: "Enables runtime filter optimization for JOIN.",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -269,8 +269,8 @@ impl Settings {
         Ok(self.try_get_u64("join_spilling_threshold")? as usize)
     }
 
-    pub fn get_runtime_filter(&self) -> Result<bool> {
-        Ok(self.try_get_u64("enable_runtime_filter")? != 0)
+    pub fn get_bloom_runtime_filter(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_bloom_runtime_filter")? != 0)
     }
 
     pub fn get_prefer_broadcast_join(&self) -> Result<bool> {

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -237,6 +237,7 @@ pub trait PhysicalPlanReplacer {
             need_hold_hash_table: plan.need_hold_hash_table,
             stat_info: plan.stat_info.clone(),
             probe_keys_rt: plan.probe_keys_rt.clone(),
+            enable_bloom_runtime_filter: plan.enable_bloom_runtime_filter,
             broadcast: plan.broadcast,
             original_join_type: plan.original_join_type.clone(),
         }))

--- a/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
@@ -323,14 +323,16 @@ impl PhysicalPlanBuilder {
 
         let mut enable_bloom_runtime_filter = false;
         // Get how many rows in probe table
-        let table = self.metadata.read().table(table_index.unwrap()).table();
-        if let Some(stats) = table.table_statistics(self.ctx.clone()).await? {
-            if let Some(num_rows) = stats.num_rows {
-                let join_cardinality = RelExpr::with_s_expr(s_expr)
-                    .derive_cardinality()?
-                    .cardinality;
-                // If the filtered data reduces to less than 1/1000 of the original dataset, we will open bloom runtime filter.
-                enable_bloom_runtime_filter = join_cardinality <= (num_rows / 1000) as f64
+        if let Some(table_index) = table_index {
+            let table = self.metadata.read().table(table_index).table();
+            if let Some(stats) = table.table_statistics(self.ctx.clone()).await? {
+                if let Some(num_rows) = stats.num_rows {
+                    let join_cardinality = RelExpr::with_s_expr(s_expr)
+                        .derive_cardinality()?
+                        .cardinality;
+                    // If the filtered data reduces to less than 1/1000 of the original dataset, we will open bloom runtime filter.
+                    enable_bloom_runtime_filter = join_cardinality <= (num_rows / 1000) as f64
+                }
             }
         }
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0026_merge_into.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0026_merge_into.test
@@ -1,13 +1,7 @@
 statement ok
 set enable_distributed_merge_into = 1;
 
-statement ok
-set enable_runtime_filter = 1;
-
 include ./09_0036_merge_into_without_distributed_enable.test
 
 statement ok
 set enable_distributed_merge_into = 0;
-
-statement ok
-set enable_runtime_filter = 0;

--- a/tests/sqllogictests/suites/query/join/runtime_filter.test
+++ b/tests/sqllogictests/suites/query/join/runtime_filter.test
@@ -1,7 +1,4 @@
 statement ok
-set enable_runtime_filter = 1;
-
-statement ok
 CREATE TABLE table1 (
     key1 String,
     key2 String,
@@ -88,9 +85,6 @@ NULL NULL
 NULL NULL
 NULL NULL
 NULL NULL
-
-statement ok
-set enable_runtime_filter = 0;
 
 statement ok
 drop table table1;

--- a/tests/sqllogictests/suites/tpcds/queries.test
+++ b/tests/sqllogictests/suites/tpcds/queries.test
@@ -2,9 +2,6 @@ statement ok
 set sandbox_tenant = 'test_tenant';
 
 statement ok
-set enable_runtime_filter = 1;
-
-statement ok
 use tpcds;
 
 # Q1
@@ -7979,6 +7976,3 @@ Conventional childr NEXT DAY ny metro 256 251 235 0 0
 Conventional childr OVERNIGHT ny metro 188 181 188 0 0
 Conventional childr REGULAR ny metro 179 150 215 0 0
 Conventional childr TWO DAY ny metro 185 183 158 0 0
-
-statement ok
-set enable_runtime_filter = 0

--- a/tests/sqllogictests/suites/tpcds/tpcds_join_order.test
+++ b/tests/sqllogictests/suites/tpcds/tpcds_join_order.test
@@ -2,9 +2,6 @@ statement ok
 set sandbox_tenant = 'test_tenant';
 
 statement ok
-set enable_runtime_filter = 1;
-
-statement ok
 use tpcds;
 
 # Q1
@@ -6715,7 +6712,7 @@ HashJoin: INNER
 
 
 # Q69
-query 
+query
 explain join
 SELECT cd_gender,
        cd_marital_status,
@@ -8146,7 +8143,7 @@ HashJoin: INNER
     └── Scan: default.tpcds.store_sales (#3) (read rows: 28810)
 
 # Q83
-query 
+query
 explain join
 WITH sr_items AS
   (SELECT i_item_id item_id,
@@ -9322,6 +9319,3 @@ HashJoin: INNER
         └── Probe
             └── Scan: default.tpcds.ship_mode (#2) (read rows: 20)
 
-
-statement ok
-set enable_runtime_filter = 0;

--- a/tests/sqllogictests/suites/tpch/join.test
+++ b/tests/sqllogictests/suites/tpch/join.test
@@ -4,9 +4,6 @@ set sandbox_tenant = 'test_tenant';
 statement ok
 use tpch_test;
 
-statement ok
-set enable_runtime_filter = 1;
-
 query I
 select
     c_custkey, count(o_orderkey) as c_count
@@ -357,6 +354,3 @@ select o_custkey from orders where not exists (select * from customer where subs
 1
 4
 
-
-statement ok
-set enable_runtime_filter = 0;

--- a/tests/sqllogictests/suites/tpch/queries.test
+++ b/tests/sqllogictests/suites/tpch/queries.test
@@ -2,9 +2,6 @@ statement ok
 set sandbox_tenant = 'test_tenant';
 
 statement ok
-set enable_runtime_filter = 1;
-
-statement ok
 use tpch_test;
 
 statement ok
@@ -2234,7 +2231,3 @@ HashJoin: RIGHT ANTI
 │           └── Scan: default.tpch_test.customer (#0) (read rows: 15000)
 └── Probe
     └── Scan: default.tpch_test.orders (#2) (read rows: 150000)
-
-
-statement ok
-set enable_runtime_filter = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Use cardinality to predicate the join selectivity, if exceeds the selectivity threshold, open bloom runtime filter.

- Fixes #14641

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14686)
<!-- Reviewable:end -->
