### PR TITLE
refactor: add NetworkPolicyIdent as NetworkPolicy meta-service key

### DIFF
--- a/src/meta/app/src/principal/mod.rs
+++ b/src/meta/app/src/principal/mod.rs
@@ -17,6 +17,7 @@
 mod connection;
 mod file_format;
 mod network_policy;
+mod network_policy_ident;
 mod ownership_info;
 mod password_policy;
 mod password_policy_ident;
@@ -40,6 +41,7 @@ mod user_stage_ident;
 pub use connection::*;
 pub use file_format::*;
 pub use network_policy::NetworkPolicy;
+pub use network_policy_ident::NetworkPolicyIdent;
 pub use ownership_info::OwnershipInfo;
 pub use password_policy::PasswordPolicy;
 pub use password_policy_ident::PasswordPolicyIdent;

--- a/src/meta/app/src/principal/network_policy_ident.rs
+++ b/src/meta/app/src/principal/network_policy_ident.rs
@@ -1,0 +1,91 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tenant::Tenant;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NetworkPolicyIdent {
+    tenant: Tenant,
+    name: String,
+}
+
+impl NetworkPolicyIdent {
+    pub fn new(tenant: Tenant, name: impl ToString) -> Self {
+        Self {
+            tenant,
+            name: name.to_string(),
+        }
+    }
+}
+
+mod kvapi_key_impl {
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+
+    use crate::principal::network_policy_ident::NetworkPolicyIdent;
+    use crate::principal::NetworkPolicy;
+    use crate::tenant::Tenant;
+    use crate::KeyWithTenant;
+
+    impl kvapi::Key for NetworkPolicyIdent {
+        const PREFIX: &'static str = "__fd_network_policies";
+        type ValueType = NetworkPolicy;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
+        }
+
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_str(self.tenant_name()).push_str(&self.name)
+        }
+
+        fn decode_key(p: &mut kvapi::KeyParser) -> Result<Self, KeyError> {
+            let tenant = p.next_nonempty()?;
+            let name = p.next_str()?;
+
+            Ok(NetworkPolicyIdent::new(Tenant::new_nonempty(tenant), name))
+        }
+    }
+
+    impl KeyWithTenant for NetworkPolicyIdent {
+        fn tenant(&self) -> &Tenant {
+            &self.tenant
+        }
+    }
+
+    impl kvapi::Value for NetworkPolicy {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::principal::network_policy_ident::NetworkPolicyIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_network_policy_ident() {
+        let tenant = Tenant::new("test".to_string());
+        let ident = NetworkPolicyIdent::new(tenant, "test1");
+
+        let key = ident.to_string_key();
+        assert_eq!(key, "__fd_network_policies/test/test1");
+
+        assert_eq!(ident, NetworkPolicyIdent::from_str_key(&key).unwrap());
+    }
+}

--- a/src/query/management/src/network_policy/network_policy_mgr.rs
+++ b/src/query/management/src/network_policy/network_policy_mgr.rs
@@ -14,53 +14,44 @@
 
 use std::sync::Arc;
 
-use databend_common_base::base::escape_for_key;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_meta_api::kv_pb_api::KVPbApi;
+use databend_common_meta_api::kv_pb_api::UpsertPB;
 use databend_common_meta_app::principal::NetworkPolicy;
+use databend_common_meta_app::principal::NetworkPolicyIdent;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_kvapi::kvapi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
+use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
-use databend_common_meta_types::Operation;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_meta_types::SeqV;
+use databend_common_meta_types::With;
+use futures::TryStreamExt;
 
 use crate::network_policy::network_policy_api::NetworkPolicyApi;
