### PR TITLE
feat: add a new `kvapi::Key` type: `Tenant`

### DIFF
--- a/src/meta/app/src/tenant/mod.rs
+++ b/src/meta/app/src/tenant/mod.rs
@@ -13,5 +13,8 @@
 // limitations under the License.
 
 mod quota;
+#[allow(clippy::module_inception)]
+mod tenant;
 
 pub use quota::TenantQuota;
+pub use tenant::Tenant;

--- a/src/meta/app/src/tenant/tenant.rs
+++ b/src/meta/app/src/tenant/tenant.rs
@@ -1,0 +1,48 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Tenant is not stored directly in meta-store.
+///
+/// It is just a type for use on the client side.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Tenant {
+    pub tenant: String,
+}
+
+mod kvapi_key_impl {
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+
+    use crate::tenant::tenant::Tenant;
+
+    impl kvapi::Key for Tenant {
+        const PREFIX: &'static str = "__fd_tenant";
+        type ValueType = ();
+
+        fn to_string_key(&self) -> String {
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_str(&self.tenant)
+                .done()
+        }
+
+        fn from_str_key(s: &str) -> Result<Self, KeyError> {
+            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+
+            let tenant = p.next_str()?;
+            p.done()?;
+
+            Ok(Self { tenant })
+        }
+    }
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feature: add a new `kvapi::Key` type: `Tenant`

`Tenant` will used as a root key when exporting data belonging to a
tenant from meta-service.
All the data to export directly or indirectly belongs to `Tenant`.

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14704)
<!-- Reviewable:end -->
