### PR TITLE
refactor: upgrade Openraft to v0.9.0-alpha.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.6#22cd3bb423ddaf21c1f4d70917f689e79a9cacb6"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.7#685fe8d11831adbaacf895f63f06b9a674fc1d49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.6#22cd3bb423ddaf21c1f4d70917f689e79a9cacb6"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.7#685fe8d11831adbaacf895f63f06b9a674fc1d49"
 dependencies = [
  "anyerror",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ opendal = { version = "0.45.0", features = [
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 # openraft for debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.6", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.7", features = [
     "compat-07",
     "tracing-log",
     "loosen-follower-log-revert", # allows removing all data from a follower and restoring from the leader.

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -99,8 +99,11 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///           Always return the previous value;
 ///           field index is reserved, no compatibility changes.
 ///
-/// - 2024-01-25: since TODO:
+/// - 2024-01-25: since 1.2.315:
 ///   server: add export_v1() to let client specify export chunk size;
+///
+/// - 2024-03-01: since: TODO(update me when merged):
+///   server: add `server_time` to `get_client_info() -> ClientInfo`,
 ///
 /// Server feature set:
 /// ```yaml


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: upgrade Openraft to v0.9.0-alpha.7

No change, just method renamed.


##### chore: udpate query-meta compatibility change log

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14809)
<!-- Reviewable:end -->
