### PR TITLE
refactor: upgrade to openraft 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8577,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.9#2cc7170ffaf87c674e5ca13370402528f8ab3958"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.11#c9a463f5ce73d1e7dd66eabfe909fe8d5a087f0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9453,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.9.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.9#2cc7170ffaf87c674e5ca13370402528f8ab3958"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.9.0-alpha.11#c9a463f5ce73d1e7dd66eabfe909fe8d5a087f0e"
 dependencies = [
  "anyerror",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ opendal = { version = "0.45.0", features = [
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1", default-features = false }
 
 # openraft for debugging
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.9.0-alpha.9", features = [
+openraft = { git = "https://github.com/datafuselabs/openraft", tag = "v0.9.0", features = [
     "serde",
     "tracing-log",
     "generic-snapshot-data",


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: upgrade to openraft 0.9.0

Openraft 0.9.0 release:
https://github.com/datafuselabs/openraft/releases/tag/v0.9.0

Implement chunk-based snapshot transmission outside openraft core.
This makes it possible to switch to another snapshot transmission
protocol in a compatible manner.

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14907)
<!-- Reviewable:end -->
