### PR TITLE
chore: show runtime filter zero for better analyze result

### DIFF
--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 
 use databend_common_ast::ast::FormatTreeNode;
 use databend_common_base::runtime::profile::get_statistics_desc;
+use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_catalog::plan::PartStatistics;
 use databend_common_exception::Result;
 use databend_common_expression::DataSchemaRef;
@@ -246,7 +247,10 @@ fn append_profile_info(
 ) {
     if let Some(prof) = profs.get(&plan_id) {
         for (_, desc) in get_statistics_desc().iter() {
-            if prof.statistics[desc.index] != 0 {
+            if prof.statistics[desc.index] != 0
+                || prof.statistics[desc.index] == 0
+                    && desc.index == ProfileStatisticsName::RuntimeFilterPruneParts as usize
+            {
                 children.push(FormatTreeNode::new(format!(
                     "{}: {}",
                     desc.display_name.to_lowercase(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
runtime filter pruned blocks are very important for us, even if the count is zero, we should also output it
```sql
mysql> explain analyze select count(*) from table50484 as a join source as b on a.rowkey = b.rowkey;                           
+--------------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                              |
+--------------------------------------------------------------------------------------------------------------------------------------+
| AggregateFinal                                                                                                                       |
| ├── output columns: [COUNT(*) (#82)]                                                                                                 |
| ├── group by: []                                                                                                                     |
| ├── aggregate functions: [count()]                                                                                                   |
| ├── estimated rows: 1.00                                                                                                             |
| ├── cpu time: 1.918834ms                                                                                                             |
| ├── output rows: 1                                                                                                                   |
| ├── output bytes: 8.00 B                                                                                                             |
| ├── parts pruned by runtime filter: 0                                                                                                |
| ├── memory usage: 4.54 KiB                                                                                                           |
| └── AggregatePartial                                                                                                                 |
|     ├── output columns: [COUNT(*) (#82)]                                                                                             |
|     ├── group by: []                                                                                                                 |
|     ├── aggregate functions: [count()]                                                                                               |
|     ├── estimated rows: 1.00                                                                                                         |
|     ├── cpu time: 1.600212ms                                                                                                         |
|     ├── output rows: 10                                                                                                              |
|     ├── output bytes: 640.00 B                                                                                                       |
|     ├── parts pruned by runtime filter: 0                                                                                            |
|     ├── memory usage: 11.41 KiB                                                                                                      |
|     └── HashJoin                                                                                                                     |
|         ├── output columns: []                                                                                                       |
|         ├── join type: INNER                                                                                                         |
|         ├── build keys: [b.rowkey (#41)]                                                                                             |
|         ├── probe keys: [a.rowkey (#0)]                                                                                              |
|         ├── filters: []                                                                                                              |
|         ├── estimated rows: 2000.00                                                                                                  |
|         ├── cpu time: 3.780041ms                                                                                                     |
|         ├── wait time: 49.425707ms                                                                                                   |
|         ├── output rows: 32                                                                                                          |
|         ├── parts pruned by runtime filter: 0                                                                                        |
|         ├── memory usage: 4.14 MiB                                                                                                   |
|         ├── TableScan(Build)                                                                                                         |
|         │   ├── table: default.default.source                                                                                        |
|         │   ├── output columns: [rowkey (#41)]                                                                                       |
|         │   ├── read rows: 2000                                                                                                      |
|         │   ├── read bytes: 10681                                                                                                    |
|         │   ├── partitions total: 1                                                                                                  |
|         │   ├── partitions scanned: 1                                                                                                |
|         │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]           |
|         │   ├── push downs: [filters: [], limit: NONE]                                                                               |
|         │   ├── estimated rows: 2000.00                                                                                              |
|         │   ├── cpu time: 2.007501ms                                                                                                 |
|         │   ├── output rows: 2 thousand                                                                                              |
|         │   ├── output bytes: 25.40 KiB                                                                                              |
|         │   ├── bytes scanned: 25.40 KiB                                                                                             |
|         │   ├── parts pruned by runtime filter: 0                                                                                    |
|         │   └── memory usage: 1.28 MiB                                                                                               |
|         └── TableScan(Probe)                                                                                                         |
|             ├── table: default.default.table50484                                                                                    |
|             ├── output columns: [rowkey (#0)]                                                                                        |
|             ├── read rows: 22400000                                                                                                  |
|             ├── read bytes: 110431265                                                                                                |
|             ├── partitions total: 90                                                                                                 |
|             ├── partitions scanned: 90                                                                                               |
|             ├── pruning stats: [segments: <range pruning: 12 to 12>, blocks: <range pruning: 90 to 90, bloom pruning: 0 to 0>]       |
|             ├── push downs: [filters: [], limit: NONE]                                                                               |
|             ├── estimated rows: 22400000.00                                                                                          |
|             ├── cpu time: 10.448673167s                                                                                              |
|             ├── output rows: 320                                                                                                     |
|             ├── output bytes: 4.77 KiB                                                                                               |
|             ├── bytes scanned: 4.77 KiB                                                                                              |
|             ├── parts pruned by runtime filter: 0                                                                                    |
|             └── memory usage: 117.10 MiB                                                                                             |
+--------------------------------------------------------------------------------------------------------------------------------------+
64 rows in set (1.17 sec)
Read 2320 rows, 30.16 KiB in 1.119 sec., 2.07 thousand rows/sec., 26.94 KiB/sec.
```
## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14842)
<!-- Reviewable:end -->
