### PR TITLE
refactor: add StageIdent and StageFileIdent

### DIFF
--- a/src/meta/app/src/principal/mod.rs
+++ b/src/meta/app/src/principal/mod.rs
@@ -32,6 +32,8 @@ mod user_privilege;
 mod user_quota;
 mod user_setting;
 mod user_stage;
+mod user_stage_file_ident;
+mod user_stage_ident;
 
 pub use connection::*;
 pub use file_format::*;
@@ -68,3 +70,5 @@ pub use user_quota::UserQuota;
 pub use user_setting::UserSetting;
 pub use user_setting::UserSettingValue;
 pub use user_stage::*;
+pub use user_stage_file_ident::StageFileIdent;
+pub use user_stage_ident::StageIdent;

--- a/src/meta/app/src/principal/user_stage_file_ident.rs
+++ b/src/meta/app/src/principal/user_stage_file_ident.rs
@@ -1,0 +1,97 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::principal::StageIdent;
+
+/// Define the meta-service key for a file belonging to a stage.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StageFileIdent {
+    pub stage: StageIdent,
+    pub path: String,
+}
+
+impl StageFileIdent {
+    pub fn new(stage: StageIdent, path: impl ToString) -> Self {
+        Self {
+            stage,
+            path: path.to_string(),
+        }
+    }
+}
+
+mod kvapi_key_impl {
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyBuilder;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+    use databend_common_meta_kvapi::kvapi::KeyParser;
+
+    use crate::principal::user_stage_file_ident::StageFileIdent;
+    use crate::principal::StageFile;
+    use crate::principal::StageIdent;
+    use crate::tenant::Tenant;
+    use crate::KeyWithTenant;
+
+    impl kvapi::Key for StageFileIdent {
+        const PREFIX: &'static str = "__fd_stage_files";
+        type ValueType = StageFile;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.stage.to_string_key())
+        }
+
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_str(&self.stage.tenant_name())
+                .push_str(&self.stage.name)
+                .push_str(&self.path)
+        }
+
+        fn decode_key(p: &mut KeyParser) -> Result<Self, KeyError> {
+            let stage = StageIdent::decode_key(p)?;
+            let path = p.next_str()?;
+            Ok(StageFileIdent::new(stage, path))
+        }
+    }
+
+    impl KeyWithTenant for StageFileIdent {
+        fn tenant(&self) -> &Tenant {
+            self.stage.tenant()
+        }
+    }
+
+    impl kvapi::Value for StageFile {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::principal::user_stage_file_ident::StageFileIdent;
+    use crate::principal::StageIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_kvapi_key_for_stage_file_ident() {
+        let tenant = Tenant::new("tenant1");
+        let stage = StageIdent::new(tenant, "stage1");
+        let sfi = StageFileIdent::new(stage, "file1");
+
+        let key = sfi.to_string_key();
+        assert_eq!("__fd_stage_files/tenant1/stage1/file1", key,);
+        assert_eq!(sfi, StageFileIdent::from_str_key(&key).unwrap());
+    }
+}

--- a/src/meta/app/src/principal/user_stage_file_ident.rs
+++ b/src/meta/app/src/principal/user_stage_file_ident.rs
@@ -51,7 +51,7 @@ mod kvapi_key_impl {
         }
 
         fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
-            b.push_str(&self.stage.tenant_name())
+            b.push_str(self.stage.tenant_name())
                 .push_str(&self.stage.name)
                 .push_str(&self.path)
         }

--- a/src/meta/app/src/principal/user_stage_ident.rs
+++ b/src/meta/app/src/principal/user_stage_ident.rs
@@ -1,0 +1,91 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tenant::Tenant;
+
+/// Define the meta-service key for a stage.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StageIdent {
+    pub tenant: Tenant,
+    pub name: String,
+}
+
+impl StageIdent {
+    pub fn new(tenant: Tenant, name: impl ToString) -> Self {
+        Self {
+            tenant,
+            name: name.to_string(),
+        }
+    }
+}
+
+mod kvapi_key_impl {
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+
+    use crate::principal::user_stage_ident::StageIdent;
+    use crate::principal::StageInfo;
+    use crate::tenant::Tenant;
+    use crate::KeyWithTenant;
+
+    impl kvapi::Key for StageIdent {
+        const PREFIX: &'static str = "__fd_stages";
+        type ValueType = StageInfo;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
+        }
+
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_str(&self.tenant_name()).push_str(&self.name)
+        }
+
+        fn decode_key(p: &mut kvapi::KeyParser) -> Result<Self, KeyError> {
+            let tenant = p.next_nonempty()?;
+            let name = p.next_str()?;
+
+            Ok(StageIdent::new(Tenant::new_nonempty(tenant), name))
+        }
+    }
+
+    impl KeyWithTenant for StageIdent {
+        fn tenant(&self) -> &Tenant {
+            &self.tenant
+        }
+    }
+
+    impl kvapi::Value for StageInfo {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::principal::user_stage_ident::StageIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_kvapi_key_for_stage_ident() {
+        let tenant = Tenant::new("test");
+        let stage = StageIdent::new(tenant, "stage");
+
+        let key = stage.to_string_key();
+        assert_eq!(key, "__fd_stages/test/stage");
+        assert_eq!(stage, StageIdent::from_str_key(&key).unwrap());
+    }
+}

