### PR TITLE
chore(query): modify new_agg_hashtable payload transmission method on singleton and support new_agg_hashtable on cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,6 +2710,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simdutf8",
+ "strength_reduce",
  "terminal_size",
  "tonic 0.10.2",
  "typetag",

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -58,6 +58,7 @@ terminal_size = "0.2.6"
 tonic = { workspace = true }
 typetag = { workspace = true }
 unicode-segmentation = "1.10.1"
+strength_reduce = "0.2.4"
 
 [dev-dependencies]
 arrow-ord = { workspace = true }

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -54,11 +54,11 @@ rust_decimal = "1.26"
 serde = { workspace = true }
 serde_json = { workspace = true }
 simdutf8 = "0.1.4"
+strength_reduce = "0.2.4"
 terminal_size = "0.2.6"
 tonic = { workspace = true }
 typetag = { workspace = true }
 unicode-segmentation = "1.10.1"
-strength_reduce = "0.2.4"
 
 [dev-dependencies]
 arrow-ord = { workspace = true }

--- a/src/query/expression/src/aggregate/payload.rs
+++ b/src/query/expression/src/aggregate/payload.rs
@@ -38,6 +38,7 @@ use crate::MAX_PAGE_SIZE;
 // [STATE_ADDRS] is the state_addrs of the aggregate functions, 8 bytes each
 pub struct Payload {
     pub arena: Arc<Bump>,
+    pub arenas: Vec<Arc<Bump>>,
     // if true, the states are moved out of the payload into other payload, and will not be dropped
     pub state_move_out: bool,
     pub group_types: Vec<DataType>,
@@ -120,7 +121,8 @@ impl Payload {
         let row_per_page = (u16::MAX as usize).min(MAX_PAGE_SIZE / tuple_size).max(1);
 
         Self {
-            arena,
+            arena: arena.clone(),
+            arenas: vec![arena],
             state_move_out: false,
             pages: vec![],
             current_write_page: 0,

--- a/src/query/service/src/pipelines/builders/builder_aggregate.rs
+++ b/src/query/service/src/pipelines/builders/builder_aggregate.rs
@@ -104,8 +104,7 @@ impl PipelineBuilder {
 
         let enable_experimental_aggregate_hashtable = self
             .settings
-            .get_enable_experimental_aggregate_hashtable()?
-            && self.ctx.get_cluster().is_empty();
+            .get_enable_experimental_aggregate_hashtable()?;
 
         let params = Self::build_aggregator_params(
             aggregate.input.output_schema()?,
@@ -213,8 +212,7 @@ impl PipelineBuilder {
         let max_block_size = self.settings.get_max_block_size()?;
         let enable_experimental_aggregate_hashtable = self
             .settings
-            .get_enable_experimental_aggregate_hashtable()?
-            && self.ctx.get_cluster().is_empty();
+            .get_enable_experimental_aggregate_hashtable()?;
 
         let params = Self::build_aggregator_params(
             aggregate.before_group_by_schema.clone(),

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_injector.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_injector.rs
@@ -78,6 +78,7 @@ impl<Method: HashMethodBounds, V: Send + Sync + 'static> ExchangeSorting
                         AggregateMeta::Serialized(v) => Ok(v.bucket),
                         AggregateMeta::HashTable(v) => Ok(v.bucket),
                         AggregateMeta::AggregateHashTable(_) => unreachable!(),
+                        AggregateMeta::AggregatePayload(_) => unreachable!(),
                         AggregateMeta::Spilled(_)
                         | AggregateMeta::Spilling(_)
                         | AggregateMeta::BucketSpilled(_) => Ok(-1),
@@ -178,6 +179,7 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static> FlightScatter
                     }
 
                     AggregateMeta::AggregateHashTable(_) => todo!("AGG_HASHTABLE"),
+                    AggregateMeta::AggregatePayload(_) => todo!("AGG_HASHTABLE"),
                 };
 
                 return Ok(blocks);

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
@@ -35,6 +35,8 @@ pub struct HashTablePayload<T: HashMethodBounds, V: Send + Sync + 'static> {
 pub struct SerializedPayload {
     pub bucket: isize,
     pub data_block: DataBlock,
+    // use for new agg_hashtable
+    pub max_partition_count: usize,
 }
 
 impl SerializedPayload {
@@ -95,10 +97,15 @@ impl<Method: HashMethodBounds, V: Send + Sync + 'static> AggregateMeta<Method, V
         ))
     }
 
-    pub fn create_serialized(bucket: isize, block: DataBlock) -> BlockMetaInfoPtr {
+    pub fn create_serialized(
+        bucket: isize,
+        block: DataBlock,
+        max_partition_count: usize,
+    ) -> BlockMetaInfoPtr {
         Box::new(AggregateMeta::<Method, V>::Serialized(SerializedPayload {
             bucket,
             data_block: block,
+            max_partition_count,
         }))
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/serde_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/serde_meta.rs
@@ -29,6 +29,9 @@ pub struct AggregateSerdeMeta {
     pub location: Option<String>,
     pub data_range: Option<Range<u64>>,
     pub columns_layout: Vec<usize>,
+    // use for new agg_hashtable
+    pub is_agg_payload: bool,
+    pub max_partition_count: usize,
 }
 
 impl AggregateSerdeMeta {
@@ -39,6 +42,20 @@ impl AggregateSerdeMeta {
             location: None,
             data_range: None,
             columns_layout: vec![],
+            is_agg_payload: false,
+            max_partition_count: 0,
+        })
+    }
+
+    pub fn create_agg_payload(bucket: isize, max_partition_count: usize) -> BlockMetaInfoPtr {
+        Box::new(AggregateSerdeMeta {
+            typ: BUCKET_TYPE,
+            bucket,
+            location: None,
+            data_range: None,
+            columns_layout: vec![],
+            is_agg_payload: true,
+            max_partition_count,
         })
     }
 
@@ -54,6 +71,8 @@ impl AggregateSerdeMeta {
             columns_layout,
             location: Some(location),
             data_range: Some(data_range),
+            is_agg_payload: false,
+            max_partition_count: 0,
         })
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_aggregate_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_aggregate_serializer.rs
@@ -146,6 +146,7 @@ impl<Method: HashMethodBounds> TransformAggregateSerializer<Method> {
                         return Ok(Event::Sync);
                     }
                     AggregateMeta::AggregateHashTable(_) => todo!("AGG_HASHTABLE"),
+                    AggregateMeta::AggregatePayload(_) => todo!("AGG_HASHTABLE"),
                 }
             }
         }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_aggregate_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_aggregate_serializer.rs
