### PR TITLE
fix(planner): use correct alias for column reference in select clause

### DIFF
--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use databend_common_ast::ast::ColumnFilter;
+use databend_common_ast::ast::ColumnID;
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::Indirection;
@@ -256,9 +257,18 @@ impl Binder {
                     let (bound_expr, _) = scalar_binder.bind(expr).await?;
 
                     // If alias is not specified, we will generate a name for the scalar expression.
-                    let expr_name = match alias {
-                        Some(alias) => normalize_identifier(alias, &self.name_resolution_ctx).name,
-                        None => {
+                    let expr_name = match (expr.as_ref(), alias) {
+                        (
+                            Expr::ColumnRef {
+                                column: ColumnID::Name(column),
+                                ..
+                            },
+                            None,
+                        ) => normalize_identifier(column, &self.name_resolution_ctx).name,
+                        (_, Some(alias)) => {
+                            normalize_identifier(alias, &self.name_resolution_ctx).name
+                        }
+                        _ => {
                             let mut expr = expr.clone();
                             let mut remove_quote_visitor = RemoveIdentifierQuote;
                             walk_expr_mut(&mut remove_quote_visitor, &mut expr);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix https://github.com/datafuselabs/databend/issues/14749


After fix:
```
root@localhost:8000/default> create table t("A" int, "a" int);

CREATE TABLE t("A" int, "a" int)

0 row written in 0.107 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)

root@localhost:8000/default> insert into t values(1, 1);

INSERT INTO
  t
VALUES
(1, 1)

1 row written in 0.142 sec. Processed 1 row, 10 B (7.04 row/s, 70 B/s)

root@localhost:8000/default> select "A", "a", "a" AS "B" from t;

SELECT
  "A",
  "a",
  "a" AS "B"
FROM
  t

┌─────────────────────────────────────────────────────┐
│        A        │        a        │        B        │
│ Nullable(Int32) │ Nullable(Int32) │ Nullable(Int32) │
├─────────────────┼─────────────────┼─────────────────┤
│               1 │               1 │               1 │
└─────────────────────────────────────────────────────┘
1 row read in 0.109 sec. Processed 1 row, 10 B (9.2 row/s, 92 B/s)

```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - We don't have the ability to test it now, see https://github.com/datafuselabs/databend/issues/14774

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
