### PR TITLE
fix: force attachment to use EmptyFieldAs::FieldDefault.

### DIFF
--- a/tests/suites/1_stateful/07_stage_attachment/07_0003_insert_with_stage_file_format.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0003_insert_with_stage_file_format.result
@@ -1,16 +1,18 @@
 >>>> drop table if exists t1
->>>> create table t1 (a string, b string)
+>>>> create table t1 (a string, b string, c string, d string not null)
 >>>> drop stage if exists s1
 >>>> create stage s1
->>>> copy into @s1 from (select 'Null', 'NULL') file_format = (type = csv)
-1	14	14
+>>>> copy into @s1 from (select 'Null', 'NULL', '', '') file_format = (type = csv)
+1	20	20
 <<<<
 Succeeded
-14
-38
+20
+71
 null
->>>> select a is null, b is null from t1
-true	false
+>>>> list @s1
+<<<<
+>>>> select a is null, b is null, c, d from t1
+true	false	NULL	
 <<<<
 >>>> drop table if exists t1
 >>>> drop stage if exists s1

--- a/tests/suites/1_stateful/07_stage_attachment/07_0003_insert_with_stage_file_format.sh
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0003_insert_with_stage_file_format.sh
@@ -4,16 +4,18 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 stmt "drop table if exists t1"
-stmt "create table t1 (a string, b string)"
+stmt "create table t1 (a string, b string, c string, d string not null)"
 
 stmt "drop stage if exists s1"
 stmt "create stage s1"
 
-query "copy into @s1 from (select 'Null', 'NULL') file_format = (type = csv)"
+query "copy into @s1 from (select 'Null', 'NULL', '', '') file_format = (type = csv)"
 
-curl -s -u root: -XPOST "http://localhost:8000/v1/query" --header 'Content-Type: application/json' -d '{"sql": "insert into t1 (a, b) values", "stage_attachment": {"location": "@s1/", "copy_options": {"purge": "true"},  "file_format_options":{"Type": "csv","Binary_Format":"hex", "null_display": "Null"}}, "pagination": { "wait_time_secs": 8}}' | jq -r '.state, .stats.scan_progress.bytes, .stats.write_progress.bytes, .error'
+curl -s -u root: -XPOST "http://localhost:8000/v1/query" --header 'Content-Type: application/json' -d '{"sql": "insert into t1 (a, b, c, d) values", "stage_attachment": {"location": "@s1/", "copy_options": {"purge": "true"},  "file_format_options":{"Type": "csv","Binary_Format":"hex", "null_display": "Null"}}, "pagination": { "wait_time_secs": 8}}' | jq -r '.state, .stats.scan_progress.bytes, .stats.write_progress.bytes, .error'
 
-query "select a is null, b is null from t1"
+query "list @s1"
+
+query "select a is null, b is null, c, d from t1"
 
 stmt "drop table if exists t1"
 stmt "drop stage if exists s1"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


CSV attachment is mainly used in Drivers for insert.
 In the future, client should use EmptyFieldAs=STRING or FieldDefault to distinguish NULL and empty string.
However, old servers ds not support `missing_field_as`, so client can not add the option directly at now.
 So we will get empty_field_as = NULL, which will raise error if there is empty string for non-nullable string field.


remove this after 
1. the old server is no longer supported 
2. Driver add the option "EmptyFieldAs=FieldDefault"

related pr https://github.com/datafuselabs/databend/pull/14335

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14767)
<!-- Reviewable:end -->
