### PR TITLE
feat: http handler txn support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,6 +4554,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-meta-types",
  "parking_lot 0.12.1",
+ "serde",
 ]
 
 [[package]]

--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -359,8 +359,10 @@ build_exceptions! {
     StorageOther(4000),
     UnresolvableConflict(4001),
 
-    //transaction error codes
+    // transaction error codes
     CurrentTransactionIsAborted(4002),
+    TransactionTimeout(4003),
+    InvalidSessionState(4004),
 }
 
 // Service errors [5001,6000].

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -338,13 +338,14 @@ impl HttpQuery {
                 Some(TxnState::Active) => {
                     if let Some(ServerInfo { id, start_time }) = &session_conf.last_server_info {
                         if http_query_manager.server_info.id != *id {
-                            return Err(ErrorCode::InvalidSessionState(
-                                "transaction is active but last_query_ids is empty".to_string(),
-                            ));
+                            return Err(ErrorCode::InvalidSessionState(format!(
+                                "transaction is active, but the request routed to the wrong server: current server is {}, the last is {}.",
+                                http_query_manager.server_info.id, id
+                            )));
                         }
                         if http_query_manager.server_info.start_time != *start_time {
                             return Err(ErrorCode::CurrentTransactionIsAborted(format!(
-                                "transaction is aborted because server restarted as {}.",
+                                "transaction is aborted because server restarted at {}.",
                                 start_time
                             )));
                         }

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -314,6 +314,9 @@ impl Session {
     pub fn txn_mgr(&self) -> TxnManagerRef {
         self.session_ctx.txn_mgr()
     }
+    pub fn set_txn_mgr(&self, txn_mgr: TxnManagerRef) {
+        self.session_ctx.set_txn_mgr(txn_mgr)
+    }
 }
 
 impl Drop for Session {

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -43,6 +43,7 @@ use databend_query::servers::HttpHandlerKind;
 use databend_query::sessions::QueryAffect;
 use databend_query::test_kits::ConfigBuilder;
 use databend_query::test_kits::TestFixture;
+use databend_storages_common_txn::TxnState;
 use futures_util::future::try_join_all;
 use headers::Header;
 use headers::HeaderMapExt;
@@ -1445,6 +1446,9 @@ async fn test_affect() -> Result<()> {
                     ("max_threads".to_string(), "1".to_string()),
                     ("timezone".to_string(), "Asia/Shanghai".to_string()),
                 ])),
+                txn_state: Some(TxnState::AutoCommit),
+                last_server_info: None,
+                last_query_ids: vec![],
             }),
         ),
         (
@@ -1464,6 +1468,9 @@ async fn test_affect() -> Result<()> {
                     "max_threads".to_string(),
                     "6".to_string(),
                 )])),
+                txn_state: Some(TxnState::AutoCommit),
+                last_server_info: None,
+                last_query_ids: vec![],
             }),
         ),
         (
@@ -1478,6 +1485,9 @@ async fn test_affect() -> Result<()> {
                     "max_threads".to_string(),
                     "6".to_string(),
                 )])),
+                txn_state: Some(TxnState::AutoCommit),
+                last_server_info: None,
+                last_query_ids: vec![],
             }),
         ),
         (
@@ -1494,6 +1504,9 @@ async fn test_affect() -> Result<()> {
                     "max_threads".to_string(),
                     "6".to_string(),
                 )])),
+                txn_state: Some(TxnState::AutoCommit),
+                last_server_info: None,
+                last_query_ids: vec![],
             }),
         ),
         (
@@ -1512,6 +1525,9 @@ async fn test_affect() -> Result<()> {
                     "timezone".to_string(),
                     "Asia/Shanghai".to_string(),
                 )])),
+                txn_state: Some(TxnState::AutoCommit),
+                last_server_info: None,
+                last_query_ids: vec![],
             }),
         ),
     ];
