### PR TITLE
refactor: use kvapi::Key to define meta-service key for QuotaMgr

### DIFF
--- a/src/meta/app/src/tenant/mod.rs
+++ b/src/meta/app/src/tenant/mod.rs
@@ -15,6 +15,8 @@
 mod quota;
 #[allow(clippy::module_inception)]
 mod tenant;
+mod tenant_quota_ident;
 
 pub use quota::TenantQuota;
 pub use tenant::Tenant;
+pub use tenant_quota_ident::TenantQuotaIdent;

--- a/src/meta/app/src/tenant/tenant_quota_ident.rs
+++ b/src/meta/app/src/tenant/tenant_quota_ident.rs
@@ -1,0 +1,85 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tenant::Tenant;
+
+/// QuotaIdent is a unique identifier for a quota.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TenantQuotaIdent {
+    pub tenant: Tenant,
+}
+
+impl TenantQuotaIdent {
+    pub fn new(tenant: Tenant) -> Self {
+        Self { tenant }
+    }
+}
+
+mod kvapi_key_impl {
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+
+    use crate::tenant::Tenant;
+    use crate::tenant::TenantQuota;
+    use crate::tenant::TenantQuotaIdent;
+    use crate::KeyWithTenant;
+
+    impl kvapi::Key for TenantQuotaIdent {
+        const PREFIX: &'static str = "__fd_quotas";
+        type ValueType = TenantQuota;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
+        }
+
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_str(self.tenant_name())
+        }
+
+        fn decode_key(p: &mut kvapi::KeyParser) -> Result<Self, KeyError> {
+            let tenant = p.next_nonempty()?;
+            Ok(TenantQuotaIdent::new(Tenant::new_nonempty(tenant)))
+        }
+    }
+
+    impl KeyWithTenant for TenantQuotaIdent {
+        fn tenant(&self) -> &Tenant {
+            &self.tenant
+        }
+    }
+
+    impl kvapi::Value for TenantQuota {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use super::*;
+
+    #[test]
+    fn test_quota_ident() {
+        let tenant = Tenant::new("test");
+        let ident = TenantQuotaIdent::new(tenant.clone());
+
+        let key = ident.to_string_key();
+        assert_eq!(key, "__fd_quotas/test");
+
+        assert_eq!(ident, TenantQuotaIdent::from_str_key(&key).unwrap());
+    }
+}

--- a/src/query/service/src/interpreters/interpreter_database_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_create.rs
@@ -109,7 +109,7 @@ impl Interpreter for CreateDatabaseInterpreter {
         debug!("ctx.id" = self.ctx.get_id().as_str(); "create_database_execute");
 
         let tenant = self.plan.tenant.clone();
-        let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
+        let quota_api = UserApiProvider::instance().tenant_quota_api(&tenant);
         let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         let catalog = self.ctx.get_catalog(&self.plan.catalog).await?;
         let databases = catalog.list_databases(tenant.as_str()).await?;

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -117,7 +117,7 @@ impl Interpreter for CreateTableInterpreter {
                 .check_enterprise_enabled(self.ctx.get_license_key(), ComputedColumn)?;
         }
 
-        let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
+        let quota_api = UserApiProvider::instance().tenant_quota_api(&tenant);
         let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         let engine = self.plan.engine;
         let catalog = self.ctx.get_catalog(self.plan.catalog.as_str()).await?;

--- a/src/query/service/src/interpreters/interpreter_user_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_create.rs
@@ -62,7 +62,7 @@ impl Interpreter for CreateUserInterpreter {
         let user_mgr = UserApiProvider::instance();
         let users = user_mgr.get_users(&tenant).await?;
 
-        let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
+        let quota_api = UserApiProvider::instance().tenant_quota_api(&tenant);
         let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         if quota.max_users != 0 && users.len() >= quota.max_users as usize {
             return Err(ErrorCode::TenantQuotaExceeded(format!(

--- a/src/query/service/src/interpreters/interpreter_user_stage_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_stage_create.rs
@@ -77,7 +77,7 @@ impl Interpreter for CreateUserStageInterpreter {
             ErrorCode::TenantIsEmpty("tenant is empty when CreateUserStateInterpreter")
         })?;
 
-        let quota_api = user_mgr.get_tenant_quota_api_client(&tenant)?;
+        let quota_api = user_mgr.tenant_quota_api(&tenant);
         let quota = quota_api.get_quota(MatchSeq::GE(0)).await?.data;
         let stages = user_mgr.get_stages(&tenant).await?;
         if quota.max_stages != 0 && stages.len() >= quota.max_stages as usize {

--- a/src/query/service/src/table_functions/others/tenant_quota.rs
+++ b/src/query/service/src/table_functions/others/tenant_quota.rs
@@ -245,7 +245,7 @@ impl AsyncSource for TenantQuotaSource {
             }
             tenant = args[0].clone();
         }
-        let quota_api = UserApiProvider::instance().get_tenant_quota_api_client(&tenant)?;
+        let quota_api = UserApiProvider::instance().tenant_quota_api(&tenant);
         let res = quota_api.get_quota(MatchSeq::GE(0)).await?;
         let mut quota = res.data;
 

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -67,7 +67,7 @@ impl UserApiProvider {
         GlobalInstance::set(Self::try_create(conf, idm_config, tenant).await?);
         let user_mgr = UserApiProvider::instance();
         if let Some(q) = quota {
-            let i = user_mgr.get_tenant_quota_api_client(tenant)?;
+            let i = user_mgr.tenant_quota_api(tenant);
             let res = i.get_quota(MatchSeq::GE(0)).await?;
             i.set_quota(&q, MatchSeq::Exact(res.seq)).await?;
         }
@@ -149,14 +149,8 @@ impl UserApiProvider {
         )?))
     }
 
-    pub fn get_tenant_quota_api_client(
-        &self,
-        tenant: &NonEmptyString,
-    ) -> Result<Arc<dyn QuotaApi>> {
-        Ok(Arc::new(QuotaMgr::create(
-            self.client.clone(),
-            tenant.as_str(),
-        )?))
+    pub fn tenant_quota_api(&self, tenant: &NonEmptyString) -> Arc<dyn QuotaApi> {
+        Arc::new(QuotaMgr::create(self.client.clone(), tenant))
     }
 
     pub fn setting_api(&self, tenant: &NonEmptyString) -> Arc<dyn SettingApi> {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: use kvapi::Key to define meta-service key for QuotaMgr

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14915)
<!-- Reviewable:end -->
