### PR TITLE
fix(query): today, yesterday, tomorrow need consider tz

### DIFF
--- a/src/query/expression/src/utils/date_helper.rs
+++ b/src/query/expression/src/utils/date_helper.rs
@@ -382,8 +382,8 @@ impl AddTimesImpl {
 }
 
 #[inline]
-pub fn today_date() -> i32 {
-    let now = Utc::now();
+pub fn today_date(tz: TzLUT) -> i32 {
+    let now = Utc::now().with_timezone(&tz.tz);
     NaiveDate::from_ymd_opt(now.year(), now.month(), now.day())
         .unwrap()
         .signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -837,19 +837,19 @@ fn register_real_time_functions(registry: &mut FunctionRegistry) {
     registry.register_0_arg_core::<DateType, _, _>(
         "today",
         |_| FunctionDomain::Full,
-        |_| Value::Scalar(today_date()),
+        |ctx| Value::Scalar(today_date(ctx.func_ctx.tz)),
     );
 
     registry.register_0_arg_core::<DateType, _, _>(
         "yesterday",
         |_| FunctionDomain::Full,
-        |_| Value::Scalar(today_date() - 1),
+        |ctx| Value::Scalar(today_date(ctx.func_ctx.tz) - 1),
     );
 
     registry.register_0_arg_core::<DateType, _, _>(
         "tomorrow",
         |_| FunctionDomain::Full,
-        |_| Value::Scalar(today_date() + 1),
+        |ctx| Value::Scalar(today_date(ctx.func_ctx.tz) + 1),
     );
 }
 

--- a/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/02_function/02_0012_function_datetimes.test
@@ -4,12 +4,34 @@ drop table if exists t all
 statement ok
 set timezone = 'UTC'
 
+query I
+select to_string(today())=substr(to_string(now()),1,10);
+----
+1
+
+statement ok
+set timezone = 'Asia/Shanghai'
+
+query I
+select to_string(today())=substr(to_string(now()),1,10);
+----
+1
+
+statement ok
+set timezone = 'America/Los_Angeles'
+
+query I
+select to_string(today())=substr(to_string(now()),1,10);
+----
+1
+
+statement ok
+set timezone = 'UTC'
+
 query B
 SELECT today() >= 18869::DATE
 ----
 1
-
-
 
 query B
 SELECT now() >= 1630295616::TIMESTAMP


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

today_date get now with UTC::now, should need consider tz

- Fixes #[Link the issue here]

## Tests


- [x] Logic Test


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14841)
<!-- Reviewable:end -->
