### PR TITLE
refactor: tenant is not allowed to be empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-grpc",
  "databend-common-meta-app",
+ "databend-common-meta-types",
  "databend-common-storage",
  "databend-common-tracing",
  "databend-common-users",

--- a/src/bendpy/src/lib.rs
+++ b/src/bendpy/src/lib.rs
@@ -57,7 +57,7 @@ fn databend(_py: Python, m: &PyModule) -> PyResult<()> {
         GlobalServices::init(&conf).await.unwrap();
 
         // init oss license manager
-        OssLicenseManager::init(conf.query.tenant_id.clone()).unwrap();
+        OssLicenseManager::init(conf.query.tenant_id.to_string()).unwrap();
         ClusterDiscovery::instance()
             .register_to_metastore(&conf)
             .await

--- a/src/binaries/query/oss_main.rs
+++ b/src/binaries/query/oss_main.rs
@@ -57,6 +57,6 @@ async fn main_entrypoint() -> Result<()> {
 
     init_services(&conf).await?;
     // init oss license manager
-    OssLicenseManager::init(conf.query.tenant_id.clone())?;
+    OssLicenseManager::init(conf.query.tenant_id.to_string())?;
     start_services(&conf).await
 }

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -322,10 +322,10 @@ impl Deref for GetDatabaseReq {
 }
 
 impl GetDatabaseReq {
-    pub fn new(tenant: impl Into<String>, db_name: impl Into<String>) -> GetDatabaseReq {
+    pub fn new(tenant: impl ToString, db_name: impl Into<String>) -> GetDatabaseReq {
         GetDatabaseReq {
             inner: DatabaseNameIdent {
-                tenant: tenant.into(),
+                tenant: tenant.to_string(),
                 db_name: db_name.into(),
             },
         }

--- a/src/meta/types/src/non_empty.rs
+++ b/src/meta/types/src/non_empty.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
+use std::fmt::Formatter;
+
 /// A container contains non-empty &str
 #[derive(Clone, Debug, Copy)]
 pub struct NonEmptyStr<'a> {
@@ -28,6 +31,12 @@ impl<'a> NonEmptyStr<'a> {
 
     pub fn get(&self) -> &str {
         self.non_empty
+    }
+}
+
+impl<'a> Display for NonEmptyStr<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.non_empty)
     }
 }
 
@@ -49,11 +58,27 @@ impl NonEmptyString {
     pub fn as_str(&self) -> &str {
         &self.non_empty
     }
+
+    pub fn as_non_empty_str(&self) -> NonEmptyStr {
+        NonEmptyStr::new(&self.non_empty).unwrap()
+    }
 }
 
-impl ToString for NonEmptyString {
-    fn to_string(&self) -> String {
-        self.non_empty.clone()
+impl Display for NonEmptyString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.non_empty)
+    }
+}
+
+impl PartialEq<str> for NonEmptyString {
+    fn eq(&self, other: &str) -> bool {
+        self.non_empty == *other
+    }
+}
+
+impl AsRef<str> for NonEmptyString {
+    fn as_ref(&self) -> &str {
+        &self.non_empty
     }
 }
 

--- a/src/query/catalog/src/catalog/manager.rs
+++ b/src/query/catalog/src/catalog/manager.rs
@@ -100,7 +100,7 @@ impl CatalogManager {
             let ctl = creator.try_create(&CatalogInfo {
                 id: CatalogId { catalog_id: 0 },
                 name_ident: CatalogNameIdent {
-                    tenant: tenant.clone(),
+                    tenant: tenant.to_string(),
                     catalog_name: name.clone(),
                 },
                 meta: CatalogMeta {

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -36,6 +36,7 @@ use databend_common_meta_app::principal::OnErrorMode;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserDefinedConnection;
 use databend_common_meta_app::principal::UserInfo;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_pipeline_core::processors::PlanProfile;
 use databend_common_pipeline_core::InputError;
 use databend_common_settings::Settings;
@@ -171,7 +172,7 @@ pub trait TableContext: Send + Sync {
     async fn get_visibility_checker(&self) -> Result<GrantObjectVisibilityChecker>;
     fn get_fuse_version(&self) -> String;
     fn get_format_settings(&self) -> Result<FormatSettings>;
-    fn get_tenant(&self) -> String;
+    fn get_tenant(&self) -> NonEmptyString;
     /// Get the kind of session running query.
     fn get_query_kind(&self) -> QueryKind;
     fn get_function_context(&self) -> Result<FunctionContext>;

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -20,6 +20,7 @@ databend-common-base = { path = "../../common/base" }
 databend-common-exception = { path = "../../common/exception" }
 databend-common-grpc = { path = "../../common/grpc" }
 databend-common-meta-app = { path = "../../meta/app" }
+databend-common-meta-types = { path = "../../meta/types" }
 databend-common-storage = { path = "../../common/storage" }
 databend-common-tracing = { path = "../../common/tracing" }
 databend-common-users = { path = "../users" }

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -43,6 +43,7 @@ use databend_common_meta_app::storage::StorageParams;
 use databend_common_meta_app::storage::StorageS3Config as InnerStorageS3Config;
 use databend_common_meta_app::storage::StorageWebhdfsConfig as InnerStorageWebhdfsConfig;
 use databend_common_meta_app::tenant::TenantQuota;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_storage::StorageConfig as InnerStorageConfig;
 use databend_common_tracing::Config as InnerLogConfig;
 use databend_common_tracing::FileConfig as InnerFileLogConfig;
@@ -1667,7 +1668,8 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
 
     fn try_into(self) -> Result<InnerQueryConfig> {
         Ok(InnerQueryConfig {
-            tenant_id: self.tenant_id,
+            tenant_id: NonEmptyString::new(self.tenant_id)
+                .map_err(|_e| ErrorCode::InvalidConfig("tenant-id can not be empty"))?,
             cluster_id: self.cluster_id,
             node_id: "".to_string(),
             num_cpus: self.num_cpus,
@@ -1746,7 +1748,7 @@ impl TryInto<InnerQueryConfig> for QueryConfig {
 impl From<InnerQueryConfig> for QueryConfig {
     fn from(inner: InnerQueryConfig) -> Self {
         Self {
-            tenant_id: inner.tenant_id,
+            tenant_id: inner.tenant_id.to_string(),
             cluster_id: inner.cluster_id,
             num_cpus: inner.num_cpus,
             mysql_handler_host: inner.mysql_handler_host,

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -28,6 +28,7 @@ use databend_common_grpc::RpcClientConf;
 use databend_common_grpc::RpcClientTlsConfig;
 use databend_common_meta_app::principal::UserSettingValue;
 use databend_common_meta_app::tenant::TenantQuota;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_storage::StorageConfig;
 use databend_common_tracing::Config as LogConfig;
 use databend_common_users::idm_config::IDMConfig;
@@ -147,7 +148,7 @@ impl Debug for InnerConfig {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct QueryConfig {
     /// Tenant id for get the information from the MetaSrv.
-    pub tenant_id: String,
+    pub tenant_id: NonEmptyString,
     /// ID for construct the cluster.
     pub cluster_id: String,
     // ID for the query node.
@@ -235,7 +236,7 @@ pub struct QueryConfig {
 impl Default for QueryConfig {
     fn default() -> Self {
         Self {
-            tenant_id: "admin".to_string(),
+            tenant_id: NonEmptyString::new("admin").unwrap(),
             cluster_id: "".to_string(),
             node_id: "".to_string(),
             num_cpus: 0,

--- a/src/query/ee/src/background_service/background_service_handler.rs
+++ b/src/query/ee/src/background_service/background_service_handler.rs
@@ -166,9 +166,9 @@ impl RealBackgroundService {
         params: BackgroundJobParams,
         creator: UserIdentity,
     ) -> Result<BackgroundJobIdent> {
-        let name = RealBackgroundService::get_compactor_job_name(conf.query.tenant_id.clone());
+        let name = RealBackgroundService::get_compactor_job_name(conf.query.tenant_id.to_string());
         let id = BackgroundJobIdent {
-            tenant: conf.query.tenant_id.clone(),
+            tenant: conf.query.tenant_id.to_string(),
             name,
         };
         let info = BackgroundJobInfo::new_compactor_job(params, creator);

--- a/src/query/ee/src/background_service/compaction_job.rs
+++ b/src/query/ee/src/background_service/compaction_job.rs
@@ -147,7 +147,10 @@ impl CompactionJob {
         finish_tx: Arc<Mutex<Sender<u64>>>,
     ) -> Self {
         let tenant = config.query.tenant_id.clone();
-        let creator = BackgroundJobIdent { tenant, name };
+        let creator = BackgroundJobIdent {
+            tenant: tenant.to_string(),
+            name,
+        };
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         Self {
             conf: config.clone(),

--- a/src/query/ee/src/enterprise_services.rs
+++ b/src/query/ee/src/enterprise_services.rs
@@ -29,7 +29,7 @@ pub struct EnterpriseServices;
 impl EnterpriseServices {
     #[async_backtrace::framed]
     pub async fn init(cfg: InnerConfig) -> Result<()> {
-        RealLicenseManager::init(cfg.query.tenant_id.clone())?;
+        RealLicenseManager::init(cfg.query.tenant_id.to_string())?;
         RealStorageEncryptionHandler::init(&cfg)?;
         RealVacuumHandler::init()?;
         RealAggregatingIndexHandler::init()?;

--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -61,7 +61,7 @@ impl StreamHandler for RealStreamHandler {
         let catalog = ctx.get_catalog(&plan.catalog).await?;
 
         let table = catalog
-            .get_table(&tenant, &plan.table_database, &plan.table_name)
+            .get_table(tenant.as_str(), &plan.table_database, &plan.table_name)
             .await?;
         let table_info = table.get_table_info();
         if table_info.options().contains_key("TRANSIENT") {
@@ -86,14 +86,14 @@ impl StreamHandler for RealStreamHandler {
             };
 
             catalog
-                .upsert_table_option(&tenant, &plan.table_database, req)
+                .upsert_table_option(tenant.as_str(), &plan.table_database, req)
                 .await?;
         }
 
         let mut options = BTreeMap::new();
         match &plan.navigation {
             Some(StreamNavigation::AtStream { database, name }) => {
-                let stream = catalog.get_table(&tenant, database, name).await?;
+                let stream = catalog.get_table(tenant.as_str(), database, name).await?;
                 let stream = StreamTable::try_from_table(stream.as_ref())?;
                 let stream_opts = stream.get_table_info().options();
                 let stream_table_name = stream_opts
@@ -192,12 +192,12 @@ impl StreamHandler for RealStreamHandler {
                 )));
             }
 
-            let db = catalog.get_database(&tenant, &db_name).await?;
+            let db = catalog.get_database(tenant.as_str(), &db_name).await?;
 
             catalog
                 .drop_table_by_id(DropTableByIdReq {
                     if_exists: plan.if_exists,
-                    tenant: tenant.clone(),
+                    tenant: tenant.to_string(),
                     table_name: stream_name.clone(),
                     tb_id: table.get_id(),
                     db_id: db.get_db_info().ident.db_id,

--- a/src/query/ee/src/test_kits/mock_services.rs
+++ b/src/query/ee/src/test_kits/mock_services.rs
@@ -30,7 +30,7 @@ pub struct MockServices;
 impl MockServices {
     #[async_backtrace::framed]
     pub async fn init(cfg: &InnerConfig, public_key: String) -> Result<()> {
-        let rm = RealLicenseManager::new(cfg.query.tenant_id.clone(), public_key);
+        let rm = RealLicenseManager::new(cfg.query.tenant_id.to_string(), public_key);
         let wrapper = LicenseManagerWrapper {
             manager: Box::new(rm),
         };

--- a/src/query/management/src/user/user_mgr.rs
+++ b/src/query/management/src/user/user_mgr.rs
@@ -28,6 +28,7 @@ use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
+use databend_common_meta_types::NonEmptyStr;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::SeqV;
 
@@ -41,18 +42,11 @@ pub struct UserMgr {
 }
 
 impl UserMgr {
-    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: &str) -> Result<Self> {
-        if tenant.is_empty() {
-            return Err(ErrorCode::TenantIsEmpty(
-                "Tenant can not empty(while user mgr create)",
-            ));
-        }
-
-        Ok(UserMgr {
+    pub fn create(kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>, tenant: NonEmptyStr) -> Self {
+        UserMgr {
             kv_api,
-            // TODO: use NonEmptyString
-            tenant: Tenant::new(tenant),
-        })
+            tenant: Tenant::new_nonempty(tenant.into()),
+        }
     }
 
     /// Create a string key to store a user@host into meta-service.

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -82,6 +82,7 @@ fn default_test_auth_info() -> AuthInfo {
 mod add {
     use databend_common_meta_app::principal::UserInfo;
     use databend_common_meta_app::schema::CreateOption;
+    use databend_common_meta_types::NonEmptyStr;
     use databend_common_meta_types::Operation;
 
     use super::*;
@@ -119,7 +120,7 @@ mod add {
                 .times(1)
                 .return_once(|_u| Ok(UpsertKVReply::new(None, Some(SeqV::new(1, v)))));
             let api = Arc::new(api);
-            let user_mgr = UserMgr::create(api, "tenant1")?;
+            let user_mgr = UserMgr::create(api, NonEmptyStr::new("tenant1").unwrap());
             let res = user_mgr.add_user(user_info, &CreateOption::None);
 
             assert!(res.await.is_ok());
@@ -145,7 +146,7 @@ mod add {
                 });
 
             let api = Arc::new(api);
-            let user_mgr = UserMgr::create(api, "tenant1")?;
+            let user_mgr = UserMgr::create(api, NonEmptyStr::new("tenant1").unwrap());
 
             let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
 
@@ -163,6 +164,7 @@ mod add {
 
 mod get {
     use databend_common_meta_app::principal::UserInfo;
+    use databend_common_meta_types::NonEmptyStr;
 
     use super::*;
 
@@ -185,7 +187,7 @@ mod get {
             .return_once(move |_k| Ok(Some(SeqV::new(1, value))));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr.get_user(user_info.identity(), MatchSeq::Exact(1));
         assert!(res.await.is_ok());
 
@@ -211,7 +213,7 @@ mod get {
             .return_once(move |_k| Ok(Some(SeqV::new(100, value))));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr.get_user(user_info.identity(), MatchSeq::GE(0));
         assert!(res.await.is_ok());
         Ok(())
@@ -233,7 +235,7 @@ mod get {
             .return_once(move |_k| Ok(None));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr
             .get_user(
                 UserIdentity::new(test_user_name, test_hostname),
@@ -261,7 +263,7 @@ mod get {
             .return_once(move |_k| Ok(Some(SeqV::new(1, vec![]))));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr
             .get_user(
                 UserIdentity::new(test_user_name, test_hostname),
@@ -289,7 +291,7 @@ mod get {
             .return_once(move |_k| Ok(Some(SeqV::new(1, vec![]))));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr.get_user(
             UserIdentity::new(test_user_name, test_hostname),
             MatchSeq::GE(0),
@@ -305,6 +307,7 @@ mod get {
 
 mod get_users {
     use databend_common_meta_app::principal::UserInfo;
+    use databend_common_meta_types::NonEmptyStr;
 
     use super::*;
 
@@ -353,7 +356,7 @@ mod get_users {
         }
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr.get_users();
         assert_eq!(res.await?, user_infos);
 
@@ -382,7 +385,7 @@ mod get_users {
         }
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr.get_users();
         assert_eq!(
             res.await.unwrap_err().code(),
@@ -394,6 +397,7 @@ mod get_users {
 }
 
 mod drop {
+    use databend_common_meta_types::NonEmptyStr;
 
     use super::*;
 
@@ -416,7 +420,7 @@ mod drop {
             .times(1)
             .returning(|_k| Ok(UpsertKVReply::new(Some(SeqV::new(1, vec![])), None)));
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr.drop_user(UserIdentity::new(test_user, test_hostname), MatchSeq::GE(1));
         assert!(res.await.is_ok());
 
@@ -442,7 +446,7 @@ mod drop {
             .times(1)
             .returning(|_k| Ok(UpsertKVReply::new(None, None)));
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
         let res = user_mgr.drop_user(UserIdentity::new(test_user, test_hostname), MatchSeq::GE(1));
         assert_eq!(
             res.await.unwrap_err().code(),
@@ -455,6 +459,7 @@ mod drop {
 mod update {
     use databend_common_meta_app::principal::AuthInfo;
     use databend_common_meta_app::principal::UserInfo;
+    use databend_common_meta_types::NonEmptyStr;
 
     use super::*;
 
@@ -518,7 +523,7 @@ mod update {
             .return_once(|_| Ok(UpsertKVReply::new(None, Some(SeqV::new(1, vec![])))));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
 
         let res = user_mgr.update_user_with(user_info.identity(), test_seq, |ui: &mut UserInfo| {
             ui.update_auth_option(Some(new_test_auth_info(full)), None)
@@ -547,7 +552,7 @@ mod update {
             .return_once(move |_k| Ok(None));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
 
         let res = user_mgr.update_user_with(
             UserIdentity::new(test_user_name, test_hostname),
@@ -592,7 +597,7 @@ mod update {
             .returning(|_| Ok(UpsertKVReply::new(None, None)));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
 
         let _ = user_mgr
             .update_user_with(user_info.identity(), MatchSeq::GE(1), |_x| {})
@@ -606,6 +611,7 @@ mod set_user_privileges {
     use databend_common_meta_app::principal::UserInfo;
     use databend_common_meta_app::principal::UserPrivilegeSet;
     use databend_common_meta_app::principal::UserPrivilegeType;
+    use databend_common_meta_types::NonEmptyStr;
 
     use super::*;
 
@@ -649,7 +655,7 @@ mod set_user_privileges {
             .return_once(|_| Ok(UpsertKVReply::new(None, Some(SeqV::new(1, vec![])))));
 
         let kv = Arc::new(kv);
-        let user_mgr = UserMgr::create(kv, "tenant1")?;
+        let user_mgr = UserMgr::create(kv, NonEmptyStr::new("tenant1").unwrap());
 
         let res = user_mgr.update_user_with(
             user_info.identity(),

--- a/src/query/service/src/api/http/v1/tenant_tables.rs
+++ b/src/query/service/src/api/http/v1/tenant_tables.rs
@@ -107,14 +107,8 @@ pub async fn list_tenant_tables_handler(
 #[async_backtrace::framed]
 pub async fn list_tables_handler() -> poem::Result<impl IntoResponse> {
     let tenant = &GlobalConfig::instance().query.tenant_id;
-    if tenant.is_empty() {
-        return Ok(Json(TenantTablesResponse {
-            tables: vec![],
-            warnings: vec![],
-        }));
-    }
 
-    let resp = load_tenant_tables(tenant)
+    let resp = load_tenant_tables(tenant.as_str())
         .await
         .map_err(poem::error::InternalServerError)?;
     Ok(Json(resp))

--- a/src/query/service/src/api/rpc/flight_service.rs
+++ b/src/query/service/src/api/rpc/flight_service.rs
@@ -162,7 +162,7 @@ impl FlightService for DatabendQueryFlightService {
                 FlightAction::InitQueryFragmentsPlan(init_query_fragments_plan) => {
                     let config = GlobalConfig::instance();
                     let session_manager = SessionManager::instance();
-                    let settings = Settings::create(config.query.tenant_id.clone());
+                    let settings = Settings::create(config.query.tenant_id.to_string());
                     unsafe {
                         // Keep settings
                         settings.unchecked_apply_changes(
@@ -228,7 +228,7 @@ impl FlightService for DatabendQueryFlightService {
                 FlightAction::TruncateTable(truncate_table) => {
                     let config = GlobalConfig::instance();
                     let session_manager = SessionManager::instance();
-                    let settings = Settings::create(config.query.tenant_id.clone());
+                    let settings = Settings::create(config.query.tenant_id.to_string());
                     let session =
                         session_manager.create_with_settings(SessionType::FlightRPC, settings)?;
                     let ctx = session.create_query_context().await?;
@@ -241,7 +241,7 @@ impl FlightService for DatabendQueryFlightService {
                 FlightAction::KillQuery(kill_query) => {
                     let config = GlobalConfig::instance();
                     let session_manager = SessionManager::instance();
-                    let settings = Settings::create(config.query.tenant_id.clone());
+                    let settings = Settings::create(config.query.tenant_id.to_string());
                     let session =
                         session_manager.create_with_settings(SessionType::FlightRPC, settings)?;
                     let ctx = session.create_query_context().await?;

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -159,7 +159,7 @@ impl AuthMgr {
                     _ => Err(ErrorCode::AuthenticateFailure("wrong auth type")),
                 };
                 UserApiProvider::instance()
-                    .update_user_login_result(&tenant, identity, authed.is_ok())
+                    .update_user_login_result(tenant, identity, authed.is_ok())
                     .await?;
 
                 authed?;

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -144,7 +144,7 @@ impl MutableCatalog {
             provider.create_meta_store().await?
         };
 
-        let tenant = conf.query.tenant_id.clone();
+        let tenant = conf.query.tenant_id.to_string();
 
         // Create default database.
         let req = CreateDatabaseReq {
@@ -173,7 +173,7 @@ impl MutableCatalog {
         };
         Ok(MutableCatalog {
             ctx,
-            tenant: conf.query.tenant_id.clone(),
+            tenant: conf.query.tenant_id.to_string(),
         })
     }
 
@@ -206,7 +206,7 @@ impl Catalog for MutableCatalog {
         let db_info = self
             .ctx
             .meta
-            .get_database(GetDatabaseReq::new(tenant, db_name))
+            .get_database(GetDatabaseReq::new(tenant.to_string(), db_name))
             .await?;
         self.build_db_instance(&db_info)
     }

--- a/src/query/service/src/clusters/cluster.rs
+++ b/src/query/service/src/clusters/cluster.rs
@@ -170,10 +170,10 @@ impl ClusterDiscovery {
                 lift_time,
                 provider,
                 cfg.query.cluster_id.clone(),
-                cfg.query.tenant_id.clone(),
+                cfg.query.tenant_id.to_string(),
             )),
             cluster_id: cfg.query.cluster_id.clone(),
-            tenant_id: cfg.query.tenant_id.clone(),
+            tenant_id: cfg.query.tenant_id.to_string(),
             flight_address: cfg.query.flight_api_address.clone(),
         }))
     }
@@ -190,7 +190,8 @@ impl ClusterDiscovery {
         let tenant_id = &cfg.query.tenant_id;
         let cluster_id = &cfg.query.cluster_id;
         let lift_time = Duration::from_secs(60);
-        let cluster_manager = ClusterMgr::create(metastore, tenant_id, cluster_id, lift_time)?;
+        let cluster_manager =
+            ClusterMgr::create(metastore, tenant_id.as_str(), cluster_id, lift_time)?;
 
         Ok((lift_time, Arc::new(cluster_manager)))
     }

--- a/src/query/service/src/global_services.rs
+++ b/src/query/service/src/global_services.rs
@@ -64,7 +64,7 @@ impl GlobalServices {
         // 2. log init.
         let mut log_labels = BTreeMap::new();
         log_labels.insert("service".to_string(), "databend-query".to_string());
-        log_labels.insert("tenant_id".to_string(), config.query.tenant_id.clone());
+        log_labels.insert("tenant_id".to_string(), config.query.tenant_id.to_string());
         log_labels.insert("cluster_id".to_string(), config.query.cluster_id.clone());
         log_labels.insert("node_id".to_string(), config.query.node_id.clone());
         GlobalLogger::init(&app_name_shuffle, &config.log, log_labels);
@@ -114,9 +114,9 @@ impl GlobalServices {
         ShareTableConfig::init(
             &config.query.share_endpoint_address,
             &config.query.share_endpoint_auth_token_file,
-            config.query.tenant_id.clone(),
+            config.query.tenant_id.to_string(),
         )?;
-        CacheManager::init(&config.cache, &config.query.tenant_id)?;
+        CacheManager::init(&config.cache, config.query.tenant_id.to_string())?;
 
         if let Some(addr) = config.query.cloud_control_grpc_server_address.clone() {
             CloudControlApiProvider::init(addr, config.query.cloud_control_grpc_timeout).await?;

--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -144,7 +144,7 @@ impl InterpreterQueryLog {
             log_type,
             log_type_name,
             handler_type,
-            tenant_id,
+            tenant_id: tenant_id.to_string(),
             cluster_id,
             node_id,
             sql_user,
@@ -209,7 +209,7 @@ impl InterpreterQueryLog {
         ctx.set_finish_time(now);
         // User.
         let handler_type = ctx.get_current_session().get_type().to_string();
-        let tenant_id = GlobalConfig::instance().query.tenant_id.clone();
+        let tenant_id = GlobalConfig::instance().query.tenant_id.to_string();
         let cluster_id = GlobalConfig::instance().query.cluster_id.clone();
         let node_id = ctx.get_cluster().local_id.clone();
         let user = ctx.get_current_user()?;

--- a/src/query/service/src/interpreters/common/task.rs
+++ b/src/query/service/src/interpreters/common/task.rs
@@ -65,5 +65,10 @@ pub fn get_client_config(ctx: Arc<QueryContext>, timeout: Duration) -> Result<Cl
     let user = ctx.get_current_user()?.identity().to_string();
     let query_id = ctx.get_id();
 
-    Ok(build_client_config(tenant, user, query_id, timeout))
+    Ok(build_client_config(
+        tenant.to_string(),
+        user,
+        query_id,
+        timeout,
+    ))
 }

--- a/src/query/service/src/interpreters/hook/refresh_hook.rs
+++ b/src/query/service/src/interpreters/hook/refresh_hook.rs
@@ -167,7 +167,7 @@ async fn generate_refresh_index_plan(
     let mut plans = vec![];
     let indexes = catalog
         .list_indexes_by_table_id(ListIndexesByIdReq {
-            tenant: ctx.get_tenant(),
+            tenant: ctx.get_tenant().to_string(),
             table_id,
         })
         .await?;
@@ -235,7 +235,7 @@ async fn generate_refresh_virtual_column_plan(
     let catalog = ctx.get_catalog(&desc.catalog).await?;
     let res = catalog
         .list_virtual_columns(ListVirtualColumnsReq {
-            tenant: ctx.get_tenant(),
+            tenant: ctx.get_tenant().to_string(),
             table_id: Some(table_info.get_id()),
         })
         .await?;

--- a/src/query/service/src/interpreters/interpreter_connection_create.rs
+++ b/src/query/service/src/interpreters/interpreter_connection_create.rs
@@ -62,7 +62,7 @@ impl Interpreter for CreateConnectionInterpreter {
 
         let tenant = self.ctx.get_tenant();
         let _create_file_format = user_mgr
-            .add_connection(&tenant, conn, &plan.create_option)
+            .add_connection(tenant.as_str(), conn, &plan.create_option)
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_connection_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_connection_desc.rs
@@ -55,7 +55,7 @@ impl Interpreter for DescConnectionInterpreter {
         let user_mgr = UserApiProvider::instance();
 
         let mut connection = user_mgr
-            .get_connection(&tenant, self.plan.name.as_str())
+            .get_connection(tenant.as_str(), self.plan.name.as_str())
             .await?;
 
         let names = vec![connection.name.clone()];

--- a/src/query/service/src/interpreters/interpreter_connection_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_connection_drop.rs
@@ -56,7 +56,7 @@ impl Interpreter for DropConnectionInterpreter {
         let user_mgr = UserApiProvider::instance();
 
         user_mgr
-            .drop_connection(&tenant, &plan.name, plan.if_exists)
+            .drop_connection(tenant.as_str(), &plan.name, plan.if_exists)
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_connection_show.rs
+++ b/src/query/service/src/interpreters/interpreter_connection_show.rs
@@ -55,7 +55,7 @@ impl Interpreter for ShowConnectionsInterpreter {
 
         let user_mgr = UserApiProvider::instance();
         let tenant = self.ctx.get_tenant();
-        let mut formats = user_mgr.get_connections(&tenant).await?;
+        let mut formats = user_mgr.get_connections(tenant.as_str()).await?;
 
         formats.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/src/query/service/src/interpreters/interpreter_data_mask_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_data_mask_desc.rs
@@ -61,7 +61,11 @@ impl Interpreter for DescDataMaskInterpreter {
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let handler = get_datamask_handler();
         let policy = handler
-            .get_data_mask(meta_api, self.ctx.get_tenant(), self.plan.name.clone())
+            .get_data_mask(
+                meta_api,
+                self.ctx.get_tenant().to_string(),
+                self.plan.name.clone(),
+            )
             .await;
 
         let policy = match policy {

--- a/src/query/service/src/interpreters/interpreter_database_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_create.rs
@@ -152,7 +152,7 @@ impl Interpreter for CreateDatabaseInterpreter {
             }
 
             save_share_spec(
-                &self.ctx.get_tenant(),
+                &self.ctx.get_tenant().to_string(),
                 self.ctx.get_data_operator()?.operator(),
                 Some(spec_vec),
                 Some(share_table_into),

--- a/src/query/service/src/interpreters/interpreter_file_format_create.rs
+++ b/src/query/service/src/interpreters/interpreter_file_format_create.rs
@@ -62,7 +62,11 @@ impl Interpreter for CreateFileFormatInterpreter {
 
         let tenant = self.ctx.get_tenant();
         let _create_file_format = user_mgr
-            .add_file_format(&tenant, user_defined_file_format, &plan.create_option)
+            .add_file_format(
+                tenant.as_str(),
+                user_defined_file_format,
+                &plan.create_option,
+            )
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_file_format_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_file_format_drop.rs
@@ -56,7 +56,7 @@ impl Interpreter for DropFileFormatInterpreter {
         let user_mgr = UserApiProvider::instance();
 
         user_mgr
-            .drop_file_format(&tenant, &plan.name, plan.if_exists)
+            .drop_file_format(tenant.as_str(), &plan.name, plan.if_exists)
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_file_format_show.rs
+++ b/src/query/service/src/interpreters/interpreter_file_format_show.rs
@@ -54,7 +54,7 @@ impl Interpreter for ShowFileFormatsInterpreter {
 
         let user_mgr = UserApiProvider::instance();
         let tenant = self.ctx.get_tenant();
-        let mut formats = user_mgr.get_file_formats(&tenant).await?;
+        let mut formats = user_mgr.get_file_formats(tenant.as_str()).await?;
 
         formats.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/src/query/service/src/interpreters/interpreter_metrics.rs
+++ b/src/query/service/src/interpreters/interpreter_metrics.rs
@@ -41,7 +41,7 @@ impl InterpreterMetrics {
         vec![
             (LABEL_HANDLER, handler_type),
             (LABEL_KIND, query_kind),
-            (LABEL_TENANT, tenant_id),
+            (LABEL_TENANT, tenant_id.to_string()),
             (LABEL_CLUSTER, cluster_id),
         ]
     }

--- a/src/query/service/src/interpreters/interpreter_network_policies_show.rs
+++ b/src/query/service/src/interpreters/interpreter_network_policies_show.rs
@@ -50,7 +50,7 @@ impl Interpreter for ShowNetworkPoliciesInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.ctx.get_tenant();
         let user_mgr = UserApiProvider::instance();
-        let network_policies = user_mgr.get_network_policies(&tenant).await?;
+        let network_policies = user_mgr.get_network_policies(tenant.as_str()).await?;
 
         let mut names = Vec::with_capacity(network_policies.len());
         let mut allowed_ip_lists = Vec::with_capacity(network_policies.len());

--- a/src/query/service/src/interpreters/interpreter_network_policy_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_network_policy_alter.rs
@@ -57,7 +57,7 @@ impl Interpreter for AlterNetworkPolicyInterpreter {
         let user_mgr = UserApiProvider::instance();
         user_mgr
             .update_network_policy(
-                &tenant,
+                tenant.as_str(),
                 &plan.name,
                 plan.allowed_ip_list.clone(),
                 plan.blocked_ip_list.clone(),

--- a/src/query/service/src/interpreters/interpreter_network_policy_create.rs
+++ b/src/query/service/src/interpreters/interpreter_network_policy_create.rs
@@ -66,7 +66,7 @@ impl Interpreter for CreateNetworkPolicyInterpreter {
             update_on: None,
         };
         user_mgr
-            .add_network_policy(&tenant, network_policy, &plan.create_option)
+            .add_network_policy(tenant.as_str(), network_policy, &plan.create_option)
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_network_policy_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_network_policy_desc.rs
@@ -54,7 +54,7 @@ impl Interpreter for DescNetworkPolicyInterpreter {
         let user_mgr = UserApiProvider::instance();
 
         let network_policy = user_mgr
-            .get_network_policy(&tenant, self.plan.name.as_str())
+            .get_network_policy(tenant.as_str(), self.plan.name.as_str())
             .await?;
 
         let names = vec![network_policy.name.clone()];

--- a/src/query/service/src/interpreters/interpreter_password_policy_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_password_policy_alter.rs
@@ -69,7 +69,7 @@ impl Interpreter for AlterPasswordPolicyInterpreter {
             AlterPasswordAction::SetOptions(set_options) => {
                 user_mgr
                     .update_password_policy(
-                        &tenant,
+                        tenant.as_str(),
                         &plan.name,
                         set_options.min_length,
                         set_options.max_length,
@@ -151,7 +151,7 @@ impl Interpreter for AlterPasswordPolicyInterpreter {
                 };
                 user_mgr
                     .update_password_policy(
-                        &tenant,
+                        tenant.as_str(),
                         &plan.name,
                         min_length,
                         max_length,

--- a/src/query/service/src/interpreters/interpreter_password_policy_create.rs
+++ b/src/query/service/src/interpreters/interpreter_password_policy_create.rs
@@ -128,7 +128,7 @@ impl Interpreter for CreatePasswordPolicyInterpreter {
             update_on: None,
         };
         user_mgr
-            .add_password_policy(&tenant, password_policy, &plan.create_option)
+            .add_password_policy(tenant.as_str(), password_policy, &plan.create_option)
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_password_policy_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_password_policy_desc.rs
@@ -64,7 +64,7 @@ impl Interpreter for DescPasswordPolicyInterpreter {
         let user_mgr = UserApiProvider::instance();
 
         let password_policy = user_mgr
-            .get_password_policy(&tenant, self.plan.name.as_str())
+            .get_password_policy(tenant.as_str(), self.plan.name.as_str())
             .await?;
 
         let properties = vec![

--- a/src/query/service/src/interpreters/interpreter_privilege_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_grant.rs
@@ -190,16 +190,16 @@ impl Interpreter for GrantPrivilegeInterpreter {
         match plan.principal {
             PrincipalIdentity::User(user) => {
                 user_mgr
-                    .grant_privileges_to_user(&tenant, user, plan.on, plan.priv_types)
+                    .grant_privileges_to_user(tenant.clone(), user, plan.on, plan.priv_types)
                     .await?;
             }
             PrincipalIdentity::Role(role) => {
                 if plan.priv_types.has_privilege(Ownership) && plan.priv_types.len() == 1 {
                     let owner_object = self
-                        .convert_to_ownerobject(&tenant, &plan.on, plan.on.catalog())
+                        .convert_to_ownerobject(tenant.as_str(), &plan.on, plan.on.catalog())
                         .await?;
                     if self.ctx.get_current_role().is_some() {
-                        self.grant_ownership(&self.ctx, &tenant, &owner_object, &role)
+                        self.grant_ownership(&self.ctx, tenant.as_str(), &owner_object, &role)
                             .await?;
                     } else {
                         return Err(databend_common_exception::ErrorCode::UnknownRole(
@@ -208,9 +208,9 @@ impl Interpreter for GrantPrivilegeInterpreter {
                     }
                 } else {
                     user_mgr
-                        .grant_privileges_to_role(&tenant, &role, plan.on, plan.priv_types)
+                        .grant_privileges_to_role(tenant.as_str(), &role, plan.on, plan.priv_types)
                         .await?;
-                    RoleCacheManager::instance().invalidate_cache(&tenant);
+                    RoleCacheManager::instance().invalidate_cache(tenant.as_str());
                 }
             }
         }

--- a/src/query/service/src/interpreters/interpreter_privilege_revoke.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_revoke.rs
@@ -83,7 +83,12 @@ impl Interpreter for RevokePrivilegeInterpreter {
                 }
                 for object in plan.on {
                     user_mgr
-                        .revoke_privileges_from_role(&tenant, &role, object, plan.priv_types)
+                        .revoke_privileges_from_role(
+                            tenant.as_str(),
+                            &role,
+                            object,
+                            plan.priv_types,
+                        )
                         .await?;
                 }
             }

--- a/src/query/service/src/interpreters/interpreter_role_create.rs
+++ b/src/query/service/src/interpreters/interpreter_role_create.rs
@@ -70,9 +70,15 @@ impl Interpreter for CreateRoleInterpreter {
         let tenant = self.ctx.get_tenant();
         let user_mgr = UserApiProvider::instance();
         user_mgr
-            .add_role(&tenant, RoleInfo::new(&role_name), plan.if_not_exists)
+            .add_role(
+                tenant.as_str(),
+                RoleInfo::new(&role_name),
+                plan.if_not_exists,
+            )
             .await?;
-        RoleCacheManager::instance().force_reload(&tenant).await?;
+        RoleCacheManager::instance()
+            .force_reload(tenant.as_str())
+            .await?;
         Ok(PipelineBuildResult::create())
     }
 }

--- a/src/query/service/src/interpreters/interpreter_role_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_role_drop.rs
@@ -67,7 +67,7 @@ impl Interpreter for DropRoleInterpreter {
         }
         let tenant = self.ctx.get_tenant();
         UserApiProvider::instance()
-            .drop_role(&tenant, plan.role_name, plan.if_exists)
+            .drop_role(tenant.as_str(), plan.role_name, plan.if_exists)
             .await?;
 
         let session = self.ctx.get_current_session();
@@ -77,7 +77,9 @@ impl Interpreter for DropRoleInterpreter {
             }
         }
 
-        RoleCacheManager::instance().force_reload(&tenant).await?;
+        RoleCacheManager::instance()
+            .force_reload(tenant.as_str())
+            .await?;
         Ok(PipelineBuildResult::create())
     }
 }

--- a/src/query/service/src/interpreters/interpreter_role_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_role_grant.rs
@@ -60,21 +60,25 @@ impl Interpreter for GrantRoleInterpreter {
         // TODO: check privileges
 
         // Check if the grant role exists.
-        user_mgr.get_role(&tenant, plan.role.clone()).await?;
+        user_mgr
+            .get_role(tenant.as_str(), plan.role.clone())
+            .await?;
         match plan.principal {
             PrincipalIdentity::User(user) => {
                 user_mgr
-                    .grant_role_to_user(&tenant, user, plan.role)
+                    .grant_role_to_user(tenant.clone(), user, plan.role)
                     .await?;
             }
             PrincipalIdentity::Role(role) => {
                 user_mgr
-                    .grant_role_to_role(&tenant, &role, plan.role)
+                    .grant_role_to_role(tenant.as_str(), &role, plan.role)
                     .await?;
             }
         }
 
-        RoleCacheManager::instance().force_reload(&tenant).await?;
+        RoleCacheManager::instance()
+            .force_reload(tenant.as_str())
+            .await?;
         Ok(PipelineBuildResult::create())
     }
 }

--- a/src/query/service/src/interpreters/interpreter_role_revoke.rs
+++ b/src/query/service/src/interpreters/interpreter_role_revoke.rs
@@ -63,12 +63,14 @@ impl Interpreter for RevokeRoleInterpreter {
             }
             PrincipalIdentity::Role(role) => {
                 UserApiProvider::instance()
-                    .revoke_role_from_role(&tenant, &role, &plan.role)
+                    .revoke_role_from_role(tenant.as_str(), &role, &plan.role)
                     .await?;
             }
         }
 
-        RoleCacheManager::instance().force_reload(&tenant).await?;
+        RoleCacheManager::instance()
+            .force_reload(tenant.as_str())
+            .await?;
         Ok(PipelineBuildResult::create())
     }
 }

--- a/src/query/service/src/interpreters/interpreter_share_alter_tenants.rs
+++ b/src/query/service/src/interpreters/interpreter_share_alter_tenants.rs
@@ -57,7 +57,7 @@ impl Interpreter for AlterShareTenantsInterpreter {
         if self.plan.is_add {
             let req = AddShareAccountsReq {
                 share_name: ShareNameIdent {
-                    tenant,
+                    tenant: tenant.to_string(),
                     share_name: self.plan.share.clone(),
                 },
                 if_exists: self.plan.if_exists,
@@ -67,7 +67,7 @@ impl Interpreter for AlterShareTenantsInterpreter {
             let resp = meta_api.add_share_tenants(req).await?;
 
             save_share_spec(
-                &self.ctx.get_tenant(),
+                &self.ctx.get_tenant().to_string(),
                 self.ctx.get_data_operator()?.operator(),
                 resp.spec_vec,
                 None,
@@ -76,7 +76,7 @@ impl Interpreter for AlterShareTenantsInterpreter {
         } else {
             let req = RemoveShareAccountsReq {
                 share_name: ShareNameIdent {
-                    tenant,
+                    tenant: tenant.to_string(),
                     share_name: self.plan.share.clone(),
                 },
                 if_exists: self.plan.if_exists,
@@ -85,7 +85,7 @@ impl Interpreter for AlterShareTenantsInterpreter {
             let resp = meta_api.remove_share_tenants(req).await?;
 
             save_share_spec(
-                &self.ctx.get_tenant(),
+                &self.ctx.get_tenant().to_string(),
                 self.ctx.get_data_operator()?.operator(),
                 resp.spec_vec,
                 None,

--- a/src/query/service/src/interpreters/interpreter_share_create.rs
+++ b/src/query/service/src/interpreters/interpreter_share_create.rs
@@ -52,7 +52,7 @@ impl Interpreter for CreateShareInterpreter {
         let resp = meta_api.create_share(self.plan.clone().into()).await?;
 
         save_share_spec(
-            &self.ctx.get_tenant(),
+            &self.ctx.get_tenant().to_string(),
             self.ctx.get_data_operator()?.operator(),
             resp.spec_vec,
             None,

--- a/src/query/service/src/interpreters/interpreter_share_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_share_desc.rs
@@ -56,7 +56,7 @@ impl Interpreter for DescShareInterpreter {
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let req = GetShareGrantObjectReq {
             share_name: ShareNameIdent {
-                tenant: self.ctx.get_tenant(),
+                tenant: self.ctx.get_tenant().to_string(),
                 share_name: self.plan.share.clone(),
             },
         };

--- a/src/query/service/src/interpreters/interpreter_share_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_share_drop.rs
@@ -52,7 +52,7 @@ impl Interpreter for DropShareInterpreter {
         let resp = meta_api.drop_share(self.plan.clone().into()).await?;
 
         save_share_spec(
-            &self.ctx.get_tenant(),
+            &self.ctx.get_tenant().to_string(),
             self.ctx.get_data_operator()?.operator(),
             resp.spec_vec,
             Some(vec![(self.plan.share.clone(), None)]),

--- a/src/query/service/src/interpreters/interpreter_share_grant_object.rs
+++ b/src/query/service/src/interpreters/interpreter_share_grant_object.rs
@@ -55,7 +55,7 @@ impl Interpreter for GrantShareObjectInterpreter {
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let req = GrantShareObjectReq {
             share_name: ShareNameIdent {
-                tenant,
+                tenant: tenant.to_string(),
                 share_name: self.plan.share.clone(),
             },
             object: self.plan.object.clone(),
@@ -65,7 +65,7 @@ impl Interpreter for GrantShareObjectInterpreter {
         let resp = meta_api.grant_share_object(req).await?;
 
         save_share_spec(
-            &self.ctx.get_tenant(),
+            &self.ctx.get_tenant().to_string(),
             self.ctx.get_data_operator()?.operator(),
             resp.spec_vec,
             Some(vec![resp.share_table_info]),

--- a/src/query/service/src/interpreters/interpreter_share_revoke_object.rs
+++ b/src/query/service/src/interpreters/interpreter_share_revoke_object.rs
@@ -55,7 +55,7 @@ impl Interpreter for RevokeShareObjectInterpreter {
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let req = RevokeShareObjectReq {
             share_name: ShareNameIdent {
-                tenant,
+                tenant: tenant.to_string(),
                 share_name: self.plan.share.clone(),
             },
             object: self.plan.object.clone(),
@@ -65,7 +65,7 @@ impl Interpreter for RevokeShareObjectInterpreter {
         let resp = meta_api.revoke_share_object(req).await?;
 
         save_share_spec(
-            &self.ctx.get_tenant(),
+            &self.ctx.get_tenant().to_string(),
             self.ctx.get_data_operator()?.operator(),
             resp.spec_vec,
             Some(vec![resp.share_table_info]),

--- a/src/query/service/src/interpreters/interpreter_share_show.rs
+++ b/src/query/service/src/interpreters/interpreter_share_show.rs
@@ -62,7 +62,7 @@ impl Interpreter for ShowSharesInterpreter {
 
         // query all share endpoint for other tenant inbound shares
         let share_specs = ShareEndpointManager::instance()
-            .get_inbound_shares(&tenant, None, None)
+            .get_inbound_shares(tenant.as_str(), None, None)
             .await?;
         for (from_tenant, share_spec) in share_specs {
             names.push(share_spec.name.clone());
@@ -70,12 +70,12 @@ impl Interpreter for ShowSharesInterpreter {
             created_owns.push(share_spec.share_on.unwrap_or_default().to_string());
             database_names.push(share_spec.database.unwrap_or_default().name);
             from.push(from_tenant);
-            to.push(tenant.clone());
+            to.push(tenant.to_string());
             comments.push(share_spec.comment.unwrap_or_default());
         }
 
         let req = ShowSharesReq {
-            tenant: tenant.clone(),
+            tenant: tenant.to_string(),
         };
         let resp = meta_api.show_shares(req).await?;
 

--- a/src/query/service/src/interpreters/interpreter_share_show_grant_tenants.rs
+++ b/src/query/service/src/interpreters/interpreter_share_show_grant_tenants.rs
@@ -56,7 +56,7 @@ impl Interpreter for ShowGrantTenantsOfShareInterpreter {
         let tenant = self.ctx.get_tenant();
         let req = GetShareGrantTenantsReq {
             share_name: ShareNameIdent {
-                tenant,
+                tenant: tenant.to_string(),
                 share_name: self.plan.share_name.clone(),
             },
         };

--- a/src/query/service/src/interpreters/interpreter_show_grants.rs
+++ b/src/query/service/src/interpreters/interpreter_show_grants.rs
@@ -70,7 +70,7 @@ impl Interpreter for ShowGrantsInterpreter {
                 }
                 PrincipalIdentity::Role(role) => {
                     let role = UserApiProvider::instance()
-                        .get_role(&tenant, role.clone())
+                        .get_role(tenant.as_str(), role.clone())
                         .await?;
                     (format!("ROLE `{}`", role.identity()), role.grants)
                 }
@@ -78,7 +78,7 @@ impl Interpreter for ShowGrantsInterpreter {
         };
         // TODO: display roles list instead of the inherited roles
         let grant_entries = RoleCacheManager::instance()
-            .find_related_roles(&tenant, &grant_set.roles())
+            .find_related_roles(tenant.as_str(), &grant_set.roles())
             .await?
             .into_iter()
             .map(|role| role.grants)

--- a/src/query/service/src/interpreters/interpreter_show_object_grant_privileges.rs
+++ b/src/query/service/src/interpreters/interpreter_show_object_grant_privileges.rs
@@ -53,7 +53,7 @@ impl Interpreter for ShowObjectGrantPrivilegesInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let req = GetObjectGrantPrivilegesReq {
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
             object: self.plan.object.clone(),
         };
         let resp = meta_api.get_grant_privileges_of_object(req).await?;

--- a/src/query/service/src/interpreters/interpreter_table_add_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_add_column.rs
@@ -135,7 +135,7 @@ impl Interpreter for AddTableColumnInterpreter {
 
             if let Some(share_table_info) = res.share_table_info {
                 save_share_table_info(
-                    &self.ctx.get_tenant(),
+                    self.ctx.get_tenant().as_str(),
                     self.ctx.get_data_operator()?.operator(),
                     share_table_info,
                 )

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -186,7 +186,7 @@ impl CreateTableInterpreter {
                 .await?;
             let db_id = db.get_db_info().ident.db_id;
 
-            let role_api = UserApiProvider::instance().get_role_api_client(&tenant)?;
+            let role_api = UserApiProvider::instance().get_role_api_client(tenant.as_str())?;
             role_api
                 .grant_ownership(
                     &OwnershipObject::Table {
@@ -197,7 +197,7 @@ impl CreateTableInterpreter {
                     &current_role.name,
                 )
                 .await?;
-            RoleCacheManager::instance().invalidate_cache(&tenant);
+            RoleCacheManager::instance().invalidate_cache(tenant.as_str());
         }
 
         // If the table creation query contains column definitions, like 'CREATE TABLE t1(a int) AS SELECT * from t2',
@@ -222,7 +222,7 @@ impl CreateTableInterpreter {
         // update share spec if needed
         if let Some((spec_vec, share_table_info)) = reply.spec_vec {
             save_share_spec(
-                &tenant,
+                &tenant.to_string(),
                 self.ctx.get_data_operator()?.operator(),
                 Some(spec_vec),
                 Some(share_table_info),
@@ -278,7 +278,7 @@ impl CreateTableInterpreter {
                 .await?;
             let db_id = db.get_db_info().ident.db_id;
 
-            let role_api = UserApiProvider::instance().get_role_api_client(&tenant)?;
+            let role_api = UserApiProvider::instance().get_role_api_client(tenant.as_str())?;
             role_api
                 .grant_ownership(
                     &OwnershipObject::Table {
@@ -289,13 +289,13 @@ impl CreateTableInterpreter {
                     &current_role.name,
                 )
                 .await?;
-            RoleCacheManager::instance().invalidate_cache(&tenant);
+            RoleCacheManager::instance().invalidate_cache(tenant.as_str());
         }
 
         // update share spec if needed
         if let Some((spec_vec, share_table_info)) = reply.spec_vec {
             save_share_spec(
-                &self.ctx.get_tenant(),
+                &self.ctx.get_tenant().to_string(),
                 self.ctx.get_data_operator()?.operator(),
                 Some(spec_vec),
                 Some(share_table_info),

--- a/src/query/service/src/interpreters/interpreter_table_drop_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop_column.rs
@@ -132,7 +132,7 @@ impl Interpreter for DropTableColumnInterpreter {
         let res = catalog.update_table_meta(table_info, req).await?;
         if let Some(share_table_info) = res.share_table_info {
             save_share_table_info(
-                &self.ctx.get_tenant(),
+                self.ctx.get_tenant().as_str(),
                 self.ctx.get_data_operator()?.operator(),
                 share_table_info,
             )

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -85,7 +85,11 @@ impl ModifyTableColumnInterpreter {
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let handler = get_datamask_handler();
         let policy = handler
-            .get_data_mask(meta_api, self.ctx.get_tenant(), mask_name.clone())
+            .get_data_mask(
+                meta_api,
+                self.ctx.get_tenant().to_string(),
+                mask_name.clone(),
+            )
             .await?;
 
         // check if column type match to the input type
@@ -117,7 +121,7 @@ impl ModifyTableColumnInterpreter {
                 None
             };
         let req = SetTableColumnMaskPolicyReq {
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
             seq: MatchSeq::Exact(table_version),
             table_id,
             column,
@@ -128,7 +132,7 @@ impl ModifyTableColumnInterpreter {
 
         if let Some(share_table_info) = res.share_table_info {
             save_share_table_info(
-                &self.ctx.get_tenant(),
+                self.ctx.get_tenant().as_str(),
                 self.ctx.get_data_operator()?.operator(),
                 share_table_info,
             )
@@ -162,7 +166,7 @@ impl ModifyTableColumnInterpreter {
 
         if let Some(prev_column_mask_name) = prev_column_mask_name {
             let req = SetTableColumnMaskPolicyReq {
-                tenant: self.ctx.get_tenant(),
+                tenant: self.ctx.get_tenant().to_string(),
                 seq: MatchSeq::Exact(table_version),
                 table_id,
                 column,
@@ -173,7 +177,7 @@ impl ModifyTableColumnInterpreter {
 
             if let Some(share_table_info) = res.share_table_info {
                 save_share_table_info(
-                    &self.ctx.get_tenant(),
+                    self.ctx.get_tenant().as_str(),
                     self.ctx.get_data_operator()?.operator(),
                     share_table_info,
                 )
@@ -359,7 +363,7 @@ impl ModifyTableColumnInterpreter {
 
             if let Some(share_table_info) = res.share_table_info {
                 save_share_table_info(
-                    &self.ctx.get_tenant(),
+                    self.ctx.get_tenant().as_str(),
                     self.ctx.get_data_operator()?.operator(),
                     share_table_info,
                 )
@@ -500,7 +504,7 @@ impl ModifyTableColumnInterpreter {
 
         if let Some(share_table_info) = res.share_table_info {
             save_share_table_info(
-                &self.ctx.get_tenant(),
+                self.ctx.get_tenant().as_str(),
                 self.ctx.get_data_operator()?.operator(),
                 share_table_info,
             )

--- a/src/query/service/src/interpreters/interpreter_table_rename_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_rename_column.rs
@@ -137,7 +137,7 @@ impl Interpreter for RenameTableColumnInterpreter {
 
             if let Some(share_table_info) = res.share_table_info {
                 save_share_table_info(
-                    &self.ctx.get_tenant(),
+                    self.ctx.get_tenant().as_str(),
                     self.ctx.get_data_operator()?.operator(),
                     share_table_info,
                 )

--- a/src/query/service/src/interpreters/interpreter_user_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_create.rs
@@ -62,7 +62,7 @@ impl Interpreter for CreateUserInterpreter {
         let user_mgr = UserApiProvider::instance();
         let users = user_mgr.get_users(&tenant).await?;
 
-        let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
+        let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(tenant.as_str())?;
         let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         if quota.max_users != 0 && users.len() >= quota.max_users as usize {
             return Err(ErrorCode::TenantQuotaExceeded(format!(

--- a/src/query/service/src/interpreters/interpreter_user_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_user_drop.rs
@@ -54,7 +54,7 @@ impl Interpreter for DropUserInterpreter {
         let plan = self.plan.clone();
         let tenant = self.ctx.get_tenant();
         UserApiProvider::instance()
-            .drop_user(&tenant, plan.user, plan.if_exists)
+            .drop_user(tenant, plan.user, plan.if_exists)
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_user_stage_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_stage_create.rs
@@ -117,7 +117,7 @@ impl Interpreter for CreateUserStageInterpreter {
 
         // Grant ownership as the current role
         let tenant = self.ctx.get_tenant();
-        let role_api = UserApiProvider::instance().get_role_api_client(&tenant)?;
+        let role_api = UserApiProvider::instance().get_role_api_client(tenant.as_str())?;
         if let Some(current_role) = self.ctx.get_current_role() {
             role_api
                 .grant_ownership(
@@ -127,7 +127,7 @@ impl Interpreter for CreateUserStageInterpreter {
                     &current_role.name,
                 )
                 .await?;
-            RoleCacheManager::instance().invalidate_cache(&tenant);
+            RoleCacheManager::instance().invalidate_cache(tenant.as_str());
         }
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_user_stage_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_user_stage_drop.rs
@@ -69,21 +69,21 @@ impl Interpreter for DropUserStageInterpreter {
             ));
         }
 
-        let stage = user_mgr.get_stage(&tenant, &plan.name).await;
+        let stage = user_mgr.get_stage(tenant.as_str(), &plan.name).await;
         user_mgr
-            .drop_stage(&tenant, &plan.name, plan.if_exists)
+            .drop_stage(tenant.as_str(), &plan.name, plan.if_exists)
             .await?;
 
         if let Ok(stage) = stage {
             // we should do `drop ownership` after actually drop stage,
             // drop the ownership
-            let role_api = UserApiProvider::instance().get_role_api_client(&tenant)?;
+            let role_api = UserApiProvider::instance().get_role_api_client(tenant.as_str())?;
             let owner_object = OwnershipObject::Stage {
                 name: self.plan.name.clone(),
             };
 
             role_api.revoke_ownership(&owner_object).await?;
-            RoleCacheManager::instance().invalidate_cache(&tenant);
+            RoleCacheManager::instance().invalidate_cache(tenant.as_str());
 
             if !matches!(&stage.stage_type, StageType::External) {
                 let op = StageTable::get_op(&stage)?;

--- a/src/query/service/src/interpreters/interpreter_user_udf_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_user_udf_alter.rs
@@ -56,7 +56,7 @@ impl Interpreter for AlterUserUDFInterpreter {
 
         let tenant = self.ctx.get_tenant();
         UserApiProvider::instance()
-            .update_udf(&tenant, plan.udf)
+            .update_udf(tenant.as_str(), plan.udf)
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_user_udf_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_udf_create.rs
@@ -58,12 +58,12 @@ impl Interpreter for CreateUserUDFInterpreter {
         let tenant = self.ctx.get_tenant();
         let udf = plan.udf;
         let _ = UserApiProvider::instance()
-            .add_udf(&tenant, udf, &plan.create_option)
+            .add_udf(tenant.as_str(), udf, &plan.create_option)
             .await?;
 
         // Grant ownership as the current role
         if let Some(current_role) = self.ctx.get_current_role() {
-            let role_api = UserApiProvider::instance().get_role_api_client(&tenant)?;
+            let role_api = UserApiProvider::instance().get_role_api_client(tenant.as_str())?;
             role_api
                 .grant_ownership(
                     &OwnershipObject::UDF {
@@ -72,7 +72,7 @@ impl Interpreter for CreateUserUDFInterpreter {
                     &current_role.name,
                 )
                 .await?;
-            RoleCacheManager::instance().invalidate_cache(&tenant);
+            RoleCacheManager::instance().invalidate_cache(tenant.as_str());
         }
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_user_udf_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_user_udf_drop.rs
@@ -60,22 +60,22 @@ impl Interpreter for DropUserUDFInterpreter {
         // we should do `drop ownership` after actually drop udf, and udf maybe not exists.
         // drop the ownership
         if UserApiProvider::instance()
-            .exists_udf(&tenant, &self.plan.udf)
+            .exists_udf(tenant.as_str(), &self.plan.udf)
             .await?
         {
-            let role_api = UserApiProvider::instance().get_role_api_client(&tenant)?;
+            let role_api = UserApiProvider::instance().get_role_api_client(tenant.as_str())?;
             let owner_object = OwnershipObject::UDF {
                 name: self.plan.udf.clone(),
             };
 
             role_api.revoke_ownership(&owner_object).await?;
-            RoleCacheManager::instance().invalidate_cache(&tenant);
+            RoleCacheManager::instance().invalidate_cache(tenant.as_str());
         }
 
         // TODO: if it is appropriate to return an ErrorCode that contains either meta-service error and UdfNotFound error?
 
         UserApiProvider::instance()
-            .drop_udf(&tenant, plan.udf.as_str(), plan.if_exists)
+            .drop_udf(tenant.as_str(), plan.udf.as_str(), plan.if_exists)
             .await??;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
@@ -78,7 +78,7 @@ impl VacuumDropTablesInterpreter {
         for c in drop_db_table_ids.chunks(chunk_size) {
             info!("vacuum drop {} table ids: {:?}", c.len(), c);
             let req = GcDroppedTableReq {
-                tenant: self.ctx.get_tenant(),
+                tenant: self.ctx.get_tenant().to_string(),
                 drop_ids: c.to_vec(),
             };
             let _ = catalog.gc_drop_tables(req).await?;
@@ -88,7 +88,7 @@ impl VacuumDropTablesInterpreter {
         for c in drop_db_ids.chunks(chunk_size) {
             info!("vacuum drop {} db ids: {:?}", c.len(), c);
             let req = GcDroppedTableReq {
-                tenant: self.ctx.get_tenant(),
+                tenant: self.ctx.get_tenant().to_string(),
                 drop_ids: c.to_vec(),
             };
             let _ = catalog.gc_drop_tables(req).await?;
@@ -135,7 +135,7 @@ impl Interpreter for VacuumDropTablesInterpreter {
         let (tables, drop_ids) = catalog
             .get_drop_table_infos(ListDroppedTableReq {
                 inner: DatabaseNameIdent {
-                    tenant,
+                    tenant: tenant.to_string(),
                     db_name: self.plan.database.clone(),
                 },
                 filter,

--- a/src/query/service/src/interpreters/interpreter_vacuum_temporary_files.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_temporary_files.rs
@@ -59,7 +59,7 @@ impl Interpreter for VacuumTemporaryFilesInterpreter {
 
         let handler = get_vacuum_handler();
 
-        let temporary_files_prefix = query_spill_prefix(&self.ctx.get_tenant());
+        let temporary_files_prefix = query_spill_prefix(self.ctx.get_tenant().as_str());
         let remove_files = handler
             .do_vacuum_temporary_files(
                 temporary_files_prefix,

--- a/src/query/service/src/interpreters/interpreter_virtual_column_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_alter.rs
@@ -73,7 +73,10 @@ impl Interpreter for AlterVirtualColumnInterpreter {
 
         let update_virtual_column_req = UpdateVirtualColumnReq {
             if_exists: self.plan.if_exists,
-            name_ident: VirtualColumnNameIdent { tenant, table_id },
+            name_ident: VirtualColumnNameIdent {
+                tenant: tenant.to_string(),
+                table_id,
+            },
             virtual_columns: self.plan.virtual_columns.clone(),
         };
 

--- a/src/query/service/src/interpreters/interpreter_virtual_column_create.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_create.rs
@@ -73,7 +73,10 @@ impl Interpreter for CreateVirtualColumnInterpreter {
 
         let create_virtual_column_req = CreateVirtualColumnReq {
             create_option: self.plan.create_option,
-            name_ident: VirtualColumnNameIdent { tenant, table_id },
+            name_ident: VirtualColumnNameIdent {
+                tenant: tenant.to_string(),
+                table_id,
+            },
             virtual_columns: self.plan.virtual_columns.clone(),
         };
 

--- a/src/query/service/src/interpreters/interpreter_virtual_column_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_drop.rs
@@ -73,7 +73,10 @@ impl Interpreter for DropVirtualColumnInterpreter {
 
         let drop_virtual_column_req = DropVirtualColumnReq {
             if_exists: self.plan.if_exists,
-            name_ident: VirtualColumnNameIdent { tenant, table_id },
+            name_ident: VirtualColumnNameIdent {
+                tenant: tenant.to_string(),
+                table_id,
+            },
         };
 
         let handler = get_virtual_column_handler();

--- a/src/query/service/src/local/mod.rs
+++ b/src/query/service/src/local/mod.rs
@@ -56,7 +56,7 @@ pub async fn query_local(query_sql: &str, output_format: &str) -> Result<()> {
 
     GlobalServices::init(&conf).await?;
     // init oss license manager
-    OssLicenseManager::init(conf.query.tenant_id.clone()).unwrap();
+    OssLicenseManager::init(conf.query.tenant_id.to_string()).unwrap();
 
     // Cluster register.
     ClusterDiscovery::instance()

--- a/src/query/service/src/pipelines/builders/builder_aggregate.rs
+++ b/src/query/service/src/pipelines/builders/builder_aggregate.rs
@@ -165,7 +165,7 @@ impl PipelineBuilder {
         // If cluster mode, spill write will be completed in exchange serialize, because we need scatter the block data first
         if self.ctx.get_cluster().is_empty() {
             let operator = DataOperator::instance().operator();
-            let location_prefix = query_spill_prefix(&self.ctx.get_tenant());
+            let location_prefix = query_spill_prefix(self.ctx.get_tenant().as_str());
             self.main_pipeline.add_transform(|input, output| {
                 Ok(ProcessorPtr::create(
                     match params.aggregate_functions.is_empty() {

--- a/src/query/service/src/pipelines/builders/builder_sort.rs
+++ b/src/query/service/src/pipelines/builders/builder_sort.rs
@@ -283,7 +283,7 @@ impl SortPipelineBuilder {
 
         if may_spill {
             let schema = add_order_field(sort_merge_output_schema.clone(), &self.sort_desc);
-            let config = SpillerConfig::create(query_spill_prefix(&self.ctx.get_tenant()));
+            let config = SpillerConfig::create(query_spill_prefix(self.ctx.get_tenant().as_str()));
             pipeline.add_transform(|input, output| {
                 let op = DataOperator::instance().operator();
                 let spiller =

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_injector.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_injector.rs
@@ -208,7 +208,7 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static> AggregateInjecto
         Arc::new(AggregateInjector::<Method, V> {
             ctx,
             method,
-            tenant,
+            tenant: tenant.to_string(),
             aggregator_params: params,
             _phantom: Default::default(),
         })

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/build_spill/build_spill_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/build_spill/build_spill_state.rs
@@ -54,7 +54,7 @@ impl BuildSpillState {
         build_state: Arc<HashJoinBuildState>,
     ) -> Self {
         let tenant = ctx.get_tenant();
-        let spill_config = SpillerConfig::create(query_spill_prefix(&tenant));
+        let spill_config = SpillerConfig::create(query_spill_prefix(tenant.as_str()));
         let operator = DataOperator::instance().operator();
         let spiller = Spiller::create(ctx, operator, spill_config, SpillerType::HashJoinBuild);
         Self {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_spill/probe_spill_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_spill/probe_spill_state.rs
@@ -39,7 +39,7 @@ pub struct ProbeSpillState {
 impl ProbeSpillState {
     pub fn create(ctx: Arc<QueryContext>, probe_state: Arc<HashJoinProbeState>) -> Self {
         let tenant = ctx.get_tenant();
-        let spill_config = SpillerConfig::create(query_spill_prefix(&tenant));
+        let spill_config = SpillerConfig::create(query_spill_prefix(tenant.as_str()));
         let operator = DataOperator::instance().operator();
         let spiller = Spiller::create(ctx, operator, spill_config, SpillerType::HashJoinProbe);
         Self {

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/catalog.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/catalog.rs
@@ -57,12 +57,12 @@ impl CatalogInfoProvider {
             vec![(
                 catalog_name.clone(),
                 catalog_mgr
-                    .get_catalog(&tenant, &catalog_name, ctx.txn_mgr())
+                    .get_catalog(tenant.as_str(), &catalog_name, ctx.txn_mgr())
                     .await?,
             )]
         } else {
             catalog_mgr
-                .list_catalogs(&tenant, ctx.txn_mgr())
+                .list_catalogs(tenant.as_str(), ctx.txn_mgr())
                 .await?
                 .iter()
                 .map(|r| (r.name(), r.clone()))

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/session.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/session.rs
@@ -128,7 +128,7 @@ impl FlightSqlServiceImpl {
         };
 
         UserApiProvider::instance()
-            .update_user_login_result(&tenant, identity, authed.is_ok())
+            .update_user_login_result(tenant, identity, authed.is_ok())
             .await?;
         authed?;
 

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -271,7 +271,7 @@ impl InteractiveWorkerBase {
 
         let authed = user_info.auth_info.auth_mysql(&info.user_password, salt)?;
         UserApiProvider::instance()
-            .update_user_login_result(&ctx.get_tenant(), identity, authed)
+            .update_user_login_result(ctx.get_tenant(), identity, authed)
             .await?;
         if authed {
             self.session.set_authed_user(user_info, None).await?;

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -37,6 +37,7 @@ use databend_common_meta_app::principal::OnErrorMode;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserDefinedConnection;
 use databend_common_meta_app::principal::UserInfo;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_pipeline_core::processors::PlanProfile;
 use databend_common_pipeline_core::InputError;
 use databend_common_settings::Settings;
@@ -279,7 +280,7 @@ impl QueryContextShared {
         StorageMetrics::merge(&metrics)
     }
 
-    pub fn get_tenant(&self) -> String {
+    pub fn get_tenant(&self) -> NonEmptyString {
         self.session.get_current_tenant()
     }
 
@@ -330,7 +331,7 @@ impl QueryContextShared {
         let table_meta_key = (catalog.to_string(), database.to_string(), table.to_string());
         let catalog = self
             .catalog_manager
-            .get_catalog(&tenant, catalog, self.session.session_ctx.txn_mgr())
+            .get_catalog(tenant.as_str(), catalog, self.session.session_ctx.txn_mgr())
             .await?;
         let cache_table = catalog.get_table(tenant.as_str(), database, table).await?;
 
@@ -451,7 +452,7 @@ impl QueryContextShared {
     pub async fn get_connection(&self, name: &str) -> Result<UserDefinedConnection> {
         let user_mgr = UserApiProvider::instance();
         let tenant = self.get_tenant();
-        user_mgr.get_connection(&tenant, name).await
+        user_mgr.get_connection(tenant.as_str(), name).await
     }
 
     pub fn get_query_cache_metrics(&self) -> &DataCacheMetrics {

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -25,6 +25,7 @@ use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserInfo;
 use databend_common_meta_app::principal::UserPrivilegeType;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_settings::Settings;
 use databend_common_users::GrantObjectVisibilityChecker;
 use databend_storages_common_txn::TxnManagerRef;
@@ -76,7 +77,7 @@ impl Session {
         let mut properties = vec![
             ("session_id", self.id.clone()),
             ("session_database", self.get_current_database()),
-            ("session_tenant", self.get_current_tenant()),
+            ("session_tenant", self.get_current_tenant().to_string()),
         ];
         if let Some(query_id) = self.get_current_query_id() {
             properties.push(("query_id", query_id));
@@ -187,7 +188,7 @@ impl Session {
         self.session_ctx.get_current_catalog()
     }
 
-    pub fn get_current_tenant(self: &Arc<Self>) -> String {
+    pub fn get_current_tenant(self: &Arc<Self>) -> NonEmptyString {
         self.session_ctx.get_current_tenant()
     }
 

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -23,6 +23,7 @@ use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserInfo;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_settings::Settings;
 use databend_storages_common_txn::TxnManager;
 use databend_storages_common_txn::TxnManagerRef;
@@ -150,20 +151,20 @@ impl SessionContext {
         *lock = role
     }
 
-    pub fn get_current_tenant(&self) -> String {
+    pub fn get_current_tenant(&self) -> NonEmptyString {
         let conf = GlobalConfig::instance();
 
         if conf.query.internal_enable_sandbox_tenant {
             let sandbox_tenant = self.settings.get_sandbox_tenant().unwrap_or_default();
             if !sandbox_tenant.is_empty() {
-                return sandbox_tenant;
+                return NonEmptyString::new(sandbox_tenant).unwrap();
             }
         }
 
         if conf.query.management_mode || self.typ == SessionType::Local {
             let lock = self.current_tenant.read();
             if !lock.is_empty() {
-                return lock.clone();
+                return NonEmptyString::new(lock.clone()).unwrap();
             }
         }
 

--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -88,7 +88,7 @@ impl SessionManager {
             self.validate_max_active_sessions(mysql_conn_map.len(), "mysql conns")?;
         }
 
-        let tenant = GlobalConfig::instance().query.tenant_id.clone();
+        let tenant = GlobalConfig::instance().query.tenant_id.to_string();
         let settings = Settings::create(tenant);
         self.load_config_changes(&settings)?;
         settings.load_global_changes().await?;

--- a/src/query/service/src/sessions/session_privilege_mgr.rs
+++ b/src/query/service/src/sessions/session_privilege_mgr.rs
@@ -86,7 +86,7 @@ impl SessionPrivilegeManagerImpl {
     async fn ensure_current_role(&self) -> Result<()> {
         let tenant = self.session_ctx.get_current_tenant();
         let public_role = RoleCacheManager::instance()
-            .find_role(&tenant, BUILTIN_ROLE_PUBLIC)
+            .find_role(tenant.as_str(), BUILTIN_ROLE_PUBLIC)
             .await?
             .unwrap_or_else(|| RoleInfo::new(BUILTIN_ROLE_PUBLIC));
 
@@ -208,7 +208,9 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl {
         // find their related roles as the final effective roles
         let role_cache = RoleCacheManager::instance();
         let tenant = self.session_ctx.get_current_tenant();
-        let effective_roles = role_cache.find_related_roles(&tenant, &role_names).await?;
+        let effective_roles = role_cache
+            .find_related_roles(tenant.as_str(), &role_names)
+            .await?;
         Ok(effective_roles)
     }
 
@@ -231,7 +233,7 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl {
 
         let tenant = self.session_ctx.get_current_tenant();
         let mut related_roles = RoleCacheManager::instance()
-            .find_related_roles(&tenant, &roles)
+            .find_related_roles(tenant.as_str(), &roles)
             .await?;
         related_roles.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(related_roles)
@@ -270,7 +272,7 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl {
         let role_mgr = RoleCacheManager::instance();
         let tenant = self.session_ctx.get_current_tenant();
         let owner_role_name = role_mgr
-            .find_object_owner(&tenant, object)
+            .find_object_owner(tenant.as_str(), object)
             .await?
             .unwrap_or_else(|| BUILTIN_ROLE_ACCOUNT_ADMIN.to_string());
 

--- a/src/query/service/src/table_functions/cloud/task_dependents.rs
+++ b/src/query/service/src/table_functions/cloud/task_dependents.rs
@@ -262,7 +262,7 @@ impl AsyncSource for TaskDependentsSource {
         let user = self.ctx.get_current_user()?.identity().to_string();
         let query_id = self.ctx.get_id();
 
-        let cfg = build_client_config(tenant, user, query_id, cloud_api.get_timeout());
+        let cfg = build_client_config(tenant.to_string(), user, query_id, cloud_api.get_timeout());
 
         let dependents = cloud_api
             .get_task_client()

--- a/src/query/service/src/table_functions/cloud/task_dependents_enable.rs
+++ b/src/query/service/src/table_functions/cloud/task_dependents_enable.rs
@@ -176,7 +176,7 @@ impl AsyncSource for TaskDependentsEnableSource {
         let user = self.ctx.get_current_user()?.identity().to_string();
         let query_id = self.ctx.get_id();
 
-        let cfg = build_client_config(tenant, user, query_id, cloud_api.get_timeout());
+        let cfg = build_client_config(tenant.to_string(), user, query_id, cloud_api.get_timeout());
         let req = make_request(self.build_request(), cfg);
         cloud_api
             .get_task_client()

--- a/src/query/service/src/table_functions/others/execute_background_job.rs
+++ b/src/query/service/src/table_functions/others/execute_background_job.rs
@@ -155,7 +155,7 @@ impl AsyncSource for ExecuteBackgroundJobSource {
         let background_handler = get_background_service_handler();
         background_handler
             .execute_scheduled_job(
-                self.ctx.get_tenant(),
+                self.ctx.get_tenant().to_string(),
                 self.ctx.get_current_user()?.identity(),
                 self.job_name.clone(),
             )

--- a/src/query/service/src/table_functions/others/suggested_background_tasks.rs
+++ b/src/query/service/src/table_functions/others/suggested_background_tasks.rs
@@ -197,7 +197,7 @@ impl SuggestedBackgroundTasksSource {
         let ctx = ctx.clone();
         info!(
             background = true,
-            tenant = ctx.get_tenant();
+            tenant = ctx.get_tenant().to_string();
             "list all lsuggestions"
         );
         Self::get_suggested_compaction_tasks(ctx).await

--- a/src/query/service/src/table_functions/others/tenant_quota.rs
+++ b/src/query/service/src/table_functions/others/tenant_quota.rs
@@ -222,7 +222,7 @@ impl AsyncSource for TenantQuotaSource {
         }
 
         self.done = true;
-        let mut tenant = self.ctx.get_tenant();
+        let mut tenant = self.ctx.get_tenant().to_string();
         let args = &self.args;
         if !args.is_empty() {
             let user_info = self.ctx.get_current_user()?;

--- a/src/query/service/src/test_kits/config.rs
+++ b/src/query/service/src/test_kits/config.rs
@@ -19,6 +19,7 @@ use databend_common_config::InnerConfig;
 use databend_common_meta_app::principal::AuthInfo;
 use databend_common_meta_app::storage::StorageFsConfig;
 use databend_common_meta_app::storage::StorageParams;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_users::idm_config::IDMConfig;
 use tempfile::TempDir;
 
@@ -29,7 +30,7 @@ pub struct ConfigBuilder {
 impl ConfigBuilder {
     pub fn create() -> ConfigBuilder {
         let mut conf = InnerConfig::default();
-        conf.query.tenant_id = "test".to_string();
+        conf.query.tenant_id = NonEmptyString::new("test").unwrap();
         conf.log = databend_common_tracing::Config::new_testing();
         // add idm users for test
         let mut users = HashMap::new();

--- a/src/query/service/src/test_kits/fixture.rs
+++ b/src/query/service/src/test_kits/fixture.rs
@@ -210,7 +210,7 @@ impl TestFixture {
         }
 
         GlobalServices::init_with(config).await?;
-        OssLicenseManager::init(config.query.tenant_id.clone())?;
+        OssLicenseManager::init(config.query.tenant_id.to_string())?;
 
         // Cluster register.
         {
@@ -266,7 +266,7 @@ impl TestFixture {
     }
 
     pub fn default_tenant(&self) -> String {
-        self.conf.query.tenant_id.clone()
+        self.conf.query.tenant_id.to_string()
     }
 
     pub fn default_db_name(&self) -> String {
@@ -459,7 +459,7 @@ impl TestFixture {
         let db_name = gen_db_name(&self.prefix);
         let plan = CreateDatabasePlan {
             catalog: "default".to_owned(),
-            tenant,
+            tenant: tenant.to_string(),
             create_option: CreateOption::None,
             database: db_name,
             meta: DatabaseMeta {

--- a/src/query/service/tests/it/api/http/status.rs
+++ b/src/query/service/tests/it/api/http/status.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use databend_common_base::base::tokio;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::UserIdentity;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_users::UserApiProvider;
 use databend_query::api::http::v1::instance_status::instance_status_handler;
 use databend_query::api::http::v1::instance_status::InstanceStatus;
@@ -58,7 +59,10 @@ async fn get_status(ep: &Route) -> InstanceStatus {
 async fn run_query(query_ctx: &Arc<QueryContext>) -> Result<Arc<dyn Interpreter>> {
     let sql = "select sleep(3) from numbers(1)";
     let user = UserApiProvider::instance()
-        .get_user("test", UserIdentity::new("root", "%"))
+        .get_user(
+            &NonEmptyString::new("test").unwrap(),
+            UserIdentity::new("root", "%"),
+        )
         .await?;
     query_ctx
         .get_current_session()

--- a/src/query/service/tests/it/auth.rs
+++ b/src/query/service/tests/it/auth.rs
@@ -154,7 +154,7 @@ async fn test_auth_mgr_with_jwt_multi_sources() -> Result<()> {
         let user2_info = UserInfo::new(user2, "%", AuthInfo::JWT);
         UserApiProvider::instance()
             .add_user(
-                tenant.as_str(),
+                &tenant,
                 user2_info.clone(),
                 &CreateOption::CreateIfNotExists,
             )
@@ -653,7 +653,7 @@ async fn test_jwt_auth_mgr_with_management() -> Result<()> {
             .await?;
         let user_info = ctx.get_current_user()?;
         let current_tenant = ctx.get_tenant();
-        assert_eq!(current_tenant, tenant.to_string());
+        assert_eq!(current_tenant.to_string(), tenant.to_string());
         assert_eq!(user_info.grants.roles().len(), 0);
     }
 

--- a/src/query/service/tests/it/spillers/spiller.rs
+++ b/src/query/service/tests/it/spillers/spiller.rs
@@ -35,7 +35,7 @@ async fn test_spill_with_partition() -> Result<()> {
 
     let ctx = fixture.new_query_ctx().await?;
     let tenant = ctx.get_tenant();
-    let spiller_config = SpillerConfig::create(query_spill_prefix(&tenant));
+    let spiller_config = SpillerConfig::create(query_spill_prefix(tenant.as_str()));
     let operator = DataOperator::instance().operator();
 
     let mut spiller = Spiller::create(ctx, operator, spiller_config, SpillerType::HashJoinBuild);

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -108,6 +108,7 @@ use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_pipeline_core::InputError;
 use databend_common_pipeline_core::PlanProfile;
 use databend_common_settings::Settings;
@@ -567,7 +568,7 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn get_tenant(&self) -> String {
+    fn get_tenant(&self) -> NonEmptyString {
         self.ctx.get_tenant()
     }
 
@@ -653,7 +654,7 @@ impl TableContext for CtxDelegation {
         let tenant = self.ctx.get_tenant();
         let db = database.to_string();
         let tbl = table.to_string();
-        let table_meta_key = (tenant, db, tbl);
+        let table_meta_key = (tenant.to_string(), db, tbl);
         let already_in_cache = { self.cache.lock().contains_key(&table_meta_key) };
         if already_in_cache {
             self.table_from_cache

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -107,6 +107,7 @@ use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_pipeline_core::InputError;
 use databend_common_pipeline_core::PlanProfile;
 use databend_common_settings::Settings;
@@ -542,7 +543,7 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn get_tenant(&self) -> String {
+    fn get_tenant(&self) -> NonEmptyString {
         self.ctx.get_tenant()
     }
 

--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -339,7 +339,7 @@ async fn test_roles_table() -> Result<()> {
     {
         let role_info = RoleInfo::new("test");
         UserApiProvider::instance()
-            .add_role(&tenant, role_info, false)
+            .add_role(tenant.as_str(), role_info, false)
             .await?;
     }
 
@@ -347,7 +347,7 @@ async fn test_roles_table() -> Result<()> {
         let mut role_info = RoleInfo::new("test1");
         role_info.grants.grant_role("test".to_string());
         UserApiProvider::instance()
-            .add_role(&tenant, role_info, false)
+            .add_role(tenant.as_str(), role_info, false)
             .await?;
     }
     let table = RolesTable::create(1);

--- a/src/query/sharing/src/share_endpoint.rs
+++ b/src/query/sharing/src/share_endpoint.rs
@@ -129,7 +129,11 @@ impl ShareEndpointManager {
         );
         let bs = Bytes::from(serde_json::to_vec(&tables)?);
         let auth = endpoint_config.token.to_header().await?;
-        let requester = GlobalConfig::instance().as_ref().query.tenant_id.clone();
+        let requester = GlobalConfig::instance()
+            .as_ref()
+            .query
+            .tenant_id
+            .to_string();
         let req = Request::builder()
             .method(Method::POST)
             .uri(&url)
@@ -190,7 +194,11 @@ impl ShareEndpointManager {
             let url = format!("{}tenant/{}/share_spec", endpoint_config.url, from_tenant);
             let bs = Bytes::from(serde_json::to_vec(&share_names)?);
             let auth = endpoint_config.token.to_header().await?;
-            let requester = GlobalConfig::instance().as_ref().query.tenant_id.clone();
+            let requester = GlobalConfig::instance()
+                .as_ref()
+                .query
+                .tenant_id
+                .to_string();
             let req = Request::builder()
                 .method(Method::POST)
                 .uri(&url)

--- a/src/query/sharing/src/signer.rs
+++ b/src/query/sharing/src/signer.rs
@@ -156,7 +156,11 @@ impl SharedSigner {
             .collect();
         let bs = Bytes::from(serde_json::to_vec(&reqs)?);
         let auth = self.token.to_header().await?;
-        let requester = GlobalConfig::instance().as_ref().query.tenant_id.clone();
+        let requester = GlobalConfig::instance()
+            .as_ref()
+            .query
+            .tenant_id
+            .to_string();
         let req = Request::builder()
             .method(Method::POST)
             .uri(&self.endpoint)

--- a/src/query/sql/src/executor/table_read_plan.rs
+++ b/src/query/sql/src/executor/table_read_plan.rs
@@ -209,7 +209,7 @@ impl ToReadDataSourcePlan for dyn Table {
                             if let Ok(policy) = handler
                                 .get_data_mask(
                                     meta_api.clone(),
-                                    tenant.clone(),
+                                    tenant.to_string(),
                                     mask_policy.clone(),
                                 )
                                 .await

--- a/src/query/sql/src/planner/binder/copy_into_table.rs
+++ b/src/query/sql/src/planner/binder/copy_into_table.rs
@@ -578,7 +578,7 @@ pub async fn resolve_stage_location(
         StageInfo::new_user_stage(&ctx.get_current_user()?.name)
     } else {
         UserApiProvider::instance()
-            .get_stage(&ctx.get_tenant(), names[0])
+            .get_stage(ctx.get_tenant().as_str(), names[0])
             .await?
     };
 

--- a/src/query/sql/src/planner/binder/ddl/account.rs
+++ b/src/query/sql/src/planner/binder/ddl/account.rs
@@ -143,13 +143,13 @@ impl Binder {
                     .clone()
                     .unwrap_or_else(|| self.ctx.get_current_database());
                 let db_id = catalog
-                    .get_database(&tenant, &database_name)
+                    .get_database(tenant.as_str(), &database_name)
                     .await?
                     .get_db_info()
                     .ident
                     .db_id;
                 let table_id = catalog
-                    .get_table(&tenant, &database_name, table_name)
+                    .get_table(tenant.as_str(), &database_name, table_name)
                     .await?
                     .get_id();
                 Ok(GrantObject::TableById(catalog_name, db_id, table_id))
@@ -159,7 +159,7 @@ impl Binder {
                     .clone()
                     .unwrap_or_else(|| self.ctx.get_current_database());
                 let db_id = catalog
-                    .get_database(&tenant, &database_name)
+                    .get_database(tenant.as_str(), &database_name)
                     .await?
                     .get_db_info()
                     .ident
@@ -188,13 +188,13 @@ impl Binder {
                     .clone()
                     .unwrap_or_else(|| self.ctx.get_current_database());
                 let db_id = catalog
-                    .get_database(&tenant, &database_name)
+                    .get_database(tenant.as_str(), &database_name)
                     .await?
                     .get_db_info()
                     .ident
                     .db_id;
                 let table_id = catalog
-                    .get_table(&tenant, &database_name, table_name)
+                    .get_table(tenant.as_str(), &database_name, table_name)
                     .await?
                     .get_id();
                 Ok(vec![
@@ -207,7 +207,7 @@ impl Binder {
                     .clone()
                     .unwrap_or_else(|| self.ctx.get_current_database());
                 let db_id = catalog
-                    .get_database(&tenant, &database_name)
+                    .get_database(tenant.as_str(), &database_name)
                     .await?
                     .get_db_info()
                     .ident
@@ -239,7 +239,7 @@ impl Binder {
         }
         UserApiProvider::instance()
             .verify_password(
-                &self.ctx.get_tenant(),
+                self.ctx.get_tenant().as_str(),
                 &user_option,
                 auth_option,
                 None,
@@ -289,7 +289,7 @@ impl Binder {
             // verify the password if changed
             UserApiProvider::instance()
                 .verify_password(
-                    &self.ctx.get_tenant(),
+                    self.ctx.get_tenant().as_str(),
                     &user_option,
                     auth_option,
                     Some(&user_info),

--- a/src/query/sql/src/planner/binder/ddl/catalog.rs
+++ b/src/query/sql/src/planner/binder/ddl/catalog.rs
@@ -109,7 +109,7 @@ impl Binder {
 
         Ok(Plan::CreateCatalog(Box::new(CreateCatalogPlan {
             if_not_exists: *if_not_exists,
-            tenant,
+            tenant: tenant.to_string(),
             catalog: catalog.to_string(),
             meta,
         })))
@@ -125,7 +125,7 @@ impl Binder {
         let catalog = normalize_identifier(catalog, &self.name_resolution_ctx).name;
         Ok(Plan::DropCatalog(Box::new(DropCatalogPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
         })))
     }

--- a/src/query/sql/src/planner/binder/ddl/column.rs
+++ b/src/query/sql/src/planner/binder/ddl/column.rs
@@ -53,7 +53,7 @@ impl Binder {
             Some(ident) => {
                 let database = normalize_identifier(ident, &self.name_resolution_ctx).name;
                 catalog
-                    .get_database(&self.ctx.get_tenant(), &database)
+                    .get_database(self.ctx.get_tenant().as_str(), &database)
                     .await?;
                 database
             }
@@ -62,7 +62,7 @@ impl Binder {
         let table = {
             let table = normalize_identifier(table, &self.name_resolution_ctx).name;
             catalog
-                .get_table(&self.ctx.get_tenant(), database.as_str(), &table)
+                .get_table(self.ctx.get_tenant().as_str(), database.as_str(), &table)
                 .await?;
             table
         };

--- a/src/query/sql/src/planner/binder/ddl/data_mask.rs
+++ b/src/query/sql/src/planner/binder/ddl/data_mask.rs
@@ -47,7 +47,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = CreateDatamaskPolicyPlan {
             create_option: *create_option,
-            tenant,
+            tenant: tenant.to_string(),
             name: name.to_string(),
             policy: policy.clone(),
         };
@@ -64,7 +64,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = DropDatamaskPolicyPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             name: name.to_string(),
         };
         Ok(Plan::DropDatamaskPolicy(Box::new(plan)))

--- a/src/query/sql/src/planner/binder/ddl/database.rs
+++ b/src/query/sql/src/planner/binder/ddl/database.rs
@@ -147,7 +147,7 @@ impl Binder {
                 };
 
                 Ok(Plan::RenameDatabase(Box::new(RenameDatabasePlan {
-                    tenant,
+                    tenant: tenant.to_string(),
                     entities: vec![entry],
                 })))
             }
@@ -174,7 +174,7 @@ impl Binder {
 
         Ok(Plan::DropDatabase(Box::new(DropDatabasePlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
         })))
@@ -195,7 +195,7 @@ impl Binder {
         let database = normalize_identifier(database, &self.name_resolution_ctx).name;
 
         Ok(Plan::UndropDatabase(Box::new(UndropDatabasePlan {
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
         })))
@@ -232,7 +232,7 @@ impl Binder {
 
         Ok(Plan::CreateDatabase(Box::new(CreateDatabasePlan {
             create_option: *create_option,
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
             meta,

--- a/src/query/sql/src/planner/binder/ddl/network_policy.rs
+++ b/src/query/sql/src/planner/binder/ddl/network_policy.rs
@@ -61,7 +61,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = CreateNetworkPolicyPlan {
             create_option: *create_option,
-            tenant,
+            tenant: tenant.to_string(),
             name: name.to_string(),
             allowed_ip_list: allowed_ip_list.clone(),
             blocked_ip_list: blocked_ip_list.clone().unwrap_or_default(),
@@ -107,7 +107,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = AlterNetworkPolicyPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             name: name.to_string(),
             allowed_ip_list: allowed_ip_list.clone(),
             blocked_ip_list: blocked_ip_list.clone(),
@@ -126,7 +126,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = DropNetworkPolicyPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             name: name.to_string(),
         };
         Ok(Plan::DropNetworkPolicy(Box::new(plan)))

--- a/src/query/sql/src/planner/binder/ddl/password_policy.rs
+++ b/src/query/sql/src/planner/binder/ddl/password_policy.rs
@@ -40,7 +40,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = CreatePasswordPolicyPlan {
             create_option: *create_option,
-            tenant,
+            tenant: tenant.to_string(),
             name: name.to_string(),
             set_options: set_options.clone(),
         };
@@ -61,7 +61,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = AlterPasswordPolicyPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             name: name.to_string(),
             action: action.clone(),
         };
@@ -78,7 +78,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = DropPasswordPolicyPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             name: name.to_string(),
         };
         Ok(Plan::DropPasswordPolicy(Box::new(plan)))

--- a/src/query/sql/src/planner/binder/ddl/share.rs
+++ b/src/query/sql/src/planner/binder/ddl/share.rs
@@ -53,7 +53,7 @@ impl Binder {
         let plan = CreateShareEndpointPlan {
             create_option: *create_option,
             endpoint: ShareEndpointIdent {
-                tenant: self.ctx.get_tenant(),
+                tenant: self.ctx.get_tenant().to_string(),
                 endpoint,
             },
             tenant: tenant.to_string(),
@@ -70,7 +70,7 @@ impl Binder {
         _stmt: &ShowShareEndpointStmt,
     ) -> Result<Plan> {
         let plan = ShowShareEndpointPlan {
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
         };
         Ok(Plan::ShowShareEndpoint(Box::new(plan)))
     }
@@ -86,7 +86,7 @@ impl Binder {
         } = stmt;
         let plan = DropShareEndpointPlan {
             if_exists: *if_exists,
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
             endpoint: endpoint.to_string(),
         };
         Ok(Plan::DropShareEndpoint(Box::new(plan)))
@@ -107,7 +107,7 @@ impl Binder {
 
         let plan = CreateSharePlan {
             if_not_exists: *if_not_exists,
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
             share,
             comment: comment.as_ref().cloned(),
         };
@@ -125,7 +125,7 @@ impl Binder {
 
         let plan = DropSharePlan {
             if_exists: *if_exists,
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
             share,
         };
         Ok(Plan::DropShare(Box::new(plan)))

--- a/src/query/sql/src/planner/binder/ddl/stage.rs
+++ b/src/query/sql/src/planner/binder/ddl/stage.rs
@@ -117,7 +117,7 @@ impl Binder {
 
         Ok(Plan::CreateStage(Box::new(CreateStagePlan {
             create_option: *create_option,
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
             stage_info,
         })))
     }

--- a/src/query/sql/src/planner/binder/ddl/stream.rs
+++ b/src/query/sql/src/planner/binder/ddl/stream.rs
@@ -74,7 +74,7 @@ impl Binder {
 
         let plan = CreateStreamPlan {
             create_option: *create_option,
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
             stream_name,
@@ -104,7 +104,7 @@ impl Binder {
             self.normalize_object_identifier_triple(catalog, database, stream);
         let plan = DropStreamPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
             stream_name,

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -390,7 +390,7 @@ impl Binder {
                 self.ctx
                     .get_catalog(&ctl_name)
                     .await?
-                    .get_database(&self.ctx.get_tenant(), &database)
+                    .get_database(self.ctx.get_tenant().as_str(), &database)
                     .await?;
                 Ok(database)
             }
@@ -586,7 +586,7 @@ impl Binder {
             // safely eliminate this "FUSE" constant and the table meta option entry.
             let catalog = self.ctx.get_catalog(&catalog).await?;
             let db = catalog
-                .get_database(&self.ctx.get_tenant(), &database)
+                .get_database(self.ctx.get_tenant().as_str(), &database)
                 .await?;
             let db_id = db.get_db_info().ident.db_id;
             options.insert(OPT_KEY_DATABASE_ID.to_owned(), db_id.to_string());
@@ -646,7 +646,7 @@ impl Binder {
 
         let plan = CreateTablePlan {
             create_option: *create_option,
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
             catalog: catalog.clone(),
             database: database.clone(),
             table,
@@ -728,7 +728,7 @@ impl Binder {
 
         Ok(Plan::CreateTable(Box::new(CreateTablePlan {
             create_option: CreateOption::None,
-            tenant: self.ctx.get_tenant(),
+            tenant: self.ctx.get_tenant().to_string(),
             catalog,
             database,
             table,
@@ -764,7 +764,7 @@ impl Binder {
 
         Ok(Plan::DropTable(Box::new(DropTablePlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
             table,
@@ -788,7 +788,7 @@ impl Binder {
             self.normalize_object_identifier_triple(catalog, database, table);
 
         Ok(Plan::UndropTable(Box::new(UndropTablePlan {
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
             table,
@@ -826,7 +826,7 @@ impl Binder {
         match action {
             AlterTableAction::RenameTable { new_table } => {
                 Ok(Plan::RenameTable(Box::new(RenameTablePlan {
-                    tenant,
+                    tenant: tenant.to_string(),
                     if_exists: *if_exists,
                     new_database: database.clone(),
                     new_table: normalize_identifier(new_table, &self.name_resolution_ctx).name,
@@ -848,7 +848,7 @@ impl Binder {
                     .analyze_rename_column(old_column, new_column, schema)
                     .await?;
                 Ok(Plan::RenameTableColumn(Box::new(RenameTableColumnPlan {
-                    tenant: self.ctx.get_tenant(),
+                    tenant: self.ctx.get_tenant().to_string(),
                     catalog,
                     database,
                     table,
@@ -875,7 +875,7 @@ impl Binder {
                     AstAddColumnOption::End => AddColumnOption::End,
                 };
                 Ok(Plan::AddTableColumn(Box::new(AddTableColumnPlan {
-                    tenant: self.ctx.get_tenant(),
+                    tenant: self.ctx.get_tenant().to_string(),
                     catalog,
                     database,
                     table,
@@ -938,7 +938,7 @@ impl Binder {
 
                 Ok(Plan::AlterTableClusterKey(Box::new(
                     AlterTableClusterKeyPlan {
-                        tenant,
+                        tenant: tenant.to_string(),
                         catalog,
                         database,
                         table,
@@ -948,7 +948,7 @@ impl Binder {
             }
             AlterTableAction::DropTableClusterKey => Ok(Plan::DropTableClusterKey(Box::new(
                 DropTableClusterKeyPlan {
-                    tenant,
+                    tenant: tenant.to_string(),
                     catalog,
                     database,
                     table,
@@ -981,7 +981,7 @@ impl Binder {
                 };
 
                 Ok(Plan::ReclusterTable(Box::new(ReclusterTablePlan {
-                    tenant,
+                    tenant: tenant.to_string(),
                     catalog,
                     database,
                     table,
@@ -994,7 +994,7 @@ impl Binder {
             AlterTableAction::RevertTo { point } => {
                 let point = self.resolve_data_travel_point(bind_context, point).await?;
                 Ok(Plan::RevertTable(Box::new(RevertTablePlan {
-                    tenant,
+                    tenant: tenant.to_string(),
                     catalog,
                     database,
                     table,
@@ -1042,7 +1042,7 @@ impl Binder {
         }
 
         Ok(Plan::RenameTable(Box::new(RenameTablePlan {
-            tenant,
+            tenant: tenant.to_string(),
             if_exists: *if_exists,
             catalog,
             database: db_name,

--- a/src/query/sql/src/planner/binder/ddl/task.rs
+++ b/src/query/sql/src/planner/binder/ddl/task.rs
@@ -110,7 +110,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = CreateTaskPlan {
             if_not_exists: *if_not_exists,
-            tenant,
+            tenant: tenant.to_string(),
             task_name: name.to_string(),
             warehouse_opts: warehouse_opts.clone(),
             schedule_opts: schedule_opts.clone(),
@@ -165,7 +165,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = AlterTaskPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             task_name: name.to_string(),
             alter_options: options.clone(),
         };
@@ -183,7 +183,7 @@ impl Binder {
 
         let plan = DropTaskPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             task_name: name.to_string(),
         };
         Ok(Plan::DropTask(Box::new(plan)))
@@ -199,7 +199,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
 
         let plan = DescribeTaskPlan {
-            tenant,
+            tenant: tenant.to_string(),
             task_name: name.to_string(),
         };
         Ok(Plan::DescribeTask(Box::new(plan)))
@@ -215,7 +215,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
 
         let plan = ExecuteTaskPlan {
-            tenant,
+            tenant: tenant.to_string(),
             task_name: name.to_string(),
         };
         Ok(Plan::ExecuteTask(Box::new(plan)))
@@ -231,7 +231,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
 
         let plan = ShowTasksPlan {
-            tenant,
+            tenant: tenant.to_string(),
             limit: limit.clone(),
         };
         Ok(Plan::ShowTasks(Box::new(plan)))

--- a/src/query/sql/src/planner/binder/ddl/view.rs
+++ b/src/query/sql/src/planner/binder/ddl/view.rs
@@ -56,7 +56,7 @@ impl Binder {
 
         let plan = CreateViewPlan {
             create_option: *create_option,
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
             view_name,
@@ -94,7 +94,7 @@ impl Binder {
         let subquery = format!("{}", query);
 
         let plan = AlterViewPlan {
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
             view_name,
@@ -121,7 +121,7 @@ impl Binder {
             self.normalize_object_identifier_triple(catalog, database, view);
         let plan = DropViewPlan {
             if_exists: *if_exists,
-            tenant,
+            tenant: tenant.to_string(),
             catalog,
             database,
             view_name,

--- a/src/query/sql/src/planner/binder/ddl/virtual_column.rs
+++ b/src/query/sql/src/planner/binder/ddl/virtual_column.rs
@@ -168,7 +168,7 @@ impl Binder {
         let catalog_info = self.ctx.get_catalog(&catalog).await?;
         let res = catalog_info
             .list_virtual_columns(ListVirtualColumnsReq {
-                tenant: self.ctx.get_tenant(),
+                tenant: self.ctx.get_tenant().to_string(),
                 table_id: Some(table_info.get_id()),
             })
             .await?;
@@ -298,7 +298,7 @@ impl Binder {
             Some(ident) => {
                 let database = normalize_identifier(ident, &self.name_resolution_ctx).name;
                 catalog
-                    .get_database(&self.ctx.get_tenant(), &database)
+                    .get_database(self.ctx.get_tenant().as_str(), &database)
                     .await?;
                 database
             }

--- a/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
@@ -94,7 +94,7 @@ impl VirtualColumnRewriter {
 
             let table_id = table.get_id();
             let req = ListVirtualColumnsReq {
-                tenant: self.ctx.get_tenant(),
+                tenant: self.ctx.get_tenant().to_string(),
                 table_id: Some(table_id),
             };
             let catalog = self.ctx.get_catalog(table_entry.catalog()).await?;

--- a/src/query/storages/fuse/src/operations/analyze.rs
+++ b/src/query/storages/fuse/src/operations/analyze.rs
@@ -112,7 +112,7 @@ impl SinkAnalyzeState {
         // always use the latest table
         let tenant = self.ctx.get_tenant();
         let catalog = CatalogManager::instance()
-            .get_catalog(&tenant, &self.catalog, self.ctx.txn_mgr())
+            .get_catalog(tenant.as_str(), &self.catalog, self.ctx.txn_mgr())
             .await?;
         let table = catalog
             .get_table(tenant.as_str(), &self.database, &self.table)

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -83,7 +83,7 @@ impl FuseTable {
         let catalog = ctx.get_catalog(&ctx.get_current_catalog()).await?;
         let table_agg_index_ids = catalog
             .list_index_ids_by_table_id(ListIndexesByIdReq {
-                tenant: ctx.get_tenant(),
+                tenant: ctx.get_tenant().to_string(),
                 table_id: self.get_id(),
             })
             .await?;

--- a/src/query/storages/result_cache/src/read/reader.rs
+++ b/src/query/storages/result_cache/src/read/reader.rs
@@ -52,7 +52,7 @@ impl ResultCacheReader {
         tolerate_inconsistent: bool,
     ) -> Self {
         let tenant = ctx.get_tenant();
-        let meta_key = gen_result_cache_meta_key(&tenant, key);
+        let meta_key = gen_result_cache_meta_key(tenant.as_str(), key);
         let partitions_shas = ctx.get_partitions_shas();
 
         Self {

--- a/src/query/storages/result_cache/src/write/sink.rs
+++ b/src/query/storages/result_cache/src/write/sink.rs
@@ -107,7 +107,7 @@ impl WriteResultCacheSink {
         let sql = ctx.get_query_str();
         let partitions_shas = ctx.get_partitions_shas();
 
-        let meta_key = gen_result_cache_meta_key(&tenant, key);
+        let meta_key = gen_result_cache_meta_key(tenant.as_str(), key);
         let location = gen_result_cache_dir(key);
 
         let operator = DataOperator::instance().operator();

--- a/src/query/storages/system/src/background_jobs_table.rs
+++ b/src/query/storages/system/src/background_jobs_table.rs
@@ -59,7 +59,9 @@ impl AsyncSystemTable for BackgroundJobTable {
         let tenant = ctx.get_tenant();
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let jobs = meta_api
-            .list_background_jobs(ListBackgroundJobsReq { tenant })
+            .list_background_jobs(ListBackgroundJobsReq {
+                tenant: tenant.to_string(),
+            })
             .await?;
         let mut names = Vec::with_capacity(jobs.len());
         let mut job_types = Vec::with_capacity(jobs.len());

--- a/src/query/storages/system/src/background_tasks_table.rs
+++ b/src/query/storages/system/src/background_tasks_table.rs
@@ -59,7 +59,9 @@ impl AsyncSystemTable for BackgroundTaskTable {
         let tenant = ctx.get_tenant();
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let tasks = meta_api
-            .list_background_tasks(ListBackgroundTasksReq { tenant })
+            .list_background_tasks(ListBackgroundTasksReq {
+                tenant: tenant.to_string(),
+            })
             .await?;
         let mut names = Vec::with_capacity(tasks.len());
         let mut types = Vec::with_capacity(tasks.len());

--- a/src/query/storages/system/src/catalogs_table.rs
+++ b/src/query/storages/system/src/catalogs_table.rs
@@ -53,7 +53,7 @@ impl AsyncSystemTable for CatalogsTable {
         let mgr = CatalogManager::instance();
 
         let catalog_names = mgr
-            .list_catalogs(&ctx.get_tenant(), ctx.txn_mgr())
+            .list_catalogs(ctx.get_tenant().as_str(), ctx.txn_mgr())
             .await?
             .into_iter()
             .map(|v| v.name())

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -234,7 +234,7 @@ pub(crate) async fn dump_tables(
     } else {
         for db in databases {
             let db_id = catalog
-                .get_database(&tenant, &db)
+                .get_database(tenant.as_str(), &db)
                 .await?
                 .get_db_info()
                 .ident

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -58,7 +58,7 @@ impl AsyncSystemTable for DatabasesTable {
         let tenant = ctx.get_tenant();
         let catalogs = CatalogManager::instance();
         let catalogs: Vec<(String, Arc<dyn Catalog>)> = catalogs
-            .list_catalogs(&tenant, ctx.txn_mgr())
+            .list_catalogs(tenant.as_str(), ctx.txn_mgr())
             .await?
             .iter()
             .map(|e| (e.name(), e.clone()))
@@ -93,7 +93,7 @@ impl AsyncSystemTable for DatabasesTable {
                 db_id.push(id);
                 owners.push(
                     user_api
-                        .get_ownership(&tenant, &OwnershipObject::Database {
+                        .get_ownership(tenant.as_str(), &OwnershipObject::Database {
                             catalog_name: ctl_name.to_string(),
                             db_id: id,
                         })

--- a/src/query/storages/system/src/indexes_table.rs
+++ b/src/query/storages/system/src/indexes_table.rs
@@ -55,7 +55,7 @@ impl AsyncSystemTable for IndexesTable {
         let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
         let indexes = catalog
             .list_indexes(ListIndexesReq {
-                tenant,
+                tenant: tenant.to_string(),
                 table_id: None,
             })
             .await?;

--- a/src/query/storages/system/src/locks_table.rs
+++ b/src/query/storages/system/src/locks_table.rs
@@ -60,7 +60,9 @@ impl AsyncSystemTable for LocksTable {
     ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let catalog_mgr = CatalogManager::instance();
-        let ctls = catalog_mgr.list_catalogs(&tenant, ctx.txn_mgr()).await?;
+        let ctls = catalog_mgr
+            .list_catalogs(tenant.as_str(), ctx.txn_mgr())
+            .await?;
 
         let mut lock_table_id = Vec::new();
         let mut lock_revision = Vec::new();

--- a/src/query/storages/system/src/password_policies_table.rs
+++ b/src/query/storages/system/src/password_policies_table.rs
@@ -53,7 +53,7 @@ impl AsyncSystemTable for PasswordPoliciesTable {
     ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let password_policies = UserApiProvider::instance()
-            .get_password_policies(&tenant)
+            .get_password_policies(tenant.as_str())
             .await?;
 
         let mut names = Vec::with_capacity(password_policies.len());

--- a/src/query/storages/system/src/query_cache_table.rs
+++ b/src/query/storages/system/src/query_cache_table.rs
@@ -59,7 +59,7 @@ impl AsyncSystemTable for QueryCacheTable {
         let meta_client = UserApiProvider::instance().get_meta_store_client();
         let result_cache_mgr = ResultCacheMetaManager::create(meta_client, 0);
         let tenant = ctx.get_tenant();
-        let prefix = gen_result_cache_prefix(&tenant);
+        let prefix = gen_result_cache_prefix(tenant.as_str());
 
         let cached_values = result_cache_mgr.list(prefix.as_str()).await?;
 

--- a/src/query/storages/system/src/roles_table.rs
+++ b/src/query/storages/system/src/roles_table.rs
@@ -53,7 +53,9 @@ impl AsyncSystemTable for RolesTable {
         _push_downs: Option<PushDownInfo>,
     ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
-        let roles = UserApiProvider::instance().get_roles(&tenant).await?;
+        let roles = UserApiProvider::instance()
+            .get_roles(tenant.as_str())
+            .await?;
 
         let names: Vec<&str> = roles.iter().map(|x| x.name.as_str()).collect();
         let inherited_roles: Vec<u64> = roles

--- a/src/query/storages/system/src/stages_table.rs
+++ b/src/query/storages/system/src/stages_table.rs
@@ -57,7 +57,9 @@ impl AsyncSystemTable for StagesTable {
         _push_downs: Option<PushDownInfo>,
     ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
-        let stages = UserApiProvider::instance().get_stages(&tenant).await?;
+        let stages = UserApiProvider::instance()
+            .get_stages(tenant.as_str())
+            .await?;
         let enable_experimental_rbac_check =
             ctx.get_settings().get_enable_experimental_rbac_check()?;
         let stages = if enable_experimental_rbac_check {
@@ -89,7 +91,9 @@ impl AsyncSystemTable for StagesTable {
             name.push(stage_name.clone());
             owners.push(
                 user_api
-                    .get_ownership(&tenant, &OwnershipObject::Stage { name: stage_name })
+                    .get_ownership(tenant.as_str(), &OwnershipObject::Stage {
+                        name: stage_name,
+                    })
                     .await
                     .ok()
                     .and_then(|ownership| ownership.map(|o| o.role.clone())),

--- a/src/query/storages/system/src/streams_table.rs
+++ b/src/query/storages/system/src/streams_table.rs
@@ -67,7 +67,7 @@ impl AsyncSystemTable for StreamsTable {
         let tenant = ctx.get_tenant();
         let catalog_mgr = CatalogManager::instance();
         let ctls: Vec<(String, Arc<dyn Catalog>)> = catalog_mgr
-            .list_catalogs(&tenant, ctx.txn_mgr())
+            .list_catalogs(tenant.as_str(), ctx.txn_mgr())
             .await?
             .iter()
             .map(|e| (e.name(), e.clone()))
@@ -171,7 +171,7 @@ impl AsyncSystemTable for StreamsTable {
                         updated_on.push(stream_info.meta.updated_on.timestamp_micros());
                         owner.push(
                             user_api
-                                .get_ownership(&tenant, &OwnershipObject::Table {
+                                .get_ownership(tenant.as_str(), &OwnershipObject::Table {
                                     catalog_name: ctl_name.to_string(),
                                     db_id,
                                     table_id: t_id,

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -105,7 +105,9 @@ where TablesTable<T>: HistoryAware
     ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let catalog_mgr = CatalogManager::instance();
-        let catalogs = catalog_mgr.list_catalogs(&tenant, ctx.txn_mgr()).await?;
+        let catalogs = catalog_mgr
+            .list_catalogs(tenant.as_str(), ctx.txn_mgr())
+            .await?;
         let visibility_checker = ctx.get_visibility_checker().await?;
 
         Ok(self
@@ -241,7 +243,10 @@ where TablesTable<T>: HistoryAware
                 })
                 .collect::<Vec<_>>();
 
-            let ownership = user_api.get_ownerships(&tenant).await.unwrap_or_default();
+            let ownership = user_api
+                .get_ownerships(tenant.as_str())
+                .await
+                .unwrap_or_default();
             for db in final_dbs {
                 let name = db.name().to_string().into_boxed_str();
                 let db_id = db.get_db_info().ident.db_id;

--- a/src/query/storages/system/src/task_history_table.rs
+++ b/src/query/storages/system/src/task_history_table.rs
@@ -136,7 +136,7 @@ impl AsyncSystemTable for TaskHistoryTable {
         let user = ctx.get_current_user()?.identity().to_string();
         let available_roles = ctx.get_available_roles().await?;
         let req = ShowTaskRunsRequest {
-            tenant_id: tenant.clone(),
+            tenant_id: tenant.to_string(),
             scheduled_time_start: "".to_string(),
             scheduled_time_end: "".to_string(),
             task_name: "".to_string(),
@@ -151,7 +151,8 @@ impl AsyncSystemTable for TaskHistoryTable {
 
         let cloud_api = CloudControlApiProvider::instance();
         let task_client = cloud_api.get_task_client();
-        let config = build_client_config(tenant, user, query_id, cloud_api.get_timeout());
+        let config =
+            build_client_config(tenant.to_string(), user, query_id, cloud_api.get_timeout());
         let req = make_request(req, config);
 
         let resp = task_client.show_task_runs(req).await?;

--- a/src/query/storages/system/src/tasks_table.rs
+++ b/src/query/storages/system/src/tasks_table.rs
@@ -129,7 +129,7 @@ impl AsyncSystemTable for TasksTable {
         let user = ctx.get_current_user()?.identity().to_string();
         let available_roles = ctx.get_available_roles().await?;
         let req = ShowTasksRequest {
-            tenant_id: tenant.clone(),
+            tenant_id: tenant.to_string(),
             name_like: "".to_string(),
             result_limit: 10000, // TODO: use plan.limit pushdown
             owners: available_roles
@@ -141,7 +141,7 @@ impl AsyncSystemTable for TasksTable {
 
         let cloud_api = CloudControlApiProvider::instance();
         let task_client = cloud_api.get_task_client();
-        let cfg = build_client_config(tenant, user, query_id, cloud_api.get_timeout());
+        let cfg = build_client_config(tenant.to_string(), user, query_id, cloud_api.get_timeout());
         let req = make_request(req, cfg);
 
         let resp = task_client.show_tasks(req).await?;

--- a/src/query/storages/system/src/temp_files_table.rs
+++ b/src/query/storages/system/src/temp_files_table.rs
@@ -68,7 +68,7 @@ impl AsyncSystemTable for TempFilesTable {
         let mut temp_files_content_length = vec![];
         let mut temp_files_last_modified = vec![];
 
-        let location_prefix = format!("{}/", query_spill_prefix(&tenant));
+        let location_prefix = format!("{}/", query_spill_prefix(tenant.as_str()));
         if let Ok(lister) = operator
             .lister_with(&location_prefix)
             .metakey(Metakey::LastModified | Metakey::ContentLength)

--- a/src/query/storages/system/src/user_functions_table.rs
+++ b/src/query/storages/system/src/user_functions_table.rs
@@ -175,6 +175,6 @@ impl UserFunctionsTable {
     #[async_backtrace::framed]
     async fn get_udfs(ctx: Arc<dyn TableContext>) -> Result<Vec<UserDefinedFunction>> {
         let tenant = ctx.get_tenant();
-        UserApiProvider::instance().get_udfs(&tenant).await
+        UserApiProvider::instance().get_udfs(tenant.as_str()).await
     }
 }

--- a/src/query/storages/system/src/virtual_columns_table.rs
+++ b/src/query/storages/system/src/virtual_columns_table.rs
@@ -59,7 +59,7 @@ impl AsyncSystemTable for VirtualColumnsTable {
         let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
         let virtual_column_metas = catalog
             .list_virtual_columns(ListVirtualColumnsReq {
-                tenant: tenant.clone(),
+                tenant: tenant.to_string(),
                 table_id: None,
             })
             .await?;

--- a/src/query/users/src/network_policy.rs
+++ b/src/query/users/src/network_policy.rs
@@ -19,6 +19,7 @@ use databend_common_management::NetworkPolicyApi;
 use databend_common_meta_app::principal::NetworkPolicy;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::NonEmptyString;
 
 use crate::UserApiProvider;
 
@@ -86,7 +87,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn drop_network_policy(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         name: &str,
         if_exists: bool,
     ) -> Result<()> {
@@ -102,7 +103,7 @@ impl UserApiProvider {
             }
         }
 
-        let client = self.get_network_policy_api_client(tenant)?;
+        let client = self.get_network_policy_api_client(tenant.as_str())?;
         match client.drop_network_policy(name, MatchSeq::GE(1)).await {
             Ok(res) => Ok(res),
             Err(e) => {

--- a/src/query/users/src/password_policy.rs
+++ b/src/query/users/src/password_policy.rs
@@ -27,6 +27,7 @@ use databend_common_meta_app::principal::UserInfo;
 use databend_common_meta_app::principal::UserOption;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::NonEmptyString;
 use log::info;
 use passwords::analyzer;
 
@@ -164,7 +165,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn drop_password_policy(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         name: &str,
         if_exists: bool,
     ) -> Result<()> {
@@ -180,7 +181,7 @@ impl UserApiProvider {
             }
         }
 
-        let client = self.get_password_policy_api_client(tenant)?;
+        let client = self.get_password_policy_api_client(tenant.as_str())?;
         match client.drop_password_policy(name, MatchSeq::GE(1)).await {
             Ok(res) => Ok(res),
             Err(e) => {
@@ -358,7 +359,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn check_login_password(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         identity: UserIdentity,
         user_info: &UserInfo,
     ) -> Result<()> {
@@ -378,7 +379,7 @@ impl UserApiProvider {
         }
 
         if let Some(name) = user_info.option.password_policy() {
-            if let Ok(password_policy) = self.get_password_policy(tenant, name).await {
+            if let Ok(password_policy) = self.get_password_policy(tenant.as_str(), name).await {
                 // Check the number of login password fails
                 if !user_info.password_fails.is_empty() && password_policy.max_retries > 0 {
                     let check_time = now

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -47,6 +47,7 @@ use databend_common_meta_store::MetaStoreProvider;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::NonEmptyStr;
+use databend_common_meta_types::NonEmptyString;
 
 use crate::idm_config::IDMConfig;
 use crate::BUILTIN_ROLE_PUBLIC;
@@ -118,8 +119,9 @@ impl UserApiProvider {
         GlobalInstance::get()
     }
 
-    pub fn get_user_api_client(&self, tenant: &str) -> Result<Arc<impl UserApi>> {
-        Ok(Arc::new(UserMgr::create(self.client.clone(), tenant)?))
+    pub fn get_user_api_client(&self, tenant: &NonEmptyString) -> Arc<impl UserApi> {
+        let user_mgr = UserMgr::create(self.client.clone(), tenant.as_non_empty_str());
+        Arc::new(user_mgr)
     }
 
     pub fn get_role_api_client(&self, tenant: &str) -> Result<Arc<impl RoleApi>> {

--- a/src/query/users/src/user_mgr.rs
+++ b/src/query/users/src/user_mgr.rs
@@ -28,6 +28,7 @@ use databend_common_meta_app::principal::UserOption;
 use databend_common_meta_app::principal::UserPrivilegeSet;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::NonEmptyString;
 
 use crate::role_mgr::BUILTIN_ROLE_ACCOUNT_ADMIN;
 use crate::UserApiProvider;
@@ -35,7 +36,7 @@ use crate::UserApiProvider;
 impl UserApiProvider {
     // Get one user from by tenant.
     #[async_backtrace::framed]
-    pub async fn get_user(&self, tenant: &str, user: UserIdentity) -> Result<UserInfo> {
+    pub async fn get_user(&self, tenant: &NonEmptyString, user: UserIdentity) -> Result<UserInfo> {
         if let Some(auth_info) = self.get_configured_user(&user.username) {
             let mut user_info = UserInfo::new(&user.username, "%", auth_info.clone());
             user_info.grants.grant_privileges(
@@ -52,7 +53,7 @@ impl UserApiProvider {
             user_info.option.set_all_flag();
             Ok(user_info)
         } else {
-            let client = self.get_user_api_client(tenant)?;
+            let client = self.get_user_api_client(tenant);
             let get_user = client.get_user(user, MatchSeq::GE(0));
             Ok(get_user.await?.data)
         }
@@ -62,7 +63,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn get_user_with_client_ip(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         user: UserIdentity,
         client_ip: Option<&str>,
     ) -> Result<UserInfo> {
@@ -76,7 +77,9 @@ impl UserApiProvider {
                 }
             };
 
-            let network_policy = self.get_network_policy(tenant, name.as_str()).await?;
+            let network_policy = self
+                .get_network_policy(tenant.as_str(), name.as_str())
+                .await?;
             for blocked_ip in network_policy.blocked_ip_list {
                 let blocked_cidr: Ipv4Cidr = blocked_ip.parse().unwrap();
                 if blocked_cidr.contains(&ip_addr) {
@@ -106,8 +109,8 @@ impl UserApiProvider {
 
     // Get the tenant all users list.
     #[async_backtrace::framed]
-    pub async fn get_users(&self, tenant: &str) -> Result<Vec<UserInfo>> {
-        let client = self.get_user_api_client(tenant)?;
+    pub async fn get_users(&self, tenant: &NonEmptyString) -> Result<Vec<UserInfo>> {
+        let client = self.get_user_api_client(tenant);
         let get_users = client.get_users();
 
         let mut res = vec![];
@@ -127,12 +130,16 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn add_user(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         user_info: UserInfo,
         create_option: &CreateOption,
     ) -> Result<()> {
         if let Some(name) = user_info.option.network_policy() {
-            if self.get_network_policy(tenant, name).await.is_err() {
+            if self
+                .get_network_policy(tenant.as_str(), name)
+                .await
+                .is_err()
+            {
                 return Err(ErrorCode::UnknownNetworkPolicy(format!(
                     "network policy `{}` is not exist",
                     name
@@ -140,7 +147,11 @@ impl UserApiProvider {
             }
         }
         if let Some(name) = user_info.option.password_policy() {
-            if self.get_password_policy(tenant, name).await.is_err() {
+            if self
+                .get_password_policy(tenant.as_str(), name)
+                .await
+                .is_err()
+            {
                 return Err(ErrorCode::UnknownPasswordPolicy(format!(
                     "password policy `{}` is not exist",
                     name
@@ -153,14 +164,14 @@ impl UserApiProvider {
                 user_info.name
             )));
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(tenant);
         client.add_user(user_info, create_option).await
     }
 
     #[async_backtrace::framed]
     pub async fn grant_privileges_to_user(
         &self,
-        tenant: &str,
+        tenant: NonEmptyString,
         user: UserIdentity,
         object: GrantObject,
         privileges: UserPrivilegeSet,
@@ -171,7 +182,7 @@ impl UserApiProvider {
                 user.username
             )));
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(&tenant);
         client
             .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
                 ui.grants.grant_privileges(&object, privileges)
@@ -183,7 +194,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn revoke_privileges_from_user(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         user: UserIdentity,
         object: GrantObject,
         privileges: UserPrivilegeSet,
@@ -194,7 +205,7 @@ impl UserApiProvider {
                 user.username
             )));
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(tenant);
         client
             .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
                 ui.grants.revoke_privileges(&object, privileges)
@@ -206,7 +217,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn grant_role_to_user(
         &self,
-        tenant: &str,
+        tenant: NonEmptyString,
         user: UserIdentity,
         grant_role: String,
     ) -> Result<Option<u64>> {
@@ -216,7 +227,7 @@ impl UserApiProvider {
                 user.username
             )));
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(&tenant);
         client
             .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
                 ui.grants.grant_role(grant_role)
@@ -228,7 +239,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn revoke_role_from_user(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         user: UserIdentity,
         revoke_role: String,
     ) -> Result<Option<u64>> {
@@ -238,7 +249,7 @@ impl UserApiProvider {
                 user.username
             )));
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(tenant);
         client
             .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
                 ui.grants.revoke_role(&revoke_role)
@@ -249,14 +260,19 @@ impl UserApiProvider {
 
     // Drop a user by name and hostname.
     #[async_backtrace::framed]
-    pub async fn drop_user(&self, tenant: &str, user: UserIdentity, if_exists: bool) -> Result<()> {
+    pub async fn drop_user(
+        &self,
+        tenant: NonEmptyString,
+        user: UserIdentity,
+        if_exists: bool,
+    ) -> Result<()> {
         if self.get_configured_user(&user.username).is_some() {
             return Err(ErrorCode::UserAlreadyExists(format!(
                 "Configured user `{}` cannot be dropped",
                 user.username
             )));
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(&tenant);
         let drop_user = client.drop_user(user, MatchSeq::GE(1));
         match drop_user.await {
             Ok(res) => Ok(res),
@@ -274,14 +290,18 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn update_user(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         user: UserIdentity,
         auth_info: Option<AuthInfo>,
         user_option: Option<UserOption>,
     ) -> Result<Option<u64>> {
         if let Some(ref user_option) = user_option {
             if let Some(name) = user_option.network_policy() {
-                if self.get_network_policy(tenant, name).await.is_err() {
+                if self
+                    .get_network_policy(tenant.as_str(), name)
+                    .await
+                    .is_err()
+                {
                     return Err(ErrorCode::UnknownNetworkPolicy(format!(
                         "network policy `{}` is not exist",
                         name
@@ -289,7 +309,11 @@ impl UserApiProvider {
                 }
             }
             if let Some(name) = user_option.password_policy() {
-                if self.get_password_policy(tenant, name).await.is_err() {
+                if self
+                    .get_password_policy(tenant.as_str(), name)
+                    .await
+                    .is_err()
+                {
                     return Err(ErrorCode::UnknownPasswordPolicy(format!(
                         "password policy `{}` is not exist",
                         name
@@ -303,7 +327,7 @@ impl UserApiProvider {
                 user.username
             )));
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(tenant);
         let update_user = client
             .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
                 ui.update_auth_option(auth_info.clone(), user_option);
@@ -321,7 +345,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn update_user_default_role(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         user: UserIdentity,
         default_role: Option<String>,
     ) -> Result<Option<u64>> {
@@ -334,14 +358,14 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn update_user_login_result(
         &self,
-        tenant: &str,
+        tenant: NonEmptyString,
         user: UserIdentity,
         authed: bool,
     ) -> Result<()> {
         if self.get_configured_user(&user.username).is_some() {
             return Ok(());
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(&tenant);
         let update_user = client
             .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
                 if authed {
@@ -361,14 +385,14 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn update_user_lockout_time(
         &self,
-        tenant: &str,
+        tenant: &NonEmptyString,
         user: UserIdentity,
         lockout_time: DateTime<Utc>,
     ) -> Result<()> {
         if self.get_configured_user(&user.username).is_some() {
             return Ok(());
         }
-        let client = self.get_user_api_client(tenant)?;
+        let client = self.get_user_api_client(tenant);
         let update_user = client
             .update_user_with(user, MatchSeq::GE(1), |ui: &mut UserInfo| {
                 ui.update_lockout_time(lockout_time);

--- a/src/query/users/tests/it/network_policy.rs
+++ b/src/query/users/tests/it/network_policy.rs
@@ -24,14 +24,16 @@ use databend_common_meta_app::principal::UserIdentity;
 use databend_common_meta_app::principal::UserInfo;
 use databend_common_meta_app::principal::UserOption;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_users::UserApiProvider;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_network_policy() -> Result<()> {
     let conf = RpcClientConf::default();
-    let tenant = "test";
+    let tenant_name = "test";
+    let tenant = NonEmptyString::new(tenant_name.to_string()).unwrap();
 
-    let user_mgr = UserApiProvider::try_create_simple(conf, tenant).await?;
+    let user_mgr = UserApiProvider::try_create_simple(conf, tenant_name).await?;
     let username = "test-user1";
     let hostname = "%";
     let pwd = "test-pwd";
@@ -50,7 +52,7 @@ async fn test_network_policy() -> Result<()> {
         update_on: None,
     };
     user_mgr
-        .add_network_policy(tenant, network_policy, &CreateOption::None)
+        .add_network_policy(tenant_name, network_policy, &CreateOption::None)
         .await?;
 
     // add user
@@ -64,29 +66,29 @@ async fn test_network_policy() -> Result<()> {
     option = option.with_network_policy(Some(policy_name.clone()));
     user_info.update_auth_option(None, Some(option));
     user_mgr
-        .add_user(tenant, user_info, &CreateOption::None)
+        .add_user(&tenant, user_info, &CreateOption::None)
         .await?;
 
     let user = UserIdentity::new(username, hostname);
 
     // check get user with client ip
     let res = user_mgr
-        .get_user_with_client_ip(tenant, user.clone(), Some("192.168.0.1"))
+        .get_user_with_client_ip(&tenant, user.clone(), Some("192.168.0.1"))
         .await;
     assert!(res.is_ok());
 
     let res = user_mgr
-        .get_user_with_client_ip(tenant, user.clone(), Some("192.168.0.10"))
+        .get_user_with_client_ip(&tenant, user.clone(), Some("192.168.0.10"))
         .await;
     assert!(res.is_err());
 
     let res = user_mgr
-        .get_user_with_client_ip(tenant, user.clone(), Some("192.168.0.20"))
+        .get_user_with_client_ip(&tenant, user.clone(), Some("192.168.0.20"))
         .await;
     assert!(res.is_err());
 
     let res = user_mgr
-        .get_user_with_client_ip(tenant, user.clone(), Some("127.0.0.1"))
+        .get_user_with_client_ip(&tenant, user.clone(), Some("127.0.0.1"))
         .await;
     assert!(res.is_err());
 
@@ -95,7 +97,7 @@ async fn test_network_policy() -> Result<()> {
     let new_blocked_ip_list = vec!["127.0.0.10".to_string()];
     user_mgr
         .update_network_policy(
-            tenant,
+            tenant_name,
             policy_name.as_ref(),
             Some(new_allowed_ip_list),
             Some(new_blocked_ip_list),
@@ -106,30 +108,32 @@ async fn test_network_policy() -> Result<()> {
 
     // check get user with client ip
     let res = user_mgr
-        .get_user_with_client_ip(tenant, user.clone(), Some("192.168.0.1"))
+        .get_user_with_client_ip(&tenant, user.clone(), Some("192.168.0.1"))
         .await;
     assert!(res.is_err());
 
     let res = user_mgr
-        .get_user_with_client_ip(tenant, user.clone(), Some("127.0.0.1"))
+        .get_user_with_client_ip(&tenant, user.clone(), Some("127.0.0.1"))
         .await;
     assert!(res.is_ok());
 
     let res = user_mgr
-        .get_user_with_client_ip(tenant, user.clone(), Some("127.0.0.10"))
+        .get_user_with_client_ip(&tenant, user.clone(), Some("127.0.0.10"))
         .await;
     assert!(res.is_err());
 
     // drop network policy
     let res = user_mgr
-        .drop_network_policy(tenant, policy_name.as_ref(), false)
+        .drop_network_policy(&tenant, policy_name.as_ref(), false)
         .await;
     assert!(res.is_err());
 
-    user_mgr.drop_user(tenant, user.clone(), false).await?;
+    user_mgr
+        .drop_user(tenant.clone(), user.clone(), false)
+        .await?;
 
     let res = user_mgr
-        .drop_network_policy(tenant, policy_name.as_ref(), false)
+        .drop_network_policy(&tenant, policy_name.as_ref(), false)
         .await;
     assert!(res.is_ok());
 

--- a/src/query/users/tests/it/password_policy.rs
+++ b/src/query/users/tests/it/password_policy.rs
@@ -26,14 +26,16 @@ use databend_common_meta_app::principal::UserIdentity;
 use databend_common_meta_app::principal::UserInfo;
 use databend_common_meta_app::principal::UserOption;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_users::UserApiProvider;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_password_policy() -> Result<()> {
     let conf = RpcClientConf::default();
-    let tenant = "test";
+    let tenant_name = "test";
+    let tenant = NonEmptyString::new(tenant_name.to_string()).unwrap();
 
-    let user_mgr = UserApiProvider::try_create_simple(conf, tenant).await?;
+    let user_mgr = UserApiProvider::try_create_simple(conf, tenant_name).await?;
     let username = "test-user1";
     let hostname = "%";
     let pwd1 = "123456abcDEF!@#1";
@@ -67,7 +69,7 @@ async fn test_password_policy() -> Result<()> {
 
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             password_policy.clone(),
             &CreateOption::CreateIfNotExists,
         )
@@ -79,7 +81,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy1.min_length = 0;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy1,
             &CreateOption::CreateIfNotExists,
         )
@@ -91,7 +93,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy2.max_length = 260;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy2,
             &CreateOption::CreateIfNotExists,
         )
@@ -104,7 +106,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy3.max_length = 20;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy3,
             &CreateOption::CreateIfNotExists,
         )
@@ -119,7 +121,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy4.min_special_chars = 273;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy4,
             &CreateOption::CreateIfNotExists,
         )
@@ -135,7 +137,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy5.min_special_chars = 13;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy5,
             &CreateOption::CreateIfNotExists,
         )
@@ -148,7 +150,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy6.max_age_days = 10;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy6,
             &CreateOption::CreateIfNotExists,
         )
@@ -160,7 +162,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy7.max_retries = 20;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy7,
             &CreateOption::CreateIfNotExists,
         )
@@ -172,7 +174,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy8.lockout_time_mins = 2000;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy8,
             &CreateOption::CreateIfNotExists,
         )
@@ -184,7 +186,7 @@ async fn test_password_policy() -> Result<()> {
     invalid_password_policy9.history = 50;
     let res = user_mgr
         .add_password_policy(
-            tenant,
+            tenant_name,
             invalid_password_policy9,
             &CreateOption::CreateIfNotExists,
         )
@@ -198,7 +200,7 @@ async fn test_password_policy() -> Result<()> {
         password: Some(pwd1.to_string()),
     };
     let res = user_mgr
-        .verify_password(tenant, &user_option, &auth_option, None, None)
+        .verify_password(tenant_name, &user_option, &auth_option, None, None)
         .await;
     assert!(res.is_ok());
 
@@ -206,7 +208,7 @@ async fn test_password_policy() -> Result<()> {
     let mut auth_option1 = auth_option.clone();
     auth_option1.password = Some(invalid_pwd.to_string());
     let res = user_mgr
-        .verify_password(tenant, &user_option, &auth_option1, None, None)
+        .verify_password(tenant_name, &user_option, &auth_option1, None, None)
         .await;
     assert!(res.is_err());
 
@@ -218,7 +220,7 @@ async fn test_password_policy() -> Result<()> {
     user_info.update_auth_option(None, Some(option));
     let res = user_mgr
         .verify_password(
-            tenant,
+            tenant_name,
             &user_option,
             &auth_option,
             Some(&user_info),
@@ -233,7 +235,7 @@ async fn test_password_policy() -> Result<()> {
     let auth_info2 = AuthInfo::create2(&None, &Some(pwd2.to_string())).unwrap();
     let res = user_mgr
         .verify_password(
-            tenant,
+            tenant_name,
             &user_option,
             &auth_option,
             Some(&user_info),
@@ -246,7 +248,7 @@ async fn test_password_policy() -> Result<()> {
     user_info.password_update_on = Some(Utc::now().checked_sub_signed(Duration::days(3)).unwrap());
     let res = user_mgr
         .verify_password(
-            tenant,
+            tenant_name,
             &user_option,
             &auth_option,
             Some(&user_info),
@@ -261,7 +263,7 @@ async fn test_password_policy() -> Result<()> {
     let new_auth_info1 = AuthInfo::create2(&None, &Some(pwd1.to_string())).unwrap();
     let res = user_mgr
         .verify_password(
-            tenant,
+            tenant_name,
             &user_option,
             &auth_option,
             Some(&user_info),
@@ -287,7 +289,7 @@ async fn test_password_policy() -> Result<()> {
     user_info.password_update_on = Some(Utc::now().checked_sub_signed(Duration::days(3)).unwrap());
     let res = user_mgr
         .verify_password(
-            tenant,
+            tenant_name,
             &user_option,
             &auth_option,
             Some(&user_info),
@@ -299,7 +301,7 @@ async fn test_password_policy() -> Result<()> {
     // check login password success
     let identity = UserIdentity::new(username, hostname);
     let res = user_mgr
-        .check_login_password(tenant, identity.clone(), &user_info)
+        .check_login_password(&tenant, identity.clone(), &user_info)
         .await;
     assert!(res.is_ok());
 
@@ -309,7 +311,7 @@ async fn test_password_policy() -> Result<()> {
     }
     // user lockout because of too many login fails
     let res = user_mgr
-        .check_login_password(tenant, identity.clone(), &user_info)
+        .check_login_password(&tenant, identity.clone(), &user_info)
         .await;
     assert!(res.is_err());
 
@@ -321,7 +323,7 @@ async fn test_password_policy() -> Result<()> {
     );
     // user can't log in because of locked out
     let res = user_mgr
-        .check_login_password(tenant, identity.clone(), &user_info)
+        .check_login_password(&tenant, identity.clone(), &user_info)
         .await;
     assert!(res.is_err());
 
@@ -331,14 +333,14 @@ async fn test_password_policy() -> Result<()> {
     user_info.password_update_on = Some(Utc::now().checked_sub_signed(Duration::days(31)).unwrap());
     // user can't log in because of not change password more than max allowed days
     let res = user_mgr
-        .check_login_password(tenant, identity.clone(), &user_info)
+        .check_login_password(&tenant, identity.clone(), &user_info)
         .await;
     assert!(res.is_err());
 
     // update password policy
     let res = user_mgr
         .update_password_policy(
-            tenant,
+            tenant_name,
             &policy_name,
             Some(10),
             Some(20),
@@ -359,19 +361,19 @@ async fn test_password_policy() -> Result<()> {
 
     // add user
     user_mgr
-        .add_user(tenant, user_info, &CreateOption::CreateIfNotExists)
+        .add_user(&tenant, user_info, &CreateOption::CreateIfNotExists)
         .await?;
 
     // drop password policy
     let res = user_mgr
-        .drop_password_policy(tenant, policy_name.as_ref(), false)
+        .drop_password_policy(&tenant, policy_name.as_ref(), false)
         .await;
     assert!(res.is_err());
 
-    user_mgr.drop_user(tenant, identity, false).await?;
+    user_mgr.drop_user(tenant.clone(), identity, false).await?;
 
     let res = user_mgr
-        .drop_password_policy(tenant, policy_name.as_ref(), false)
+        .drop_password_policy(&tenant, policy_name.as_ref(), false)
         .await;
     assert!(res.is_ok());
 

--- a/src/query/users/tests/it/user_mgr.rs
+++ b/src/query/users/tests/it/user_mgr.rs
@@ -25,15 +25,17 @@ use databend_common_meta_app::principal::UserInfo;
 use databend_common_meta_app::principal::UserPrivilegeSet;
 use databend_common_meta_app::principal::UserPrivilegeType;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_users::UserApiProvider;
 use pretty_assertions::assert_eq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_user_manager() -> Result<()> {
     let conf = RpcClientConf::default();
-    let tenant = "test";
+    let tenant_name = "test";
+    let tenant = NonEmptyString::new(tenant_name.to_string()).unwrap();
 
-    let user_mgr = UserApiProvider::try_create_simple(conf, tenant).await?;
+    let user_mgr = UserApiProvider::try_create_simple(conf, tenant_name).await?;
     let username = "test-user1";
     let hostname = "%";
     let pwd = "test-pwd";
@@ -47,7 +49,7 @@ async fn test_user_manager() -> Result<()> {
     {
         let user_info = UserInfo::new(username, hostname, auth_info.clone());
         user_mgr
-            .add_user(tenant, user_info, &CreateOption::None)
+            .add_user(&tenant, user_info, &CreateOption::None)
             .await?;
     }
 
@@ -55,7 +57,7 @@ async fn test_user_manager() -> Result<()> {
     {
         let user_info = UserInfo::new(username, hostname, auth_info.clone());
         let res = user_mgr
-            .add_user(tenant, user_info, &CreateOption::None)
+            .add_user(&tenant, user_info, &CreateOption::None)
             .await;
         assert!(res.is_err());
         assert_eq!(res.err().unwrap().code(), ErrorCode::USER_ALREADY_EXISTS);
@@ -65,13 +67,13 @@ async fn test_user_manager() -> Result<()> {
     {
         let user_info = UserInfo::new(username, hostname, auth_info.clone());
         user_mgr
-            .add_user(tenant, user_info, &CreateOption::CreateIfNotExists)
+            .add_user(&tenant, user_info, &CreateOption::CreateIfNotExists)
             .await?;
     }
 
     // get all users.
     {
-        let users = user_mgr.get_users(tenant).await?;
+        let users = user_mgr.get_users(&tenant).await?;
         assert_eq!(1, users.len());
         assert_eq!(pwd.as_bytes(), users[0].auth_info.get_password().unwrap());
     }
@@ -79,7 +81,7 @@ async fn test_user_manager() -> Result<()> {
     // get user hostname.
     {
         let user_info = user_mgr
-            .get_user(tenant, UserIdentity::new(username, hostname))
+            .get_user(&tenant, UserIdentity::new(username, hostname))
             .await?;
         assert_eq!(hostname, user_info.hostname);
         assert_eq!(pwd.as_bytes(), user_info.auth_info.get_password().unwrap());
@@ -88,16 +90,16 @@ async fn test_user_manager() -> Result<()> {
     // drop.
     {
         user_mgr
-            .drop_user(tenant, UserIdentity::new(username, hostname), false)
+            .drop_user(tenant.clone(), UserIdentity::new(username, hostname), false)
             .await?;
-        let users = user_mgr.get_users(tenant).await?;
+        let users = user_mgr.get_users(&tenant).await?;
         assert_eq!(0, users.len());
     }
 
     // repeat drop same user not with if exist.
     {
         let res = user_mgr
-            .drop_user(tenant, UserIdentity::new(username, hostname), false)
+            .drop_user(tenant.clone(), UserIdentity::new(username, hostname), false)
             .await;
         assert!(res.is_err());
     }
@@ -105,7 +107,7 @@ async fn test_user_manager() -> Result<()> {
     // repeat drop same user with if exist.
     {
         let res = user_mgr
-            .drop_user(tenant, UserIdentity::new(username, hostname), true)
+            .drop_user(tenant.clone(), UserIdentity::new(username, hostname), true)
             .await;
         assert!(res.is_ok());
     }
@@ -114,17 +116,22 @@ async fn test_user_manager() -> Result<()> {
     {
         let user_info: UserInfo = UserInfo::new(username, hostname, auth_info.clone());
         user_mgr
-            .add_user(tenant, user_info.clone(), &CreateOption::None)
+            .add_user(&tenant, user_info.clone(), &CreateOption::None)
             .await?;
-        let old_user = user_mgr.get_user(tenant, user_info.identity()).await?;
+        let old_user = user_mgr.get_user(&tenant, user_info.identity()).await?;
         assert_eq!(old_user.grants, UserGrantSet::empty());
 
         let mut add_priv = UserPrivilegeSet::empty();
         add_priv.set_privilege(UserPrivilegeType::Set);
         user_mgr
-            .grant_privileges_to_user(tenant, user_info.identity(), GrantObject::Global, add_priv)
+            .grant_privileges_to_user(
+                tenant.clone(),
+                user_info.identity(),
+                GrantObject::Global,
+                add_priv,
+            )
             .await?;
-        let new_user = user_mgr.get_user(tenant, user_info.identity()).await?;
+        let new_user = user_mgr.get_user(&tenant, user_info.identity()).await?;
         assert!(
             new_user
                 .grants
@@ -136,7 +143,7 @@ async fn test_user_manager() -> Result<()> {
                 .verify_privilege(&GrantObject::Global, vec![UserPrivilegeType::Create])
         );
         user_mgr
-            .drop_user(tenant, new_user.identity(), true)
+            .drop_user(tenant.clone(), new_user.identity(), true)
             .await?;
     }
 
@@ -144,31 +151,31 @@ async fn test_user_manager() -> Result<()> {
     {
         let user_info: UserInfo = UserInfo::new(username, hostname, auth_info.clone());
         user_mgr
-            .add_user(tenant, user_info.clone(), &CreateOption::None)
+            .add_user(&tenant, user_info.clone(), &CreateOption::None)
             .await?;
         user_mgr
             .grant_privileges_to_user(
-                tenant,
+                tenant.clone(),
                 user_info.identity(),
                 GrantObject::Global,
                 UserPrivilegeSet::all_privileges(),
             )
             .await?;
-        let user_info = user_mgr.get_user(tenant, user_info.identity()).await?;
+        let user_info = user_mgr.get_user(&tenant, user_info.identity()).await?;
         assert_eq!(user_info.grants.entries().len(), 1);
 
         user_mgr
             .revoke_privileges_from_user(
-                tenant,
+                &tenant,
                 user_info.identity(),
                 GrantObject::Global,
                 UserPrivilegeSet::all_privileges(),
             )
             .await?;
-        let user_info = user_mgr.get_user(tenant, user_info.identity()).await?;
+        let user_info = user_mgr.get_user(&tenant, user_info.identity()).await?;
         assert_eq!(user_info.grants.entries().len(), 0);
         user_mgr
-            .drop_user(tenant, user_info.identity(), true)
+            .drop_user(tenant.clone(), user_info.identity(), true)
             .await?;
     }
 
@@ -183,10 +190,10 @@ async fn test_user_manager() -> Result<()> {
         };
         let user_info: UserInfo = UserInfo::new(user, hostname, auth_info.clone());
         user_mgr
-            .add_user(tenant, user_info.clone(), &CreateOption::None)
+            .add_user(&tenant, user_info.clone(), &CreateOption::None)
             .await?;
 
-        let old_user = user_mgr.get_user(tenant, user_info.identity()).await?;
+        let old_user = user_mgr.get_user(&tenant, user_info.identity()).await?;
         assert_eq!(old_user.auth_info.get_password().unwrap(), Vec::from(pwd));
 
         // alter both password & password_type
@@ -196,9 +203,9 @@ async fn test_user_manager() -> Result<()> {
             hash_method: PasswordHashMethod::Sha256,
         };
         user_mgr
-            .update_user(tenant, user_info.identity(), Some(auth_info), None)
+            .update_user(&tenant, user_info.identity(), Some(auth_info), None)
             .await?;
-        let new_user = user_mgr.get_user(tenant, user_info.identity()).await?;
+        let new_user = user_mgr.get_user(&tenant, user_info.identity()).await?;
         assert_eq!(
             new_user.auth_info.get_password().unwrap(),
             Vec::from(new_pwd)
@@ -215,9 +222,9 @@ async fn test_user_manager() -> Result<()> {
             hash_method: PasswordHashMethod::Sha256,
         };
         user_mgr
-            .update_user(tenant, user_info.identity(), Some(auth_info.clone()), None)
+            .update_user(&tenant, user_info.identity(), Some(auth_info.clone()), None)
             .await?;
-        let new_new_user = user_mgr.get_user(tenant, user_info.identity()).await?;
+        let new_new_user = user_mgr.get_user(&tenant, user_info.identity()).await?;
         assert_eq!(
             new_new_user.auth_info.get_password().unwrap(),
             Vec::from(new_new_pwd)
@@ -225,7 +232,7 @@ async fn test_user_manager() -> Result<()> {
 
         let not_exist = user_mgr
             .update_user(
-                tenant,
+                &tenant,
                 UserIdentity::new("user", hostname),
                 Some(auth_info.clone()),
                 None,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: tenant is not allowed to be empty

In this commit, when loading databend-query config, if `tenant` is empty
string, return an error and shutdown.
This way, the in-process `tenant` is always non-empty and is stored in a
`NonEmptyString`, and it get rid of all empty-tenant error handling.

The return value of `get_tenant()` is also changed to `NonEmptyString`.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14815)
<!-- Reviewable:end -->