@@ -22,6 +22,7 @@ use databend_common_expression::types::binary::BinaryColumnBuilder;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
+use databend_common_expression::PayloadFlushState;
 use databend_common_functions::aggregates::StateAddr;
 use databend_common_hashtable::HashtableEntryRefLike;
 use databend_common_hashtable::HashtableLike;
@@ -31,15 +32,15 @@ use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::Processor;
 use databend_common_pipeline_core::processors::ProcessorPtr;
 
+use super::SerializePayload;
 use crate::pipelines::processors::transforms::aggregator::create_state_serializer;
+use crate::pipelines::processors::transforms::aggregator::empty_block;
 use crate::pipelines::processors::transforms::aggregator::estimated_key_size;
 use crate::pipelines::processors::transforms::aggregator::AggregateMeta;
 use crate::pipelines::processors::transforms::aggregator::AggregateSerdeMeta;
 use crate::pipelines::processors::transforms::aggregator::AggregatorParams;
-use crate::pipelines::processors::transforms::aggregator::HashTablePayload;
 use crate::pipelines::processors::transforms::group_by::HashMethodBounds;
 use crate::pipelines::processors::transforms::group_by::KeysColumnBuilder;
-
 pub struct TransformAggregateSerializer<Method: HashMethodBounds> {
     method: Method,
     params: Arc<AggregatorParams>,
@@ -137,16 +138,23 @@ impl<Method: HashMethodBounds> TransformAggregateSerializer<Method> {
                     AggregateMeta::Serialized(_) => unreachable!(),
                     AggregateMeta::BucketSpilled(_) => unreachable!(),
                     AggregateMeta::Partitioned { .. } => unreachable!(),
+                    AggregateMeta::AggregateHashTable(_) => unreachable!(),
                     AggregateMeta::HashTable(payload) => {
                         self.input_data = Some(SerializeAggregateStream::create(
                             &self.method,
                             &self.params,
-                            payload,
+                            SerializePayload::<Method, usize>::HashTablePayload(payload),
                         ));
                         return Ok(Event::Sync);
                     }
-                    AggregateMeta::AggregateHashTable(_) => todo!("AGG_HASHTABLE"),
-                    AggregateMeta::AggregatePayload(_) => todo!("AGG_HASHTABLE"),
+                    AggregateMeta::AggregatePayload(p) => {
+                        self.input_data = Some(SerializeAggregateStream::create(
+                            &self.method,
+                            &self.params,
+                            SerializePayload::<Method, usize>::AggregatePayload(p),
+                        ));
+                        return Ok(Event::Sync);
+                    }
                 }
             }
         }
