### PR TITLE
refactor: Add RoleGrantee to provide meta-service key for RoleMgr

### DIFF
--- a/src/meta/app/src/principal/mod.rs
+++ b/src/meta/app/src/principal/mod.rs
@@ -52,6 +52,7 @@ pub use user_defined_function::UserDefinedFunction;
 pub use user_grant::GrantEntry;
 pub use user_grant::GrantObject;
 pub use user_grant::OwnershipObject;
+pub use user_grant::TenantOwnershipObject;
 pub use user_grant::UserGrantSet;
 pub use user_identity::UserIdentity;
 pub use user_info::UserInfo;

--- a/src/meta/app/src/principal/user_grant.rs
+++ b/src/meta/app/src/principal/user_grant.rs
@@ -16,10 +16,13 @@ use std::collections::HashSet;
 use std::fmt;
 use std::ops;
 
+use databend_common_meta_kvapi::kvapi;
+use databend_common_meta_kvapi::kvapi::Key;
 use enumflags2::BitFlags;
 
 use crate::principal::UserPrivilegeSet;
 use crate::principal::UserPrivilegeType;
+use crate::tenant::Tenant;
 
 /// [`OwnershipObject`] is used to maintain the grant object that support rename by id. Using ID over name
 /// have many benefits, it can avoid lost privileges after the object get renamed.
