### PR TITLE
fix: `check_and_upgrade_to_pb()` should return MetaError, add quota

### DIFF
--- a/src/query/management/src/serde/mod.rs
+++ b/src/query/management/src/serde/mod.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 mod pb_serde;
+mod quota;
 
 pub use pb_serde::check_and_upgrade_to_pb;
 pub use pb_serde::deserialize_struct;
 pub use pb_serde::serialize_struct;
+pub use quota::Quota;

--- a/src/query/management/src/serde/pb_serde.rs
+++ b/src/query/management/src/serde/pb_serde.rs
@@ -13,18 +13,22 @@
 // limitations under the License.
 
 use std::fmt::Display;
-use std::sync::Arc;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_exception::ToErrorCode;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
+use databend_common_meta_types::InvalidReply;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
+use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::SeqV;
+use databend_common_meta_types::SeqValue;
 use databend_common_proto_conv::FromToProto;
+
+use crate::serde::Quota;
 
 pub fn serialize_struct<T, ErrFn, CtxFn, D>(
     value: &T,
@@ -60,21 +64,21 @@ where
     Ok(v)
 }
 
-pub async fn check_and_upgrade_to_pb<T, ErrFn, CtxFn, D>(
+/// Check if the data is in protobuf format, if not, upgrade it to protobuf format.
+///
+/// Because upgrading relies on RPC, it takes a long time if it upgrades too many records.
+/// Thus if the upgrading quota is used up,
+/// it will just convert the data but do not write to backend storage.
+pub async fn check_and_upgrade_to_pb<T>(
+    quota: &mut Quota,
     key: String,
     seq_value: &SeqV,
-    kv_api: Arc<dyn kvapi::KVApi<Error = MetaError> + Send + Sync>,
-    err_code_fn: ErrFn,
-    context_fn: CtxFn,
-) -> std::result::Result<SeqV<T>, ErrorCode>
+    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
+) -> std::result::Result<SeqV<T>, MetaError>
 where
     T: FromToProto + serde::de::DeserializeOwned + 'static,
-    ErrFn: FnOnce(String) -> ErrorCode + Copy,
-    D: Display,
-    CtxFn: FnOnce() -> D + Copy,
 {
-    let deserialize_result =
-        deserialize_struct(&seq_value.data, ErrorCode::IllegalUserInfoFormat, || "");
+    let deserialize_result = databend_common_meta_api::deserialize_struct(&seq_value.data);
 
     let err = match deserialize_result {
         Ok(data) => return Ok(SeqV::new(seq_value.seq, data)),
@@ -84,30 +88,33 @@ where
     log::debug!("deserialize as pb err: {}, rollback to use serde json", err);
 
     // If there's an error, try to deserialize as JSON.
-    let data = serde_json::from_slice::<T>(&seq_value.data)?;
+    let data = serde_json::from_slice::<T>(&seq_value.data).map_err(|e| {
+        let inv_reply = InvalidReply::new("non json non pb data", &e);
+        MetaNetworkError::from(inv_reply)
+    })?;
+
+    if quota.is_used_up() {
+        return Ok(SeqV::new(seq_value.seq, data));
+    }
+    quota.decrement();
 
     // If we reached here, it means JSON deserialization was successful but we need to serialize to protobuf format.
-    let value = serialize_struct(&data, ErrorCode::IllegalUserInfoFormat, || "")?;
-    match kv_api
+    let value = databend_common_meta_api::serialize_struct(&data)?;
+
+    let res = kv_api
         .upsert_kv(UpsertKVReq::new(
             &key,
             MatchSeq::Exact(seq_value.seq),
             Operation::Update(value),
             None,
         ))
-        .await
-        .map_err_to_code(err_code_fn, context_fn)
-    {
-        Ok(res) => {
-            if let Some(seq) = res.result {
-                Ok(SeqV::new(seq.seq, data))
-            } else {
-                Ok(SeqV::new(seq_value.seq, data))
-            }
-        }
-        Err(err) => {
-            log::error!("json to pb upsert_kv failed, error: {}", err);
-            Err(err)
-        }
-    }
+        .await?;
+
+    let seq = if res.is_changed() {
+        res.result.seq()
+    } else {
+        seq_value.seq
+    };
+
+    Ok(SeqV::new(seq, data))
 }

--- a/src/query/management/src/serde/quota.rs
+++ b/src/query/management/src/serde/quota.rs
@@ -1,0 +1,60 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use log::warn;
+
+/// To limit RPC calls done by `check_and_upgrade_to_pb()`.
+/// Each RPC takes about 3ms.
+/// The delay time taken by upgrading is about 300ms.
+static MAX_UPGRADE: usize = 100;
+
+/// Quota to limit number of calls for upgrading data to protobuf format.
+pub struct Quota {
+    state: Result<usize, ()>,
+
+    /// The resource this quota is for.
+    target: String,
+}
+
+impl Quota {
+    /// Create a Quota with default limit.
+    pub fn new(target: impl ToString) -> Self {
+        Self::new_limit(target, MAX_UPGRADE)
+    }
+
+    /// Create a Quota with a specific limit.
+    pub fn new_limit(target: impl ToString, limit: usize) -> Self {
+        Quota {
+            state: if limit == 0 { Err(()) } else { Ok(limit) },
+            target: target.to_string(),
+        }
+    }
+
+    pub fn is_used_up(&self) -> bool {
+        self.state.is_err()
+    }
+
+    /// Decrement the quota by 1.
+    pub fn decrement(&mut self) {
+        if let Ok(n) = &mut self.state {
+            *n = n.saturating_sub(1);
+        }
+
+        // Warning will be logged only once when the first time quota is used up.
+        if self.state == Ok(0) {
+            warn!("quota is used up for {}", self.target);
+            self.state = Err(());
+        }
+    }
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: `check_and_upgrade_to_pb()` should return MetaError, add quota

When writing back upgraded json-to-pb data to meta-service,
it should return `MetaError`, instead of business error such as
`ErrorCode::UnknownRole`.

Add quota limit to `check_and_upgrade_to_pb`: for each API calls, it
upgrades upto 100 records. So that an API call won't be delay a lot.

After upgrading, it should returns the `seq` number after upgrading.

## Changelog


- Bug Fix




## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14899)
<!-- Reviewable:end -->