@@ -199,8 +207,9 @@ pub fn serialize_aggregate<Method: HashMethodBounds>(
 pub struct SerializeAggregateStream<Method: HashMethodBounds> {
     method: Method,
     params: Arc<AggregatorParams>,
-    pub payload: Pin<Box<HashTablePayload<Method, usize>>>,
-    iter: <Method::HashTable<usize> as HashtableLike>::Iterator<'static>,
+    pub payload: Pin<Box<SerializePayload<Method, usize>>>,
+    // old hashtable' iter
+    iter: Option<<Method::HashTable<usize> as HashtableLike>::Iterator<'static>>,
     end_iter: bool,
 }
 
@@ -212,13 +221,16 @@ impl<Method: HashMethodBounds> SerializeAggregateStream<Method> {
     pub fn create(
         method: &Method,
         params: &Arc<AggregatorParams>,
-        payload: HashTablePayload<Method, usize>,
+        payload: SerializePayload<Method, usize>,
     ) -> Self {
         unsafe {
             let payload = Box::pin(payload);
 
-            let point = NonNull::from(&payload.cell.hashtable);
-            let iter = point.as_ref().iter();
+            let iter = if let SerializePayload::HashTablePayload(p) = payload.as_ref().get_ref() {
+                Some(NonNull::from(&p.cell.hashtable).as_ref().iter())
+            } else {
+                None
+            };
 
             SerializeAggregateStream::<Method> {
                 iter,
@@ -245,49 +257,71 @@ impl<Method: HashMethodBounds> SerializeAggregateStream<Method> {
             return Ok(None);
         }
 
-        let max_block_rows = std::cmp::min(8192, self.payload.cell.hashtable.len());
-        let max_block_bytes = std::cmp::min(
-            8 * 1024 * 1024 + 1024,
-            self.payload
-                .cell
-                .hashtable
-                .unsize_key_size()
-                .unwrap_or(usize::MAX),
-        );
+        match self.payload.as_ref().get_ref() {
+            SerializePayload::HashTablePayload(p) => {
+                let max_block_rows = std::cmp::min(8192, p.cell.hashtable.len());
+                let max_block_bytes = std::cmp::min(
+                    8 * 1024 * 1024 + 1024,
+                    p.cell.hashtable.unsize_key_size().unwrap_or(usize::MAX),
+                );
 
-        let funcs = &self.params.aggregate_functions;
-        let offsets_aggregate_states = &self.params.offsets_aggregate_states;
+                let funcs = &self.params.aggregate_functions;
+                let offsets_aggregate_states = &self.params.offsets_aggregate_states;
 
-        let mut state_builders: Vec<BinaryColumnBuilder> = funcs
-            .iter()
-            .map(|func| create_state_serializer(func, max_block_rows))
-            .collect();
+                let mut state_builders: Vec<BinaryColumnBuilder> = funcs
+                    .iter()
+                    .map(|func| create_state_serializer(func, max_block_rows))
+                    .collect();
 
-        let mut group_key_builder = self
-            .method
-            .keys_column_builder(max_block_rows, max_block_bytes);
+                let mut group_key_builder = self
+                    .method
+                    .keys_column_builder(max_block_rows, max_block_bytes);
 
-        #[allow(clippy::while_let_on_iterator)]
-        while let Some(group_entity) = self.iter.next() {
-            let mut bytes = 0;
-            let place = Into::<StateAddr>::into(*group_entity.get());
+                #[allow(clippy::while_let_on_iterator)]
+                while let Some(group_entity) = self.iter.as_mut().and_then(|iter| iter.next()) {
+                    let mut bytes = 0;
+                    let place = Into::<StateAddr>::into(*group_entity.get());
 
-            for (idx, func) in funcs.iter().enumerate() {
-                let arg_place = place.next(offsets_aggregate_states[idx]);
-                func.serialize(arg_place, &mut state_builders[idx].data)?;
-                state_builders[idx].commit_row();
-                bytes += state_builders[idx].memory_size();
+                    for (idx, func) in funcs.iter().enumerate() {
+                        let arg_place = place.next(offsets_aggregate_states[idx]);
+                        func.serialize(arg_place, &mut state_builders[idx].data)?;
+                        state_builders[idx].commit_row();
+                        bytes += state_builders[idx].memory_size();
+                    }
+
+                    group_key_builder.append_value(group_entity.key());
+
+                    if bytes >= 8 * 1024 * 1024 {
+                        return self.finish(state_builders, group_key_builder);
+                    }
+                }
+
+                self.end_iter = true;
+                self.finish(state_builders, group_key_builder)
             }
+            SerializePayload::AggregatePayload(p) => {
+                let mut state = PayloadFlushState::default();
+                let mut blocks = vec![];
 
-            group_key_builder.append_value(group_entity.key());
+                while p.payload.flush(&mut state) {
+                    let mut cols = state.take_aggregate_results();
+                    cols.extend_from_slice(&state.take_group_columns());
 
-            if bytes >= 8 * 1024 * 1024 {
-                return self.finish(state_builders, group_key_builder);
+                    blocks.push(DataBlock::new_from_columns(cols));
+                }
+
+                self.end_iter = true;
+
+                let data_block = if blocks.is_empty() {
+                    empty_block(p)
+                } else {
+                    DataBlock::concat(&blocks).unwrap()
+                };
+                Ok(Some(data_block.add_meta(Some(
+                    AggregateSerdeMeta::create_agg_payload(p.bucket, p.max_partition_count),
+                ))?))
             }
         }
-
-        self.end_iter = true;
-        self.finish(state_builders, group_key_builder)
     }
 
     fn finish(
@@ -301,7 +335,12 @@ impl<Method: HashMethodBounds> SerializeAggregateStream<Method> {
             columns.push(Column::Binary(builder.build()));
         }
 
-        let bucket = self.payload.bucket;
+        let bucket = if let SerializePayload::HashTablePayload(p) = self.payload.as_ref().get_ref()
+        {
+            p.bucket
+        } else {
+            0
+        };
         columns.push(group_key_builder.finish());
         let block = DataBlock::new_from_columns(columns);
         Ok(Some(

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_deserializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_deserializer.rs
@@ -118,6 +118,7 @@ impl<Method: HashMethodBounds, V: Send + Sync + 'static> TransformDeserializer<M
                                     schema,
                                     &self.schema,
                                 )?,
+                                meta.max_partition_count,
                             ),
                         )),
                         false => {

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
@@ -177,6 +177,7 @@ impl<Method: HashMethodBounds> BlockMetaTransform<ExchangeShuffleMeta>
                 }
 
                 Some(AggregateMeta::AggregateHashTable(_)) => todo!("AGG_HASHTABLE"),
+                Some(AggregateMeta::AggregatePayload(_)) => todo!("AGG_HASHTABLE"),
             };
         }
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
@@ -48,6 +48,7 @@ use futures_util::future::BoxFuture;
 use log::info;
 use opendal::Operator;
 
+use super::SerializePayload;
 use crate::api::serialize_block;
 use crate::api::ExchangeShuffleMeta;
 use crate::pipelines::processors::transforms::aggregator::aggregate_meta::AggregateMeta;
@@ -134,6 +135,7 @@ impl<Method: HashMethodBounds> BlockMetaTransform<ExchangeShuffleMeta>
                 Some(AggregateMeta::Serialized(_)) => unreachable!(),
                 Some(AggregateMeta::BucketSpilled(_)) => unreachable!(),
                 Some(AggregateMeta::Partitioned { .. }) => unreachable!(),
+                Some(AggregateMeta::AggregateHashTable(_)) => unreachable!(),
                 Some(AggregateMeta::Spilling(payload)) => {
                     serialized_blocks.push(FlightSerialized::Future(
                         match index == self.local_pos {
@@ -156,7 +158,6 @@ impl<Method: HashMethodBounds> BlockMetaTransform<ExchangeShuffleMeta>
                         },
                     ));
                 }
-
                 Some(AggregateMeta::HashTable(payload)) => {
                     if index == self.local_pos {
                         serialized_blocks.push(FlightSerialized::DataBlock(block.add_meta(
@@ -165,9 +166,12 @@ impl<Method: HashMethodBounds> BlockMetaTransform<ExchangeShuffleMeta>
                         continue;
                     }
 
-                    let mut stream =
-                        SerializeAggregateStream::create(&self.method, &self.params, payload);
-                    let bucket = stream.payload.bucket;
+                    let bucket = payload.bucket;
+                    let mut stream = SerializeAggregateStream::create(
+                        &self.method,
+                        &self.params,
+                        SerializePayload::<Method, usize>::HashTablePayload(payload),
+                    );
                     serialized_blocks.push(FlightSerialized::DataBlock(match stream.next() {
                         None => DataBlock::empty(),
                         Some(data_block) => {
@@ -175,9 +179,29 @@ impl<Method: HashMethodBounds> BlockMetaTransform<ExchangeShuffleMeta>
                         }
                     }));
                 }
+                Some(AggregateMeta::AggregatePayload(p)) => {
+                    if index == self.local_pos {
+                        serialized_blocks.push(FlightSerialized::DataBlock(block.add_meta(
+                            Some(Box::new(AggregateMeta::<Method, usize>::AggregatePayload(
+                                p,
+                            ))),
+                        )?));
+                        continue;
+                    }
 
-                Some(AggregateMeta::AggregateHashTable(_)) => todo!("AGG_HASHTABLE"),
-                Some(AggregateMeta::AggregatePayload(_)) => todo!("AGG_HASHTABLE"),
+                    let bucket = p.bucket;
+                    let mut stream = SerializeAggregateStream::create(
+                        &self.method,
+                        &self.params,
+                        SerializePayload::<Method, usize>::AggregatePayload(p),
+                    );
+                    serialized_blocks.push(FlightSerialized::DataBlock(match stream.next() {
+                        None => DataBlock::empty(),
+                        Some(data_block) => {
+                            serialize_block(bucket, data_block?, &self.ipc_fields, &self.options)?
+                        }
+                    }));
+                }
             };
         }
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_group_by_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_group_by_serializer.rs
@@ -208,6 +208,7 @@ impl<Method: HashMethodBounds> BlockMetaTransform<ExchangeShuffleMeta>
                     ));
                 }
                 Some(AggregateMeta::AggregateHashTable(_)) => todo!("AGG_HASHTABLE"),
+                Some(AggregateMeta::AggregatePayload(_)) => todo!("AGG_HASHTABLE"),
                 Some(AggregateMeta::HashTable(payload)) => {
                     if index == self.local_pos {
                         serialized_blocks.push(FlightSerialized::DataBlock(block.add_meta(

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_group_by_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_group_by_serializer.rs
@@ -127,6 +127,7 @@ impl<Method: HashMethodBounds> TransformGroupBySerializer<Method> {
                     AggregateMeta::BucketSpilled(_) => unreachable!(),
                     AggregateMeta::Partitioned { .. } => unreachable!(),
                     AggregateMeta::AggregateHashTable(_) => todo!("AGG_HASHTABLE"),
+                    AggregateMeta::AggregatePayload(_) => todo!("AGG_HASHTABLE"),
                     AggregateMeta::HashTable(payload) => {
                         self.input_data =
                             Some(SerializeGroupByStream::create(&self.method, payload));

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_spill_reader.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_spill_reader.rs
@@ -300,6 +300,7 @@ impl<Method: HashMethodBounds, V: Send + Sync + 'static> TransformSpillReader<Me
         AggregateMeta::<Method, V>::Serialized(SerializedPayload {
             bucket: payload.bucket,
             data_block: DataBlock::new_from_columns(columns),
+            max_partition_count: 0,
         })
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_spill_reader.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_spill_reader.rs
@@ -137,6 +137,7 @@ impl<Method: HashMethodBounds, V: Send + Sync + 'static> Processor
                 AggregateMeta::Spilled(_) => unreachable!(),
                 AggregateMeta::Spilling(_) => unreachable!(),
                 AggregateMeta::AggregateHashTable(_) => unreachable!(),
+                AggregateMeta::AggregatePayload(_) => unreachable!(),
                 AggregateMeta::HashTable(_) => unreachable!(),
                 AggregateMeta::Serialized(_) => unreachable!(),
                 AggregateMeta::BucketSpilled(payload) => {
@@ -179,6 +180,7 @@ impl<Method: HashMethodBounds, V: Send + Sync + 'static> Processor
                 AggregateMeta::Spilling(_) => unreachable!(),
                 AggregateMeta::HashTable(_) => unreachable!(),
                 AggregateMeta::AggregateHashTable(_) => unreachable!(),
+                AggregateMeta::AggregatePayload(_) => unreachable!(),
                 AggregateMeta::Serialized(_) => unreachable!(),
                 AggregateMeta::BucketSpilled(payload) => {
                     let instant = Instant::now();

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -240,6 +240,7 @@ where Method: HashMethodBounds
                         }
                     },
                     AggregateMeta::AggregateHashTable(_) => unreachable!(),
+                    AggregateMeta::AggregatePayload(_) => unreachable!(),
                 }
             }
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_final.rs
@@ -161,6 +161,7 @@ where Method: HashMethodBounds
                         }
                     },
                     AggregateMeta::AggregateHashTable(_) => unreachable!(),
+                    AggregateMeta::AggregatePayload(_) => unreachable!(),
                 }
             }
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_partial.rs
@@ -264,9 +264,22 @@ impl<Method: HashMethodBounds> AccumulatingTransform for TransformPartialGroupBy
 
                 blocks
             }
-            HashTable::AggregateHashTable(hashtable) => vec![DataBlock::empty_with_meta(
-                AggregateMeta::<Method, ()>::create_agg_hashtable(hashtable.payload),
-            )],
+            HashTable::AggregateHashTable(hashtable) => {
+                let partition_count = hashtable.payload.partition_count();
+                let mut blocks = Vec::with_capacity(partition_count);
+                for (bucket, mut payload) in hashtable.payload.payloads.into_iter().enumerate() {
+                    payload.arenas.extend_from_slice(&hashtable.payload.arenas);
+                    blocks.push(DataBlock::empty_with_meta(
+                        AggregateMeta::<Method, ()>::create_agg_payload(
+                            bucket as isize,
+                            payload,
+                            partition_count,
+                        ),
+                    ));
+                }
+
+                blocks
+            }
         })
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
@@ -36,8 +36,8 @@ use databend_common_pipeline_core::Pipe;
 use databend_common_pipeline_core::PipeItem;
 use databend_common_pipeline_core::Pipeline;
 use databend_common_storage::DataOperator;