@@ -46,6 +49,170 @@ pub enum OwnershipObject {
     UDF {
         name: String,
     },
+}
+
+impl OwnershipObject {
+    // # Legacy issue: Catalog is not encoded into key.
+    //
+    // But at that time, only `"default"` catalog is used.
+    // Thus we follow the same rule, if catalog is `"default"`, we don't encode it.
+    //
+    // This issue is introduced in https://github.com/drmingdrmer/databend/blob/7681763dc54306e55b5e0326af0510292d244be3/src/query/management/src/role/role_mgr.rs#L86
+    const DEFAULT_CATALOG: &'static str = "default";
+
+    /// Build key with the provided KeyBuilder as sub part of key used to access meta-service
+    pub(crate) fn build_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+        match self {
+            OwnershipObject::Database {
+                catalog_name,
+                db_id,
+            } => {
+                // Legacy issue: Catalog is not encoded into key.
+                if catalog_name == Self::DEFAULT_CATALOG {
+                    b.push_raw("database-by-id").push_u64(*db_id)
+                } else {
+                    b.push_raw("database-by-catalog-id")
+                        .push_str(catalog_name)
+                        .push_u64(*db_id)
+                }
+            }
+            OwnershipObject::Table {
+                catalog_name,
+                db_id,
+                table_id,
+            } => {
+                // TODO(flaneur): db_id is not encoded into key. Thus such key can not be decoded.
+                let _ = db_id;
+
+                // Legacy issue: Catalog is not encoded into key.
+                if catalog_name == Self::DEFAULT_CATALOG {
+                    b.push_raw("table-by-id").push_u64(*table_id)
+                } else {
+                    b.push_raw("table-by-catalog-id")
+                        .push_str(catalog_name)
+                        .push_u64(*table_id)
+                }
+            }
+            OwnershipObject::Stage { name } => b.push_raw("stage-by-name").push_str(name),
+            OwnershipObject::UDF { name } => b.push_raw("udf-by-name").push_str(name),
+        }
+    }
+
+    /// Parse encoded key and return the OwnershipObject
+    pub(crate) fn parse_key(p: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+        let q = p.next_raw()?;
+        match q {
+            "database-by-id" => {
+                let db_id = p.next_u64()?;
+                Ok(OwnershipObject::Database {
+                    catalog_name: Self::DEFAULT_CATALOG.to_string(),
+                    db_id,
+                })
+            }
+            "database-by-catalog-id" => {
+                let catalog_name = p.next_str()?;
+                let db_id = p.next_u64()?;
+                Ok(OwnershipObject::Database {
+                    catalog_name,
+                    db_id,
+                })
+            }
+            "table-by-id" => {
+                let table_id = p.next_u64()?;
+                Ok(OwnershipObject::Table {
+                    catalog_name: Self::DEFAULT_CATALOG.to_string(),
+                    db_id: 0,
+                    table_id,
+                })
+            }
+            "table-by-catalog-id" => {
+                let catalog_name = p.next_str()?;
+                let table_id = p.next_u64()?;
+                Ok(OwnershipObject::Table {
+                    catalog_name,
+                    db_id: 0, // string key does not contain db_id
+                    table_id,
+                })
+            }
+            "stage-by-name" => {
+                let name = p.next_str()?;
+                Ok(OwnershipObject::Stage { name })
+            }
+            "udf-by-name" => {
+                let name = p.next_str()?;
+                Ok(OwnershipObject::UDF { name })
+            }
+            _ => Err(kvapi::KeyError::InvalidSegment {
+                i: p.index(),
+                expect: "database-by-id|database-by-catalog-id|table-by-id|table-by-catalog-id|stage-by-name|udf-by-name"
+                    .to_string(),
+                got: q.to_string(),
+            }),
+        }
+        //
+    }
+}
+
+/// The meta-service key of object whose ownership to grant.
+///
+/// It could be a tenant's database, a tenant's table etc.
+/// It is in form of `__fd_object_owners/<tenant>/<object>`.
+/// where `<object>` could be:
+/// - `database-by-id/<db_id>`
+/// - `database-by-catalog-id/<catalog>/<db_id>`
+/// - `table-by-id/<table_id>`
+/// - `table-by-catalog-id/<catalog>/<table_id>`
+/// - `stage-by-name/<stage_name>`
+/// - `udf-by-name/<udf_name>`
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct TenantOwnershipObject {
+    tenant: Tenant,
+    object: OwnershipObject,
+}
+
+impl TenantOwnershipObject {
+    pub fn new(tenant: Tenant, subject: OwnershipObject) -> Self {
+        // Legacy issue: Assert compatibility: No other catalog should be used.
+        // Assertion is disabled.
+        // Instead, accessing field `object` is disallowed.
+        // match &subject {
+        //     OwnershipObject::Database { catalog_name, .. } => {
+        //         assert_eq!(catalog_name, OwnershipObject::DEFAULT_CATALOG);
+        //     }
+        //     OwnershipObject::Table { catalog_name, .. } => {
+        //         assert_eq!(catalog_name, OwnershipObject::DEFAULT_CATALOG);
+        //     }
+        //     OwnershipObject::Stage { .. } => {}
+        //     OwnershipObject::UDF { .. } => {}
+        // }
+
+        Self::new_unchecked(tenant, subject)
+    }
+
+    pub(crate) fn new_unchecked(tenant: Tenant, object: OwnershipObject) -> Self {
+        TenantOwnershipObject { tenant, object }
+    }
+
+    /// Return a encoded key prefix for listing keys belongs to the tenant.
+    ///
+    /// It is in form of `__fd_object_owners/<tenant>/`.
+    /// The trailing `/` is important for exclude tenants with prefix same as this tenant.
+    pub fn tenant_prefix(&self) -> String {
+        kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+            .push_str(&self.tenant.tenant)
+            .done()
+    }
+
+    pub fn tenant(&self) -> &Tenant {
+        &self.tenant
+    }
+
+    // Because the encoded string key does not contain all of the field:
+    // Catalog and db_id is missing, so we can not rebuild the complete key from string key.
+    // Thus it is not allow to access this field.
+    // pub fn subject(&self) -> &OwnershipObject {
+    //     &self.object
+    // }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
@@ -313,5 +480,174 @@ impl fmt::Display for UserGrantSet {
             write!(f, "{}, ", entry)?;
         }
         write!(f, "ROLES: {:?}", self.roles())
+    }
+}
+
+mod kvapi_key_impl {
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+
+    use crate::principal::user_grant::TenantOwnershipObject;
+    use crate::principal::OwnershipInfo;
+    use crate::principal::OwnershipObject;
+    use crate::tenant::Tenant;
+
+    impl kvapi::Key for TenantOwnershipObject {
+        const PREFIX: &'static str = "__fd_object_owners";
+        type ValueType = OwnershipInfo;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
+        }
+
+        fn to_string_key(&self) -> String {
+            let b = kvapi::KeyBuilder::new_prefixed(Self::PREFIX).push_str(&self.tenant.tenant);
+            self.object.build_key(b).done()
+        }
+
+        fn from_str_key(s: &str) -> Result<Self, KeyError> {
+            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+
+            let tenant = p.next_str()?;
+            let subject = OwnershipObject::parse_key(&mut p)?;
+            p.done()?;
+
+            Ok(TenantOwnershipObject {
+                tenant: Tenant::new(tenant),
+                object: subject,
+            })
+        }
+    }
+
+    impl kvapi::Value for OwnershipInfo {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::principal::user_grant::TenantOwnershipObject;
+    use crate::principal::OwnershipObject;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_role_grantee_as_kvapi_key() {
+        // db with default catalog
+        {
+            let role_grantee = TenantOwnershipObject::new_unchecked(
+                Tenant::new("test"),
+                OwnershipObject::Database {
+                    catalog_name: "default".to_string(),
+                    db_id: 1,
+                },
+            );
+
+            let key = role_grantee.to_string_key();
+            assert_eq!("__fd_object_owners/test/database-by-id/1", key);
+
+            let parsed = TenantOwnershipObject::from_str_key(&key).unwrap();
+            assert_eq!(role_grantee, parsed);
+        }
+
+        // db with catalog
+        {
+            let role_grantee = TenantOwnershipObject::new_unchecked(
+                Tenant::new("test"),
+                OwnershipObject::Database {
+                    catalog_name: "cata/foo".to_string(),
+                    db_id: 1,
+                },
+            );
+
+            let key = role_grantee.to_string_key();
+            assert_eq!(
+                "__fd_object_owners/test/database-by-catalog-id/cata%2ffoo/1",
+                key
+            );
+
+            let parsed = TenantOwnershipObject::from_str_key(&key).unwrap();
+            assert_eq!(role_grantee, parsed);
+        }
+
+        // table with default catalog
+        {
+            let obj =
+                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Table {
+                    catalog_name: "default".to_string(),
+                    db_id: 1,
+                    table_id: 2,
+                });
+
+            let key = obj.to_string_key();
+            assert_eq!("__fd_object_owners/test/table-by-id/2", key);
+
+            let parsed = TenantOwnershipObject::from_str_key(&key).unwrap();
+            assert_eq!(
+                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Table {
+                    catalog_name: "default".to_string(),
+                    db_id: 0, // db_id is not encoded into key
+                    table_id: 2,
+                }),
+                parsed
+            );
+        }
+
+        // table with catalog
+        {
+            let obj =
+                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Table {
+                    catalog_name: "cata/foo".to_string(),
+                    db_id: 1,
+                    table_id: 2,
+                });
+
+            let key = obj.to_string_key();
+            assert_eq!(
+                "__fd_object_owners/test/table-by-catalog-id/cata%2ffoo/2",
+                key
+            );
+
+            let parsed = TenantOwnershipObject::from_str_key(&key).unwrap();
+            assert_eq!(
+                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Table {
+                    catalog_name: "cata/foo".to_string(),
+                    db_id: 0, // db_id is not encoded into key
+                    table_id: 2,
+                }),
+                parsed
+            );
+        }
+
+        // stage
+        {
+            let role_grantee =
+                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Stage {
+                    name: "foo".to_string(),
+                });
+
+            let key = role_grantee.to_string_key();
+            assert_eq!("__fd_object_owners/test/stage-by-name/foo", key);
+
+            let parsed = TenantOwnershipObject::from_str_key(&key).unwrap();
+            assert_eq!(role_grantee, parsed);
+        }
+
+        // udf
+        {
+            let role_grantee =
+                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::UDF {
+                    name: "foo".to_string(),
+                });
+
+            let key = role_grantee.to_string_key();
+            assert_eq!("__fd_object_owners/test/udf-by-name/foo", key);
+
+            let parsed = TenantOwnershipObject::from_str_key(&key).unwrap();
+            assert_eq!(role_grantee, parsed);
+        }
     }
 }

