### PR TITLE
chore: Improve runtime filter

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -150,6 +150,7 @@ impl HashJoinBuildState {
             // For cluster, only support runtime filter for broadcast join.
             let is_broadcast_join = hash_join_state.hash_join_desc.broadcast;
             if !is_cluster || is_broadcast_join {
+                info!("enable broadcast join or standalone join runtime filter");
                 enable_inlist_runtime_filter = true;
                 enable_min_max_runtime_filter = true;
                 enable_bloom_runtime_filter =
@@ -800,6 +801,7 @@ impl HashJoinBuildState {
             let mut runtime_filter = RuntimeFilterInfo::default();
             if self.enable_inlist_runtime_filter && build_num_rows < INLIST_RUNTIME_FILTER_THRESHOLD
             {
+                info!("add inlist runtime filter");
                 self.inlist_runtime_filter(
                     &mut runtime_filter,
                     build_chunks,
@@ -808,9 +810,11 @@ impl HashJoinBuildState {
                 )?;
             }
             if self.enable_bloom_runtime_filter {
+                info!("add bloom runtime filter");
                 self.bloom_runtime_filter(build_chunks, &mut runtime_filter, build_key, probe_key)?;
             }
             if self.enable_min_max_runtime_filter {
+                info!("add min-max runtime filter");
                 self.min_max_runtime_filter(
                     build_chunks,
                     &mut runtime_filter,
@@ -819,6 +823,7 @@ impl HashJoinBuildState {
                 )?;
             }
             if !runtime_filter.is_empty() {
+                info!("set runtime filter");
                 self.ctx.set_runtime_filter((*table_index, runtime_filter));
             }
         }

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
@@ -233,15 +233,17 @@ impl Processor for ReadParquetDataSource<false> {
 
         if !parts.is_empty() {
             let mut chunks = Vec::with_capacity(parts.len());
-            let mut filters = self
-                .partitions
-                .ctx
-                .get_inlist_runtime_filter_with_id(self.table_index);
+            // do min-max filter firstly.
             filters.extend(
                 self.partitions
                     .ctx
                     .get_min_max_runtime_filter_with_id(self.table_index),
             );
+            let mut filters = self
+                .partitions
+                .ctx
+                .get_inlist_runtime_filter_with_id(self.table_index);
+
             let mut fuse_part_infos = Vec::with_capacity(parts.len());
             for part in parts.into_iter() {
                 if runtime_filter_pruner(

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
@@ -235,7 +235,7 @@ impl Processor for ReadParquetDataSource<false> {
         if !parts.is_empty() {
             let mut chunks = Vec::with_capacity(parts.len());
             // do min-max filter firstly.
-            let filters = self
+            let mut filters = self
                 .partitions
                 .ctx
                 .get_min_max_runtime_filter_with_id(self.table_index);

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
@@ -20,7 +20,6 @@ use databend_common_catalog::plan::StealablePartitions;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::filter;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::TableSchema;

--- a/src/query/storages/fuse/src/operations/read/runtime_filter_prunner.rs
+++ b/src/query/storages/fuse/src/operations/read/runtime_filter_prunner.rs
@@ -61,6 +61,7 @@ pub fn runtime_filter_pruner(
         if let Some(stats) = &part.columns_stat {
             let column_ids = table_schema.leaf_columns_of(name);
             if column_ids.len() != 1 {
+                info!("cloumns ids len is not 1 for {}", name);
                 return false;
             }
             debug_assert!(column_ids.len() == 1);
@@ -79,10 +80,14 @@ pub fn runtime_filter_pruner(
                     func_ctx,
                     &BUILTIN_FUNCTIONS,
                 );
-                return matches!(new_expr, Expr::Constant {
+                let res = matches!(new_expr, Expr::Constant {
                     scalar: Scalar::Boolean(false),
                     ..
                 });
+                if res {
+                    info!("pruned by name {}", name);
+                }
+                return res;
             }
         }
         false


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
we find the join runtime filter doesn't make effect. I use this log and change the possible position which causes this to check in this pr.
```sql
explain ANALYZE select * from target_table_cluster as t1 join source_table as t2 on 
t1.l_shipdate = t2.l_shipdate and t1.l_partkey = t2.l_partkey and t1.l_orderkey = t2.l_orderkey and
t1.l_suppkey = t2.l_suppkey and t1.l_linenumber = t2.l_linenumber;
cost 3.1 s.
```

```sql
explain ANALYZE select * from target_table_cluster as t1 join source_table as t2 on 
t1.l_shipdate = t2.l_shipdate and t1.l_partkey = t2.l_partkey;
cost 32 s
```

in fact we can filter blocks only by `l_shipdate `. But it's not expected.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14757)
<!-- Reviewable:end -->