@@ -1525,7 +1541,13 @@ async fn test_affect() -> Result<()> {
         assert!(result.1.error.is_none(), "{} {:?}", json, result.1.error);
         assert_eq!(result.1.state, ExecuteStateKind::Succeeded);
         assert_eq!(result.1.affect, affect);
-        assert_eq!(result.1.session, session_conf);
+        let session = result.1.session.map(|s| HttpSessionConf {
+            last_server_info: None,
+            last_query_ids: vec![],
+            ..s
+        });
+
+        assert_eq!(session, session_conf);
     }
 
     Ok(())

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -1616,3 +1616,63 @@ async fn test_auth_configured_user() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_txn_error() -> Result<()> {
+    let _fixture = TestFixture::setup().await?;
+    let wait_time_secs = 5;
+
+    let json =
+        serde_json::json!({"sql": "begin", "pagination": {"wait_time_secs": wait_time_secs}});
+    let reply = TestHttpQueryRequest::new(json).fetch_total().await?;
+    let last = reply.last().1;
+    let session = last.session.unwrap();
+
+    {
+        let mut session = session.clone();
+        session.last_server_info = None;
+        let json = serde_json::json! ({
+            "sql": "select 1",
+            "session": session,
+            "pagination": {"wait_time_secs": wait_time_secs}
+        });
+        let reply = TestHttpQueryRequest::new(json).fetch_total().await?;
+        assert_eq!(reply.last().1.error.unwrap().code, 4004u16);
+        assert_eq!(
+            &reply.last().1.error.unwrap().message,
+            "transaction is active but missing server_info"
+        );
+    }
+
+    {
+        let mut session = session.clone();
+        if let Some(s) = &mut session.last_server_info {
+            s.id = "abc".to_string()
+        }
+        let json = serde_json::json! ({
+            "sql": "select 1",
+            "session": session,
+            "pagination": {"wait_time_secs": wait_time_secs}
+        });
+        let reply = TestHttpQueryRequest::new(json).fetch_total().await?;
+        assert_eq!(reply.last().1.error.unwrap().code, 4004u16);
+        assert!(reply.last().1.error.unwrap().message.contains("routed"));
+    }
+
+    {
+        let mut session = session.clone();
+        if let Some(s) = &mut session.last_server_info {
+            s.start_time = "abc".to_string()
+        }
+        let json = serde_json::json! ({
+            "sql": "select 1",
+            "session": session,
+            "pagination": {"wait_time_secs": wait_time_secs}
+        });
+        let reply = TestHttpQueryRequest::new(json).fetch_total().await?;
+        assert_eq!(reply.last().1.error.unwrap().code, 4002u16);
+        assert!(reply.last().1.error.unwrap().message.contains("restarted"));
+    }
+
+    Ok(())
+}

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -691,6 +691,12 @@ impl DefaultSettings {
                     mode:SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1))
                 }),