--- a/src/meta/kvapi/src/kvapi/key_parser.rs
+++ b/src/meta/kvapi/src/kvapi/key_parser.rs
@@ -51,6 +51,13 @@ impl<'s> KeyParser<'s> {
         Ok(s)
     }
 
+    /// Get the index of the last returned element.
+    ///
+    /// If no element is returned, it will panic.
+    pub fn index(&self) -> usize {
+        self.i - 1
+    }
+
     /// Pop the next element in raw `&str`, without unescaping or decoding.
     ///
     /// If there is no more element, it returns KeyError::WrongNumberOfSegments.

--- a/src/meta/types/src/non_empty.rs
+++ b/src/meta/types/src/non_empty.rs
@@ -26,7 +26,7 @@ impl<'a> NonEmptyStr<'a> {
         Ok(NonEmptyStr { non_empty: s })
     }
 
-    fn get(&self) -> &str {
+    pub fn get(&self) -> &str {
         self.non_empty
     }
 }

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -24,14 +24,19 @@ use databend_common_meta_app::principal::GrantObject;
 use databend_common_meta_app::principal::OwnershipInfo;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::RoleInfo;
+use databend_common_meta_app::principal::TenantOwnershipObject;
 use databend_common_meta_app::principal::UserPrivilegeType;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_kvapi::kvapi;