-use itertools::Itertools;
 
+use super::AggregatePayload;
 use crate::pipelines::processors::transforms::aggregator::aggregate_meta::AggregateMeta;
 use crate::pipelines::processors::transforms::aggregator::aggregate_meta::HashTablePayload;
 use crate::pipelines::processors::transforms::aggregator::aggregate_meta::SerializedPayload;
@@ -68,9 +68,10 @@ pub struct TransformPartitionBucket<Method: HashMethodBounds, V: Copy + Send + S
     initialized_all_inputs: bool,
     buckets_blocks: BTreeMap<isize, Vec<DataBlock>>,
     flush_state: PayloadFlushState,
-    partition_payloads: Vec<PartitionedPayload>,
+    agg_payloads: Vec<AggregatePayload>,
     unsplitted_blocks: Vec<DataBlock>,
     max_partition_count: usize,
+    current_partition_count: usize,
     _phantom: PhantomData<V>,
 }
 
@@ -97,9 +98,10 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
             buckets_blocks: BTreeMap::new(),
             unsplitted_blocks: vec![],
             flush_state: PayloadFlushState::default(),
-            partition_payloads: vec![],
+            agg_payloads: vec![],
             initialized_all_inputs: false,
             max_partition_count: 0,
+            current_partition_count: 0,
             _phantom: Default::default(),
         })
     }