--- a/src/meta/app/src/principal/user_stage_ident.rs
+++ b/src/meta/app/src/principal/user_stage_ident.rs
@@ -48,7 +48,7 @@ mod kvapi_key_impl {
         }
 
         fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
-            b.push_str(&self.tenant_name()).push_str(&self.name)
+            b.push_str(self.tenant_name()).push_str(&self.name)
         }
 
         fn decode_key(p: &mut kvapi::KeyParser) -> Result<Self, KeyError> {

--- a/src/meta/kvapi/src/kvapi/key.rs
+++ b/src/meta/kvapi/src/kvapi/key.rs
@@ -70,10 +70,34 @@ where Self: Sized
     fn parent(&self) -> Option<String>;
 
     /// Encode structured key into a string.
-    fn to_string_key(&self) -> String;
+    fn to_string_key(&self) -> String {
+        let b = kvapi::KeyBuilder::new_prefixed(Self::PREFIX);
+        self.encode_key(b).done()
+    }
+
+    /// Encode structured key into a key builder.
+    ///
+    /// Implement either this method or `to_string_key()`.
+    /// `to_string_key()` provides a default implementation that create a default builder and relies on this method.
+    fn encode_key(&self, mut _b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+        unimplemented!()
+    }
 
     /// Decode str into a structured key.
-    fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError>;
+    fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
+        let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        let k = Self::decode_key(&mut p)?;
+        p.done()?;
+        Ok(k)
+    }
+
+    /// Parse a structured key from a key parser.
+    ///
+    /// Implement either this method or `from_str_key()`.
+    /// `from_str_key()` provides a default implementation that create a default parser and relies on this method.
+    fn decode_key(_parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+        unimplemented!()
+    }
 }
 
 impl kvapi::Key for String {

--- a/src/query/management/src/stage/stage_mgr.rs
+++ b/src/query/management/src/stage/stage_mgr.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use databend_common_base::base::escape_for_key;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_api::reply::txn_reply_to_api_result;

--- a/src/query/management/src/stage/stage_mgr.rs
+++ b/src/query/management/src/stage/stage_mgr.rs
@@ -23,9 +23,14 @@ use databend_common_meta_api::txn_op_del;
 use databend_common_meta_api::txn_op_put;
 use databend_common_meta_app::app_error::TxnRetryMaxTimes;
 use databend_common_meta_app::principal::StageFile;
+use databend_common_meta_app::principal::StageFileIdent;
+use databend_common_meta_app::principal::StageIdent;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_app::tenant::Tenant;
+use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_kvapi::kvapi;
+use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::ConditionResult::Eq;
 use databend_common_meta_types::MatchSeq;
@@ -39,14 +44,11 @@ use crate::serde::deserialize_struct;
 use crate::serde::serialize_struct;
 use crate::stage::StageApi;
 
-static USER_STAGE_API_KEY_PREFIX: &str = "__fd_stages";
-static STAGE_FILE_API_KEY_PREFIX: &str = "__fd_stage_files";
 const TXN_MAX_RETRY_TIMES: u32 = 10;
 
 pub struct StageMgr {
     kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
-    stage_prefix: String,
-    stage_file_prefix: String,
+    tenant: Tenant,
 }
 
 impl StageMgr {
@@ -56,30 +58,40 @@ impl StageMgr {
     ) -> Self {
         StageMgr {
             kv_api,
-            stage_prefix: format!(
-                "{}/{}",
-                USER_STAGE_API_KEY_PREFIX,
-                escape_for_key(tenant.as_str()).unwrap()
-            ),
-            stage_file_prefix: format!(
-                "{}/{}",
-                STAGE_FILE_API_KEY_PREFIX,
-                escape_for_key(tenant.as_str()).unwrap()
-            ),
+            tenant: Tenant::new_nonempty(tenant.clone()),
         }
+    }
+
+    fn stage_key(&self, stage: &str) -> String {
+        let si = StageIdent::new(self.tenant.clone(), stage);
+        si.to_string_key()
+    }
+
+    fn stage_prefix(&self) -> String {
+        let dummy = StageIdent::new(self.tenant.clone(), "dummpy");
+        dummy.tenant_prefix()
+    }
+
+    fn stage_file_key(&self, stage: &str, path: &str) -> String {
+        let si = StageIdent::new(self.tenant.clone(), stage);
+        let fi = StageFileIdent::new(si, path);
+        fi.to_string_key()
+    }
+
+    fn stage_file_prefix(&self, stage: &str) -> String {
+        let si = StageIdent::new(self.tenant.clone(), stage);
+        let fi = StageFileIdent::new(si, "");
+        fi.to_string_key()
     }
 }
 
+// TODO: use KVPbApi
 #[async_trait::async_trait]
 impl StageApi for StageMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn add_stage(&self, info: StageInfo, create_option: &CreateOption) -> Result<()> {
-        let key = format!(
-            "{}/{}",
-            self.stage_prefix,
-            escape_for_key(&info.stage_name)?
-        );
+        let key = self.stage_key(&info.stage_name);
 
         let val = Operation::Update(serialize_struct(
             &info,
@@ -109,10 +121,8 @@ impl StageApi for StageMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn get_stage(&self, name: &str) -> Result<StageInfo> {
-        let key = format!("{}/{}", self.stage_prefix, escape_for_key(name)?);
-        let kv_api = self.kv_api.clone();
-        let get_kv = async move { kv_api.get_kv(&key).await };
-        let res = get_kv.await?;
+        let key = self.stage_key(name);
+        let res = self.kv_api.get_kv(&key).await?;
         let seq_value = res
             .ok_or_else(|| ErrorCode::UnknownStage(format!("Stage '{}' does not exist.", name)))?;
 
@@ -126,7 +136,8 @@ impl StageApi for StageMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn get_stages(&self) -> Result<Vec<StageInfo>> {
-        let values = self.kv_api.prefix_list_kv(&self.stage_prefix).await?;
+        let prefix = self.stage_prefix();
+        let values = self.kv_api.prefix_list_kv(&prefix).await?;
 
         let mut stage_infos = Vec::with_capacity(values.len());
         for (_, value) in values {
@@ -140,8 +151,8 @@ impl StageApi for StageMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn drop_stage(&self, name: &str) -> Result<()> {
-        let stage_key = format!("{}/{}", self.stage_prefix, escape_for_key(name)?);
-        let file_key_prefix = format!("{}/{}/", self.stage_file_prefix, escape_for_key(name)?);
+        let stage_key = self.stage_key(name);
+        let file_key_prefix = self.stage_file_prefix(name);
 
         let mut retry = 0;
         while retry < TXN_MAX_RETRY_TIMES {
@@ -181,13 +192,8 @@ impl StageApi for StageMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn add_file(&self, name: &str, file: StageFile) -> Result<u64> {
-        let stage_key = format!("{}/{}", self.stage_prefix, escape_for_key(name)?);
-        let file_key = format!(
-            "{}/{}/{}",
-            self.stage_file_prefix,
-            escape_for_key(name)?,
-            escape_for_key(&file.path)?
-        );
+        let stage_key = self.stage_key(name);
+        let file_key = self.stage_file_key(name, &file.path);
 
         let mut retry = 0;
         while retry < TXN_MAX_RETRY_TIMES {
@@ -249,8 +255,8 @@ impl StageApi for StageMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn list_files(&self, name: &str) -> Result<Vec<StageFile>> {
-        let list_prefix = format!("{}/{}/", self.stage_file_prefix, escape_for_key(name)?);
-        let values = self.kv_api.prefix_list_kv(&list_prefix).await?;
+        let file_prefix = self.stage_file_prefix(name);
+        let values = self.kv_api.prefix_list_kv(&file_prefix).await?;
         let mut files = Vec::with_capacity(values.len());
         for (_, value) in values {
             let file = deserialize_struct(&value.data, ErrorCode::IllegalStageFileFormat, || "")?;
@@ -262,7 +268,7 @@ impl StageApi for StageMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn remove_files(&self, name: &str, paths: Vec<String>) -> Result<()> {
-        let stage_key = format!("{}/{}", self.stage_prefix, escape_for_key(name)?);
+        let stage_key = self.stage_key(name);
 
         let mut retry = 0;
         while retry < TXN_MAX_RETRY_TIMES {
@@ -280,12 +286,7 @@ impl StageApi for StageMgr {
 
             let mut if_then = Vec::with_capacity(paths.len());
             for path in &paths {
-                let key = format!(
-                    "{}/{}/{}",
-                    self.stage_file_prefix,
-                    escape_for_key(name)?,
-                    escape_for_key(path)?
-                );
+                let key = self.stage_file_key(name, path);
                 if_then.push(txn_op_del(&key));
             }
             old_stage.number_of_files -= paths.len() as u64;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add StageIdent and StageFileIdent

Use kvapi::Key to define meta-service keys for StageMgr

- Fix: #14849

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14863)
<!-- Reviewable:end -->
