### PR TITLE
fix: Display of `merge into ..  insert *` 

### DIFF
--- a/src/query/ast/src/ast/statements/merge_into.rs
+++ b/src/query/ast/src/ast/statements/merge_into.rs
@@ -144,6 +144,7 @@ impl Display for MergeIntoStmt {
                         write!(f, "AND {} ", e)?;
                     }
                     write!(f, "THEN INSERT")?;
+
                     if let Some(columns) = &unmatch_clause.insert_operation.columns {
                         if !columns.is_empty() {
                             write!(f, " (")?;
@@ -151,9 +152,17 @@ impl Display for MergeIntoStmt {
                             write!(f, ")")?;
                         }
                     }
-                    write!(f, " VALUES(")?;
-                    write_comma_separated_list(f, unmatch_clause.insert_operation.values.clone())?;
-                    write!(f, ")")?;
+
+                    if unmatch_clause.insert_operation.is_star {
+                        write!(f, " *")?;
+                    } else {
+                        write!(f, " VALUES(")?;
+                        write_comma_separated_list(
+                            f,
+                            unmatch_clause.insert_operation.values.clone(),
+                        )?;
+                        write!(f, ")")?;
+                    }
                 }
             }
         }

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -544,6 +544,16 @@ fn test_statement() {
               merge into t using s on t.id = s.id when matched then update *;
               commit;
             END"#,
+        r#"CREATE TASK IF NOT EXISTS merge_task WAREHOUSE = 'test-parser' SCHEDULE = 1 SECOND
+        AS BEGIN
+          MERGE INTO t USING s ON t.c = s.c
+            WHEN MATCHED THEN
+            UPDATE
+                *
+                WHEN NOT MATCHED THEN
+            INSERT
+                *;
+        END"#,
         r#"ALTER TASK MyTask1 RESUME"#,
         r#"ALTER TASK MyTask1 SUSPEND"#,
         r#"ALTER TASK MyTask1 ADD AFTER 'task2', 'task3'"#,

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -554,6 +554,15 @@ fn test_statement() {
             INSERT
                 *;
         END"#,
+        r#"CREATE TASK IF NOT EXISTS merge_task WAREHOUSE = 'test-parser' SCHEDULE = 1 SECOND
+        AS BEGIN
+          MERGE INTO t USING s ON t.c = s.c
+            WHEN MATCHED THEN
+            UPDATE
+                *
+                WHEN NOT MATCHED THEN
+            INSERT values('a;', 1, "str");
+        END"#,
         r#"ALTER TASK MyTask1 RESUME"#,
         r#"ALTER TASK MyTask1 SUSPEND"#,
         r#"ALTER TASK MyTask1 ADD AFTER 'task2', 'task3'"#,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -15742,6 +15742,51 @@ CreateTask(
 
 
 ---------- Input ----------
+CREATE TASK IF NOT EXISTS merge_task WAREHOUSE = 'test-parser' SCHEDULE = 1 SECOND
+        AS BEGIN
+          MERGE INTO t USING s ON t.c = s.c
+            WHEN MATCHED THEN
+            UPDATE
+                *
+                WHEN NOT MATCHED THEN
+            INSERT
+                *;
+        END
+---------- Output ---------
+CREATE TASK IF NOT EXISTS merge_task WAREHOUSE = test-parser SCHEDULE 1 SECOND AS BEGIN
+MERGE INTO t USING s ON (t.c = s.c) WHEN MATCHED THEN UPDATE * WHEN NOT MATCHED THEN INSERT VALUES();
+END;
+---------- AST ------------
+CreateTask(
+    CreateTaskStmt {
+        if_not_exists: true,
+        name: "merge_task",
+        warehouse_opts: WarehouseOptions {
+            warehouse: Some(
+                "test-parser",
+            ),
+        },
+        schedule_opts: Some(
+            IntervalSecs(
+                1,
+            ),
+        ),
+        session_parameters: {},
+        suspend_task_after_num_failures: None,
+        error_integration: None,
+        comments: "",
+        after: [],
+        when_condition: None,
+        sql: ScriptBlock(
+            [
+                "MERGE INTO t USING s ON (t.c = s.c) WHEN MATCHED THEN UPDATE * WHEN NOT MATCHED THEN INSERT VALUES()",
+            ],
+        ),
+    },
+)
+
+
+---------- Input ----------
 ALTER TASK MyTask1 RESUME
 ---------- Output ---------
 ALTER TASK MyTask1 RESUME

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -15754,7 +15754,7 @@ CREATE TASK IF NOT EXISTS merge_task WAREHOUSE = 'test-parser' SCHEDULE = 1 SECO
         END
 ---------- Output ---------
 CREATE TASK IF NOT EXISTS merge_task WAREHOUSE = test-parser SCHEDULE 1 SECOND AS BEGIN
-MERGE INTO t USING s ON (t.c = s.c) WHEN MATCHED THEN UPDATE * WHEN NOT MATCHED THEN INSERT VALUES();
+MERGE INTO t USING s ON (t.c = s.c) WHEN MATCHED THEN UPDATE * WHEN NOT MATCHED THEN INSERT *;
 END;
 ---------- AST ------------
 CreateTask(
@@ -15779,7 +15779,51 @@ CreateTask(
         when_condition: None,
         sql: ScriptBlock(
             [
-                "MERGE INTO t USING s ON (t.c = s.c) WHEN MATCHED THEN UPDATE * WHEN NOT MATCHED THEN INSERT VALUES()",
+                "MERGE INTO t USING s ON (t.c = s.c) WHEN MATCHED THEN UPDATE * WHEN NOT MATCHED THEN INSERT *",
+            ],
+        ),
+    },
+)
+
+
+---------- Input ----------
+CREATE TASK IF NOT EXISTS merge_task WAREHOUSE = 'test-parser' SCHEDULE = 1 SECOND
+        AS BEGIN
+          MERGE INTO t USING s ON t.c = s.c
+            WHEN MATCHED THEN
+            UPDATE
+                *
+                WHEN NOT MATCHED THEN
+            INSERT values('a;', 1, "str");
+        END
+---------- Output ---------
+CREATE TASK IF NOT EXISTS merge_task WAREHOUSE = test-parser SCHEDULE 1 SECOND AS BEGIN
+MERGE INTO t USING s ON (t.c = s.c) WHEN MATCHED THEN UPDATE * WHEN NOT MATCHED THEN INSERT VALUES('a;', 1, "str");
+END;
+---------- AST ------------
+CreateTask(
+    CreateTaskStmt {
+        if_not_exists: true,
+        name: "merge_task",
+        warehouse_opts: WarehouseOptions {
+            warehouse: Some(
+                "test-parser",
+            ),
+        },
+        schedule_opts: Some(
+            IntervalSecs(
+                1,
+            ),
+        ),
+        session_parameters: {},
+        suspend_task_after_num_failures: None,
+        error_integration: None,
+        comments: "",
+        after: [],
+        when_condition: None,
+        sql: ScriptBlock(
+            [
+                "MERGE INTO t USING s ON (t.c = s.c) WHEN MATCHED THEN UPDATE * WHEN NOT MATCHED THEN INSERT VALUES('a;', 1, \"str\")",
             ],
         ),
     },


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When `Display`ing a "merge into" statement that specifies "insert *" as the unmatched branch, the output should show "insert *" rather than "insert values()".


may fix 
  - https://github.com/datafuselabs/databend/issues/14890

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14892)
<!-- Reviewable:end -->