+                ("idle_transaction_timeout_secs", DefaultSettingValue{
+                    value: UserSettingValue::UInt64(4 * 60 * 60),
+                    desc: "Set the timeout in seconds for active session without any query",
+                    mode:SettingMode::Both,
+                    range: Some(SettingRange::Numeric(1..=u64::MAX))
+                }),
                 ("enable_experimental_queries_executor", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "Enables experimental new executor",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -615,6 +615,10 @@ impl Settings {
         self.try_set_u64("enable_geo_create_table", u64::from(val))
     }
 
+    pub fn get_idle_transaction_timeout_secs(&self) -> Result<u64> {
+        self.try_get_u64("idle_transaction_timeout_secs")
+    }
+
     pub fn get_enable_experimental_queries_executor(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_experimental_queries_executor")? == 1)
     }

--- a/src/query/storages/common/txn/Cargo.toml
+++ b/src/query/storages/common/txn/Cargo.toml
@@ -10,3 +10,4 @@ edition = { workspace = true }
 databend-common-meta-app = { path = "../../../../meta/app" }
 databend-common-meta-types = { path = "../../../../meta/types" }
 parking_lot = { workspace = true }
+serde = { version = "1.0.194", features = ["derive"] }

--- a/src/query/storages/common/txn/src/manager.rs
+++ b/src/query/storages/common/txn/src/manager.rs
@@ -26,6 +26,9 @@ use databend_common_meta_app::schema::UpdateTableMetaReq;
 use databend_common_meta_app::schema::UpsertTableCopiedFileReq;
 use databend_common_meta_types::MatchSeq;
 use parking_lot::Mutex;
+use serde::Deserialize;
+use serde::Serialize;
+
 #[derive(Debug, Clone)]
 pub struct TxnManager {
     state: TxnState,
@@ -34,7 +37,7 @@ pub struct TxnManager {
 
 pub type TxnManagerRef = Arc<Mutex<TxnManager>>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub enum TxnState {
     AutoCommit,
     Active,
@@ -119,6 +122,10 @@ impl TxnManager {
         if let TxnState::Active = self.state {
             self.state = TxnState::Fail;
         }
+    }
+
+    pub fn force_set_fail(&mut self) {
+        self.state = TxnState::Fail;
     }
 
     pub fn is_fail(&self) -> bool {

--- a/tests/sqllogictests/src/util.rs
+++ b/tests/sqllogictests/src/util.rs
@@ -26,12 +26,22 @@ use walkdir::WalkDir;
 use crate::arg::SqlLogicTestArgs;
 use crate::error::DSqlLogicTestError;
 use crate::error::Result;
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct ServerInfo {
+    pub id: String,
+    pub start_time: String,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct HttpSessionConf {
     pub database: Option<String>,
-    pub keep_server_session_secs: Option<u64>,
+    pub role: Option<String>,
+    pub secondary_roles: Option<Vec<String>>,
     pub settings: Option<BTreeMap<String, String>>,
+    pub txn_state: Option<String>,
+    pub last_server_info: Option<ServerInfo>,
+    #[serde(default)]
+    pub last_query_ids: Vec<String>,
 }
 
 pub fn parser_rows(rows: &Value) -> Result<Vec<Vec<String>>> {

--- a/tests/sqllogictests/suites/base/14_transaction/14_0001_dedup_label.test
+++ b/tests/sqllogictests/suites/base/14_transaction/14_0001_dedup_label.test
@@ -7,39 +7,31 @@ use test_txn_dedup_label;
 statement ok
 CREATE TABLE t1(a Int, b bool);
 
-onlyif mysql
 statement ok
 begin;
 
-onlyif mysql
 statement ok
 INSERT /*+ SET_VAR(deduplicate_label='databend') */ INTO t1 (a, b) VALUES(1, false);
 
-onlyif mysql
 statement ok
 UPDATE /*+ SET_VAR(deduplicate_label='databend') */ t1 SET a = 20 WHERE b = false;
 
-onlyif mysql
 query II
 SELECT * FROM t1;
 ----
 1 0
 
-onlyif mysql
 statement ok
 commit;
 
-onlyif mysql
 query II
 SELECT * FROM t1;
 ----
 1 0
 
-onlyif mysql
 statement ok
 REPLACE /*+ SET_VAR(deduplicate_label='databend') */ INTO t1 on(a,b) VALUES(40, false);
 
-onlyif mysql
 query II
 SELECT * FROM t1;
 ----

--- a/tests/sqllogictests/suites/base/14_transaction/14_0003_merge_into.test
+++ b/tests/sqllogictests/suites/base/14_transaction/14_0003_merge_into.test
@@ -20,11 +20,9 @@ CREATE TABLE salaries (
     salary DECIMAL(10, 2)
 );
 
-onlyif mysql
 statement ok
 BEGIN;
 
-onlyif mysql
 statement ok
 INSERT INTO employees VALUES
     (1, 'Alice', 'HR'),
@@ -32,13 +30,11 @@ INSERT INTO employees VALUES
     (3, 'Charlie', 'Finance'),
     (4, 'David', 'HR');
 
-onlyif mysql
 statement ok
 INSERT INTO salaries VALUES
     (1, 50000.00),
     (2, 60000.00);
 
-onlyif mysql
 statement ok
 MERGE INTO salaries
     USING (SELECT * FROM employees) AS employees
@@ -53,7 +49,6 @@ MERGE INTO salaries
         INSERT (employee_id, salary)
             VALUES (employees.employee_id, 55000.00);
 
-onlyif mysql
 query IF
 SELECT employee_id, salary FROM salaries order by employee_id;
 ----
@@ -62,11 +57,9 @@ SELECT employee_id, salary FROM salaries order by employee_id;
 3   55000.00
 4   55000.00
 
-onlyif mysql
 statement ok
 COMMIT;
 
-onlyif mysql
 query IF
 SELECT employee_id, salary FROM salaries order by employee_id;
 ----

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0005_txn_stream.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0005_txn_stream.test
@@ -40,47 +40,36 @@ select a from s_append_only;
 2
 3
 
-onlyif mysql
 statement ok
 BEGIN;
 
-onlyif mysql
 statement ok
 INSERT INTO t_append_only VALUES(4), (5);
 
-onlyif mysql
 statement ok
 INSERT INTO t_consume_append_only_1 SELECT a FROM s_append_only;
 
-onlyif mysql
 statement ok
 INSERT INTO t_consume_append_only_2 SELECT a FROM s_append_only;
 
-onlyif mysql
 statement ok
 INSERT INTO t_append_only VALUES(6), (7);
 
-onlyif mysql
 statement ok
 INSERT INTO t_consume_append_only_3 SELECT a FROM s_append_only;
 
-onlyif mysql
 statement ok
 INSERT INTO t_consume_append_only_4 SELECT a FROM s_append_only_1;
 
-onlyif mysql
 statement ok
 COMMIT;
 
-onlyif mysql
 statement ok
 INSERT INTO t_consume_append_only_5 SELECT a FROM s_append_only;
 
-onlyif mysql
 statement ok
 INSERT INTO t_consume_append_only_6 SELECT a FROM s_append_only_1;
 
-onlyif mysql
 query I
 SELECT * FROM t_consume_append_only_1 order by b;  -- 2,3,4,5
 ----
@@ -89,7 +78,6 @@ SELECT * FROM t_consume_append_only_1 order by b;  -- 2,3,4,5
 4
 5
 
-onlyif mysql
 query I
 SELECT * FROM t_consume_append_only_2 order by b; -- 2,3,4,5
 ----
@@ -98,7 +86,6 @@ SELECT * FROM t_consume_append_only_2 order by b; -- 2,3,4,5
 4
 5
 
-onlyif mysql
 query I
 SELECT * FROM t_consume_append_only_3 order by b; -- 2,3,4,5
 ----
@@ -107,7 +94,6 @@ SELECT * FROM t_consume_append_only_3 order by b; -- 2,3,4,5
 4
 5
 
-onlyif mysql
 query I
 SELECT * FROM t_consume_append_only_4 order by b; -- 2,3,4,5,6,7
 ----
@@ -118,14 +104,12 @@ SELECT * FROM t_consume_append_only_4 order by b; -- 2,3,4,5,6,7
 6
 7
 
-onlyif mysql
 query I
 SELECT * FROM t_consume_append_only_5 order by b; -- 6,7
 ----
 6
 7
 
-onlyif mysql
 query I
 SELECT * FROM t_consume_append_only_6; -- empty
 ----

--- a/tests/sqllogictests/suites/stage/copy_into_txn.sql
+++ b/tests/sqllogictests/suites/stage/copy_into_txn.sql
@@ -11,7 +11,6 @@ use test_txn_copy;
 statement ok
 create table t1(c int);
 
-onlyif mysql
 statement ok
 begin;
 
@@ -29,13 +28,11 @@ query
 copy into t1 from @data/csv/numbers.csv file_format = (type = CSV);
 ----
 
-
 query I
 select count(*) from t1;
 ----
 18
 
-onlyif mysql
 statement ok
 commit;
 
@@ -47,7 +44,6 @@ select count(*) from t1;
 query
 copy into t1 from @data/csv/numbers.csv file_format = (type = CSV);
 ----
-
 
 query I
 select count(*) from t1;
@@ -67,47 +63,38 @@ use test_txn_copy_1;
 statement ok
 create table t1(c int);
 
-onlyif mysql
 statement ok
 begin;
 
-onlyif mysql
+
 query
 copy into t1 from @data/csv/numbers.csv file_format = (type = CSV) purge = true;
 ----
 csv/numbers.csv 18 0 NULL NULL
 
-onlyif mysql
 statement error 1025
 select * from t100;
 
-onlyif mysql
 statement error 4002
 select * from t1;
 
-onlyif mysql
 statement ok
 commit;
 
-onlyif mysql
 query I
 select count(*) from t1;
 ----
 0
 
-onlyif mysql
 statement ok
 create table t2(c int);
 
-onlyif mysql
 query
 copy into t2 from @data/csv/numbers.csv file_format = (type = CSV);
 ----
 csv/numbers.csv 18 0 NULL NULL
 
-onlyif mysql
 query I
 select count(*) from t2;
 ----
 18
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

https://github.com/datafuselabs/databend/issues/14789

1. `txn state` is send to client along with results for each request, client is supposed to carry it in next request.
2. at the end of a HTTP query,  if the txn state is active, the transaction mgr is saved to global map with query id as key, on next query of the session (and txn),, seeing the txn state is active, the transaction mgr is fetched and set to the new session.
 

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14802)
<!-- Reviewable:end -->
