### PR TITLE
chore: add metrics for compact and recluster

### DIFF
--- a/src/common/metrics/src/metrics/storage.rs
+++ b/src/common/metrics/src/metrics/storage.rs
@@ -153,6 +153,13 @@ static COMPACT_BLOCK_READ_MILLISECONDS: LazyLock<Histogram> =
 static COMPACT_BLOCK_BUILD_TASK_MILLISECONDS: LazyLock<Histogram> = LazyLock::new(|| {
     register_histogram_in_milliseconds("fuse_compact_block_build_task_milliseconds")
 });
+static COMPACT_BLOCK_BUILD_LAZY_PART_MILLISECONDS: LazyLock<Histogram> = LazyLock::new(|| {
+    register_histogram_in_milliseconds("fuse_compact_block_build_lazy_part_milliseconds")
+});
+static RECLUSTER_BUILD_TASK_MILLISECONDS: LazyLock<Histogram> =
+    LazyLock::new(|| register_histogram_in_milliseconds("fuse_recluster_build_task_milliseconds"));
+static RECLUSTER_SEGMENT_NUMS_SCHEDULED: LazyLock<Counter> =
+    LazyLock::new(|| register_counter("fuse_recluster_segment_nums_scheduled"));
 static RECLUSTER_BLOCK_NUMS_TO_READ: LazyLock<Counter> =
     LazyLock::new(|| register_counter("fuse_recluster_block_nums_to_read"));
 static RECLUSTER_BLOCK_BYTES_TO_READ: LazyLock<Counter> =
@@ -502,6 +509,10 @@ pub fn metrics_inc_compact_block_build_task_milliseconds(c: u64) {
     COMPACT_BLOCK_BUILD_TASK_MILLISECONDS.observe(c as f64);
 }
 
