### PR TITLE
chore(query): improve new filter execution

### DIFF
--- a/src/query/expression/src/filter/select.rs
+++ b/src/query/expression/src/filter/select.rs
@@ -95,7 +95,7 @@ impl<'a> Selector<'a> {
         match left_data_type.remove_nullable() {
             DataType::Number(ty) => {
                 with_number_mapped_type!(|T| match ty {
-                    NumberDataType::T => self.select_type_values::<NumberType<T>>(
+                    NumberDataType::T => self.select_type_values_cmp::<NumberType<T>>(
                         &op,
                         left,
                         right,
@@ -112,7 +112,7 @@ impl<'a> Selector<'a> {
 
             DataType::Decimal(ty) => {
                 with_decimal_mapped_type!(|T| match ty {
-                    DecimalDataType::T(_) => self.select_type_values::<DecimalType<T>>(
+                    DecimalDataType::T(_) => self.select_type_values_cmp::<DecimalType<T>>(
                         &op,
                         left,
                         right,
@@ -126,7 +126,7 @@ impl<'a> Selector<'a> {
                     ),
                 })
             }
-            DataType::Date => self.select_type_values::<DateType>(
+            DataType::Date => self.select_type_values_cmp::<DateType>(
                 &op,
                 left,
                 right,
@@ -138,7 +138,7 @@ impl<'a> Selector<'a> {
                 select_strategy,
                 count,
             ),
-            DataType::Timestamp => self.select_type_values::<TimestampType>(
+            DataType::Timestamp => self.select_type_values_cmp::<TimestampType>(
                 &op,
                 left,
                 right,
@@ -150,7 +150,7 @@ impl<'a> Selector<'a> {
                 select_strategy,
                 count,
             ),
-            DataType::String => self.select_type_values::<StringType>(
+            DataType::String => self.select_type_values_cmp::<StringType>(
                 &op,
                 left,
                 right,
@@ -162,7 +162,7 @@ impl<'a> Selector<'a> {
                 select_strategy,
                 count,
             ),
-            DataType::Variant => self.select_type_values::<VariantType>(
+            DataType::Variant => self.select_type_values_cmp::<VariantType>(
                 &op,
                 left,
                 right,
@@ -174,7 +174,7 @@ impl<'a> Selector<'a> {
                 select_strategy,
                 count,
             ),
-            DataType::Boolean => self.select_type_values::<BooleanType>(
+            DataType::Boolean => self.select_type_values_cmp::<BooleanType>(
                 &op,
                 left,
                 right,
@@ -186,7 +186,7 @@ impl<'a> Selector<'a> {
                 select_strategy,
                 count,
             ),
-            DataType::EmptyArray => self.select_type_values::<EmptyArrayType>(
+            DataType::EmptyArray => self.select_type_values_cmp::<EmptyArrayType>(
                 &op,
                 left,
                 right,
@@ -198,7 +198,7 @@ impl<'a> Selector<'a> {
                 select_strategy,
                 count,
             ),
-            _ => self.select_type_values::<AnyType>(
+            _ => self.select_type_values_cmp::<AnyType>(
                 &op,
                 left,
                 right,

--- a/src/query/expression/src/filter/select_op.rs
+++ b/src/query/expression/src/filter/select_op.rs
@@ -53,3 +53,20 @@ impl SelectOp {
         }
     }
 }
+
+#[macro_export]
+macro_rules! with_mapped_cmp_method {
+    ( | $t:tt | $($tail:tt)* ) => {
+        match_template::match_template! {
+            $t = [
+                Equal => equal,
+                NotEqual => not_equal,
+                Gt => greater_than,
+                Lt => less_than,
+                Gte => greater_than_equal,
+                Lte => less_than_equal,
+            ],
+            $($tail)*
+        }
+    }
+}

--- a/src/query/expression/src/filter/select_value/select_column.rs
+++ b/src/query/expression/src/filter/select_value/select_column.rs
@@ -15,7 +15,6 @@
 use databend_common_arrow::arrow::bitmap::Bitmap;
 use databend_common_exception::Result;
 
-use crate::filter::SelectOp;
 use crate::filter::SelectStrategy;
 use crate::filter::Selector;
 use crate::types::ValueType;
@@ -25,7 +24,7 @@ impl<'a> Selector<'a> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn select_columns<T: ValueType, const FALSE: bool>(
         &self,
-        op: &SelectOp,
+        cmp: impl Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
         left: T::Column,
         right: T::Column,
         validity: Option<Bitmap>,
@@ -39,7 +38,6 @@ impl<'a> Selector<'a> {
         let mut true_idx = *mutable_true_idx;
         let mut false_idx = *mutable_false_idx;
 
-        let cmp = T::compare_operation(op);
         match select_strategy {
             SelectStrategy::True => unsafe {
                 let start = *mutable_true_idx;

--- a/src/query/expression/src/filter/select_value/select_column.rs
+++ b/src/query/expression/src/filter/select_value/select_column.rs
@@ -22,9 +22,13 @@ use crate::types::ValueType;
 impl<'a> Selector<'a> {
     // Select indices by comparing two columns.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn select_columns<T: ValueType, const FALSE: bool>(
+    pub(crate) fn select_columns<
+        T: ValueType,
+        C: Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
+        const FALSE: bool,
+    >(
         &self,
-        cmp: impl Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
+        cmp: C,
         left: T::Column,
         right: T::Column,
         validity: Option<Bitmap>,

--- a/src/query/expression/src/filter/select_value/select_column_scalar.rs
+++ b/src/query/expression/src/filter/select_value/select_column_scalar.rs
@@ -22,9 +22,13 @@ use crate::types::ValueType;
 impl<'a> Selector<'a> {
     // Select indices by comparing scalar and column.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn select_column_scalar<T: ValueType, const FALSE: bool>(
+    pub(crate) fn select_column_scalar<
+        T: ValueType,
+        C: Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
+        const FALSE: bool,
+    >(
         &self,
-        cmp: impl Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
+        cmp: C,
         column: T::Column,
         scalar: T::ScalarRef<'a>,
         validity: Option<Bitmap>,

--- a/src/query/expression/src/filter/select_value/select_column_scalar.rs
+++ b/src/query/expression/src/filter/select_value/select_column_scalar.rs
@@ -15,7 +15,6 @@
 use databend_common_arrow::arrow::bitmap::Bitmap;
 use databend_common_exception::Result;
 
-use crate::filter::SelectOp;
 use crate::filter::SelectStrategy;
 use crate::filter::Selector;
 use crate::types::ValueType;
@@ -25,7 +24,7 @@ impl<'a> Selector<'a> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn select_column_scalar<T: ValueType, const FALSE: bool>(
         &self,
-        op: &SelectOp,
+        cmp: impl Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
         column: T::Column,
         scalar: T::ScalarRef<'a>,
         validity: Option<Bitmap>,
@@ -39,7 +38,6 @@ impl<'a> Selector<'a> {
         let mut true_idx = *mutable_true_idx;
         let mut false_idx = *mutable_false_idx;
 
-        let cmp = T::compare_operation(op);
         match select_strategy {
             SelectStrategy::True => unsafe {
                 let start = *mutable_true_idx;

--- a/src/query/expression/src/filter/select_value/select_scalar.rs
+++ b/src/query/expression/src/filter/select_value/select_scalar.rs
@@ -22,9 +22,12 @@ use crate::Scalar;
 impl<'a> Selector<'a> {
     #[allow(clippy::too_many_arguments)]
     // Select indices by comparing two scalars.
-    pub(crate) fn select_scalars<T: ValueType>(
+    pub(crate) fn select_scalars<
+        T: ValueType,
+        C: Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
+    >(
         &self,
-        cmp: impl Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
+        cmp: C,
         left: Scalar,
         right: Scalar,
         true_selection: &mut [u32],

--- a/src/query/expression/src/filter/select_value/select_scalar.rs
+++ b/src/query/expression/src/filter/select_value/select_scalar.rs
@@ -18,14 +18,13 @@ use crate::filter::SelectStrategy;
 use crate::filter::Selector;
 use crate::types::ValueType;
 use crate::Scalar;
-use crate::SelectOp;
 
 impl<'a> Selector<'a> {
     #[allow(clippy::too_many_arguments)]
     // Select indices by comparing two scalars.
     pub(crate) fn select_scalars<T: ValueType>(
         &self,
-        op: &SelectOp,
+        cmp: impl Fn(T::ScalarRef<'_>, T::ScalarRef<'_>) -> bool,
         left: Scalar,
         right: Scalar,
         true_selection: &mut [u32],
@@ -39,7 +38,7 @@ impl<'a> Selector<'a> {
         let left = T::try_downcast_scalar(&left).unwrap();
         let right = right.as_ref();
         let right = T::try_downcast_scalar(&right).unwrap();
-        let result = T::compare_operation(op)(left, right);
+        let result = cmp(left, right);
         let count = self.select_boolean_scalar_adapt(
             result,
             true_selection,

--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -65,7 +65,6 @@ use crate::values::Column;
 use crate::values::Scalar;
 use crate::ColumnBuilder;
 use crate::ScalarRef;
-use crate::SelectOp;
 
 pub type GenericMap = [DataType];
 
@@ -382,19 +381,6 @@ pub trait ValueType: Debug + Clone + PartialEq + Sized + 'static {
     #[inline(always)]
     fn compare(_: Self::ScalarRef<'_>, _: Self::ScalarRef<'_>) -> Option<Ordering> {
         None
-    }
-
-    /// Return the comparison function for the given select operation, some data types not support comparison.
-    #[inline(always)]
-    fn compare_operation(op: &SelectOp) -> fn(Self::ScalarRef<'_>, Self::ScalarRef<'_>) -> bool {
-        match op {
-            SelectOp::Equal => Self::equal,
-            SelectOp::NotEqual => Self::not_equal,
-            SelectOp::Gt => Self::greater_than,
-            SelectOp::Gte => Self::greater_than_equal,
-            SelectOp::Lt => Self::less_than,
-            SelectOp::Lte => Self::less_than_equal,
-        }
     }
 
     /// Equal comparison between two scalars, some data types not support comparison.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When advancing PR #14689, it was found that the performance of the filter could be improved: when the comparison function is used as a return value, its `#[inline(always)]` will be ignored, after fixing this issue, the execution of the filter can be accelerated by ~ 40%

## FlameGraph
**Q1 filter before**
<img width="1728" alt="截屏2024-02-22 20 04 13" src="https://github.com/datafuselabs/databend/assets/54522439/c2c2fc19-1c4e-479f-b7c3-3ea2b6cfda9c">

**Q1 filter after**
<img width="1728" alt="截屏2024-02-22 20 04 45" src="https://github.com/datafuselabs/databend/assets/54522439/2274079d-b79e-4a71-b54b-eda54262a217">


**Q3 filter before**
<img width="1728" alt="截屏2024-02-22 20 06 40" src="https://github.com/datafuselabs/databend/assets/54522439/dd5e4d14-bd95-40fc-9edc-1207c81a7922">

**Q3 filter after**
<img width="1728" alt="截屏2024-02-22 20 07 05" src="https://github.com/datafuselabs/databend/assets/54522439/2fec067c-1bcb-42ff-9f8e-0fa81c0c561d">

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Covered by existing tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14715)
<!-- Reviewable:end -->
