### PR TITLE
refactor: add TenantUserIdent as meta-service key to access user data

### DIFF
--- a/src/meta/app/src/background/background_job.rs
+++ b/src/meta/app/src/background/background_job.rs
@@ -70,7 +70,7 @@ impl Display for BackgroundJobType {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct ManualTriggerParams {
     pub id: String,
     pub trigger: UserIdentity,

--- a/src/meta/app/src/principal/mod.rs
+++ b/src/meta/app/src/principal/mod.rs
@@ -56,6 +56,7 @@ pub use user_grant::GrantObject;
 pub use user_grant::OwnershipObject;
 pub use user_grant::TenantOwnershipObject;
 pub use user_grant::UserGrantSet;
+pub use user_identity::TenantUserIdent;
 pub use user_identity::UserIdentity;
 pub use user_info::UserInfo;
 pub use user_info::UserOption;

--- a/src/meta/app/src/principal/principal_identity.rs
+++ b/src/meta/app/src/principal/principal_identity.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 use crate::principal::UserIdentity;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PrincipalIdentity {
     User(UserIdentity),
     Role(String),

--- a/src/meta/app/src/principal/user_identity.rs
+++ b/src/meta/app/src/principal/user_identity.rs
@@ -14,23 +14,178 @@
 
 use std::fmt;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+use databend_common_meta_kvapi::kvapi;
+
+use crate::tenant::Tenant;
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub struct UserIdentity {
     pub username: String,
     pub hostname: String,
 }
 
 impl UserIdentity {
+    const ESCAPE_CHARS: [u8; 2] = [b'\'', b'@'];
+
     pub fn new(name: &str, host: &str) -> Self {
         Self {
             username: name.to_string(),
             hostname: host.to_string(),
         }
     }
+
+    /// Format into form `'username'@'hostname'`.
+    pub fn format(&self) -> String {
+        format!(
+            "'{}'@'{}'",
+            kvapi::KeyBuilder::escape_specified(&self.username, &Self::ESCAPE_CHARS),
+            kvapi::KeyBuilder::escape_specified(&self.hostname, &Self::ESCAPE_CHARS),
+        )
+    }
+
+    pub fn parse(s: &str) -> Result<Self, kvapi::KeyError> {
+        let parts = s.splitn(2, '@').collect::<Vec<&str>>();
+        if parts.len() != 2 {
+            return Err(kvapi::KeyError::WrongNumberOfSegments {
+                expect: 2,
+                got: s.to_string(),
+            });
+        }
+
+        // trim single quotes
+        let username =
+            kvapi::KeyParser::unescape_specified(parts[0].trim_matches('\''), &Self::ESCAPE_CHARS)?;
+        let hostname =
+            kvapi::KeyParser::unescape_specified(parts[1].trim_matches('\''), &Self::ESCAPE_CHARS)?;
+
+        Ok(UserIdentity { username, hostname })
+    }
 }
 
 impl fmt::Display for UserIdentity {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::result::Result<(), fmt::Error> {
         write!(f, "'{}'@'{}'", self.username, self.hostname)
+    }
+}
+
+/// A user identity belonging to a tenant.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct TenantUserIdent {
+    pub tenant: Tenant,
+    pub user: UserIdentity,
+}
+
+impl TenantUserIdent {
+    pub fn new(tenant: Tenant, user: UserIdentity) -> Self {
+        Self { tenant, user }
+    }
+
+    pub fn new_user_host(tenant: Tenant, user: &str, host: &str) -> Self {
+        Self {
+            tenant,
+            user: UserIdentity::new(user, host),
+        }
+    }
+}
+
+mod kvapi_key_impl {
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+
+    use crate::principal::user_identity::TenantUserIdent;
+    use crate::principal::UserIdentity;
+    use crate::principal::UserInfo;
+    use crate::tenant::Tenant;
+    use crate::KeyWithTenant;
+
+    impl kvapi::Key for TenantUserIdent {
+        const PREFIX: &'static str = "__fd_users";
+        type ValueType = UserInfo;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
+        }
+
+        fn to_string_key(&self) -> String {
+            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
+                .push_str(self.tenant_name())
+                .push_str(&self.user.format())
+                .done()
+        }
+
+        fn from_str_key(s: &str) -> Result<Self, KeyError> {
+            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+            let tenant = p.next_nonempty()?;
+            let user_str = p.next_str()?;
+            p.done()?;
+
+            let user = UserIdentity::parse(&user_str)?;
+            Ok(TenantUserIdent {
+                tenant: Tenant::new_nonempty(tenant),
+                user,
+            })
+        }
+    }
+
+    impl KeyWithTenant for TenantUserIdent {
+        fn tenant(&self) -> &Tenant {
+            &self.tenant
+        }
+    }
+
+    impl kvapi::Value for UserInfo {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::principal::user_identity::TenantUserIdent;
+    use crate::principal::UserIdentity;
+    use crate::tenant::Tenant;
+
+    fn test_format_parse(user: &str, host: &str, expect: &str) {
+        let tenant = Tenant::new("test_tenant");
+        let user_ident = UserIdentity::new(user, host);
+        let tenant_user_ident = TenantUserIdent {
+            tenant,
+            user: user_ident,
+        };
+
+        let key = tenant_user_ident.to_string_key();
+        assert_eq!(key, expect, "'{user}' '{host}' '{expect}'");
+
+        let tenant_user_ident_parsed = TenantUserIdent::from_str_key(&key).unwrap();
+        assert_eq!(
+            tenant_user_ident, tenant_user_ident_parsed,
+            "'{user}' '{host}' '{expect}'"
+        );
+    }
+
+    #[test]
+    fn test_tenant_user_ident_as_kvapi_key() {
+        test_format_parse("user", "%", "__fd_users/test_tenant/%27user%27%40%27%25%27");
+        test_format_parse(
+            "user'",
+            "%",
+            "__fd_users/test_tenant/%27user%2527%27%40%27%25%27",
+        );
+
+        // With correct encoding the following two pair should not be encoded into the same string.
+
+        test_format_parse(
+            "u'@'h",
+            "h",
+            "__fd_users/test_tenant/%27u%2527%2540%2527h%27%40%27h%27",
+        );
+        test_format_parse(
+            "u",
+            "h'@'h",
+            "__fd_users/test_tenant/%27u%27%40%27h%2527%2540%2527h%27",
+        );
     }
 }

--- a/src/meta/kvapi/src/kvapi/key_builder.rs
+++ b/src/meta/kvapi/src/kvapi/key_builder.rs
@@ -15,6 +15,7 @@
 //! A helper for building a string key from a structured key
 
 use crate::kvapi::helper::escape;
+use crate::kvapi::helper::escape_specified;
 
 pub struct KeyBuilder {
     buf: Vec<u8>,
@@ -51,6 +52,16 @@ impl KeyBuilder {
 
     pub fn done(self) -> String {
         String::from_utf8(self.buf).unwrap()
+    }
+
+    /// Re-export escape()
+    pub fn escape(s: &str) -> String {
+        escape(s)
+    }
+
+    /// Re-export escape_specified()
+    pub fn escape_specified(s: &str, chars: &[u8]) -> String {
+        escape_specified(s, chars)
     }
 }
 

--- a/src/meta/kvapi/src/kvapi/key_parser.rs
+++ b/src/meta/kvapi/src/kvapi/key_parser.rs
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 use std::str::Split;
+use std::string::FromUtf8Error;
 
 use databend_common_meta_types::NonEmptyString;
 
 use crate::kvapi::helper::decode_id;
 use crate::kvapi::helper::unescape;
+use crate::kvapi::helper::unescape_specified;
 use crate::kvapi::KeyError;
 
 /// A helper for parsing a string key into structured key.
@@ -138,6 +140,16 @@ impl<'s> KeyParser<'s> {
             });
         }
         Ok(())
+    }
+
+    /// Re-export unescape()
+    pub fn unescape(s: &str) -> Result<String, FromUtf8Error> {
+        unescape(s)
+    }
+
+    /// Re-export unescape()
+    pub fn unescape_specified(s: &str, chars: &[u8]) -> Result<String, FromUtf8Error> {
+        unescape_specified(s, chars)
     }
 }
 

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -347,7 +347,7 @@ mod get_users {
         let (res, user_infos) = prepare()?;
         let mut kv = MockKV::new();
         {
-            let k = "__fd_users/tenant1";
+            let k = "__fd_users/tenant1/";
             kv.expect_prefix_list_kv()
                 .with(predicate::eq(k))
                 .times(1)
@@ -376,7 +376,7 @@ mod get_users {
 
         let mut kv = MockKV::new();
         {
-            let k = "__fd_users/tenant1";
+            let k = "__fd_users/tenant1/";
             kv.expect_prefix_list_kv()
                 .with(predicate::eq(k))
                 .times(1)


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add TenantUserIdent as meta-service key to access user data

The encoding is refined to prevent two records are encoeded into the
same key. Before this commit: `user="u", host="h'@'h"` and
`user="u'@'h", host="h"` will both be encoded into `"u'@'h'@'h"`.

To address this issue, the special chars `@` and `'` in `user` and
`host` are escaped before encoding the key.

Other changes:

- Add `kvapi::KeyBuilder::escape_specified()` and
  `kvapi::KeyParser::unescape_specified()` to escape and unescape
  specified chars.

---

- Fix: #14792

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14793)
<!-- Reviewable:end -->