+pub fn metrics_inc_compact_block_build_lazy_part_milliseconds(c: u64) {
+    COMPACT_BLOCK_BUILD_LAZY_PART_MILLISECONDS.observe(c as f64);
+}
+
 /// Pruning metrics.
 pub fn metrics_inc_segments_range_pruning_before(c: u64) {
     SEGMENTS_RANGE_PRUNING_BEFORE.inc_by(c);
@@ -666,6 +677,15 @@ pub fn metrics_inc_replace_deleted_blocks_rows(c: u64) {
 // rows of blocks that are appended
 pub fn metrics_inc_replace_append_blocks_rows(c: u64) {
     REPLACE_INTO_APPEND_BLOCKS_ROWS.inc_by(c);
+}
+
+/// Recluster metrics.
+pub fn metrics_inc_recluster_build_task_milliseconds(c: u64) {
+    RECLUSTER_BUILD_TASK_MILLISECONDS.observe(c as f64);
+}
+
+pub fn metrics_inc_recluster_segment_nums_scheduled(c: u64) {
+    RECLUSTER_SEGMENT_NUMS_SCHEDULED.inc_by(c);
 }
 
 pub fn metrics_inc_recluster_block_nums_to_read(c: u64) {

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -173,12 +173,14 @@ impl BlockCompactMutator {
         );
 
         // Status.
+        let elapsed_time = start.elapsed().as_millis() as u64;
         self.ctx.set_status_info(&format!(
-            "compact: end to build lazy compact parts:{}, segments to be compacted:{}, cost:{} sec",
+            "compact: end to build lazy compact parts:{}, segments to be compacted:{}, cost:{} ms",
             parts.len(),
             checker.compacted_segment_cnt,
-            start.elapsed().as_secs()
+            elapsed_time
         ));
+        metrics_inc_compact_block_build_lazy_part_milliseconds(elapsed_time);
 
         let cluster = self.ctx.get_cluster();
         let max_threads = self.ctx.get_settings().get_max_threads()? as usize;

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -312,7 +312,7 @@ impl ReclusterMutator {
     ) -> bool {
         if let Some(stats) = &summary.cluster_stats {
             stats.cluster_key_id == cluster_key_id
-                && (stats.level >= 0 || (summary.block_count as usize) >= block_per_seg)
+                && (stats.level >= 0 || (summary.block_count as usize) < block_per_seg)
         } else {
             false
         }

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use databend_common_base::runtime::TrySpawn;
 use databend_common_base::GLOBAL_TASK;
@@ -22,6 +23,8 @@ use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::TableSchemaRef;
+use databend_common_metrics::storage::metrics_inc_recluster_build_task_milliseconds;
+use databend_common_metrics::storage::metrics_inc_recluster_segment_nums_scheduled;
 use databend_common_sql::BloomIndexColumns;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use log::warn;
@@ -84,6 +87,8 @@ impl FuseTable {
             return Ok(None);
         };
 
+        let start = Instant::now();
+
         let settings = ctx.get_settings();
         let mut max_tasks = 1;
         let cluster = ctx.get_cluster();
@@ -100,8 +105,7 @@ impl FuseTable {
             FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD,
             DEFAULT_AVG_DEPTH_THRESHOLD,
         );
-        let block_count = snapshot.summary.block_count;
-        let threshold = (block_count as f64 * avg_depth_threshold)
+        let threshold = (snapshot.summary.block_count as f64 * avg_depth_threshold)
             .max(1.0)
             .min(64.0);
         let mut mutator = ReclusterMutator::try_create(
@@ -125,6 +129,9 @@ impl FuseTable {
         // The max number of segments to be reclustered.
         let max_seg_num = limit.min(max_threads * 2);
 
+        let number_segments = segment_locations.len();
+        let mut segment_idx = 0;
+        let mut recluster_seg_num = 0;
         'F: for chunk in segment_locations.chunks(chunk_size) {
             // read segments.
             let compact_segments = Self::segment_pruning(
@@ -135,6 +142,19 @@ impl FuseTable {
                 chunk.to_vec(),
             )
             .await?;
+
+            // Status.
+            {
+                segment_idx += chunk.len();
+                let status = format!(
+                    "recluster: read segment files:{}/{}, cost:{} sec",
+                    segment_idx,
+                    number_segments,
+                    start.elapsed().as_secs()
+                );
+                ctx.set_status_info(&status);
+            }
+
             if compact_segments.is_empty() {
                 continue;
             }
@@ -148,18 +168,28 @@ impl FuseTable {
             )?;
             // select the blocks with the highest depth.
             if selected_segs.is_empty() {
+                let mut selected_segs = vec![];
+                let mut block_count = 0;
                 for compact_segment in compact_segments.into_iter() {
-                    if !ReclusterMutator::segment_can_recluster(
+                    if ReclusterMutator::segment_can_recluster(
                         &compact_segment.1.summary,
                         block_per_seg,
                         default_cluster_key_id,
                     ) {
-                        continue;
+                        block_count += compact_segment.1.summary.block_count as usize;
+                        selected_segs.push(compact_segment);
                     }
 
-                    if mutator.target_select(vec![compact_segment]).await? {
-                        log::info!("Number of segments scheduled for recluster: 1");
-                        break 'F;
+                    if block_count >= block_per_seg {
+                        let seg_num = selected_segs.len();
+                        if mutator
+                            .target_select(std::mem::take(&mut selected_segs))
+                            .await?
+                        {
+                            recluster_seg_num = seg_num as u64;
+                            break 'F;
+                        }
+                        block_count = 0;
                     }
                 }
             } else {
@@ -169,12 +199,23 @@ impl FuseTable {
                     selected_segments.push(compact_segments[i].clone());
                 });
                 if mutator.target_select(selected_segments).await? {
-                    log::info!("Number of segments scheduled for recluster: {}", seg_num);
+                    recluster_seg_num = seg_num as u64;
                     break;
                 }
             }
         }
 
+        {
+            let elapsed_time = start.elapsed().as_millis() as u64;
+            ctx.set_status_info(&format!(
+                "recluster: end to build recluster tasks, recluster segments count: {}, blocks count: {}, cost:{} ms",
+                recluster_seg_num,
+                mutator.recluster_blocks_count,
+                elapsed_time,
+            ));
+            metrics_inc_recluster_build_task_milliseconds(elapsed_time);
+            metrics_inc_recluster_segment_nums_scheduled(recluster_seg_num);
+        }
         Ok(Some(mutator))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- new metrics

   - fuse_compact_block_build_lazy_part_milliseconds (histogram)
   - fuse_recluster_build_task_milliseconds (histo)
   - fuse_recluster_segment_nums_scheduled (counter)

- While selecting the blocks with the highest depth

   segments no longer processed one by one,  multiple segments might be squashed into one unit for selection, if the number of blocks of these segments reaches the value of setting FUSE_OPT_KEY_BLOCK_PER_SEGMENT.

- tweak(fix) the logic of `ReclusterMutator::segment_can_recluster`

  the segment will be a candidate for recluster, only if it does not consist of constant blocks(only), or the number of blocks does not reach the value of setting FUSE_OPT_KEY_BLOCK_PER_SEGMENT.


- adjusted log messages for clarity and precision.


- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14717)
<!-- Reviewable:end -->
