### PR TITLE
feat: get_client_info() returns the server time in milliseconds

### DIFF
--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -44,6 +44,7 @@ use databend_common_meta_types::Cmd;
 use databend_common_meta_types::Endpoint;
 use databend_common_meta_types::GrpcHelper;
 use databend_common_meta_types::LogEntry;
+use databend_common_meta_types::SeqV;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
 use databend_common_metrics::count::Count;
@@ -475,6 +476,7 @@ impl MetaService for MetaServiceImpl {
         if let Some(addr) = r {
             let resp = ClientInfo {
                 client_addr: addr.to_string(),
+                server_time: Some(SeqV::<()>::now_ms()),
             };
             return Ok(Response::new(resp));
         }

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_get_client_info.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_get_client_info.rs
@@ -37,5 +37,7 @@ async fn test_get_client_info() -> anyhow::Result<()> {
         .to_string();
 
     assert_eq!("1.1.1.1:1", masked_addr);
+
+    assert!(resp.server_time > Some(1), "server time is returned");
     Ok(())
 }

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -178,6 +178,13 @@ message ClusterStatus {
 message ClientInfo {
   // The address of the connected in form of "<ip>:<port>"
   string client_addr = 10;
+
+  // The timestamp when the meta-server received the request in milliseconds since 1970 .
+  //
+  // It is created with `SeqV::now_ms()`
+  // To convert it back to time with:
+  // `SystemTime::UNIX_EPOCH + Duration::from_millis(server_time)`
+  optional uint64 server_time = 20;
 }
 
 // Item for a Streaming read reply, e.g., for `Mget` and `List`.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: get_client_info() returns the server time in milliseconds

## Changelog

- New Feature





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14805)
<!-- Reviewable:end -->
