### PR TITLE
feat: add vacuum table dry run result table

### DIFF
--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -698,13 +698,17 @@ pub enum CompactTarget {
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
 pub struct VacuumTableOption {
     #[drive(skip)]
-    pub dry_run: bool,
+    // Some(true) means summary
+    pub dry_run: Option<bool>,
 }
 
 impl Display for VacuumTableOption {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if self.dry_run {
+        if let Some(summary) = self.dry_run {
             write!(f, "DRY RUN")?;
+            if summary {
+                write!(f, " SUMMARY")?;
+            }
         }
         Ok(())
     }

--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -698,7 +698,7 @@ pub enum CompactTarget {
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
 pub struct VacuumTableOption {
     #[drive(skip)]
-    // Some(true) means summary
+    // Some(true) means dry run with summary option
     pub dry_run: Option<bool>,
 }
 

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -3221,11 +3221,7 @@ pub fn vacuum_table_option(i: Input) -> IResult<VacuumTableOption> {
             (DRY ~ ^RUN ~ SUMMARY?)?
         },
         |opt_dry_run| VacuumTableOption {
-            dry_run: if let Some(dry_run) = opt_dry_run {
-                Some(dry_run.2.is_some())
-            } else {
-                None
-            },
+            dry_run: opt_dry_run.map(|dry_run| dry_run.2.is_some()),
         },
     ),))(i)
 }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -3218,10 +3218,14 @@ pub fn vacuum_drop_table_option(i: Input) -> IResult<VacuumDropTableOption> {
 pub fn vacuum_table_option(i: Input) -> IResult<VacuumTableOption> {
     alt((map(
         rule! {
-            (DRY ~ ^RUN)?
+            (DRY ~ ^RUN ~ SUMMARY?)?
         },
         |opt_dry_run| VacuumTableOption {
-            dry_run: opt_dry_run.is_some(),
+            dry_run: if let Some(dry_run) = opt_dry_run {
+                Some(dry_run.2.is_some())
+            } else {
+                None
+            },
         },
     ),))(i)
 }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -2045,7 +2045,7 @@ pub fn statement(i: Input) -> IResult<StatementWithFormat> {
             | #rename_table : "`RENAME TABLE [<database>.]<table> TO <new_table>`"
             | #truncate_table : "`TRUNCATE TABLE [<database>.]<table>`"
             | #optimize_table : "`OPTIMIZE TABLE [<database>.]<table> (ALL | PURGE | COMPACT [SEGMENT])`"
-            | #vacuum_table : "`VACUUM TABLE [<database>.]<table> [RETAIN number HOURS] [DRY RUN]`"
+            | #vacuum_table : "`VACUUM TABLE [<database>.]<table> [RETAIN number HOURS] [DRY RUN | DRY RUN SUMMARY]`"
             | #vacuum_drop_table : "`VACUUM DROP TABLE [FROM [<catalog>.]<database>] [RETAIN number HOURS] [DRY RUN]`"
             | #analyze_table : "`ANALYZE TABLE [<database>.]<table>`"
             | #exists_table : "`EXISTS TABLE [<database>.]<table>`"

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -923,6 +923,8 @@ pub enum TokenKind {
     STAGES,
     #[token("STATISTIC", ignore(ascii_case))]
     STATISTIC,
+    #[token("SUMMARY", ignore(ascii_case))]
+    SUMMARY,
     #[token("SHA256_PASSWORD", ignore(ascii_case))]
     SHA256_PASSWORD,
     #[token("SHOW", ignore(ascii_case))]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -239,6 +239,7 @@ fn test_statement() {
         r#"ALTER DATABASE ctl.c RENAME TO a;"#,
         r#"VACUUM TABLE t;"#,
         r#"VACUUM TABLE t DRY RUN;"#,
+        r#"VACUUM TABLE t DRY RUN SUMMARY;"#,
         r#"VACUUM DROP TABLE;"#,
         r#"VACUUM DROP TABLE DRY RUN;"#,
         r#"VACUUM DROP TABLE FROM db;"#,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -9814,7 +9814,7 @@ VacuumTable(
             quote: None,
         },
         option: VacuumTableOption {
-            dry_run: false,
+            dry_run: None,
         },
     },
 )
