### PR TITLE
feat(query): read write inverted index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,6 +2817,7 @@ dependencies = [
  "prost 0.12.3",
  "serde",
  "serde_json",
+ "tantivy",
  "thiserror",
  "tonic 0.10.2",
 ]
@@ -3685,6 +3692,7 @@ dependencies = [
  "backoff",
  "bytes",
  "chrono",
+ "crc32fast",
  "criterion",
  "databend-common-arrow",
  "databend-common-base",
@@ -3730,6 +3738,8 @@ dependencies = [
  "siphasher",
  "streaming-decompression",
  "sys-info",
+ "tantivy",
+ "tantivy-common",
  "typetag",
  "uuid",
  "xorf",
@@ -4189,6 +4199,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "databend-enterprise-inverted-index"
+version = "0.1.0"
+dependencies = [
+ "async-backtrace",
+ "async-trait-fn",
+ "databend-common-base",
+ "databend-common-catalog",
+ "databend-common-exception",
+ "databend-common-expression",
+ "databend-common-storages-fuse",
+ "databend-storages-common-table-meta",
+]
+
+[[package]]
 name = "databend-enterprise-meta"
 version = "0.1.0"
 dependencies = [
@@ -4228,6 +4252,7 @@ dependencies = [
  "databend-enterprise-aggregating-index",
  "databend-enterprise-background-service",
  "databend-enterprise-data-mask-feature",
+ "databend-enterprise-inverted-index",
  "databend-enterprise-storage-encryption",
  "databend-enterprise-stream-handler",
  "databend-enterprise-vacuum-handler",
@@ -4998,6 +5023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5362,6 +5393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
+name = "fastdivide"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
+
+[[package]]
 name = "faster-hex"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5639,6 +5676,16 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fs4"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
+dependencies = [
+ "rustix 0.38.31",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7503,6 +7550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7820,6 +7873,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -8141,6 +8197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
 name = "lexical-core"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8390,11 +8452,21 @@ checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
 dependencies = [
  "cfg-if",
  "generator",
+ "pin-utils",
  "scoped-tls",
  "serde",
  "serde_json",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lru"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
+dependencies = [
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -8539,6 +8611,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
+]
+
+[[package]]
+name = "measure_time"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56220900f1a0923789ecd6bf25fbae8af3b2f1ff3e9e297fc9b6b8674dd4d852"
+dependencies = [
+ "instant",
+ "log",
 ]
 
 [[package]]
@@ -8873,6 +8955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
 name = "mysql-common-derive"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8904,7 +8992,7 @@ dependencies = [
  "futures-util",
  "keyed_priority_queue",
  "lazy_static",
- "lru",
+ "lru 0.12.3",
  "mio",
  "mysql_common",
  "once_cell",
@@ -9271,6 +9359,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oneshot"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9544,6 +9641,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "ownedbytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8a72b918ae8198abb3a18c190288123e1d442b6b9a7d709305fd194688b4b7"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "owo-colors"
@@ -11372,6 +11478,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12133,6 +12249,9 @@ name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "slab"
@@ -12643,6 +12762,146 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tantivy"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6083cd777fa94271b8ce0fe4533772cb8110c3044bab048d20f70108329a1f2"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "async-trait",
+ "base64 0.21.7",
+ "bitpacking",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fastdivide",
+ "fs4",
+ "htmlescape",
+ "itertools 0.11.0",
+ "levenshtein_automata",
+ "log",
+ "lru 0.11.1",
+ "lz4_flex",
+ "measure_time",
+ "memmap2 0.7.1",
+ "murmurhash32",
+ "num_cpus",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecb164321482301f514dd582264fa67f70da2d7eb01872ccd71e35e0d96655a"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d85f8019af9a78b3118c11298b36ffd21c2314bd76bbcd9d12e00124cbb7e70"
+dependencies = [
+ "fastdivide",
+ "fnv",
+ "itertools 0.11.0",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4a3a975e604a2aba6b1106a04505e1e7a025e6def477fab6e410b4126471e1"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3c506b1a8443a3a65352df6382a1fb6a7afe1a02e871cee0d25e2c3d5f3944"
+dependencies = [
+ "byteorder",
+ "regex-syntax 0.6.29",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d39c5a03100ac10c96e0c8b07538e2ab8b17da56434ab348309b31f23fada77"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0c1bb43e5e8b8e05eb8009610344dbf285f06066c844032fbb3e546b3c71df"
+dependencies = [
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd 0.12.4",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c078595413f13f218cf6f97b23dcfd48936838f1d3d13a1016e05acd64ed6c"
+dependencies = [
+ "murmurhash32",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347b6fb212b26d3505d224f438e3c4b827ab8bd847fe9953ad5ac6b8f9443b66"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "tap"
@@ -13471,6 +13730,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8-width"

--- a/src/common/exception/Cargo.toml
+++ b/src/common/exception/Cargo.toml
@@ -32,4 +32,5 @@ prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tantivy = "0.21.1"
 tonic = { workspace = true }

--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -199,7 +199,12 @@ build_exceptions! {
     IllegalCloudControlMessageFormat(1703),
 
     // Geometry errors.
-    GeometryError(1801)
+    GeometryError(1801),
+
+    // Tantivy errors.
+    TantivyError(1901),
+    TantivyOpenReadError(1902),
+    TantivyQueryParserError(1903)
 }
 
 // Meta service errors [2001, 3000].

--- a/src/common/exception/src/exception_into.rs
+++ b/src/common/exception/src/exception_into.rs
@@ -237,6 +237,24 @@ impl From<GeozeroError> for ErrorCode {
     }
 }
 
+impl From<tantivy::TantivyError> for ErrorCode {
+    fn from(error: tantivy::TantivyError) -> Self {
+        ErrorCode::TantivyError(error.to_string())
+    }
+}
+
+impl From<tantivy::directory::error::OpenReadError> for ErrorCode {
+    fn from(error: tantivy::directory::error::OpenReadError) -> Self {
+        ErrorCode::TantivyOpenReadError(error.to_string())
+    }
+}
+
+impl From<tantivy::query::QueryParserError> for ErrorCode {
+    fn from(error: tantivy::query::QueryParserError) -> Self {
+        ErrorCode::TantivyQueryParserError(error.to_string())
+    }
+}
+
 // ===  prost error ===
 impl From<prost::EncodeError> for ErrorCode {
     fn from(error: prost::EncodeError) -> Self {

--- a/src/query/ee/Cargo.toml
+++ b/src/query/ee/Cargo.toml
@@ -36,6 +36,7 @@ databend-common-users = { path = "../users" }
 databend-enterprise-aggregating-index = { path = "../ee_features/aggregating_index" }
 databend-enterprise-background-service = { path = "../ee_features/background_service" }
 databend-enterprise-data-mask-feature = { path = "../ee_features/data_mask" }
+databend-enterprise-inverted-index = { path = "../ee_features/inverted_index" }
 databend-enterprise-storage-encryption = { path = "../ee_features/storage_encryption" }
 databend-enterprise-stream-handler = { path = "../ee_features/stream_handler" }
 databend-enterprise-vacuum-handler = { path = "../ee_features/vacuum_handler" }

--- a/src/query/ee/src/enterprise_services.rs
+++ b/src/query/ee/src/enterprise_services.rs
@@ -19,6 +19,7 @@ use databend_common_license::license_manager::LicenseManager;
 use crate::aggregating_index::RealAggregatingIndexHandler;
 use crate::background_service::RealBackgroundService;
 use crate::data_mask::RealDatamaskHandler;
+use crate::inverted_index::RealInvertedIndexHandler;
 use crate::license::license_mgr::RealLicenseManager;
 use crate::storage_encryption::RealStorageEncryptionHandler;
 use crate::storages::fuse::operations::RealVacuumHandler;
@@ -37,6 +38,7 @@ impl EnterpriseServices {
         RealBackgroundService::init(&cfg).await?;
         RealVirtualColumnHandler::init()?;
         RealStreamHandler::init()?;
+        RealInvertedIndexHandler::init()?;
         Ok(())
     }
 }

--- a/src/query/ee/src/inverted_index/indexer.rs
+++ b/src/query/ee/src/inverted_index/indexer.rs
@@ -1,0 +1,113 @@
+// Copyright 2024 Databend Cloud
+//
+// Licensed under the Elastic License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.elastic.co/licensing/elastic-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_catalog::plan::Projection;
+use databend_common_catalog::table::Table;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::Result;
+use databend_common_expression::DataSchema;
+use databend_common_storages_fuse::io::InvertedIndexWriter;
+use databend_common_storages_fuse::io::MetaReaders;
+use databend_common_storages_fuse::io::ReadSettings;
+use databend_common_storages_fuse::FuseTable;
+use databend_storages_common_cache::LoadParams;
+use databend_storages_common_table_meta::meta::Location;
+
+pub struct Indexer {}
+
+impl Indexer {
+    pub(crate) fn new() -> Indexer {
+        Indexer {}
+    }
+
+    #[async_backtrace::framed]
+    pub(crate) async fn index(
+        &self,
+        fuse_table: &FuseTable,
+        ctx: Arc<dyn TableContext>,
+        schema: DataSchema,
+        segment_locs: Option<Vec<Location>>,
+    ) -> Result<String> {
+        let snapshot_opt = fuse_table.read_table_snapshot().await?;
+        let snapshot = if let Some(val) = snapshot_opt {
+            val
+        } else {
+            // no snapshot
+            return Ok("".to_string());
+        };
+        if schema.fields.is_empty() {
+            // no field for index
+            return Ok("".to_string());
+        }
+
+        let table_schema = &fuse_table.get_table_info().meta.schema;
+
+        // Collect field indices used by inverted index.
+        let mut field_indices = Vec::new();
+        for field in &schema.fields {
+            let field_index = table_schema.index_of(field.name())?;
+            field_indices.push(field_index);
+        }
+
+        let projection = Projection::Columns(field_indices);
+        let block_reader =
+            fuse_table.create_block_reader(ctx.clone(), projection, false, false, false)?;
+
+        let segment_reader =
+            MetaReaders::segment_info_reader(fuse_table.get_operator(), table_schema.clone());
+
+        let settings = ReadSettings::from_ctx(&ctx)?;
+        let write_settings = fuse_table.get_write_settings();
+        let storage_format = write_settings.storage_format;
+
+        let operator = fuse_table.get_operator_ref();
+
+        // If no segment locations are specified, iterates through all segments
+        let segment_locs = if let Some(segment_locs) = segment_locs {
+            segment_locs
+        } else {
+            snapshot.segments.clone()
+        };
+
+        let mut index_writer = InvertedIndexWriter::try_create(schema)?;
+
+        for (location, ver) in segment_locs {
+            let segment_info = segment_reader
+                .read(&LoadParams {
+                    location: location.to_string(),
+                    len_hint: None,
+                    ver,
+                    put_cache: false,
+                })
+                .await?;
+
+            let block_metas = segment_info.block_metas()?;
+            for block_meta in block_metas {
+                let block = block_reader
+                    .read_by_meta(&settings, &block_meta, &storage_format)
+                    .await?;
+
+                index_writer.add_block(block)?;
+            }
+        }
+
+        let location_generator = fuse_table.meta_location_generator();
+
+        let index_location = index_writer.finalize(operator, location_generator).await?;
+        // TODO: add index location to meta
+        Ok(index_location)
+    }
+}

--- a/src/query/ee/src/inverted_index/inverted_index_handler.rs
+++ b/src/query/ee/src/inverted_index/inverted_index_handler.rs
@@ -1,0 +1,52 @@
+// Copyright 2024 Databend Cloud
+//
+// Licensed under the Elastic License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.elastic.co/licensing/elastic-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_base::base::GlobalInstance;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::Result;
+use databend_common_expression::DataSchema;
+use databend_common_storages_fuse::FuseTable;
+use databend_enterprise_inverted_index::InvertedIndexHandler;
+use databend_enterprise_inverted_index::InvertedIndexHandlerWrapper;
+use databend_storages_common_table_meta::meta::Location;
+
+use super::indexer::Indexer;
+
+pub struct RealInvertedIndexHandler {}
+
+#[async_trait::async_trait]
+impl InvertedIndexHandler for RealInvertedIndexHandler {
+    #[async_backtrace::framed]
+    async fn do_refresh_index(
+        &self,
+        fuse_table: &FuseTable,
+        ctx: Arc<dyn TableContext>,
+        schema: DataSchema,
+        segment_locs: Option<Vec<Location>>,
+    ) -> Result<String> {
+        let indexer = Indexer::new();
+        indexer.index(fuse_table, ctx, schema, segment_locs).await
+    }
+}
+
+impl RealInvertedIndexHandler {
+    pub fn init() -> Result<()> {
+        let rm = RealInvertedIndexHandler {};
+        let wrapper = InvertedIndexHandlerWrapper::new(Box::new(rm));
+        GlobalInstance::set(Arc::new(wrapper));
+        Ok(())
+    }
+}

--- a/src/query/ee/src/inverted_index/mod.rs
+++ b/src/query/ee/src/inverted_index/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Databend Cloud
+// Copyright 2024 Databend Cloud
 //
 // Licensed under the Elastic License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod aggregating_index;
-pub mod background_service;
-pub mod data_mask;
-pub mod enterprise_services;
-pub mod inverted_index;
-pub mod license;
-pub mod storage_encryption;
-pub mod storages;
-pub mod stream;
-pub mod test_kits;
-pub mod virtual_column;
+mod indexer;
+mod inverted_index_handler;
+pub use inverted_index_handler::RealInvertedIndexHandler;

--- a/src/query/ee/src/test_kits/mock_services.rs
+++ b/src/query/ee/src/test_kits/mock_services.rs
@@ -21,6 +21,7 @@ use databend_common_license::license_manager::LicenseManagerWrapper;
 
 use crate::aggregating_index::RealAggregatingIndexHandler;
 use crate::data_mask::RealDatamaskHandler;
+use crate::inverted_index::RealInvertedIndexHandler;
 use crate::license::RealLicenseManager;
 use crate::storages::fuse::operations::RealVacuumHandler;
 use crate::stream::RealStreamHandler;
@@ -40,6 +41,7 @@ impl MockServices {
         RealDatamaskHandler::init()?;
         RealVirtualColumnHandler::init()?;
         RealStreamHandler::init()?;
+        RealInvertedIndexHandler::init()?;
         Ok(())
     }
 }

--- a/src/query/ee/tests/it/inverted_index/index_refresh.rs
+++ b/src/query/ee/tests/it/inverted_index/index_refresh.rs
@@ -1,0 +1,74 @@
+// Copyright 2024 Databend Cloud
+//
+// Licensed under the Elastic License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.elastic.co/licensing/elastic-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_base::base::tokio;
+use databend_common_exception::Result;
+use databend_common_expression::DataSchema;
+use databend_common_storages_fuse::io::read::InvertedIndexReader;
+use databend_common_storages_fuse::FuseTable;
+use databend_enterprise_inverted_index::get_inverted_index_handler;
+use databend_enterprise_query::test_kits::context::EESetup;
+use databend_query::test_kits::append_string_sample_data;
+use databend_query::test_kits::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fuse_do_refresh_inverted_index() -> Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+
+    fixture
+        .default_session()
+        .get_settings()
+        .set_data_retention_time_in_days(0)?;
+    fixture.create_default_database().await?;
+    fixture.create_string_table().await?;
+
+    let number_of_block = 2;
+    append_string_sample_data(number_of_block, &fixture).await?;
+
+    let table = fixture.latest_default_table().await?;
+    let table_schema = table.schema();
+    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+    let dal = fuse_table.get_operator_ref();
+
+    let table_ctx = fixture.new_query_ctx().await?;
+    let schema = DataSchema::from(table_schema);
+
+    let handler = get_inverted_index_handler();
+    let location = handler
+        .do_refresh_index(fuse_table, table_ctx.clone(), schema.clone(), None)
+        .await?;
+
+    let index_reader = InvertedIndexReader::create(dal.clone(), schema);
+
+    let num = 5;
+    let query = "rust";
+    let docs = index_reader.do_read(location.clone(), query, num)?;
+    assert_eq!(docs.len(), 2);
+    assert_eq!(docs[0].1.doc_id, 0);
+    assert_eq!(docs[1].1.doc_id, 1);
+
+    let query = "java";
+    let docs = index_reader.do_read(location.clone(), query, num)?;
+    assert_eq!(docs.len(), 1);
+    assert_eq!(docs[0].1.doc_id, 2);
+
+    let query = "data";
+    let docs = index_reader.do_read(location, query, num)?;
+    assert_eq!(docs.len(), 3);
+    assert_eq!(docs[0].1.doc_id, 4);
+    assert_eq!(docs[1].1.doc_id, 1);
+    assert_eq!(docs[2].1.doc_id, 5);
+
+    Ok(())
+}

--- a/src/query/ee/tests/it/inverted_index/mod.rs
+++ b/src/query/ee/tests/it/inverted_index/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Databend Cloud
+// Copyright 2024 Databend Cloud
 //
 // Licensed under the Elastic License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod aggregating_index;
-pub mod background_service;
-pub mod data_mask;
-pub mod enterprise_services;
-pub mod inverted_index;
-pub mod license;
-pub mod storage_encryption;
-pub mod storages;
-pub mod stream;
-pub mod test_kits;
-pub mod virtual_column;
+mod index_refresh;

--- a/src/query/ee/tests/it/main.rs
+++ b/src/query/ee/tests/it/main.rs
@@ -15,5 +15,6 @@
 #![feature(unwrap_infallible)]
 mod aggregating_index;
 mod background_service;
+mod inverted_index;
 mod license;
 mod storages;

--- a/src/query/ee_features/inverted_index/Cargo.toml
+++ b/src/query/ee_features/inverted_index/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "databend-enterprise-inverted-index"
+description = "inverted index handler"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+# Workspace dependencies
+databend-common-base = { path = "../../../common/base" }
+databend-common-catalog = { path = "../../catalog" }
+databend-common-exception = { path = "../../../common/exception" }
+databend-common-expression = { path = "../../expression" }
+databend-common-storages-fuse = { path = "../../storages/fuse" }
+databend-storages-common-table-meta = { path = "../../storages/common/table_meta" }
+
+async-backtrace = { workspace = true }
+async-trait = { workspace = true }
+
+[build-dependencies]

--- a/src/query/ee_features/inverted_index/src/inverted_index_handler.rs
+++ b/src/query/ee_features/inverted_index/src/inverted_index_handler.rs
@@ -1,0 +1,60 @@
+// Copyright 2024 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_base::base::GlobalInstance;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::Result;
+use databend_common_expression::DataSchema;
+use databend_common_storages_fuse::FuseTable;
+use databend_storages_common_table_meta::meta::Location;
+
+#[async_trait::async_trait]
+pub trait InvertedIndexHandler: Sync + Send {
+    async fn do_refresh_index(
+        &self,
+        fuse_table: &FuseTable,
+        ctx: Arc<dyn TableContext>,
+        schema: DataSchema,
+        segment_locs: Option<Vec<Location>>,
+    ) -> Result<String>;
+}
+
+pub struct InvertedIndexHandlerWrapper {
+    handler: Box<dyn InvertedIndexHandler>,
+}
+
+impl InvertedIndexHandlerWrapper {
+    pub fn new(handler: Box<dyn InvertedIndexHandler>) -> Self {
+        Self { handler }
+    }
+
+    #[async_backtrace::framed]
+    pub async fn do_refresh_index(
+        &self,
+        fuse_table: &FuseTable,
+        ctx: Arc<dyn TableContext>,
+        schema: DataSchema,
+        segment_locs: Option<Vec<Location>>,
+    ) -> Result<String> {
+        self.handler
+            .do_refresh_index(fuse_table, ctx, schema, segment_locs)
+            .await
+    }
+}
+
+pub fn get_inverted_index_handler() -> Arc<InvertedIndexHandlerWrapper> {
+    GlobalInstance::get()
+}

--- a/src/query/ee_features/inverted_index/src/lib.rs
+++ b/src/query/ee_features/inverted_index/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Datafuse Labs
+// Copyright 2024 Datafuse Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod block_writer;
-mod inverted_index_writer;
-mod meta_writer;
-mod segment_writer;
-mod write_settings;
+pub mod inverted_index_handler;
 
-pub use block_writer::serialize_block;
-pub use block_writer::write_data;
-pub use block_writer::BlockBuilder;
-pub use block_writer::BlockSerialization;
-pub use inverted_index_writer::InvertedIndexWriter;
-pub use meta_writer::CachedMetaWriter;
-pub use meta_writer::MetaWriter;
-pub use segment_writer::SegmentWriter;
-pub use write_settings::WriteSettings;
+pub use inverted_index_handler::get_inverted_index_handler;
+pub use inverted_index_handler::InvertedIndexHandler;
+pub use inverted_index_handler::InvertedIndexHandlerWrapper;

--- a/src/query/service/src/test_kits/fixture.rs
+++ b/src/query/service/src/test_kits/fixture.rs
@@ -27,6 +27,7 @@ use databend_common_expression::infer_table_schema;
 use databend_common_expression::types::binary::BinaryColumnBuilder;
 use databend_common_expression::types::number::Int32Type;
 use databend_common_expression::types::number::Int64Type;
+use databend_common_expression::types::string::StringColumnBuilder;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::StringType;
@@ -384,6 +385,42 @@ impl TestFixture {
         }
     }
 
+    pub fn string_schema() -> DataSchemaRef {
+        DataSchemaRefExt::create(vec![
+            DataField::new("title", DataType::String),
+            DataField::new("content", DataType::String),
+        ])
+    }
+
+    pub fn string_table_schema() -> TableSchemaRef {
+        infer_table_schema(&Self::string_schema()).unwrap()
+    }
+
+    // create a string table for inverted index
+    pub fn string_create_table_plan(&self) -> CreateTablePlan {
+        CreateTablePlan {
+            create_option: CreateOption::None,
+            tenant: self.default_tenant(),
+            catalog: self.default_catalog_name(),
+            database: self.default_db_name(),
+            table: self.default_table_name(),
+            schema: TestFixture::string_table_schema(),
+            engine: Engine::Fuse,
+            engine_options: Default::default(),
+            storage_params: None,
+            read_only_attach: false,
+            part_prefix: "".to_string(),
+            options: [
+                // database id is required for FUSE
+                (OPT_KEY_DATABASE_ID.to_owned(), "1".to_owned()),
+            ]
+            .into(),
+            field_comments: vec![],
+            as_select: None,
+            cluster_key: None,
+        }
+    }
+
     pub fn computed_schema() -> DataSchemaRef {
         DataSchemaRefExt::create(vec![
             DataField::new("id", DataType::Number(NumberDataType::Int32)),
@@ -447,6 +484,14 @@ impl TestFixture {
 
     pub async fn create_variant_table(&self) -> Result<()> {
         let create_table_plan = self.variant_create_table_plan();
+        let interpreter =
+            CreateTableInterpreter::try_create(self.default_ctx.clone(), create_table_plan)?;
+        let _ = interpreter.execute(self.default_ctx.clone()).await?;
+        Ok(())
+    }
+
+    pub async fn create_string_table(&self) -> Result<()> {
+        let create_table_plan = self.string_create_table_plan();
         let interpreter =
             CreateTableInterpreter::try_create(self.default_ctx.clone(), create_table_plan)?;
         let _ = interpreter.execute(self.default_ctx.clone()).await?;
@@ -614,6 +659,82 @@ impl TestFixture {
 
     pub fn gen_variant_sample_blocks_stream(num: usize, start: i32) -> SendableDataBlockStream {
         let (_, blocks) = Self::gen_variant_sample_blocks(num, start);
+        Box::pin(futures::stream::iter(blocks))
+    }
+
+    pub fn gen_string_sample_blocks(
+        num_of_blocks: usize,
+        start: i32,
+    ) -> (TableSchemaRef, Vec<Result<DataBlock>>) {
+        Self::gen_string_sample_blocks_ex(num_of_blocks, 3, start)
+    }
+
+    pub fn gen_string_sample_blocks_ex(
+        num_of_block: usize,
+        rows_per_block: usize,
+        _start: i32,
+    ) -> (TableSchemaRef, Vec<Result<DataBlock>>) {
+        let schema = TableSchemaRefExt::create(vec![
+            TableField::new("title", TableDataType::String),
+            TableField::new("content", TableDataType::String),
+        ]);
+
+        let sample_books = [
+            (
+                "The Rust Programming Language",
+                "The Rust Programming Language is the official book on Rust: an open source systems programming language that helps you write faster, more reliable software. Rust offers control over low-level details (such as memory usage) in combination with high-level ergonomics, eliminating the hassle traditionally associated with low-level languages.",
+            ),
+            (
+                "Rust Atomics and Locks",
+                "The Rust programming language is extremely well suited for concurrency, and its ecosystem has many libraries that include lots of concurrent data structures, locks, and more. But implementing those structures correctly can be very difficult. Even in the most well-used libraries, memory ordering bugs are not uncommon.",
+            ),
+            (
+                "Effective Java",
+                "Java has changed dramatically since the previous edition of Effective Java was published shortly after the release of Java 6. This Jolt award-winning classic has now been thoroughly updated to take full advantage of the latest language and library features. The support in modern Java for multiple paradigms increases the need for specific best-practices advice, and this book delivers.",
+            ),
+            (
+                "Database Internals",
+                "When it comes to choosing, using, and maintaining a database, understanding its internals is essential. But with so many distributed databases and tools available today, it’s often difficult to understand what each one offers and how they differ. With this practical guide, Alex Petrov guides developers through the concepts behind modern database and storage engine internals.",
+            ),
+            (
+                "Designing Data-Intensive Applications",
+                "Data is at the center of many challenges in system design today. Difficult issues need to be figured out, such as scalability, consistency, reliability, efficiency, and maintainability. In addition, we have an overwhelming variety of tools, including relational databases, NoSQL datastores, stream or batch processors, and message brokers. What are the right choices for your application? How do you make sense of all these buzzwords?",
+            ),
+            (
+                "Elasticsearch in Action",
+                "Modern search seems like magic—you type a few words and the search engine appears to know what you want. With the Elasticsearch real-time search and analytics engine, you can give your users this magical experience without having to do complex low-level programming or understand advanced data science algorithms. You just install it, tweak it, and get on with your work.",
+            ),
+        ];
+
+        (
+            schema,
+            (0..num_of_block)
+                .map(|idx| {
+                    let mut title_builder =
+                        StringColumnBuilder::with_capacity(rows_per_block, rows_per_block * 10);
+                    let mut content_builder =
+                        StringColumnBuilder::with_capacity(rows_per_block, rows_per_block * 10);
+
+                    for i in 0..rows_per_block {
+                        let j = (idx * rows_per_block + i) % sample_books.len();
+                        title_builder.put_str(sample_books[j].0);
+                        title_builder.commit_row();
+                        content_builder.put_str(sample_books[j].1);
+                        content_builder.commit_row();
+                    }
+                    let title_column = Column::String(title_builder.build());
+                    let content_column = Column::String(content_builder.build());
+
+                    let columns = vec![title_column, content_column];
+
+                    Ok(DataBlock::new_from_columns(columns))
+                })
+                .collect(),
+        )
+    }
+
+    pub fn gen_string_sample_blocks_stream(num: usize, start: i32) -> SendableDataBlockStream {
+        let (_, blocks) = Self::gen_string_sample_blocks(num, start);
         Box::pin(futures::stream::iter(blocks))
     }
 

--- a/src/query/service/src/test_kits/fuse.rs
+++ b/src/query/service/src/test_kits/fuse.rs
@@ -314,6 +314,16 @@ pub async fn append_variant_sample_data(num_blocks: usize, fixture: &TestFixture
         .await
 }
 
+pub async fn append_string_sample_data(num_blocks: usize, fixture: &TestFixture) -> Result<()> {
+    let stream = TestFixture::gen_string_sample_blocks_stream(num_blocks, 1);
+    let table = fixture.latest_default_table().await?;
+
+    let blocks = stream.try_collect().await?;
+    fixture
+        .append_commit_blocks(table.clone(), blocks, true, true)
+        .await
+}
+
 pub async fn append_computed_sample_data(num_blocks: usize, fixture: &TestFixture) -> Result<()> {
     let stream = TestFixture::gen_computed_sample_blocks_stream(num_blocks, 1);
     let table = fixture.latest_default_table().await?;

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -47,6 +47,7 @@ async-trait = { workspace = true }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
+crc32fast = "1.3.2"
 enum-as-inner = "0.5"
 futures = { workspace = true }
 futures-util = { workspace = true }
@@ -65,6 +66,8 @@ sha2 = "0.10.6"
 siphasher = "0.3.10"
 streaming-decompression = "0.1.2"
 sys-info = "0.9"
+tantivy = "0.21.1"
+tantivy-common = "0.6.0"
 typetag = { workspace = true }
 uuid = { workspace = true }
 xorf = { version = "0.11.0", default-features = false, features = ["binary-fuse"] }

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -27,6 +27,7 @@ pub const FUSE_TBL_SNAPSHOT_STATISTICS_PREFIX: &str = "_ts";
 pub const FUSE_TBL_LAST_SNAPSHOT_HINT: &str = "last_snapshot_location_hint";
 pub const FUSE_TBL_VIRTUAL_BLOCK_PREFIX: &str = "_vb";
 pub const FUSE_TBL_AGG_INDEX_PREFIX: &str = "_i_a";
+pub const FUSE_TBL_INVERTED_INDEX_PREFIX: &str = "_i_f";
 
 pub const DEFAULT_BLOCK_PER_SEGMENT: usize = 1000;
 pub const DEFAULT_ROW_PER_PAGE: usize = 131072;

--- a/src/query/storages/fuse/src/io/locations.rs
+++ b/src/query/storages/fuse/src/io/locations.rs
@@ -30,6 +30,7 @@ use crate::constants::FUSE_TBL_SNAPSHOT_STATISTICS_PREFIX;
 use crate::constants::FUSE_TBL_VIRTUAL_BLOCK_PREFIX;
 use crate::index::filters::BlockFilter;
 use crate::FUSE_TBL_AGG_INDEX_PREFIX;
+use crate::FUSE_TBL_INVERTED_INDEX_PREFIX;
 use crate::FUSE_TBL_LAST_SNAPSHOT_HINT;
 use crate::FUSE_TBL_XOR_BLOOM_INDEX_PREFIX;
 
@@ -162,6 +163,13 @@ impl TableMetaLocationGenerator {
         let prefix = splits[..len - 2].join("/");
         let block_name = splits[len - 1];
         format!("{prefix}/{FUSE_TBL_AGG_INDEX_PREFIX}/{index_id}/{block_name}")
+    }
+
+    pub fn gen_inverted_index_location(&self, id: String) -> String {
+        format!(
+            "{}/{}/{}.index",
+            &self.prefix, FUSE_TBL_INVERTED_INDEX_PREFIX, id
+        )
     }
 }
 

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -44,6 +44,7 @@ pub use write::write_data;
 pub use write::BlockBuilder;
 pub use write::BlockSerialization;
 pub use write::CachedMetaWriter;
+pub use write::InvertedIndexWriter;
 pub use write::MetaWriter;
 pub use write::SegmentWriter;
 pub use write::WriteSettings;

--- a/src/query/storages/fuse/src/io/read/inverted_index/cache_directory.rs
+++ b/src/query/storages/fuse/src/io/read/inverted_index/cache_directory.rs
@@ -1,0 +1,310 @@
+// Copyright (c) 2018 by the tantivy project authors
+// (https://github.com/quickwit-oss/tantivy), as listed in the AUTHORS file.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::io::BufWriter;
+use std::io::Cursor;
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
+use std::ops::Range;
+use std::path::Path;
+use std::path::PathBuf;
+use std::result;
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+use log::warn;
+use tantivy::directory::error::DeleteError;
+use tantivy::directory::error::OpenReadError;
+use tantivy::directory::error::OpenWriteError;
+use tantivy::directory::AntiCallToken;
+use tantivy::directory::FileHandle;
+use tantivy::directory::FileSlice;
+use tantivy::directory::OwnedBytes;
+use tantivy::directory::TerminatingWrite;
+use tantivy::directory::WatchCallback;
+use tantivy::directory::WatchHandle;
+use tantivy::directory::WritePtr;
+use tantivy::Directory;
+
+/// The Writer just writes a buffer.
+struct VecWriter {
+    path: PathBuf,
+    data: Cursor<Vec<u8>>,
+    is_flushed: bool,
+}
+
+impl VecWriter {
+    fn new(path_buf: PathBuf) -> VecWriter {
+        VecWriter {
+            path: path_buf,
+            data: Cursor::new(Vec::new()),
+            is_flushed: true,
+        }
+    }
+}
+
+impl Drop for VecWriter {
+    fn drop(&mut self) {
+        if !self.is_flushed {
+            warn!(
+                "You forgot to flush {:?} before its writer got Drop. Do not rely on drop. This \
+                 also occurs when the indexer crashed, so you may want to check the logs for the \
+                 root cause.",
+                self.path
+            )
+        }
+    }
+}
+
+impl Write for VecWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.is_flushed = false;
+        self.data.write_all(buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.is_flushed = true;
+        Ok(())
+    }
+}
+
+impl TerminatingWrite for VecWriter {
+    fn terminate_ref(&mut self, _: AntiCallToken) -> io::Result<()> {
+        self.flush()
+    }
+}
+
+// CacheDirectory holds all indexed data for tantivy queries to search for relevant data.
+// The data is read-only, write and delete operations will be ignored and return success directly.
+#[derive(Clone, Debug)]
+pub struct CacheDirectory {
+    data: OwnedBytes,
+
+    fast_fields_range: Range<usize>,
+    store_range: Range<usize>,
+    fieldnorm_range: Range<usize>,
+    position_range: Range<usize>,
+    posting_range: Range<usize>,
+    term_range: Range<usize>,
+    meta_range: Range<usize>,
+    managed_range: Range<usize>,
+
+    meta_path: PathBuf,
+    managed_path: PathBuf,
+}
+
+impl CacheDirectory {
+    pub fn try_create(data: Vec<u8>) -> Result<Self> {
+        if data.len() < 64 {
+            return Err(OpenReadError::IoError {
+                io_error: std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid data")
+                    .into(),
+                filepath: PathBuf::from("CacheDirectory"),
+            }
+            .into());
+        }
+
+        let mut reader = Cursor::new(data.clone());
+        reader.seek(SeekFrom::End(-64))?;
+
+        let mut buf = vec![0u8; 8];
+        let fast_fields_offset = read_u64(&mut reader, buf.as_mut_slice())? as usize;
+        let store_offset = read_u64(&mut reader, buf.as_mut_slice())? as usize;
+        let field_norms_offset = read_u64(&mut reader, buf.as_mut_slice())? as usize;
+        let positions_offset = read_u64(&mut reader, buf.as_mut_slice())? as usize;
+        let postings_offset = read_u64(&mut reader, buf.as_mut_slice())? as usize;
+        let terms_offset = read_u64(&mut reader, buf.as_mut_slice())? as usize;
+        let meta_offset = read_u64(&mut reader, buf.as_mut_slice())? as usize;
+        let managed_offset = read_u64(&mut reader, buf.as_mut_slice())? as usize;
+
+        if data.len() < managed_offset {
+            return Err(OpenReadError::IoError {
+                io_error: std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid data")
+                    .into(),
+                filepath: PathBuf::from("CacheDirectory"),
+            }
+            .into());
+        }
+
+        let data = OwnedBytes::new(data);
+
+        let fast_fields_range = Range {
+            start: 0,
+            end: fast_fields_offset as usize,
+        };
+        let store_range = Range {
+            start: fast_fields_offset as usize,
+            end: store_offset as usize,
+        };
+        let fieldnorm_range = Range {
+            start: store_offset as usize,
+            end: field_norms_offset as usize,
+        };
+        let position_range = Range {
+            start: field_norms_offset as usize,
+            end: positions_offset as usize,
+        };
+        let posting_range = Range {
+            start: positions_offset as usize,
+            end: postings_offset as usize,
+        };
+        let term_range = Range {
+            start: postings_offset as usize,
+            end: terms_offset as usize,
+        };
+        let meta_range = Range {
+            start: terms_offset as usize,
+            end: meta_offset as usize,
+        };
+        let managed_range = Range {
+            start: meta_offset as usize,
+            end: managed_offset as usize,
+        };
+
+        let meta_path = PathBuf::from("meta.json");
+        let managed_path = PathBuf::from(".managed.json");
+
+        Ok(Self {
+            data,
+            fast_fields_range,
+            store_range,
+            fieldnorm_range,
+            position_range,
+            posting_range,
+            term_range,
+            meta_range,
+            managed_range,
+            meta_path,
+            managed_path,
+        })
+    }
+}
+
+impl Directory for CacheDirectory {
+    fn get_file_handle(&self, path: &Path) -> result::Result<Arc<dyn FileHandle>, OpenReadError> {
+        let file_slice = self.open_read(path)?;
+        Ok(Arc::new(file_slice))
+    }
+
+    fn open_read(&self, path: &Path) -> result::Result<FileSlice, OpenReadError> {
+        if path == self.meta_path.as_path() {
+            let bytes = self.data.slice(self.meta_range.clone());
+            return Ok(FileSlice::new(Arc::new(bytes)));
+        } else if path == self.managed_path.as_path() {
+            let bytes = self.data.slice(self.managed_range.clone());
+            return Ok(FileSlice::new(Arc::new(bytes)));
+        }
+
+        if let Some(ext) = path.extension() {
+            let bytes = match ext.to_str() {
+                Some("term") => self.data.slice(self.term_range.clone()),
+                Some("idx") => self.data.slice(self.posting_range.clone()),
+                Some("pos") => self.data.slice(self.position_range.clone()),
+                Some("fieldnorm") => self.data.slice(self.fieldnorm_range.clone()),
+                Some("store") => self.data.slice(self.store_range.clone()),
+                Some("fast") => self.data.slice(self.fast_fields_range.clone()),
+                _ => {
+                    return Err(OpenReadError::FileDoesNotExist(PathBuf::from(path)));
+                }
+            };
+            Ok(FileSlice::new(Arc::new(bytes)))
+        } else {
+            Err(OpenReadError::FileDoesNotExist(PathBuf::from(path)))
+        }
+    }
+
+    fn delete(&self, _path: &Path) -> result::Result<(), DeleteError> {
+        Ok(())
+    }
+
+    fn exists(&self, path: &Path) -> result::Result<bool, OpenReadError> {
+        if path == self.meta_path.as_path() || path == self.managed_path.as_path() {
+            return Ok(true);
+        }
+        if let Some(ext) = path.extension() {
+            match ext.to_str() {
+                Some("term") => Ok(true),
+                Some("idx") => Ok(true),
+                Some("pos") => Ok(true),
+                Some("fieldnorm") => Ok(true),
+                Some("store") => Ok(true),
+                Some("fast") => Ok(true),
+                _ => Ok(false),
+            }
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn open_write(&self, path: &Path) -> result::Result<WritePtr, OpenWriteError> {
+        let path_buf = PathBuf::from(path);
+        let vec_writer = VecWriter::new(path_buf);
+        Ok(BufWriter::new(Box::new(vec_writer)))
+    }
+
+    fn atomic_read(&self, path: &Path) -> result::Result<Vec<u8>, OpenReadError> {
+        let bytes =
+            self.open_read(path)?
+                .read_bytes()
+                .map_err(|io_error| OpenReadError::IoError {
+                    io_error: Arc::new(io_error),
+                    filepath: path.to_path_buf(),
+                })?;
+        Ok(bytes.as_slice().to_owned())
+    }
+
+    fn atomic_write(&self, _path: &Path, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn watch(&self, watch_callback: WatchCallback) -> tantivy::Result<WatchHandle> {
+        let watch_handle = WatchHandle::new(Arc::new(watch_callback));
+        Ok(watch_handle)
+    }
+
+    fn sync_directory(&self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[inline(always)]
+fn read_u64<R: Read>(r: &mut R, buf: &mut [u8]) -> Result<u64> {
+    r.read_exact(buf)?;
+    Ok(u64::from_le_bytes(buf.try_into().unwrap()))
+}

--- a/src/query/storages/fuse/src/io/read/inverted_index/inverted_index_reader.rs
+++ b/src/query/storages/fuse/src/io/read/inverted_index/inverted_index_reader.rs
@@ -1,0 +1,81 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_exception::Result;
+use databend_common_expression::DataSchema;
+use opendal::Operator;
+use tantivy::collector::TopDocs;
+use tantivy::query::QueryParser;
+use tantivy::schema::Field;
+use tantivy::tokenizer::Language;
+use tantivy::tokenizer::LowerCaser;
+use tantivy::tokenizer::RemoveLongFilter;
+use tantivy::tokenizer::SimpleTokenizer;
+use tantivy::tokenizer::Stemmer;
+use tantivy::tokenizer::TextAnalyzer;
+use tantivy::tokenizer::TokenizerManager;
+use tantivy::DocAddress;
+use tantivy::Index;
+use tantivy::Score;
+
+use crate::io::read::inverted_index::cache_directory::CacheDirectory;
+
+#[derive(Clone)]
+pub struct InvertedIndexReader {
+    dal: Operator,
+    schema: DataSchema,
+}
+
+impl InvertedIndexReader {
+    pub fn create(dal: Operator, schema: DataSchema) -> Self {
+        Self { dal, schema }
+    }
+
+    pub fn do_read(
+        &self,
+        path: String,
+        query: &str,
+        num: usize,
+    ) -> Result<Vec<(Score, DocAddress)>> {
+        let data = self.dal.blocking().read_with(&path).call()?;
+
+        let directory = CacheDirectory::try_create(data)?;
+        let mut index = Index::open(directory)?;
+        let tokenizer_manager = TokenizerManager::new();
+        tokenizer_manager.register(
+            "en",
+            TextAnalyzer::builder(SimpleTokenizer::default())
+                .filter(RemoveLongFilter::limit(40))
+                .filter(LowerCaser)
+                .filter(Stemmer::new(Language::English))
+                .build(),
+        );
+        index.set_tokenizers(tokenizer_manager);
+
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+
+        let fields = (0..self.schema.fields.len())
+            .map(|i| Field::from_field_id(i as u32))
+            .collect::<Vec<_>>();
+
+        let query_parser = QueryParser::for_index(&index, fields);
+
+        let query = query_parser.parse_query(query)?;
+        let collector = TopDocs::with_limit(num);
+        let docs = searcher.search(&query, &collector)?;
+
+        Ok(docs)
+    }
+}

--- a/src/query/storages/fuse/src/io/read/inverted_index/mod.rs
+++ b/src/query/storages/fuse/src/io/read/inverted_index/mod.rs
@@ -12,18 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod block_writer;
-mod inverted_index_writer;
-mod meta_writer;
-mod segment_writer;
-mod write_settings;
+mod cache_directory;
+mod inverted_index_reader;
 
-pub use block_writer::serialize_block;
-pub use block_writer::write_data;
-pub use block_writer::BlockBuilder;
-pub use block_writer::BlockSerialization;
-pub use inverted_index_writer::InvertedIndexWriter;
-pub use meta_writer::CachedMetaWriter;
-pub use meta_writer::MetaWriter;
-pub use segment_writer::SegmentWriter;
-pub use write_settings::WriteSettings;
+pub use inverted_index_reader::InvertedIndexReader;

--- a/src/query/storages/fuse/src/io/read/mod.rs
+++ b/src/query/storages/fuse/src/io/read/mod.rs
@@ -15,6 +15,7 @@
 mod agg_index;
 mod block;
 pub mod bloom;
+mod inverted_index;
 pub mod meta;
 mod read_settings;
 mod snapshot_history_reader;
@@ -28,6 +29,7 @@ pub use block::NativeReaderExt;
 pub use block::NativeSourceData;
 pub use block::UncompressedBuffer;
 pub use bloom::BloomBlockFilterReader;
+pub use inverted_index::InvertedIndexReader;
 pub use meta::CompactSegmentInfoReader;
 pub use meta::MetaReaders;
 pub use meta::TableSnapshotReader;

--- a/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
+++ b/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
@@ -1,0 +1,408 @@
+// Copyright (c) 2018 by the tantivy project authors
+// (https://github.com/quickwit-oss/tantivy), as listed in the AUTHORS file.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::path::Path;
+
+use crc32fast::Hasher;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::types::DataType;
+use databend_common_expression::DataBlock;
+use databend_common_expression::DataSchema;
+use databend_common_expression::ScalarRef;
+use databend_common_io::constants::DEFAULT_BLOCK_INDEX_BUFFER_SIZE;
+use opendal::Operator;
+use serde::Deserialize;
+use serde::Serialize;
+use tantivy::directory::RamDirectory;
+use tantivy::schema::Document;
+use tantivy::schema::Field;
+use tantivy::schema::IndexRecordOption;
+use tantivy::schema::Schema;
+use tantivy::schema::TextFieldIndexing;
+use tantivy::schema::TextOptions;
+use tantivy::tokenizer::Language;
+use tantivy::tokenizer::LowerCaser;
+use tantivy::tokenizer::RemoveLongFilter;
+use tantivy::tokenizer::SimpleTokenizer;
+use tantivy::tokenizer::Stemmer;
+use tantivy::tokenizer::TextAnalyzer;
+use tantivy::tokenizer::TokenizerManager;
+use tantivy::Directory;
+use tantivy::Index;
+use tantivy::IndexBuilder;
+use tantivy::IndexSettings;
+use tantivy::SegmentComponent;
+use tantivy::SegmentId;
+use tantivy::SingleSegmentIndexWriter;
+use tantivy_common::BinarySerializable;
+
+use crate::io::write_data;
+use crate::io::TableMetaLocationGenerator;
+
+// tantivy version is used to generate the footer data
+
+// Index major version.
+const INDEX_MAJOR_VERSION: u32 = 0;
+// Index minor version.
+const INDEX_MINOR_VERSION: u32 = 21;
+// Index patch version.
+const INDEX_PATCH_VERSION: u32 = 1;
+// Index format version.
+const INDEX_FORMAT_VERSION: u32 = 5;
+
+// The magic byte of the footer to identify corruption
+// or an old version of the footer.
+const FOOTER_MAGIC_NUMBER: u32 = 1337;
+
+type CrcHashU32 = u32;
+
+/// Structure version for the index.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Version {
+    major: u32,
+    minor: u32,
+    patch: u32,
+    index_format_version: u32,
+}
+
+/// A Footer is appended every part of data, like tantivy file.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Footer {
+    pub version: Version,
+    pub crc: CrcHashU32,
+}
+
+impl Footer {
+    pub fn new(crc: CrcHashU32) -> Self {
+        let version = Version {
+            major: INDEX_MAJOR_VERSION,
+            minor: INDEX_MINOR_VERSION,
+            patch: INDEX_PATCH_VERSION,
+            index_format_version: INDEX_FORMAT_VERSION,
+        };
+        Footer { version, crc }
+    }
+
+    pub fn append_footer<W: std::io::Write>(&self, write: &mut W) -> Result<()> {
+        let footer_payload_len = write.write(serde_json::to_string(&self)?.as_ref())?;
+        BinarySerializable::serialize(&(footer_payload_len as u32), write)?;
+        BinarySerializable::serialize(&FOOTER_MAGIC_NUMBER, write)?;
+        Ok(())
+    }
+}
+
+pub struct InvertedIndexWriter {
+    schema: DataSchema,
+    index_writer: SingleSegmentIndexWriter,
+}
+
+impl InvertedIndexWriter {
+    pub fn try_create(schema: DataSchema) -> Result<InvertedIndexWriter> {
+        let text_field_indexing = TextFieldIndexing::default()
+            .set_tokenizer("en")
+            .set_index_option(IndexRecordOption::WithFreqsAndPositions);
+        let text_options = TextOptions::default().set_indexing_options(text_field_indexing);
+
+        let mut schema_builder = Schema::builder();
+        let mut index_fields = Vec::with_capacity(schema.fields.len());
+        for field in &schema.fields {
+            if field.data_type().remove_nullable() != DataType::String {
+                return Err(ErrorCode::IllegalDataType(format!(
+                    "inverted index only support String type, but got {}",
+                    field.data_type()
+                )));
+            }
+            let index_field = schema_builder.add_text_field(field.name(), text_options.clone());
+            index_fields.push(index_field);
+        }
+        let index_schema = schema_builder.build();
+
+        let index_settings = IndexSettings {
+            sort_by_field: None,
+            ..Default::default()
+        };
+        let tokenizer_manager = TokenizerManager::new();
+        tokenizer_manager.register(
+            "en",
+            TextAnalyzer::builder(SimpleTokenizer::default())
+                .filter(RemoveLongFilter::limit(40))
+                .filter(LowerCaser)
+                .filter(Stemmer::new(Language::English))
+                .build(),
+        );
+
+        let index_builder = IndexBuilder::new()
+            .settings(index_settings)
+            .schema(index_schema.clone())
+            .tokenizers(tokenizer_manager.clone());
+
+        let ram_directory = RamDirectory::create();
+        let index_writer = index_builder.single_segment_index_writer(ram_directory, 50_000_000)?;
+
+        Ok(Self {
+            schema,
+            index_writer,
+        })
+    }
+
+    pub fn add_block(&mut self, block: DataBlock) -> Result<()> {
+        if block.num_columns() != self.schema.num_fields() {
+            return Err(ErrorCode::TableSchemaMismatch(format!(
+                "Data schema mismatched. Data columns length: {}, schema fields length: {}",
+                block.num_columns(),
+                self.schema.num_fields()
+            )));
+        }
+        for (column, field) in block.columns().iter().zip(self.schema.fields().iter()) {
+            if &column.data_type != field.data_type() {
+                return Err(ErrorCode::TableSchemaMismatch(format!(
+                    "Data schema mismatched (col name: {}). Data column type is {:?}, but schema field type is {:?}",
+                    field.name(),
+                    column.data_type,
+                    field.data_type()
+                )));
+            }
+        }
+
+        for i in 0..block.num_rows() {
+            let mut doc = Document::new();
+            for j in 0..block.num_columns() {
+                let field = Field::from_field_id(j as u32);
+                let column = block.get_by_offset(j);
+                if let ScalarRef::String(text) = unsafe { column.value.index_unchecked(i) } {
+                    doc.add_text(field, text);
+                } else {
+                    doc.add_text(field, "");
+                }
+            }
+            self.index_writer.add_document(doc)?;
+        }
+        Ok(())
+    }
+
+    #[async_backtrace::framed]
+    pub async fn finalize(
+        self,
+        operator: &Operator,
+        location_generator: &TableMetaLocationGenerator,
+    ) -> Result<String> {
+        let index = self.index_writer.finalize()?;
+
+        let mut buffer = Vec::with_capacity(DEFAULT_BLOCK_INDEX_BUFFER_SIZE);
+        let segment_id = Self::write_index(&mut buffer, index).await?;
+
+        let index_location =
+            location_generator.gen_inverted_index_location(segment_id.uuid_string());
+
+        write_data(buffer, operator, &index_location).await?;
+
+        Ok(index_location)
+    }
+
+    // The tantivy index data consists of eight files.
+    // `.managed.json` file stores the name of the file that the index contains, for example:
+    // [
+    //   "94bce521d5bc4eccbf3e7a0212093622.pos",
+    //   "94bce521d5bc4eccbf3e7a0212093622.fieldnorm",
+    //   "94bce521d5bc4eccbf3e7a0212093622.fast",
+    //   "meta.json",
+    //   "94bce521d5bc4eccbf3e7a0212093622.term",
+    //   "94bce521d5bc4eccbf3e7a0212093622.store",
+    //   "94bce521d5bc4eccbf3e7a0212093622.idx"
+    // ]
+    //
+    // `meta.json` file store the meta information associated with the index, for example:
+    // {
+    //   "index_settings": {
+    //     "docstore_compression": "lz4",
+    //     "docstore_blocksize": 16384
+    //   },
+    //   "segments":[{
+    //     "segment_id": "94bce521-d5bc-4ecc-bf3e-7a0212093622",
+    //     "max_doc": 6,
+    //     "deletes": null
+    //   }],
+    //   "schema":[{
+    //     "name": "title",
+    //     "type": "text",
+    //     "options": {
+    //       "indexing": {
+    //         "record": "position",
+    //         "fieldnorms": true,
+    //         "tokenizer": "en"
+    //       },
+    //       "stored": false,
+    //       "fast": false
+    //     }
+    //   }, {
+    //     "name": "content",
+    //     "type": "text",
+    //     "options": {
+    //       "indexing": {
+    //         "record": "position",
+    //         "fieldnorms": true,
+    //         "tokenizer": "en"
+    //       },
+    //       "stored": false,
+    //       "fast": false
+    //     }
+    //   }],
+    //   "opstamp":0
+    // }
+    //
+    // `terms` file stores the term dictionary, the value is
+    // an address into the `postings` file and the `positions` file.
+    // `postings` file stores the lists of document ids and freqs.
+    // `positions` file stores the positions of terms in each document.
+    // `field norms` file stores the sum of the length of the term.
+    // `fast fields` file stores column-oriented documents.
+    // `store` file stores row-oriented documents.
+    //
+    // More details can be seen here
+    // https://github.com/quickwit-oss/tantivy/blob/main/src/index/segment_component.rs#L8
+    //
+    // We merge the data from these files into one file and
+    // record the offset to read each part of the data.
+    #[async_backtrace::framed]
+    async fn write_index<W: Write>(mut writer: &mut W, index: Index) -> Result<SegmentId> {
+        let directory = index.directory();
+
+        let managed_filepath = Path::new(".managed.json");
+        let managed_bytes = directory.atomic_read(managed_filepath)?;
+
+        let meta_filepath = Path::new("meta.json");
+        let meta_data = directory.atomic_read(meta_filepath)?;
+
+        let meta_string = std::str::from_utf8(&meta_data)?;
+        let meta_val: serde_json::Value = serde_json::from_str(meta_string)?;
+        let meta_json: String = serde_json::to_string(&meta_val)?;
+
+        let segments = index.searchable_segments()?;
+        let segment = &segments[0];
+
+        let fast_fields = segment.open_read(SegmentComponent::FastFields)?;
+        let fast_fields_bytes = fast_fields.read_bytes()?;
+
+        let store = segment.open_read(SegmentComponent::Store)?;
+        let store_bytes = store.read_bytes()?;
+
+        let field_norms = segment.open_read(SegmentComponent::FieldNorms)?;
+        let field_norms_bytes = field_norms.read_bytes()?;
+
+        let positions = segment.open_read(SegmentComponent::Positions)?;
+        let positions_bytes = positions.read_bytes()?;
+
+        let postings = segment.open_read(SegmentComponent::Postings)?;
+        let postings_bytes = postings.read_bytes()?;
+
+        let terms = segment.open_read(SegmentComponent::Terms)?;
+        let terms_bytes = terms.read_bytes()?;
+
+        // write each tantivy files as part of data
+        let mut fast_fields_length = writer.write(&fast_fields_bytes)?;
+        let footer_length = Self::build_footer(&mut writer, &fast_fields_bytes)?;
+        fast_fields_length += footer_length;
+
+        let mut store_length = writer.write(&store_bytes)?;
+        let footer_length = Self::build_footer(&mut writer, &store_bytes)?;
+        store_length += footer_length;
+
+        let mut field_norms_length = writer.write(&field_norms_bytes)?;
+        let footer_length = Self::build_footer(&mut writer, &field_norms_bytes)?;
+        field_norms_length += footer_length;
+
+        let mut positions_length = writer.write(&positions_bytes)?;
+        let footer_length = Self::build_footer(&mut writer, &positions_bytes)?;
+        positions_length += footer_length;
+
+        let mut postings_length = writer.write(&postings_bytes)?;
+        let footer_length = Self::build_footer(&mut writer, &postings_bytes)?;
+        postings_length += footer_length;
+
+        let mut terms_length = writer.write(&terms_bytes)?;
+        let footer_length = Self::build_footer(&mut writer, &terms_bytes)?;
+        terms_length += footer_length;
+
+        let meta_length = writer.write(meta_json.as_bytes())?;
+        let managed_length = writer.write(&managed_bytes)?;
+
+        // write offsets of each parts
+        let mut offset: u64 = 0;
+        offset += fast_fields_length as u64;
+        writer.write_all(&offset.to_le_bytes())?;
+
+        offset += store_length as u64;
+        writer.write_all(&offset.to_le_bytes())?;
+
+        offset += field_norms_length as u64;
+        writer.write_all(&offset.to_le_bytes())?;
+
+        offset += positions_length as u64;
+        writer.write_all(&offset.to_le_bytes())?;
+
+        offset += postings_length as u64;
+        writer.write_all(&offset.to_le_bytes())?;
+
+        offset += terms_length as u64;
+        writer.write_all(&offset.to_le_bytes())?;
+
+        offset += meta_length as u64;
+        writer.write_all(&offset.to_le_bytes())?;
+
+        offset += managed_length as u64;
+        writer.write_all(&offset.to_le_bytes())?;
+
+        writer.flush()?;
+
+        let segment_id = segment.id();
+
+        Ok(segment_id)
+    }
+
+    fn build_footer<W: Write>(writer: &mut W, bytes: &[u8]) -> Result<usize> {
+        let mut hasher = Hasher::new();
+        hasher.update(bytes);
+        let crc = hasher.finalize();
+
+        let footer = Footer::new(crc);
+        let mut buf = Vec::new();
+        footer.append_footer(&mut buf)?;
+
+        let len = writer.write(&buf)?;
+        Ok(len)
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

using tantivy to generate inverted index data, and merge each part of index files to one index file to store in S3. Using custom `CacheDirectory` to read index data.

- part of #14825

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