-use crate::serde::deserialize_struct;
-use crate::serde::serialize_struct;
-
-static NETWORK_POLICY_API_KEY_PREFIX: &str = "__fd_network_policies";
 
 pub struct NetworkPolicyMgr {
     kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
-    network_policy_prefix: String,
+    tenant: Tenant,
 }
 
 impl NetworkPolicyMgr {
     pub fn create(
         kv_api: Arc<dyn kvapi::KVApi<Error = MetaError>>,
-        tenant: &str,
-    ) -> Result<Self, ErrorCode> {
-        if tenant.is_empty() {
-            return Err(ErrorCode::TenantIsEmpty(
-                "Tenant can not empty (while create network policy)",
-            ));
-        }
-
-        Ok(NetworkPolicyMgr {
+        tenant: &NonEmptyString,
+    ) -> Self {
+        NetworkPolicyMgr {
             kv_api,
-            network_policy_prefix: format!("{}/{}", NETWORK_POLICY_API_KEY_PREFIX, tenant),
-        })
+            tenant: Tenant::new(tenant.as_str()),
+        }
     }
 
-    fn make_network_policy_key(&self, name: &str) -> Result<String> {
-        Ok(format!(
-            "{}/{}",
-            self.network_policy_prefix,
-            escape_for_key(name)?
-        ))
+    fn ident(&self, name: &str) -> NetworkPolicyIdent {
+        NetworkPolicyIdent::new(self.tenant.clone(), name)
     }
 }
 
@@ -73,18 +64,12 @@ impl NetworkPolicyApi for NetworkPolicyMgr {
         network_policy: NetworkPolicy,
         create_option: &CreateOption,
     ) -> Result<()> {
-        let seq = MatchSeq::from(*create_option);
-        let key = self.make_network_policy_key(network_policy.name.as_str())?;
-        let value = Operation::Update(serialize_struct(
-            &network_policy,
-            ErrorCode::IllegalNetworkPolicy,
-            || "",
-        )?);
+        let ident = self.ident(network_policy.name.as_str());
 
-        let kv_api = self.kv_api.clone();
-        let res = kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, value, None))
-            .await?;
+        let seq = MatchSeq::from(*create_option);
+        let upsert = UpsertPB::insert(ident, network_policy.clone()).with(seq);
+
+        let res = self.kv_api.upsert_pb(&upsert).await?;
 
         if let CreateOption::None = create_option {
             if res.prev.is_some() {
@@ -105,19 +90,12 @@ impl NetworkPolicyApi for NetworkPolicyMgr {
         network_policy: NetworkPolicy,
         match_seq: MatchSeq,
     ) -> Result<u64> {
-        let key = self.make_network_policy_key(network_policy.name.as_str())?;
-        let value = Operation::Update(serialize_struct(
-            &network_policy,
-            ErrorCode::IllegalNetworkPolicy,
-            || "",
-        )?);
+        let ident = self.ident(network_policy.name.as_str());
+        let upsert = UpsertPB::update(ident, network_policy.clone()).with(match_seq);
 
-        let kv_api = self.kv_api.clone();
-        let upsert_kv = kv_api
-            .upsert_kv(UpsertKVReq::new(&key, match_seq, value, None))
-            .await?;
+        let res = self.kv_api.upsert_pb(&upsert).await?;
 
-        match upsert_kv.result {
+        match res.result {
             Some(SeqV { seq: s, .. }) => Ok(s),
             None => Err(ErrorCode::UnknownNetworkPolicy(format!(
                 "Network policy '{}' cannot be updated as it may not exist or the request is invalid.",
@@ -129,35 +107,34 @@ impl NetworkPolicyApi for NetworkPolicyMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn drop_network_policy(&self, name: &str, seq: MatchSeq) -> Result<()> {
-        let key = self.make_network_policy_key(name)?;
-        let kv_api = self.kv_api.clone();
-        let res = kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Delete, None))
-            .await?;
-        if res.prev.is_some() && res.result.is_none() {
-            Ok(())
-        } else {
-            Err(ErrorCode::UnknownNetworkPolicy(format!(
-                "Network policy '{}' does not exist.",
-                name
-            )))
-        }
+        let ident = self.ident(name);
+
+        let upsert = UpsertPB::delete(ident).with(seq);
+
+        let res = self.kv_api.upsert_pb(&upsert).await?;
+        res.removed_or_else(|e| {
+            ErrorCode::UnknownNetworkPolicy(format!(
+                "Network policy '{}' does not exist. {:?}",
+                name, e
+            ))
+        })?;
+
+        Ok(())
     }
 
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn get_network_policy(&self, name: &str, seq: MatchSeq) -> Result<SeqV<NetworkPolicy>> {
-        let key = self.make_network_policy_key(name)?;
-        let res = self.kv_api.get_kv(&key).await?;
+        let ident = self.ident(name);
+
+        let res = self.kv_api.get_pb(&ident).await?;
+
         let seq_value = res.ok_or_else(|| {
             ErrorCode::UnknownNetworkPolicy(format!("Network policy '{}' does not exist.", name))
         })?;
 
         match seq.match_seq(&seq_value) {
-            Ok(_) => Ok(SeqV::new(
-                seq_value.seq,
-                deserialize_struct(&seq_value.data, ErrorCode::IllegalNetworkPolicy, || "")?,
-            )),
+            Ok(_) => Ok(seq_value),
             Err(_) => Err(ErrorCode::UnknownNetworkPolicy(format!(
                 "Network policy '{}' does not exist.",
                 name
@@ -168,17 +145,11 @@ impl NetworkPolicyApi for NetworkPolicyMgr {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn get_network_policies(&self) -> Result<Vec<NetworkPolicy>> {
-        let values = self
-            .kv_api
-            .prefix_list_kv(&self.network_policy_prefix)
-            .await?;
+        let dir_name = DirName::new(self.ident("dummy"));
 
-        let mut network_policies = Vec::with_capacity(values.len());
-        for (_, value) in values {
-            let network_policy =
-                deserialize_struct(&value.data, ErrorCode::IllegalNetworkPolicy, || "")?;
-            network_policies.push(network_policy);
-        }
-        Ok(network_policies)
+        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = values.try_collect().await?;
+
+        Ok(values)
     }
 }

--- a/src/query/service/src/interpreters/interpreter_network_policies_show.rs
+++ b/src/query/service/src/interpreters/interpreter_network_policies_show.rs
@@ -50,7 +50,7 @@ impl Interpreter for ShowNetworkPoliciesInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let tenant = self.ctx.get_tenant();
         let user_mgr = UserApiProvider::instance();
-        let network_policies = user_mgr.get_network_policies(tenant.as_str()).await?;
+        let network_policies = user_mgr.get_network_policies(&tenant).await?;
 
         let mut names = Vec::with_capacity(network_policies.len());
         let mut allowed_ip_lists = Vec::with_capacity(network_policies.len());

--- a/src/query/service/src/interpreters/interpreter_network_policy_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_network_policy_alter.rs
@@ -57,7 +57,7 @@ impl Interpreter for AlterNetworkPolicyInterpreter {
         let user_mgr = UserApiProvider::instance();
         user_mgr
             .update_network_policy(
-                tenant.as_str(),
+                &tenant,
                 &plan.name,
                 plan.allowed_ip_list.clone(),
                 plan.blocked_ip_list.clone(),

--- a/src/query/service/src/interpreters/interpreter_network_policy_create.rs
+++ b/src/query/service/src/interpreters/interpreter_network_policy_create.rs
@@ -66,7 +66,7 @@ impl Interpreter for CreateNetworkPolicyInterpreter {
             update_on: None,
         };
         user_mgr
-            .add_network_policy(tenant.as_str(), network_policy, &plan.create_option)
+            .add_network_policy(&tenant, network_policy, &plan.create_option)
             .await?;
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_network_policy_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_network_policy_desc.rs
@@ -54,7 +54,7 @@ impl Interpreter for DescNetworkPolicyInterpreter {
         let user_mgr = UserApiProvider::instance();
 
         let network_policy = user_mgr
-            .get_network_policy(tenant.as_str(), self.plan.name.as_str())
+            .get_network_policy(&tenant, self.plan.name.as_str())
             .await?;
 
         let names = vec![network_policy.name.clone()];

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -157,14 +157,8 @@ impl UserApiProvider {
         Arc::new(SettingMgr::create(self.client.clone(), tenant))
     }
 
-    pub fn get_network_policy_api_client(
-        &self,
-        tenant: &str,
-    ) -> Result<Arc<impl NetworkPolicyApi>> {
-        Ok(Arc::new(NetworkPolicyMgr::create(
-            self.client.clone(),
-            tenant,
-        )?))
+    pub fn network_policy_api(&self, tenant: &NonEmptyString) -> Arc<impl NetworkPolicyApi> {
+        Arc::new(NetworkPolicyMgr::create(self.client.clone(), tenant))
     }
 
     pub fn password_policy_api(&self, tenant: &NonEmptyString) -> Arc<impl PasswordPolicyApi> {

--- a/src/query/users/src/user_mgr.rs
+++ b/src/query/users/src/user_mgr.rs
@@ -77,9 +77,7 @@ impl UserApiProvider {
                 }
             };
 
-            let network_policy = self
-                .get_network_policy(tenant.as_str(), name.as_str())
-                .await?;
+            let network_policy = self.get_network_policy(tenant, name.as_str()).await?;
             for blocked_ip in network_policy.blocked_ip_list {
                 let blocked_cidr: Ipv4Cidr = blocked_ip.parse().unwrap();
                 if blocked_cidr.contains(&ip_addr) {
@@ -135,11 +133,7 @@ impl UserApiProvider {
         create_option: &CreateOption,
     ) -> Result<()> {
         if let Some(name) = user_info.option.network_policy() {
-            if self
-                .get_network_policy(tenant.as_str(), name)
-                .await
-                .is_err()
-            {
+            if self.get_network_policy(tenant, name).await.is_err() {
                 return Err(ErrorCode::UnknownNetworkPolicy(format!(
                     "network policy `{}` is not exist",
                     name
@@ -293,11 +287,7 @@ impl UserApiProvider {
     ) -> Result<Option<u64>> {
         if let Some(ref user_option) = user_option {
             if let Some(name) = user_option.network_policy() {
-                if self
-                    .get_network_policy(tenant.as_str(), name)
-                    .await
-                    .is_err()
-                {
+                if self.get_network_policy(tenant, name).await.is_err() {
                     return Err(ErrorCode::UnknownNetworkPolicy(format!(
                         "network policy `{}` is not exist",
                         name

--- a/src/query/users/tests/it/network_policy.rs
+++ b/src/query/users/tests/it/network_policy.rs
@@ -52,7 +52,7 @@ async fn test_network_policy() -> Result<()> {
         update_on: None,
     };
     user_mgr
-        .add_network_policy(tenant_name, network_policy, &CreateOption::None)
+        .add_network_policy(&tenant, network_policy, &CreateOption::None)
         .await?;
 
     // add user
@@ -97,7 +97,7 @@ async fn test_network_policy() -> Result<()> {
     let new_blocked_ip_list = vec!["127.0.0.10".to_string()];
     user_mgr
         .update_network_policy(
-            tenant_name,
+            &tenant,
             policy_name.as_ref(),
             Some(new_allowed_ip_list),
             Some(new_blocked_ip_list),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add NetworkPolicyIdent as NetworkPolicy meta-service key

- Fix: #14932

## Changelog




- Improvement


## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14933)
<!-- Reviewable:end -->