@@ -127,7 +129,8 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
             }
 
             // We pull the first unsplitted data block
-            if self.inputs[index].bucket > SINGLE_LEVEL_BUCKET_NUM {
+            if self.inputs[index].bucket > SINGLE_LEVEL_BUCKET_NUM && self.max_partition_count == 0
+            {
                 continue;
             }
 
@@ -140,7 +143,10 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
             let data_block = self.inputs[index].port.pull_data().unwrap()?;
             self.inputs[index].bucket = self.add_bucket(data_block);
 
-            if self.inputs[index].bucket <= SINGLE_LEVEL_BUCKET_NUM {
+            if self.inputs[index].bucket <= SINGLE_LEVEL_BUCKET_NUM
+                || (self.max_partition_count > 0
+                    && self.inputs[index].bucket < self.current_partition_count as isize - 1)
+            {
                 self.inputs[index].port.set_need_data();
                 self.initialized_all_inputs = false;
             }
@@ -190,11 +196,12 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
 
                         unreachable!()
                     }
-                    AggregateMeta::AggregateHashTable(p) => {
+                    AggregateMeta::AggregateHashTable(_) => unreachable!(),
+                    AggregateMeta::AggregatePayload(p) => {
                         self.max_partition_count =
-                            self.max_partition_count.max(p.partition_count());
-
-                        (0, 0)
+                            self.max_partition_count.max(p.max_partition_count);
+                        self.current_partition_count = p.max_partition_count;
+                        (p.bucket, p.bucket)
                     }
                 };
 
@@ -215,10 +222,12 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
 
         if self.max_partition_count > 0 {
             let meta = data_block.take_meta().unwrap();
-            if let Some(AggregateMeta::AggregateHashTable(p)) =
+            if let Some(AggregateMeta::AggregatePayload(p)) =
                 AggregateMeta::<Method, V>::downcast_from(meta)
             {
-                self.partition_payloads.push(p);
+                let res = p.bucket;
+                self.agg_payloads.push(p);
+                return res;
             }
             return 0;
         }
@@ -349,7 +358,7 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static> Processor
             return Ok(Event::NeedData);
         }
 
