### PR TITLE
refactor: reduce meta call

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -15,6 +15,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::plan::DataSourceInfo;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
@@ -151,7 +152,6 @@ impl PrivilegeAccess {
         if_exists: bool,
     ) -> Result<()> {
         let tenant = self.ctx.get_tenant();
-
         match self
             .validate_access(
                 &GrantObject::Database(catalog_name.to_string(), db_name.to_string()),
@@ -163,8 +163,9 @@ impl PrivilegeAccess {
                 return Ok(());
             }
             Err(_err) => {
+                let catalog = self.ctx.get_catalog(catalog_name).await?;
                 match self
-                    .convert_to_id(tenant.as_str(), catalog_name, db_name, None)
+                    .convert_to_id(tenant.as_str(), &catalog, db_name, None)
                     .await
                 {
                     Ok(obj) => {
@@ -172,11 +173,34 @@ impl PrivilegeAccess {
                             ObjectId::Table(db_id, table_id) => (db_id, Some(table_id)),
                             ObjectId::Database(db_id) => (db_id, None),
                         };
-                        self.validate_access(
-                            &GrantObject::DatabaseById(catalog_name.to_string(), db_id),
-                            privileges,
-                        )
-                        .await?
+                        if let Err(err) = self
+                            .validate_access(
+                                &GrantObject::DatabaseById(catalog_name.to_string(), db_id),
+                                privileges.clone(),
+                            )
+                            .await
+                        {
+                            if err.code() != ErrorCode::PermissionDenied("").code() {
+                                return Err(err);
+                            }
+                            let current_user = self.ctx.get_current_user()?;
+                            let session = self.ctx.get_current_session();
+                            let roles_name = session
+                                .get_all_effective_roles()
+                                .await?
+                                .iter()
+                                .map(|r| r.name.clone())
+                                .collect::<Vec<_>>()
+                                .join(",");
+                            return Err(ErrorCode::PermissionDenied(format!(
+                                "Permission denied: privilege {:?} is required on '{}'.'{}'.* for user {} with roles [{}]",
+                                privileges,
+                                catalog_name,
+                                db_name,
+                                &current_user.identity(),
+                                roles_name,
+                            )));
+                        }
                     }
                     Err(e) => match e.code() {
                         ErrorCode::UNKNOWN_DATABASE
@@ -202,12 +226,93 @@ impl PrivilegeAccess {
         privileges: Vec<UserPrivilegeType>,
         if_exists: bool,
     ) -> Result<()> {
+        // skip checking the privilege on system tables.
+        if ((db_name == "system" && SYSTEM_TABLES_ALLOW_LIST.iter().any(|x| x == &table_name))
+            || db_name == "information_schema")
+            && privileges == [UserPrivilegeType::Select]
+        {
+            return Ok(());
+        }
+
         let tenant = self.ctx.get_tenant();
 
         match self.ctx.get_catalog(catalog_name).await {
             Ok(catalog) => {
                 if catalog.exists_table_function(table_name) {
                     return Ok(());
+                }
+                // to keep compatibility with the legacy privileges which granted by table name,
+                // we'd both check the privileges by name and id.
+                // we'll completely move to the id side in the future.
+                match self
+                    .validate_access(
+                        &GrantObject::Table(
+                            catalog_name.to_string(),
+                            db_name.to_string(),
+                            table_name.to_string(),
+                        ),
+                        privileges.clone(),
+                    )
+                    .await
+                {
+                    Ok(_) => return Ok(()),
+                    Err(_err) => {
+                        match self
+                            .convert_to_id(tenant.as_str(), &catalog, db_name, Some(table_name))
+                            .await
+                        {
+                            Ok(obj) => {
+                                let (db_id, table_id) = match obj {
+                                    ObjectId::Table(db_id, table_id) => (db_id, Some(table_id)),
+                                    ObjectId::Database(db_id) => (db_id, None),
+                                };
+                                if let Err(err) = self
+                                    .validate_access(
+                                        &GrantObject::TableById(
+                                            catalog_name.to_string(),
+                                            db_id,
+                                            table_id.unwrap(),
+                                        ),
+                                        privileges.clone(),
+                                    )
+                                    .await
+                                {
+                                    if err.code() != ErrorCode::PermissionDenied("").code() {
+                                        return Err(err);
+                                    }
+                                    let current_user = self.ctx.get_current_user()?;
+                                    let session = self.ctx.get_current_session();
+                                    let roles_name = session
+                                        .get_all_effective_roles()
+                                        .await?
+                                        .iter()
+                                        .map(|r| r.name.clone())
+                                        .collect::<Vec<_>>()
+                                        .join(",");
+                                    return Err(ErrorCode::PermissionDenied(format!(
+                                        "Permission denied: privilege {:?} is required on '{}'.'{}'.'{}' for user {} with roles [{}]",
+                                        privileges,
+                                        catalog_name,
+                                        db_name,
+                                        table_name,
+                                        &current_user.identity(),
+                                        roles_name,
+                                    )));
+                                }
+                            }
+                            Err(e) => match e.code() {
+                                ErrorCode::UNKNOWN_DATABASE
+                                | ErrorCode::UNKNOWN_TABLE
+                                | ErrorCode::UNKNOWN_CATALOG
+                                    if if_exists =>
+                                {
+                                    return Ok(());
+                                }
+
+                                _ => return Err(e.add_message("error on validating table access")),
+                            },
+                        }
+                    }
                 }
             }
             Err(error) => {
@@ -219,54 +324,6 @@ impl PrivilegeAccess {
             }
         }
 
-        // to keep compatibility with the legacy privileges which granted by table name,
-        // we'd both check the privileges by name and id.
-        // we'll completely move to the id side in the future.
-        match self
-            .validate_access(
-                &GrantObject::Table(
-                    catalog_name.to_string(),
-                    db_name.to_string(),
-                    table_name.to_string(),
-                ),
-                privileges.clone(),
-            )
-            .await
-        {
-            Ok(_) => return Ok(()),
-            Err(_err) => {
-                match self
-                    .convert_to_id(tenant.as_str(), catalog_name, db_name, Some(table_name))
-                    .await
-                {
-                    Ok(obj) => {
-                        let (db_id, table_id) = match obj {
-                            ObjectId::Table(db_id, table_id) => (db_id, Some(table_id)),
-                            ObjectId::Database(db_id) => (db_id, None),
-                        };
-                        self.validate_access(
-                            &GrantObject::TableById(
-                                catalog_name.to_string(),
-                                db_id,
-                                table_id.unwrap(),
-                            ),
-                            privileges,
-                        )
-                        .await?
-                    }
-                    Err(e) => match e.code() {
-                        ErrorCode::UNKNOWN_DATABASE
-                        | ErrorCode::UNKNOWN_TABLE
-                        | ErrorCode::UNKNOWN_CATALOG
-                            if if_exists =>
-                        {
-                            return Ok(());
-                        }
-                        _ => return Err(e.add_message("error on validating table access")),
-                    },
-                }
-            }
-        }
         Ok(())
     }
 
@@ -301,35 +358,6 @@ impl PrivilegeAccess {
     ) -> Result<()> {
         let session = self.ctx.get_current_session();
 
-        // translate the db_id and table_id to db_name and table_name, used on
-        // skipping the privilege check on system tables, and on the error message.
-        let (db_name, table_name) = match grant_object {
-            GrantObject::Database(_, db_name) => (db_name.to_lowercase(), "".to_string()),
-            GrantObject::Table(_, db_name, table_name) => {
-                (db_name.to_lowercase(), table_name.to_lowercase())
-            }
-            GrantObject::DatabaseById(catalog_name, db_id) => {
-                let catalog = self.ctx.get_catalog(catalog_name).await?;
-                let db_name = catalog.get_db_name_by_id(*db_id).await?;
-                (db_name.to_lowercase(), "".to_string())
-            }
-            GrantObject::TableById(catalog_name, db_id, table_id) => {
-                let catalog = self.ctx.get_catalog(catalog_name).await?;
-                let db_name = catalog.get_db_name_by_id(*db_id).await?;
-                let table_name = catalog.get_table_name_by_id(*table_id).await?;
-                (db_name.to_lowercase(), table_name.to_lowercase())
-            }
-            _ => ("".to_string(), "".to_string()),
-        };
-
-        // skip checking the privilege on system tables.
-        if ((db_name == "system" && SYSTEM_TABLES_ALLOW_LIST.iter().any(|x| x == &table_name))
-            || db_name == "information_schema")
-            && privileges == [UserPrivilegeType::Select]
-        {
-            return Ok(());
-        }
-
         let verify_ownership = match grant_object {
             GrantObject::Database(_, _)
             | GrantObject::Table(_, _, _)
@@ -355,41 +383,23 @@ impl PrivilegeAccess {
                     return Err(err);
                 }
                 let current_user = self.ctx.get_current_user()?;
-                let effective_roles = session.get_all_effective_roles().await?;
 
-                let roles_name = effective_roles
+                let roles_name = session
+                    .get_all_effective_roles()
+                    .await?
                     .iter()
                     .map(|r| r.name.clone())
                     .collect::<Vec<_>>()
                     .join(",");
                 match grant_object {
-                    GrantObject::TableById(catalog_name, _, _) => {
-                        Err(ErrorCode::PermissionDenied(format!(
-                            "Permission denied, privilege {:?} is required on '{}'.'{}'.'{}' for user {} with roles [{}]",
-                            privileges.clone(),
-                            catalog_name,
-                            db_name,
-                            table_name,
-                            &current_user.identity(),
-                            roles_name,
-                        )))
-                    }
-                    GrantObject::DatabaseById(catalog_name, _) => {
-                        Err(ErrorCode::PermissionDenied(format!(
-                            "Permission denied, privilege {:?} is required on '{}'.'{}'.* for user {} with roles [{}]",
-                            privileges.clone(),
-                            catalog_name,
-                            db_name,
-                            &current_user.identity(),
-                            roles_name,
-                        )))
-                    }
+                    GrantObject::TableById(_, _, _) => Err(ErrorCode::PermissionDenied("")),
+                    GrantObject::DatabaseById(_, _) => Err(ErrorCode::PermissionDenied("")),
                     GrantObject::Global
                     | GrantObject::UDF(_)
                     | GrantObject::Stage(_)
                     | GrantObject::Database(_, _)
                     | GrantObject::Table(_, _, _) => Err(ErrorCode::PermissionDenied(format!(
-                        "Permission denied, privilege {:?} is required on {} for user {} with roles [{}]",
+                        "Permission denied: privilege {:?} is required on {} for user {} with roles [{}]",
                         privileges.clone(),
                         grant_object,
                         &current_user.identity(),
@@ -446,11 +456,10 @@ impl PrivilegeAccess {
     async fn convert_to_id(
         &self,
         tenant: &str,
-        catalog_name: &str,
+        catalog: &Arc<dyn Catalog>,
         database_name: &str,
         table_name: Option<&str>,
     ) -> Result<ObjectId> {
-        let catalog = self.ctx.get_catalog(catalog_name).await?;
         let db_id = catalog
             .get_database(tenant, database_name)
             .await?
@@ -504,7 +513,8 @@ impl AccessChecker for PrivilegeAccess {
                         if self.has_ownership(&session, &GrantObject::Database(catalog.clone(), database.clone())).await? {
                             return Ok(());
                         }
-                        let (db_id, table_id) = match self.convert_to_id(tenant.as_str(), catalog, database, None).await? {
+                        let catalog = self.ctx.get_catalog(catalog).await?;
+                        let (db_id, table_id) = match self.convert_to_id(tenant.as_str(), &catalog, database, None).await? {
                             ObjectId::Table(db_id, table_id) => { (db_id, Some(table_id)) }
                             ObjectId::Database(db_id) => { (db_id, None) }
                         };
@@ -523,7 +533,8 @@ impl AccessChecker for PrivilegeAccess {
                         if self.has_ownership(&session, &GrantObject::Database(catalog_name.clone(), database.clone())).await? {
                             return Ok(());
                         }
-                        let (db_id, table_id) = match self.convert_to_id(tenant.as_str(), &catalog_name, database, None).await? {
+                        let catalog = self.ctx.get_catalog(&catalog_name).await?;
+                        let (db_id, table_id) = match self.convert_to_id(tenant.as_str(), &catalog, database, None).await? {
                             ObjectId::Table(db_id, table_id) => { (db_id, Some(table_id)) }
                             ObjectId::Database(db_id) => { (db_id, None) }
                         };
@@ -542,7 +553,8 @@ impl AccessChecker for PrivilegeAccess {
                         if self.has_ownership(&session, &GrantObject::Table(catalog_name.clone(), database.clone(), table.clone())).await? {
                             return Ok(());
                         }
-                        let (db_id, table_id) = match self.convert_to_id(tenant.as_str(), catalog_name, database, Some(table)).await? {
+                        let catalog = self.ctx.get_catalog(catalog_name).await?;
+                        let (db_id, table_id) = match self.convert_to_id(tenant.as_str(), &catalog, database, Some(table)).await? {
                             ObjectId::Table(db_id, table_id) => { (db_id, Some(table_id)) }
                             ObjectId::Database(db_id) => { (db_id, None) }
                         };
@@ -624,9 +636,10 @@ impl AccessChecker for PrivilegeAccess {
                 if self.has_ownership(&session, &GrantObject::Database(catalog_name.clone(), plan.database.clone())).await? {
                     return Ok(());
                 }
+                let catalog = self.ctx.get_catalog(&catalog_name).await?;
                 // Use db is special. Should not check the privilege.
                 // Just need to check user grant objects contain the db that be used.
-                let (db_id, _) = match self.convert_to_id(tenant.as_str(), &catalog_name, &plan.database, None).await? {
+                let (db_id, _) = match self.convert_to_id(tenant.as_str(), &catalog, &plan.database, None).await? {
                     ObjectId::Table(db_id, table_id) => { (db_id, Some(table_id)) }
                     ObjectId::Database(db_id) => { (db_id, None) }
                 };

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_ast::ast::ExplainKind;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_sql::binder::ExplainConfig;
 use log::error;
@@ -80,10 +81,16 @@ impl InterpreterFactory {
     pub async fn get(ctx: Arc<QueryContext>, plan: &Plan) -> Result<InterpreterPtr> {
         // Check the access permission.
         let access_checker = Accessor::create(ctx.clone());
-        access_checker.check(plan).await.map_err(|e| {
-            error!("Access.denied(v2): {:?}", e);
-            e
-        })?;
+        access_checker
+            .check(plan)
+            .await
+            .map_err(|e| match e.code() {
+                ErrorCode::PERMISSION_DENIED => {
+                    error!("Access.denied(v2): {:?}", e);
+                    e
+                }
+                _ => e,
+            })?;
         Self::get_inner(ctx, plan)
     }
 

--- a/src/query/service/src/interpreters/interpreter_privilege_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_grant.rs
@@ -211,8 +211,10 @@ impl Interpreter for GrantPrivilegeInterpreter {
                     user_mgr
                         .grant_privileges_to_role(&tenant, &role, plan.on, plan.priv_types)
                         .await?;
-                    RoleCacheManager::instance().invalidate_cache(&tenant);
                 }
+                // grant_ownership and grant_privileges_to_role will modify the kv in meta.
+                // So we need invalidate the role cache.
+                RoleCacheManager::instance().invalidate_cache(&tenant);
             }
         }
 

--- a/src/query/service/src/interpreters/interpreter_privilege_revoke.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_revoke.rs
@@ -18,6 +18,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::PrincipalIdentity;
 use databend_common_sql::plans::RevokePrivilegePlan;
+use databend_common_users::RoleCacheManager;
 use databend_common_users::UserApiProvider;
 use databend_common_users::BUILTIN_ROLE_ACCOUNT_ADMIN;
 use log::debug;
@@ -86,6 +87,9 @@ impl Interpreter for RevokePrivilegeInterpreter {
                         .revoke_privileges_from_role(&tenant, &role, object, plan.priv_types)
                         .await?;
                 }
+                // grant_ownership and grant_privileges_to_role will modify the kv in meta.
+                // So we need invalidate the role cache.
+                RoleCacheManager::instance().invalidate_cache(&tenant);
             }
         }
 

--- a/src/query/service/src/table_functions/infer_schema/parquet.rs
+++ b/src/query/service/src/table_functions/infer_schema/parquet.rs
@@ -111,7 +111,7 @@ impl AsyncSource for ParquetInferSchemaSource {
                 && !visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
             {
                 return Err(ErrorCode::PermissionDenied(format!(
-                    "Permission denied, privilege READ is required on stage {} for user {}",
+                    "Permission denied: privilege READ is required on stage {} for user {}",
                     stage_info.stage_name.clone(),
                     &self.ctx.get_current_user()?.identity(),
                 )));

--- a/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
+++ b/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
@@ -218,7 +218,7 @@ impl AsyncSource for InspectParquetSource {
                 && !visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
             {
                 return Err(ErrorCode::PermissionDenied(format!(
-                    "Permission denied, privilege READ is required on stage {} for user {}",
+                    "Permission denied: privilege READ is required on stage {} for user {}",
                     stage_info.stage_name.clone(),
                     &self.ctx.get_current_user()?.identity(),
                 )));

--- a/src/query/service/src/table_functions/list_stage/list_stage_table.rs
+++ b/src/query/service/src/table_functions/list_stage/list_stage_table.rs
@@ -195,7 +195,7 @@ impl AsyncSource for ListStagesSource {
                 && !visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
             {
                 return Err(ErrorCode::PermissionDenied(format!(
-                    "Permission denied, privilege READ is required on stage {} for user {}",
+                    "Permission denied: privilege READ is required on stage {} for user {}",
                     stage_info.stage_name.clone(),
                     &self.ctx.get_current_user()?.identity(),
                 )));

--- a/tests/suites/0_stateless/18_rbac/18_0001_udf_priv.result
+++ b/tests/suites/0_stateless/18_rbac/18_0001_udf_priv.result
@@ -1,42 +1,42 @@
 === test UDF priv
 === Only Has Privilege on f2 ===
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
 2
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
 select 1 from (select f2(f1(10)));
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
 select * from system.one where f2(f1(1));
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
 1	NULL
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f1 for user 'test-user'@'%' with roles [public]
 === Only Has Privilege on f1 ===
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
 2
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
 1	NULL
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF f2 for user 'test-user'@'%' with roles [public]
 === Has Privilege on f1, f2 ===
 1
 2
@@ -55,4 +55,4 @@ Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] i
 100
 200
 4
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF b for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF b for user 'test-user'@'%' with roles [public]

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
@@ -11,9 +11,9 @@
 0
 200
 === test role r_0002 ===
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Usage] is required on UDF a for user 'owner'@'%' with roles [public,r_0002]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE hello for user 'owner'@'%' with roles [public,r_0002]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'d_0002'.'t' for user 'owner'@'%' with roles [public,r_0002]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Usage] is required on UDF a for user 'owner'@'%' with roles [public,r_0002]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE hello for user 'owner'@'%' with roles [public,r_0002]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'d_0002'.'t' for user 'owner'@'%' with roles [public,r_0002]
 === test ownership: show stmt ===
 public	0	false	false
 role1	0	true	true

--- a/tests/suites/0_stateless/18_rbac/18_0003_db_visibility.result
+++ b/tests/suites/0_stateless/18_rbac/18_0003_db_visibility.result
@@ -2,7 +2,7 @@
 information_schema
 system
 1
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'db_root'.'t1' for user 'u1'@'%' with roles [public,role1]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'db_root'.'t1' for user 'u1'@'%' with roles [public,role1]
 db1
 information_schema
 system
@@ -23,9 +23,9 @@ system
 db_u3
 information_schema
 system
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'db1'.'t1' for user 'u3'@'%' with roles [public,role2]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'db2'.'t2' for user 'u3'@'%' with roles [public,role2]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'db_root'.'t1' for user 'u3'@'%' with roles [public,role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'db1'.'t1' for user 'u3'@'%' with roles [public,role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'db2'.'t2' for user 'u3'@'%' with roles [public,role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'db_root'.'t1' for user 'u3'@'%' with roles [public,role2]
 3
 === test u3 with role2 and role1 secondary roles all ===
 db1
@@ -35,7 +35,7 @@ information_schema
 system
 1
 2
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'db_root'.'t1' for user 'u3'@'%' with roles [public,role1,role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'db_root'.'t1' for user 'u3'@'%' with roles [public,role1,role2]
 3
 === test u3(set role1) with role2 and role1 secondary roles none ===
 db1
@@ -44,8 +44,8 @@ information_schema
 system
 1
 2
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'db_root'.'t1' for user 'u3'@'%' with roles [role1,public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'db_u3'.'t3' for user 'u3'@'%' with roles [role1,public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'db_root'.'t1' for user 'u3'@'%' with roles [role1,public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'db_u3'.'t3' for user 'u3'@'%' with roles [role1,public]
 === test root user ===
 db1
 db2

--- a/tests/suites/0_stateless/18_rbac/20_0012_privilege_access.result
+++ b/tests/suites/0_stateless/18_rbac/20_0012_privilege_access.result
@@ -1,18 +1,18 @@
 information_schema
 system
 test -- insert
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Insert] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Insert] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public]
 1
 2
 test -- update
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Update] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Update] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 2
 3
 test -- delete
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Delete] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Delete] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 true
 test -- optimize table
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Super] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Super] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 true
 test -- select
 1
@@ -20,7 +20,7 @@ test -- select
 1
 1
 test -- select view
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'default2'.'v_t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default2'.'v_t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 1
 test -- clustering_information
 true
@@ -46,12 +46,12 @@ Error: APIError: ResponseError with 1063: Permission denied: User 'a'@'%' does n
 1
 0
 1	64	378
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'default'.'t1' for user 'b'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'default'.'t' for user 'b'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'default'.'t1' for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'t1' for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'t' for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'t1' for user 'b'@'%' with roles [public]
 a b/data_UUID_0000_00000000.parquet	1	0	NULL	NULL
 === check db/table_id ===
 GRANT Read ON STAGE s3 TO 'b'@'%'

--- a/tests/suites/0_stateless/18_rbac/20_0015_set_role.result
+++ b/tests/suites/0_stateless/18_rbac/20_0015_set_role.result
@@ -7,11 +7,11 @@ testrole1
 Error: APIError: ResponseError with 2206: Invalid role nonexisting_role for current session, available: public,testrole1,testrole2,testrole3
 Error: APIError: ResponseError with 2206: Invalid role testrole4 for current session, available: public,testrole1,testrole2,testrole3
 -- test 3: set role as testrole1, secondary roles as NONE, can access table1, can not access table2
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Insert] is required on 'default'.'default'.'t20_0015_table2' for user 'testuser1'@'%' with roles [testrole1,public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Insert] is required on 'default'.'default'.'t20_0015_table2' for user 'testuser1'@'%' with roles [testrole1,public]
 -- test 4: set role as testrole2, secondary roles as NONE, can access table2, can not access table1
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Insert] is required on 'default'.'default'.'t20_0015_table1' for user 'testuser1'@'%' with roles [testrole2,public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Insert] is required on 'default'.'default'.'t20_0015_table1' for user 'testuser1'@'%' with roles [testrole2,public]
 -- test 5: set role as testrole3, secondary roles as NONE, can access table2, can not access table1, because role3 inherited from role2
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Insert] is required on 'default'.'default'.'t20_0015_table1' for user 'testuser1'@'%' with roles [testrole3,public,testrole2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Insert] is required on 'default'.'default'.'t20_0015_table1' for user 'testuser1'@'%' with roles [testrole3,public,testrole2]
 -- test 6: set role as testrole1, secondary roles as ALL, can access both table1 and table2
 -- test 7: set role as testrole1, testrole2, secondary roles defaults as ALL, can both table1 and table2
 -- test 8: not change role, secondary roles defaults as ALL, can both table1 and table2

--- a/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
+++ b/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
@@ -1,27 +1,27 @@
 ==== check internal stage write priv ===
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Write] is required on STAGE s2 for user 'u1'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Select] is required on 'default'.'default'.'test_table' for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Write] is required on STAGE s2 for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'test_table' for user 'u1'@'%' with roles [public]
 20	160	160
 1
 ==== check external stage priv ===
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Write] is required on STAGE s1 for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Write] is required on STAGE s1 for user 'u1'@'%' with roles [public]
 20	160	160
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s1 for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE s1 for user 'u1'@'%' with roles [public]
 csv/data_UUID_0000_00000000.csv	20	0	NULL	NULL
 ==== check internal stage read priv ===
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s2 for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE s2 for user 'u1'@'%' with roles [public]
 data_UUID_0000_00000000.csv	20	0	NULL	NULL
 === check presign ===
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Write] is required on STAGE presign_stage for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Write] is required on STAGE presign_stage for user 'u1'@'%' with roles [public]
 000
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE presign_stage for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE presign_stage for user 'u1'@'%' with roles [public]
 000
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Write] is required on STAGE s3 for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Write] is required on STAGE s3 for user 'u1'@'%' with roles [public]
 1	64	378
-Error: APIError: ResponseError with 1063: Permission denied, privilege [Read] is required on STAGE s3 for user 'u1'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied, privilege READ is required on stage s3 for user 'u1'@'%'
-Error: APIError: ResponseError with 1063: Permission denied, privilege READ is required on stage s3 for user 'u1'@'%'
-Error: APIError: ResponseError with 1063: Permission denied, privilege READ is required on stage s3 for user 'u1'@'%'
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE s3 for user 'u1'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege READ is required on stage s3 for user 'u1'@'%'
+Error: APIError: ResponseError with 1063: Permission denied: privilege READ is required on stage s3 for user 'u1'@'%'
+Error: APIError: ResponseError with 1063: Permission denied: privilege READ is required on stage s3 for user 'u1'@'%'
 2
 1
 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR minimizes additional meta calls in permission access as much as possible.

Now:

Considering that the user is a self created user which grant with the self created role

```sql
create role role1;

grant all on *.* to role1;

create user a identified by'123 'with DEFAULT_ROLE='role1';

grant role role1 to a;

```

### The number of times to call the meta API when the query is successful:

In the case of successful HTTP auth, private related meta API calls: **2** times:

```rust
get_user_with_client_ip

update_user_login_result
```

### Send SQL after successful session establishment:

#### Query n tables

`get_catalog` accessed n times

Database/Table Name `convert_to_id`, each table involves 2n meta calls.

`has_ownership` need get_ownership which accessed n times. And requires reload cache due to cache failure Call get_roles and a meta access occurs. Afterwards, cache data will be read

So will generate **4n** ~ **4n+1*** (when cache invalid) times

#### show tables from db;

**4** times



- Fixes #https://github.com/datafuselabs/databend/issues/14918

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14917)
<!-- Reviewable:end -->
