### PR TITLE
refactor: upgrade openraft v0.9.0-alpha.7 to v0.9.0-alpha.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8489,7 +8489,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.7#685fe8d11831adbaacf895f63f06b9a674fc1d49"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.8#884f0da65ec10ce5777165e6906c61c326f2394b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9340,7 +9340,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.7#685fe8d11831adbaacf895f63f06b9a674fc1d49"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.8#884f0da65ec10ce5777165e6906c61c326f2394b"
 dependencies = [
  "anyerror",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ opendal = { version = "0.45.0", features = [
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 # openraft for debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.7", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.8", features = [
     "serde",
     "tracing-log",
     "loosen-follower-log-revert", # allows removing all data from a follower and restoring from the leader.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: upgrade openraft v0.9.0-alpha.7 to v0.9.0-alpha.8

Openraft change log from v0.9.0-alpha.7 to v0.9.0-alpha.8:

### Feature: add trait `RaftLogStorageExt` to provide additional raft-log methods

The `RaftLogReaderExt::blocking_append()` method enables the caller to
append logs to storage in a blocking manner, eliminating the need to
create and await a callback. This method simplifies the process of
writing tests.

### Change: remove openraft-0.7 compatibility support

### Add: AsyncRuntime::oneshot (#1026)

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14832)
<!-- Reviewable:end -->
