### PR TITLE
feat: add `parent()` method to kvapi::Key to describe the hierarchical structure of meta-service data

### DIFF
--- a/src/meta/api/src/id_generator.rs
+++ b/src/meta/api/src/id_generator.rs
@@ -101,6 +101,10 @@ impl kvapi::Key for IdGenerator {
 
     type ValueType = Infallible;
 
+    fn parent(&self) -> Option<String> {
+        None
+    }
+
     fn to_string_key(&self) -> String {
         kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
             .push_raw(&self.resource)

--- a/src/meta/app/src/background/background_job.rs
+++ b/src/meta/app/src/background/background_job.rs
@@ -383,12 +383,18 @@ mod kvapi_key_impl {
     use crate::background::background_job::BackgroundJobId;
     use crate::background::background_job::BackgroundJobIdent;
     use crate::background::BackgroundJobInfo;
+    use crate::tenant::Tenant;
 
     /// <prefix>/<tenant>/<background_job_ident> -> <id>
     impl kvapi::Key for BackgroundJobIdent {
         const PREFIX: &'static str = "__fd_background_job";
 
         type ValueType = BackgroundJobId;
+
+        /// It belongs to a tenant
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
@@ -412,6 +418,10 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_background_job_by_id";
 
         type ValueType = BackgroundJobInfo;
+
+        fn parent(&self) -> Option<String> {
+            None
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/background/background_task.rs
+++ b/src/meta/app/src/background/background_task.rs
@@ -220,6 +220,7 @@ mod kvapi_key_impl {
 
     use crate::background::background_task::BackgroundTaskIdent;
     use crate::background::BackgroundTaskInfo;
+    use crate::tenant::Tenant;
 
     // task is named by id, and will not encounter renaming issue.
     /// <prefix>/<tenant>/<background_task_ident> -> info
@@ -227,6 +228,11 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_background_task_by_name";
 
         type ValueType = BackgroundTaskInfo;
+
+        /// It belongs to a tenant
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/data_mask/mod.rs
+++ b/src/meta/app/src/data_mask/mod.rs
@@ -128,12 +128,18 @@ mod kvapi_key_impl {
     use super::MaskpolicyTableIdListKey;
     use crate::data_mask::DatamaskMeta;
     use crate::data_mask::MaskpolicyTableIdList;
+    use crate::tenant::Tenant;
 
     /// __fd_database/<tenant>/<name> -> <data_mask_id>
     impl kvapi::Key for DatamaskNameIdent {
         const PREFIX: &'static str = "__fd_datamask";
 
         type ValueType = DatamaskId;
+
+        /// It belongs to a tenant
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
@@ -159,6 +165,10 @@ mod kvapi_key_impl {
 
         type ValueType = DatamaskMeta;
 
+        fn parent(&self) -> Option<String> {
+            None
+        }
+
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
                 .push_u64(self.id)
@@ -179,6 +189,11 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_datamask_id_list";
 
         type ValueType = MaskpolicyTableIdList;
+
+        /// It belongs to a tenant
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/principal/user_defined_function.rs
+++ b/src/meta/app/src/principal/user_defined_function.rs
@@ -154,11 +154,17 @@ mod kv_api_impl {
 
     use super::UdfName;
     use crate::principal::UserDefinedFunction;
+    use crate::tenant::Tenant;
 
     impl kvapi::Key for UdfName {
         const PREFIX: &'static str = "__fd_udfs";
 
         type ValueType = UserDefinedFunction;
+
+        /// It belongs to a tenant
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -67,6 +67,12 @@ pub struct DatabaseId {
     pub db_id: u64,
 }
 
+impl DatabaseId {
+    pub fn new(db_id: u64) -> Self {
+        DatabaseId { db_id }
+    }
+}
+
 impl From<u64> for DatabaseId {
     fn from(db_id: u64) -> Self {
         DatabaseId { db_id }
@@ -345,12 +351,17 @@ mod kvapi_key_impl {
     use crate::schema::DatabaseNameIdent;
     use crate::schema::DbIdList;
     use crate::schema::DbIdListKey;
+    use crate::tenant::Tenant;
 
     /// __fd_database/<tenant>/<db_name> -> <db_id>
     impl kvapi::Key for DatabaseNameIdent {
         const PREFIX: &'static str = "__fd_database";
 
         type ValueType = DatabaseId;
+
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
@@ -376,6 +387,10 @@ mod kvapi_key_impl {
 
         type ValueType = DatabaseMeta;
 
+        fn parent(&self) -> Option<String> {
+            None
+        }
+
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
                 .push_u64(self.db_id)
@@ -398,6 +413,10 @@ mod kvapi_key_impl {
 
         type ValueType = DatabaseNameIdent;
 
+        fn parent(&self) -> Option<String> {
+            Some(DatabaseId::new(self.db_id).to_string_key())
+        }
+
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
                 .push_u64(self.db_id)
@@ -419,6 +438,10 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_db_id_list";
 
         type ValueType = DbIdList;
+
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -63,6 +63,12 @@ pub struct IndexId {
     pub index_id: u64,
 }
 
+impl IndexId {
+    pub fn new(index_id: u64) -> IndexId {
+        IndexId { index_id }
+    }
+}
+
 impl Display for IndexId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.index_id)
@@ -242,12 +248,17 @@ mod kvapi_key_impl {
     use crate::schema::IndexIdToName;
     use crate::schema::IndexMeta;
     use crate::schema::IndexNameIdent;
+    use crate::tenant::Tenant;
 
     /// <prefix>/<tenant>/<index_name> -> <index_id>
     impl kvapi::Key for IndexNameIdent {
         const PREFIX: &'static str = "__fd_index";
 
         type ValueType = IndexId;
+
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
@@ -273,6 +284,10 @@ mod kvapi_key_impl {
 
         type ValueType = IndexMeta;
 
+        fn parent(&self) -> Option<String> {
+            None
+        }
+
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
                 .push_u64(self.index_id)
@@ -294,6 +309,10 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_index_id_to_name";
 
         type ValueType = IndexNameIdent;
+
+        fn parent(&self) -> Option<String> {
+            Some(IndexId::new(self.index_id).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/schema/lock.rs
+++ b/src/meta/app/src/schema/lock.rs
@@ -182,6 +182,7 @@ mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::schema::LockMeta;
+    use crate::schema::TableId;
     use crate::schema::TableLockKey;
 
     /// __fd_table_lock/table_id/revision -> LockMeta
@@ -189,6 +190,10 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_table_lock";
 
         type ValueType = LockMeta;
+
+        fn parent(&self) -> Option<String> {
+            Some(TableId::new(self.table_id).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -129,6 +129,12 @@ pub struct TableId {
     pub table_id: u64,
 }
 
+impl TableId {
+    pub fn new(table_id: u64) -> Self {
+        TableId { table_id }
+    }
+}
+
 impl Display for TableId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "TableId{{{}}}", self.table_id)
@@ -885,6 +891,7 @@ mod kvapi_key_impl {
     use crate::primitive::Id;
     use crate::schema::CountTablesKey;
     use crate::schema::DBIdTableName;
+    use crate::schema::DatabaseId;
     use crate::schema::LeastVisibleTime;
     use crate::schema::LeastVisibleTimeKey;
     use crate::schema::TableCopiedFileInfo;
@@ -894,12 +901,17 @@ mod kvapi_key_impl {
     use crate::schema::TableIdListKey;
     use crate::schema::TableIdToName;
     use crate::schema::TableMeta;
+    use crate::tenant::Tenant;
 
     /// "__fd_table/<db_id>/<tb_name>"
     impl kvapi::Key for DBIdTableName {
         const PREFIX: &'static str = "__fd_table";
 
         type ValueType = TableId;
+
+        fn parent(&self) -> Option<String> {
+            Some(DatabaseId::new(self.db_id).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
@@ -925,6 +937,10 @@ mod kvapi_key_impl {
 
         type ValueType = DBIdTableName;
 
+        fn parent(&self) -> Option<String> {
+            Some(TableId::new(self.table_id).to_string_key())
+        }
+
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
                 .push_u64(self.table_id)
@@ -947,6 +963,10 @@ mod kvapi_key_impl {
 
         type ValueType = TableMeta;
 
+        fn parent(&self) -> Option<String> {
+            None
+        }
+
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
                 .push_u64(self.table_id)
@@ -968,6 +988,10 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_table_id_list";
 
         type ValueType = TableIdList;
+
+        fn parent(&self) -> Option<String> {
+            Some(DatabaseId::new(self.db_id).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
@@ -993,6 +1017,10 @@ mod kvapi_key_impl {
 
         type ValueType = Id;
 
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
+
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
                 .push_raw(&self.tenant)
@@ -1014,6 +1042,10 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_table_copied_files";
 
         type ValueType = TableCopiedFileInfo;
+
+        fn parent(&self) -> Option<String> {
+            Some(TableId::new(self.table_id).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             // TODO: file is not escaped!!!
@@ -1040,6 +1072,10 @@ mod kvapi_key_impl {
         const PREFIX: &'static str = "__fd_table_lvt";
 
         type ValueType = LeastVisibleTime;
+
+        fn parent(&self) -> Option<String> {
+            Some(TableId::new(self.table_id).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/schema/virtual_column.rs
+++ b/src/meta/app/src/schema/virtual_column.rs
@@ -131,12 +131,18 @@ mod kvapi_key_impl {
 
     use crate::schema::VirtualColumnMeta;
     use crate::schema::VirtualColumnNameIdent;
+    use crate::tenant::Tenant;
 
     /// <prefix>/<tenant>/<table_id>
     impl kvapi::Key for VirtualColumnNameIdent {
         const PREFIX: &'static str = "__fd_virtual_column";
 
         type ValueType = VirtualColumnMeta;
+
+        /// It belongs to a tenant
+        fn parent(&self) -> Option<String> {
+            Some(Tenant::new(&self.tenant).to_string_key())
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/app/src/tenant/tenant.rs
+++ b/src/meta/app/src/tenant/tenant.rs
@@ -17,7 +17,16 @@
 /// It is just a type for use on the client side.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Tenant {
+    // TODO: consider using NonEmptyString?
     pub tenant: String,
+}
+
+impl Tenant {
+    pub fn new(tenant: impl ToString) -> Self {
+        Self {
+            tenant: tenant.to_string(),
+        }
+    }
 }
 
 mod kvapi_key_impl {
@@ -31,6 +40,10 @@ mod kvapi_key_impl {
     impl kvapi::Key for Tenant {
         const PREFIX: &'static str = "__fd_tenant";
         type ValueType = Infallible;
+
+        fn parent(&self) -> Option<String> {
+            None
+        }
 
         fn to_string_key(&self) -> String {
             kvapi::KeyBuilder::new_prefixed(Self::PREFIX)

--- a/src/meta/kvapi/src/kvapi/key.rs
+++ b/src/meta/kvapi/src/kvapi/key.rs
@@ -61,6 +61,11 @@ where Self: Sized
         format!("{}/", Self::PREFIX)
     }
 
+    /// Return the parent key of this key.
+    ///
+    /// For example, a table name's parent is db-id.
+    fn parent(&self) -> Option<String>;
+
     /// Encode structured key into a string.
     fn to_string_key(&self) -> String;
 
@@ -73,6 +78,10 @@ impl kvapi::Key for String {
 
     /// For a non structured key, the value type can never be used.
     type ValueType = Infallible;
+
+    fn parent(&self) -> Option<String> {
+        unimplemented!("illegal to get parent of generic String key")
+    }
 
     fn to_string_key(&self) -> String {
         self.clone()
@@ -121,6 +130,10 @@ impl<K: Key> Key for DirName<K> {
     const PREFIX: &'static str = K::PREFIX;
     type ValueType = K::ValueType;
 
+    fn parent(&self) -> Option<String> {
+        unimplemented!("DirName is not a record thus it has no parent")
+    }
+
     fn to_string_key(&self) -> String {
         let k = self.key.to_string_key();
         k.rsplitn(self.level + 1, '/').last().unwrap().to_string()
@@ -150,6 +163,10 @@ mod tests {
     impl Key for FooKey {
         const PREFIX: &'static str = "pref";
         type ValueType = Infallible;
+
+        fn parent(&self) -> Option<String> {
+            None
+        }
 
         fn to_string_key(&self) -> String {
             format!("{}/{}/{}/{}", Self::PREFIX, self.a, self.b, self.c)


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: add `parent()` method to kvapi::Key to describe the hierarchical structure of meta-service data

Keys in meta-service have hierarchical structure.
For example a database is the parent of a table.

The `kvapi::Key` should expose a structure that enables the traversal
from a `Tenant` to all associated data when exporting metadata for that
tenant.

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14716)
<!-- Reviewable:end -->