+use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::ConditionResult::Eq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
+use databend_common_meta_types::NonEmptyStr;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::SeqV;
 use databend_common_meta_types::TxnRequest;
@@ -42,7 +47,6 @@ use crate::serde::check_and_upgrade_to_pb;
 use crate::serialize_struct;
 
 static ROLE_API_KEY_PREFIX: &str = "__fd_roles";
-static OBJECT_OWNER_API_KEY_PREFIX: &str = "__fd_object_owners";
 
 static TXN_MAX_RETRY_TIMES: u32 = 5;
 
@@ -50,26 +54,21 @@ static BUILTIN_ROLE_ACCOUNT_ADMIN: &str = "account_admin";
 
 pub struct RoleMgr {
     kv_api: Arc<dyn kvapi::KVApi<Error = MetaError> + Send + Sync>,
+    tenant: NonEmptyString,
     role_prefix: String,
-    object_owner_prefix: String,
 }
 
 impl RoleMgr {
     pub fn create(
         kv_api: Arc<dyn kvapi::KVApi<Error = MetaError> + Send + Sync>,
-        tenant: &str,
-    ) -> Result<Self, ErrorCode> {
-        if tenant.is_empty() {
-            return Err(ErrorCode::TenantIsEmpty(
-                "Tenant can not empty(while role mgr create)",
-            ));
-        }
-        let tenant = tenant.to_string();
-        Ok(RoleMgr {
+        tenant: NonEmptyStr,
+    ) -> Self {
+        let t = tenant.get();
+        RoleMgr {
             kv_api,
-            role_prefix: format!("{}/{}", ROLE_API_KEY_PREFIX, tenant),
-            object_owner_prefix: format!("{}/{}", OBJECT_OWNER_API_KEY_PREFIX, tenant),
-        })
+            tenant: tenant.into(),
+            role_prefix: format!("{}/{}", ROLE_API_KEY_PREFIX, t),
+        }
     }
 
     #[async_backtrace::framed]
@@ -107,35 +106,25 @@ impl RoleMgr {
             .await
     }
 
-    fn make_role_key(&self, role: &str) -> String {
-        format!("{}/{}", self.role_prefix, role)
+    /// Build meta-service for a role grantee, which is a tenant's database, table, stage, udf, etc.
+    fn ownership_object_key(&self, object: &OwnershipObject) -> String {
+        let grantee = TenantOwnershipObject::new(Tenant::new(self.tenant.as_str()), object.clone());
+        grantee.to_string_key()
     }
 
-    fn make_object_owner_key(&self, object: &OwnershipObject) -> String {
-        match object {
-            OwnershipObject::Database {
-                catalog_name: _,
-                db_id: database_id,
-            } => {
-                format!(
-                    "{}/database-by-id/{}",
-                    self.object_owner_prefix, database_id
-                )
-            }
-            OwnershipObject::Table {
-                catalog_name: _,
-                db_id: _,
-                table_id,
-            } => {
-                format!("{}/table-by-id/{}", self.object_owner_prefix, table_id)
-            }
-            OwnershipObject::Stage { name } => {
-                format!("{}/stage-by-name/{}", self.object_owner_prefix, name)
-            }
-            OwnershipObject::UDF { name } => {
-                format!("{}/udf-by-name/{}", self.object_owner_prefix, name)
-            }
-        }
+    /// Build meta-service for a listing keys belongs to the tenant.
+    ///
+    /// In form of `__fd_object_owners/<tenant>/`.
+    fn ownership_object_prefix(&self) -> String {
+        let dummy = OwnershipObject::UDF {
+            name: "dummy".to_string(),
+        };
+        let grantee = TenantOwnershipObject::new(Tenant::new(self.tenant.as_str()), dummy);
+        grantee.tenant_prefix()
+    }
+
+    fn make_role_key(&self, role: &str) -> String {
+        format!("{}/{}", self.role_prefix, role)
     }
 }
 
@@ -217,7 +206,7 @@ impl RoleApi for RoleMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn get_ownerships(&self) -> Result<Vec<SeqV<OwnershipInfo>>, ErrorCode> {
-        let object_owner_prefix = self.object_owner_prefix.clone();
+        let object_owner_prefix = self.ownership_object_prefix();
         let kv_api = self.kv_api.clone();
         let values = kv_api.prefix_list_kv(object_owner_prefix.as_str()).await?;
 
@@ -277,7 +266,9 @@ impl RoleApi for RoleMgr {
     ) -> databend_common_exception::Result<()> {
         let old_role = self.get_ownership(object).await?.map(|o| o.role);
         let grant_object = convert_to_grant_obj(object);
-        let owner_key = self.make_object_owner_key(object);
+
+        let owner_key = self.ownership_object_key(object);
+
         let owner_value = serialize_struct(
             &OwnershipInfo {
                 object: object.clone(),
@@ -356,7 +347,8 @@ impl RoleApi for RoleMgr {
         &self,
         object: &OwnershipObject,
     ) -> databend_common_exception::Result<Option<OwnershipInfo>> {
-        let key = self.make_object_owner_key(object);
+        let key = self.ownership_object_key(object);
+
         let res = self.kv_api.get_kv(&key).await?;
         let seq_value = match res {
             Some(value) => value,
@@ -383,7 +375,8 @@ impl RoleApi for RoleMgr {
         object: &OwnershipObject,
     ) -> databend_common_exception::Result<()> {
         let role = self.get_ownership(object).await?.map(|o| o.role);
-        let owner_key = self.make_object_owner_key(object);
+
+        let owner_key = self.ownership_object_key(object);
 
         let mut if_then = vec![txn_op_del(&owner_key)];
         let mut condition = vec![];

--- a/src/query/management/tests/it/role.rs
+++ b/src/query/management/tests/it/role.rs
@@ -19,6 +19,7 @@ use databend_common_management::*;
 use databend_common_meta_embedded::MetaEmbedded;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::NonEmptyStr;
 use mockall::predicate::*;
 
 fn make_role_key(role: &str) -> String {
@@ -64,6 +65,6 @@ mod add {
 
 async fn new_role_api() -> databend_common_exception::Result<(Arc<MetaEmbedded>, RoleMgr)> {
     let test_api = Arc::new(MetaEmbedded::new_temp().await?);
-    let mgr = RoleMgr::create(test_api.clone(), "admin")?;
+    let mgr = RoleMgr::create(test_api.clone(), NonEmptyStr::new("admin").unwrap());
     Ok((test_api, mgr))
 }

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -123,7 +123,8 @@ impl UserApiProvider {
     }
 
     pub fn get_role_api_client(&self, tenant: &str) -> Result<Arc<impl RoleApi>> {
-        Ok(Arc::new(RoleMgr::create(self.client.clone(), tenant)?))
+        let role_mgr = self.for_tenant(tenant)?.role_api();
+        Ok(Arc::new(role_mgr))
     }
 
     pub fn get_stage_api_client(&self, tenant: &str) -> Result<Arc<dyn StageApi>> {
@@ -208,5 +209,9 @@ pub struct ForTenant<'a> {
 impl<'a> ForTenant<'a> {
     pub fn udf_api(&self) -> UdfMgr {
         UdfMgr::create(self.user_api.client.clone(), self.tenant)
+    }
+
+    pub fn role_api(&self) -> RoleMgr {
+        RoleMgr::create(self.user_api.client.clone(), self.tenant)
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Add RoleGrantee to provide meta-service key for RoleMgr

Encapsulate the logic of encoding/decoding role-grantee key into
`RoleGrantee`. `RoleGrantee` is a standard `kvapi::Key` implementation
so that the export program could rely on the `kvapi::Key` API to
traverse meta-data to fetch all data that belongs to a tenant.

Legacy issue:

- For `OwnershipObject::Database{ catalog_name, db_id }`, `catalog_name`
  is not encoded into the key, we have to be compatible with this. The
  solution is to encode a `"default"` catalog with
  `database-by-id/<db-id>` prefix, and encode a non-default catalog with
  `database-by-catalog-id/<catalog>/<db-id>` prefix.

  The same for the `OwnershipObject::Table{ catalog_name, ... }`.

- For `OwnershipObject::Table{ catalog_name, db_id, table_id }`, `db_id`
  is not encoded into the key. Thus `kvapi::Key::from_str_key()` can not
  be implemented because `db_id` is absent.

- In this version, only `"default"` catalog is allowed. Using other
  catalog will panic. This restrict will be removed if it is confirmed
  there is no other catalog in our meta-data.

---

- Part of #14738

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14752)
<!-- Reviewable:end -->
