### PR TITLE
refactor: upgrade Openraft v0.9.0-alpha.5..v0.9.0-alpha.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8417,7 +8417,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.5#3f834771c42c4c9a18df25fde25cc5d71e7b09f8"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.6#22cd3bb423ddaf21c1f4d70917f689e79a9cacb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9295,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.5#3f834771c42c4c9a18df25fde25cc5d71e7b09f8"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.6#22cd3bb423ddaf21c1f4d70917f689e79a9cacb6"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ opendal = { version = "0.45.0", features = [
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 # openraft for debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.5", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.6", features = [
     "compat-07",
     "tracing-log",
     "loosen-follower-log-revert", # allows removing all data from a follower and restoring from the leader.

--- a/src/meta/service/src/network.rs
+++ b/src/meta/service/src/network.rs
@@ -27,6 +27,7 @@ use databend_common_base::future::TimingFutureExt;
 use databend_common_meta_sled_store::openraft;
 use databend_common_meta_sled_store::openraft::error::PayloadTooLarge;
 use databend_common_meta_sled_store::openraft::error::Unreachable;
+use databend_common_meta_sled_store::openraft::network::RPCOption;
 use databend_common_meta_sled_store::openraft::MessageSummary;
 use databend_common_meta_sled_store::openraft::RaftNetworkFactory;
 use databend_common_meta_types::protobuf::RaftRequest;
@@ -290,9 +291,10 @@ impl NetworkConnection {
 impl RaftNetwork<TypeConfig> for NetworkConnection {
     #[logcall::logcall(err = "debug")]
     #[minitrace::trace]
-    async fn send_append_entries(
+    async fn append_entries(
         &mut self,
         rpc: AppendEntriesRequest,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse, RPCError<RaftError>> {
         debug!(
             id = self.id,
@@ -328,9 +330,10 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
 
     #[logcall::logcall(err = "debug")]
     #[minitrace::trace]
-    async fn send_install_snapshot(
+    async fn install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse, RPCError<RaftError<InstallSnapshotError>>> {
         info!(
             id = self.id,
@@ -407,7 +410,11 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
 
     #[logcall::logcall(err = "debug")]
     #[minitrace::trace]
-    async fn send_vote(&mut self, rpc: VoteRequest) -> Result<VoteResponse, RPCError<RaftError>> {
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest,
+        _option: RPCOption,
+    ) -> Result<VoteResponse, RPCError<RaftError>> {
         info!(id = self.id, target = self.target, rpc = rpc.summary(); "send_vote");
 
         let mut client = self.make_client().await?;

--- a/src/meta/service/src/store/store.rs
+++ b/src/meta/service/src/store/store.rs
@@ -89,7 +89,7 @@ impl Deref for RaftStore {
 
 impl RaftLogReader<TypeConfig> for RaftStore {
     #[minitrace::trace]
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send>(
         &mut self,
         range: RB,
     ) -> Result<Vec<Entry>, StorageError> {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: upgrade Openraft v0.9.0-alpha.5..v0.9.0-alpha.6

### Change: remove deprecated RaftNetwork methods without `option` argument

### Refactor: try_get_log_entries() does not need Sync

### Refactor: if `storage-v2` enabled, deprecated `RaftStorage`

### Feature: feature flag `generic-snapshot-data`
Add feature flag `generic-snapshot-data`: when enabled, `SnapshotData`

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14769)
<!-- Reviewable:end -->
