### PR TITLE
refactor: use relative expire time `ttl` to replace `expire_at`, tolerate query-meta time drift

### DIFF
--- a/src/binaries/meta/kvapi.rs
+++ b/src/binaries/meta/kvapi.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use chrono::Duration;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MetaError;
@@ -40,7 +41,9 @@ impl KvApiCommand {
                 let req = UpsertKVReq::update(config.key[0].as_str(), config.value.as_bytes());
 
                 let req = if let Some(expire_after) = config.expire_after {
-                    req.with(MetaSpec::new_expire(SeqV::<()>::now_sec() + expire_after))
+                    req.with(MetaSpec::new_ttl(std::time::Duration::from_secs(
+                        expire_after,
+                    )))
                 } else {
                     req
                 };

--- a/src/meta/api/src/kv_pb_api/upsert_pb.rs
+++ b/src/meta/api/src/kv_pb_api/upsert_pb.rs
@@ -79,10 +79,6 @@ impl<K: kvapi::Key> UpsertPB<K> {
         }
     }
 
-    pub fn with_expire_sec(self, expire_at_sec: u64) -> Self {
-        self.with(MetaSpec::new_expire(expire_at_sec))
-    }
-
     /// Set the time to last for the value.
     /// When the ttl is passed, the value is deleted.
     pub fn with_ttl(self, ttl: Duration) -> Self {

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -99,8 +99,11 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///           Always return the previous value;
 ///           field index is reserved, no compatibility changes.
 ///
-/// - 2024-01-25: since TODO:
+/// - 2024-01-25: since 1.2.315:
 ///   server: add export_v1() to let client specify export chunk size;
+///
+/// - 2024-03-01: since: TODO(update me when merged):
+///   client: `MetaSpec` use `ttl`, remove `expire_at`, require 1.2.258
 ///
 /// Server feature set:
 /// ```yaml
@@ -112,8 +115,7 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 pub static MIN_METASRV_SEMVER: Version = Version {
     major: 1,
     minor: 2,
-    // [1.2.163, 1.2.226) are removed from release download, due to some known bugs found in these versions.
-    patch: 226,
+    patch: 258,
     pre: Prerelease::EMPTY,
     build: BuildMetadata::EMPTY,
 };

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -253,7 +253,9 @@ impl kvapi::TestSuite {
         let now_sec = SeqV::<()>::now_sec();
 
         let _res = kv
-            .upsert_kv(UpsertKVReq::update("k1", b"v1").with(MetaSpec::new_expire(now_sec + 2)))
+            .upsert_kv(
+                UpsertKVReq::update("k1", b"v1").with(MetaSpec::new_ttl(Duration::from_secs(2))),
+            )
             .await?;
         // dbg!("upsert non expired k1", _res);
 
@@ -291,7 +293,7 @@ impl kvapi::TestSuite {
                 .upsert_kv(
                     UpsertKVReq::update("k2", b"v2")
                         .with(MatchSeq::Exact(0))
-                        .with(MetaSpec::new_expire(now_sec + 10)),
+                        .with(MetaSpec::new_ttl(Duration::from_secs(10))),
                 )
                 .await?;
             // dbg!("update non expired k2", _res);
@@ -380,7 +382,7 @@ impl kvapi::TestSuite {
                 test_key,
                 MatchSeq::Exact(seq + 1),
                 Operation::AsIs,
-                Some(MetaSpec::new_expire(now_sec + 20)),
+                Some(MetaSpec::new_ttl(Duration::from_secs(20))),
             ))
             .await?;
         assert_eq!(Some(SeqV::with_meta(1, None, b"v1".to_vec())), r.prev);
@@ -393,7 +395,7 @@ impl kvapi::TestSuite {
                 test_key,
                 MatchSeq::Exact(seq),
                 Operation::AsIs,
-                Some(MetaSpec::new_expire(now_sec + 20)),
+                Some(MetaSpec::new_ttl(Duration::from_secs(20))),
             ))
             .await?;
         assert_eq!(Some(SeqV::with_meta(1, None, b"v1".to_vec())), r.prev);

--- a/src/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/src/meta/raft-store/tests/it/state_machine/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -142,7 +143,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
         prev: Option<(u64, &'static str)>,
         result: Option<(u64, &'static str)>,
     ) -> T {
-        let m = meta.map(MetaSpec::new_expire);
+        let m = meta.map(|x| MetaSpec::new_ttl(Duration::from_secs(x)));
         T {
             key: name.to_string(),
             seq,
@@ -207,7 +208,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
             "wow",
             MatchSeq::GE(0),
             "y",
-            Some(now + 1000),
+            Some(1000),
             None,
             Some((6, "y")),
         ),
@@ -290,7 +291,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_value_meta() -> anyhow::Res
                     key: key.clone(),
                     seq: MatchSeq::GE(0),
                     value: Operation::AsIs,
-                    value_meta: Some(MetaSpec::new_expire(now + 10)),
+                    value_meta: Some(MetaSpec::new_ttl(Duration::from_secs(10))),
                 }),
                 &mut t,
                 None,
@@ -315,7 +316,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_value_meta() -> anyhow::Res
                     key: key.clone(),
                     seq: MatchSeq::GE(0),
                     value: Operation::Update(b"value_meta_bar".to_vec()),
-                    value_meta: Some(MetaSpec::new_expire(now + 10)),
+                    value_meta: Some(MetaSpec::new_ttl(Duration::from_secs(10))),
                 }),
                 &mut t,
                 None,