-        if self.partition_payloads.len() == self.inputs.len()
+        if !self.agg_payloads.is_empty()
             || (!self.buckets_blocks.is_empty() && !self.unsplitted_blocks.is_empty())
         {
             // Split data blocks if it's unsplitted.
@@ -423,50 +432,42 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static> Processor
     }
 
     fn process(&mut self) -> Result<()> {
-        if !self.partition_payloads.is_empty() {
-            let mut payloads = Vec::with_capacity(self.partition_payloads.len());
+        if !self.agg_payloads.is_empty() {
+            let group_types = self.agg_payloads[0].payload.group_types.clone();
+            let aggrs = self.agg_payloads[0].payload.aggrs.clone();
 
-            for p in self.partition_payloads.drain(0..) {
-                if p.partition_count() != self.max_partition_count {
-                    let p = p.repartition(self.max_partition_count, &mut self.flush_state);
-                    payloads.push(p);
+            let mut partitioned_payload = PartitionedPayload::new(
+                group_types.clone(),
+                aggrs.clone(),
+                self.max_partition_count as u64,
+            );
+
+            for agg_payload in self.agg_payloads.drain(0..) {
+                partitioned_payload
+                    .arenas
+                    .extend_from_slice(&agg_payload.payload.arenas);
+                if agg_payload.max_partition_count != self.max_partition_count {
+                    debug_assert!(agg_payload.max_partition_count < self.max_partition_count);
+                    partitioned_payload.combine_single(agg_payload.payload, &mut self.flush_state);
                 } else {
-                    payloads.push(p);
-                };
+                    partitioned_payload.payloads[agg_payload.bucket as usize]
+                        .combine(agg_payload.payload);
+                }
             }
 
-            let group_types = payloads[0].group_types.clone();
-            let aggrs = payloads[0].aggrs.clone();
+            for (bucket, payload) in partitioned_payload.payloads.into_iter().enumerate() {
+                let mut part = PartitionedPayload::new(group_types.clone(), aggrs.clone(), 1);
+                part.arenas.extend_from_slice(&partitioned_payload.arenas);
+                part.combine_single(payload, &mut self.flush_state);
 
-            let mut payload_map = (0..self.max_partition_count).map(|_| vec![]).collect_vec();
-
-            // All arenas should be kept in the bucket partition payload
-            let mut arenas = vec![];
-
-            for mut payload in payloads.into_iter() {
-                for (bucket, p) in payload.payloads.into_iter().enumerate() {
-                    payload_map[bucket].push(p);
-                }
-                arenas.append(&mut payload.arenas);
-            }
-
-            for (bucket, mut payloads) in payload_map.into_iter().enumerate() {
-                let mut partition_payload =
-                    PartitionedPayload::new(group_types.clone(), aggrs.clone(), 1);
-
-                for payload in payloads.drain(0..) {
-                    partition_payload.combine_single(payload, &mut self.flush_state);
-                }
-
-                partition_payload.arenas.extend_from_slice(&arenas);
-
-                if partition_payload.len() != 0 {
+                if part.len() != 0 {
                     self.buckets_blocks
                         .insert(bucket as isize, vec![DataBlock::empty_with_meta(
-                            AggregateMeta::<Method, V>::create_agg_hashtable(partition_payload),
+                            AggregateMeta::<Method, V>::create_agg_hashtable(part),
                         )]);
                 }
             }
+
             return Ok(());
         }
 
@@ -489,6 +490,7 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static> Processor
                     AggregateMeta::Serialized(payload) => self.partition_block(payload)?,
                     AggregateMeta::HashTable(payload) => self.partition_hashtable(payload)?,
                     AggregateMeta::AggregateHashTable(_) => unreachable!(),
+                    AggregateMeta::AggregatePayload(_) => unreachable!(),
                 };
 
                 for (bucket, block) in data_blocks.into_iter().enumerate() {

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
@@ -432,7 +432,9 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static> Processor
         }
 
         if !self.agg_payloads.is_empty()
-            || (!self.buckets_blocks.is_empty() && !self.unsplitted_blocks.is_empty())
+            || (!self.buckets_blocks.is_empty()
+                && !self.unsplitted_blocks.is_empty()
+                && self.max_partition_count == 0)
         {
             // Split data blocks if it's unsplitted.
             return Ok(Event::Sync);

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
@@ -473,7 +473,9 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static> Processor
 
                 let data_block = self.inputs[index].port.pull_data().unwrap()?;
                 self.inputs[index].bucket = self.add_bucket(data_block);
-                debug_assert!(self.unsplitted_blocks.is_empty());
+                if self.max_partition_count == 0 {
+                    debug_assert!(self.unsplitted_blocks.is_empty());
+                }
 
                 if self.inputs[index].bucket <= self.working_bucket {
                     all_port_prepared_data = false;

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_partition_bucket.rs
@@ -249,6 +249,7 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
                             config,
                             capacity,
                         );
+                        hashtable.direct_append = true;
 
                         let agg_len = self.params.aggregate_functions.len();
                         let group_len = self.params.group_columns.len();

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -619,7 +619,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
                 ("enable_experimental_aggregate_hashtable", DefaultSettingValue {
-                        value: UserSettingValue::UInt64(1),
+                        value: UserSettingValue::UInt64(0),
                         desc: "Enables experimental aggregate hashtable",
                         mode: SettingMode::Both,
                         range: Some(SettingRange::Numeric(0..=1)),

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -619,7 +619,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
                 ("enable_experimental_aggregate_hashtable", DefaultSettingValue {
-                        value: UserSettingValue::UInt64(0),
+                        value: UserSettingValue::UInt64(1),
                         desc: "Enables experimental aggregate hashtable",
                         mode: SettingMode::Both,
                         range: Some(SettingRange::Numeric(0..=1)),

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -178,6 +178,7 @@ pub trait PhysicalPlanReplacer {
         Ok(PhysicalPlan::AggregatePartial(AggregatePartial {
             plan_id: plan.plan_id,
             input: Box::new(input),
+            enable_experimental_aggregate_hashtable: plan.enable_experimental_aggregate_hashtable,
             group_by: plan.group_by.clone(),
             group_by_display: plan.group_by_display.clone(),
             agg_funcs: plan.agg_funcs.clone(),

--- a/src/query/sql/src/executor/physical_plans/physical_aggregate_final.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_aggregate_final.rs
@@ -157,6 +157,8 @@ impl PhysicalPlanBuilder {
 
                 let settings = self.ctx.get_settings();
                 let group_by_shuffle_mode = settings.get_group_by_shuffle_mode()?;
+                let enable_experimental_aggregate_hashtable =
+                    settings.get_enable_experimental_aggregate_hashtable()?;
 
                 if let Some(grouping_sets) = agg.grouping_sets.as_ref() {
                     assert_eq!(grouping_sets.dup_group_items.len(), group_items.len() - 1); // ignore `_grouping_id`.
@@ -191,6 +193,7 @@ impl PhysicalPlanBuilder {
                                 plan_id: 0,
                                 input: Box::new(PhysicalPlan::AggregateExpand(expand)),
                                 agg_funcs,
+                                enable_experimental_aggregate_hashtable,
                                 group_by_display,
                                 group_by: group_items,
                                 stat_info: Some(stat_info),
@@ -200,6 +203,7 @@ impl PhysicalPlanBuilder {
                                 plan_id: 0,
                                 input,
                                 agg_funcs,
+                                enable_experimental_aggregate_hashtable,
                                 group_by_display,
                                 group_by: group_items,
                                 stat_info: Some(stat_info),
@@ -246,6 +250,7 @@ impl PhysicalPlanBuilder {
                             PhysicalPlan::AggregatePartial(AggregatePartial {
                                 plan_id: 0,
                                 agg_funcs,
+                                enable_experimental_aggregate_hashtable,
                                 group_by_display,
                                 group_by: group_items,
                                 input: Box::new(PhysicalPlan::AggregateExpand(expand)),
@@ -255,6 +260,7 @@ impl PhysicalPlanBuilder {
                             PhysicalPlan::AggregatePartial(AggregatePartial {
                                 plan_id: 0,
                                 agg_funcs,
+                                enable_experimental_aggregate_hashtable,
                                 group_by_display,
                                 group_by: group_items,
                                 input: Box::new(input),

--- a/src/query/sql/src/executor/physical_plans/physical_aggregate_partial.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_aggregate_partial.rs
@@ -86,11 +86,8 @@ impl AggregatePartial {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        for (idx, data_type) in group_types.iter().enumerate() {
-            fields.push(DataField::new(
-                &format!("_group_by_key_{}", idx),
-                data_type.clone(),
-            ));
+        for data_type in group_types.iter() {
+            fields.push(DataField::new("_group_by_key", data_type.clone()));
         }
         Ok(DataSchemaRefExt::create(fields))
     }

--- a/src/query/sql/src/executor/physical_plans/physical_aggregate_partial.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_aggregate_partial.rs
@@ -86,8 +86,11 @@ impl AggregatePartial {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        for data_type in group_types.iter() {
-            fields.push(DataField::new("_group_by_key", data_type.clone()));
+        for (idx, data_type) in group_types.iter().enumerate() {
+            fields.push(DataField::new(
+                &format!("_group_by_key_{}", idx),
+                data_type.clone(),
+            ));
         }
         Ok(DataSchemaRefExt::create(fields))
     }

--- a/src/query/sql/src/executor/physical_plans/physical_aggregate_partial.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_aggregate_partial.rs
@@ -64,10 +64,7 @@ impl AggregatePartial {
                 .collect::<Result<Vec<_>>>()?;
 
             for (idx, data_type) in group_types.iter().enumerate() {
-                fields.push(DataField::new(
-                    &format!("_group_by_key_{}", idx),
-                    data_type.clone(),
-                ));
+                fields.push(DataField::new(&idx.to_string(), data_type.clone()));
             }
             return Ok(DataSchemaRefExt::create(fields));
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. In the previous PR #14524, we implemented a new_agg_hashtable on singleton. In the partial phase, we sent the entire `PartitionedPayload`. While this approach is correct for singletons, it may cause scatter skew if used in the same manner on a cluster. To ensure compatibility with the cluster, we refactored the payload transmission method for new_agg_hashtable in the standalone version. Now, we send each individual `Payload` separately.

2. support new_agg_hashtable on cluster, to be enabled using: `set enable_experimental_aggregate_hashtable = 1;`

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14798)
<!-- Reviewable:end -->
