### PR TITLE
feat: add kvapi::ValueType::dependency_keys() to retrieve relation such as table-name-to-table-id and table-id-to-table-meta

### DIFF
--- a/src/meta/app/src/background/background_job.rs
+++ b/src/meta/app/src/background/background_job.rs
@@ -379,6 +379,7 @@ impl Display for ListBackgroundJobsReq {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
 
     use crate::background::background_job::BackgroundJobId;
     use crate::background::background_job::BackgroundJobIdent;
@@ -439,7 +440,15 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for BackgroundJobId {}
+    impl kvapi::Value for BackgroundJobId {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
 
-    impl kvapi::Value for BackgroundJobInfo {}
+    impl kvapi::Value for BackgroundJobInfo {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/app/src/background/background_task.rs
+++ b/src/meta/app/src/background/background_task.rs
@@ -255,5 +255,9 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for BackgroundTaskInfo {}
+    impl kvapi::Value for BackgroundTaskInfo {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/app/src/data_mask/mod.rs
+++ b/src/meta/app/src/data_mask/mod.rs
@@ -124,6 +124,7 @@ impl Display for MaskpolicyTableIdListKey {
     }
 }
 
+/// A list of table ids
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, Default, PartialEq)]
 pub struct MaskpolicyTableIdList {
     pub id_list: BTreeSet<u64>,
@@ -131,6 +132,7 @@ pub struct MaskpolicyTableIdList {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
 
     use super::DatamaskId;
     use super::DatamaskNameIdent;
@@ -222,9 +224,22 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for DatamaskId {}
+    impl kvapi::Value for DatamaskId {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
 
-    impl kvapi::Value for DatamaskMeta {}
+    impl kvapi::Value for DatamaskMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for MaskpolicyTableIdList {}
+    impl kvapi::Value for MaskpolicyTableIdList {
+        /// It contains table ids but it does not own these table in the meta-data hierarchy.
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/app/src/primitive.rs
+++ b/src/meta/app/src/primitive.rs
@@ -44,4 +44,8 @@ impl Deref for Id {
     }
 }
 
-impl kvapi::Value for Id {}
+impl kvapi::Value for Id {
+    fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+        []
+    }
+}

--- a/src/meta/app/src/principal/user_defined_function.rs
+++ b/src/meta/app/src/principal/user_defined_function.rs
@@ -184,5 +184,9 @@ mod kv_api_impl {
         }
     }
 
-    impl kvapi::Value for UserDefinedFunction {}
+    impl kvapi::Value for UserDefinedFunction {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -237,6 +237,7 @@ impl ListCatalogReq {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
 
     use super::CatalogId;
     use super::CatalogIdToName;
@@ -328,9 +329,21 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for CatalogId {}
+    impl kvapi::Value for CatalogId {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
 
-    impl kvapi::Value for CatalogMeta {}
+    impl kvapi::Value for CatalogMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for CatalogNameIdent {}
+    impl kvapi::Value for CatalogNameIdent {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -344,6 +344,7 @@ pub struct ListDatabaseReq {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
 
     use crate::schema::DatabaseId;
     use crate::schema::DatabaseIdToName;
@@ -461,11 +462,29 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for DatabaseId {}
+    impl kvapi::Value for DatabaseId {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
 
-    impl kvapi::Value for DatabaseMeta {}
+    impl kvapi::Value for DatabaseMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for DatabaseNameIdent {}
+    impl kvapi::Value for DatabaseNameIdent {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for DbIdList {}
+    impl kvapi::Value for DbIdList {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            self.id_list
+                .iter()
+                .map(|id| DatabaseId::new(*id).to_string_key())
+        }
+    }
 }

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -243,6 +243,7 @@ impl ListIndexesByIdReq {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
 
     use crate::schema::IndexId;
     use crate::schema::IndexIdToName;
@@ -330,9 +331,22 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for IndexId {}
+    impl kvapi::Value for IndexId {
+        /// IndexId is id of the two level `name->id,id->value` mapping
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
 
-    impl kvapi::Value for IndexMeta {}
+    impl kvapi::Value for IndexMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for IndexNameIdent {}
+    impl kvapi::Value for IndexNameIdent {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/app/src/schema/lock.rs
+++ b/src/meta/app/src/schema/lock.rs
@@ -213,5 +213,9 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for LockMeta {}
+    impl kvapi::Value for LockMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -887,6 +887,7 @@ pub struct EmptyProto {}
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
 
     use crate::primitive::Id;
     use crate::schema::CountTablesKey;
@@ -1093,17 +1094,43 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for TableId {}
+    impl kvapi::Value for TableId {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
 
-    impl kvapi::Value for DBIdTableName {}
+    impl kvapi::Value for DBIdTableName {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for TableMeta {}
+    impl kvapi::Value for TableMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for TableIdList {}
+    impl kvapi::Value for TableIdList {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            self.id_list
+                .iter()
+                .map(|id| TableId::new(*id).to_string_key())
+        }
+    }
 
-    impl kvapi::Value for TableCopiedFileInfo {}
+    impl kvapi::Value for TableCopiedFileInfo {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for LeastVisibleTime {}
+    impl kvapi::Value for LeastVisibleTime {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/meta/app/src/schema/virtual_column.rs
+++ b/src/meta/app/src/schema/virtual_column.rs
@@ -162,5 +162,9 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for VirtualColumnMeta {}
+    impl kvapi::Value for VirtualColumnMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/app/src/share/share.rs
+++ b/src/meta/app/src/share/share.rs
@@ -763,6 +763,7 @@ pub struct ShareSpec {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
 
     use super::ShareEndpointId;
     use crate::schema::DatabaseId;
@@ -1028,19 +1029,53 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Value for ObjectSharedByShareIds {}
+    impl kvapi::Value for ObjectSharedByShareIds {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for ShareId {}
+    impl kvapi::Value for ShareId {
+        /// ShareId is id of the two level `name->id,id->value` mapping
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
 
-    impl kvapi::Value for ShareMeta {}
+    impl kvapi::Value for ShareMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for ShareAccountMeta {}
+    impl kvapi::Value for ShareAccountMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for ShareNameIdent {}
+    impl kvapi::Value for ShareNameIdent {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for ShareEndpointId {}
+    impl kvapi::Value for ShareEndpointId {
+        /// ShareEndpointId is id of the two level `name->id,id->value` mapping
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
 
-    impl kvapi::Value for ShareEndpointMeta {}
+    impl kvapi::Value for ShareEndpointMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 
-    impl kvapi::Value for ShareEndpointIdent {}
+    impl kvapi::Value for ShareEndpointIdent {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
 }

--- a/src/meta/kvapi/src/kvapi/value.rs
+++ b/src/meta/kvapi/src/kvapi/value.rs
@@ -16,6 +16,17 @@ use std::convert::Infallible;
 use std::fmt::Debug;
 
 /// A value that can be stored in kvapi::KVApi.
-pub trait Value: Debug {}
+pub trait Value: Debug {
+    /// Return keys this value depends on.
+    ///
+    /// For example, the name-to-id record `database-name -> a database-id`
+    /// depends on the `database-id -> database-meta` record.
+    /// Thus `DatabaseId::dependency_keys()` returns itself for further traversing.
+    fn dependency_keys(&self) -> impl IntoIterator<Item = String>;
+}
 
-impl Value for Infallible {}
+impl Value for Infallible {
+    fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+        []
+    }
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: add kvapi::ValueType::dependency_keys() to retrieve relation such as table-name-to-table-id and table-id-to-table-meta

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14735)
<!-- Reviewable:end -->