@@ -332,7 +333,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_value_meta() -> anyhow::Res
                     key: key.clone(),
                     seq: MatchSeq::GE(0),
                     value: Operation::AsIs,
-                    value_meta: Some(MetaSpec::new_expire(now + 20)),
+                    value_meta: Some(MetaSpec::new_ttl(Duration::from_secs(20))),
                 }),
                 &mut t,
                 None,

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
@@ -15,6 +15,7 @@
 //! Test kv_read_v1() API, which handles kv-read request and return result in a stream.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::Streamed;
@@ -129,7 +130,7 @@ async fn initialize_kvs(client: &Arc<ClientHandle>, now_sec: u64) -> anyhow::Res
     info!("--- prepare keys: a(meta),c,c1,c2");
 
     let updates = vec![
-        UpsertKVReq::insert("a", &b("a")).with(MetaSpec::new_expire(now_sec + 10)),
+        UpsertKVReq::insert("a", &b("a")).with(MetaSpec::new_ttl(Duration::from_secs(10))),
         UpsertKVReq::insert("c", &b("c")),
         UpsertKVReq::insert("c1", &b("c1")),
         UpsertKVReq::insert("c2", &b("c2")),

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -59,7 +59,8 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
 
     info!("--- write a kv expiring in 3 sec");
     {
-        let upsert = UpsertKV::update(key, key.as_bytes()).with(MetaSpec::new_expire(now_sec + 3));
+        let upsert =
+            UpsertKV::update(key, key.as_bytes()).with(MetaSpec::new_ttl(Duration::from_secs(3)));
 
         leader.write(LogEntry::new(Cmd::UpsertKV(upsert))).await?;
         log_index += 1;
@@ -77,7 +78,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     {
         let upsert = UpsertKV::update(key, value2.as_bytes())
             .with(MatchSeq::Exact(seq))
-            .with(MetaSpec::new_expire(now_sec + 1000));
+            .with(MetaSpec::new_ttl(Duration::from_secs(1000)));
         leader.write(LogEntry::new(Cmd::UpsertKV(upsert))).await?;
         log_index += 1;
     }

--- a/src/query/management/src/cluster/cluster_mgr.rs
+++ b/src/query/management/src/cluster/cluster_mgr.rs
@@ -66,13 +66,7 @@ impl ClusterMgr {
     }
 
     fn new_lift_time(&self) -> MetaSpec {
-        let now = std::time::SystemTime::now();
-        let expire_at = now
-            .add(self.lift_time)
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards");
-
-        MetaSpec::new_expire(expire_at.as_secs())
+        MetaSpec::new_ttl(self.lift_time)
     }
 }
 

--- a/src/query/storages/result_cache/src/meta_manager.rs
+++ b/src/query/storages/result_cache/src/meta_manager.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use databend_common_exception::Result;
 use databend_common_meta_kvapi::kvapi::KVApi;
@@ -41,7 +42,7 @@ impl ResultCacheMetaManager {
         key: String,
         value: ResultCacheValue,
         seq: MatchSeq,
-        expire_at: u64,
+        ttl: Duration,
     ) -> Result<()> {
         let value = serde_json::to_vec(&value)?;
         let _ = self
@@ -50,7 +51,7 @@ impl ResultCacheMetaManager {
                 key,
                 seq,
                 value: Operation::Update(value),
-                value_meta: Some(MetaSpec::new_expire(expire_at)),
+                value_meta: Some(MetaSpec::new_ttl(ttl)),
             })
             .await?;
         Ok(())


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: use relative expire time `ttl` to replace `expire_at`, tolerate query-meta time drift

## Changelog




- Improvement


## Related Issues