@@ -9837,7 +9837,34 @@ VacuumTable(
             quote: None,
         },
         option: VacuumTableOption {
-            dry_run: true,
+            dry_run: Some(
+                false,
+            ),
+        },
+    },
+)
+
+
+---------- Input ----------
+VACUUM TABLE t DRY RUN SUMMARY;
+---------- Output ---------
+VACUUM TABLE t DRY RUN SUMMARY
+---------- AST ------------
+VacuumTable(
+    VacuumTableStmt {
+        catalog: None,
+        database: None,
+        table: Identifier {
+            span: Some(
+                13..14,
+            ),
+            name: "t",
+            quote: None,
+        },
+        option: VacuumTableOption {
+            dry_run: Some(
+                true,
+            ),
         },
     },
 )

--- a/src/query/service/src/interpreters/interpreter_table_vacuum.rs
+++ b/src/query/service/src/interpreters/interpreter_table_vacuum.rs
@@ -173,6 +173,7 @@ impl Interpreter for VacuumTableInterpreter {
                     file_sizes.push(operator.stat(file).await?.content_length());
                 }
 
+                // when `purge_files_opt` is some, it means `dry_run` is some, so safe to unwrap()
                 if self.plan.option.dry_run.unwrap() {
                     PipelineBuildResult::from_blocks(vec![DataBlock::new_from_columns(vec![
                         UInt64Type::from_data(vec![purge_files.len() as u64]),

--- a/src/query/sql/src/planner/plans/ddl/table.rs
+++ b/src/query/sql/src/planner/plans/ddl/table.rs
@@ -109,11 +109,18 @@ pub struct VacuumTablePlan {
 
 impl VacuumTablePlan {
     pub fn schema(&self) -> DataSchemaRef {
-        if self.option.dry_run {
-            Arc::new(DataSchema::new(vec![DataField::new(
-                "Files",
-                DataType::String,
-            )]))
+        if let Some(summary) = self.option.dry_run {
+            if summary {
+                Arc::new(DataSchema::new(vec![
+                    DataField::new("total_files", DataType::Number(NumberDataType::UInt64)),
+                    DataField::new("total_size", DataType::Number(NumberDataType::UInt64)),
+                ]))
+            } else {
+                Arc::new(DataSchema::new(vec![
+                    DataField::new("file", DataType::String),
+                    DataField::new("file_size", DataType::Number(NumberDataType::UInt64)),
+                ]))
+            }
         } else {
             Arc::new(DataSchema::new(vec![
                 DataField::new("snapshot_files", DataType::Number(NumberDataType::UInt64)),
@@ -175,7 +182,7 @@ pub struct VacuumDropTableOption {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VacuumTableOption {
-    pub dry_run: bool,
+    pub dry_run: Option<bool>,
 }
 
 /// Optimize.

--- a/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
+++ b/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
@@ -107,7 +107,7 @@ if [[ "$count" != "4" ]]; then
   echo "vacuum table, count:$count"
   exit 1
 fi
-count=$(echo "set data_retention_time_in_days=0; vacuum table test_vacuum_drop_4.c dry run summary" | $BENDSQL_CLIENT_CONNECT | wc -l
+count=$(echo "set data_retention_time_in_days=0; vacuum table test_vacuum_drop_4.c dry run summary" | $BENDSQL_CLIENT_CONNECT | wc -l)
 if [[ "$count" != "1" ]]; then
   echo "vacuum table dry run summary, count:$count"
   exit 1

--- a/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
+++ b/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
@@ -107,6 +107,11 @@ if [[ "$count" != "4" ]]; then
   echo "vacuum table, count:$count"
   exit 1
 fi
+count=$(echo "set data_retention_time_in_days=0; vacuum table test_vacuum_drop_4.c dry run summary" | $BENDSQL_CLIENT_CONNECT | wc -l
+if [[ "$count" != "1" ]]; then
+  echo "vacuum table dry run summary, count:$count"
+  exit 1
+fi
 
 echo "drop database if exists test_vacuum_drop_4" | $BENDSQL_CLIENT_CONNECT
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

feat: add vacuum table dry run result table

- Fixes #14810

add `vacuum table dry run summary` grammar:
* when dry run without summary option, output column will be `file` and `file_size`;
* when dry run with summary option, output column will be `total_files` and `total_size`.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14851)
<!-- Reviewable:end -->
