### PR TITLE
feat: ndjson support option null_if.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,6 +2621,7 @@ dependencies = [
  "pretty",
  "pretty_assertions",
  "regex",
+ "serde_json",
  "strsim 0.10.0",
  "strum 0.24.1",
  "strum_macros 0.24.3",

--- a/src/meta/app/src/principal/file_format.rs
+++ b/src/meta/app/src/principal/file_format.rs
@@ -41,6 +41,7 @@ const OPT_ROW_TAG: &str = "row_tag";
 const OPT_ERROR_ON_COLUMN_COUNT_MISMATCH: &str = "error_on_column_count_mismatch";
 const MISSING_FIELD_AS: &str = "missing_field_as";
 const NULL_FIELD_AS: &str = "null_field_as";
+const NULL_IF: &str = "null_if";
 const OPT_EMPTY_FIELD_AS: &str = "empty_field_as";
 const OPT_BINARY_FORMAT: &str = "binary_format";
 
@@ -184,10 +185,24 @@ impl FileFormatParams {
                 let compression = ast.take_compression()?;
                 let missing_field_as = ast.options.remove(MISSING_FIELD_AS);
                 let null_field_as = ast.options.remove(NULL_FIELD_AS);
+                let null_if = ast.options.remove(NULL_IF);
+                let null_if = match null_if {
+                    None => {
+                        vec![]
+                    }
+                    Some(s) => {
+                        let values: Vec<String> = serde_json::from_str(&s).map_err(|_|
+                            ErrorCode::InvalidArgument(format!(
+                            "Invalid option value: NULL_IF is currently set to {s} (in JSON). The valid values are a list of strings."
+                            )))?;
+                        values
+                    }
+                };
                 FileFormatParams::NdJson(NdJsonFileFormatParams::try_create(
                     compression,
                     missing_field_as.as_deref(),
                     null_field_as.as_deref(),
+                    null_if,
                 )?)
             }
             StageFileFormatType::Parquet => {
@@ -586,6 +601,7 @@ pub struct NdJsonFileFormatParams {
     pub compression: StageFileCompression,
     pub missing_field_as: NullAs,
     pub null_field_as: NullAs,
+    pub null_if: Vec<String>,
 }
 
 impl NdJsonFileFormatParams {
@@ -593,6 +609,7 @@ impl NdJsonFileFormatParams {
         compression: StageFileCompression,
         missing_field_as: Option<&str>,
         null_field_as: Option<&str>,
+        null_if: Vec<String>,
     ) -> Result<Self> {
         let missing_field_as = NullAs::parse(missing_field_as, MISSING_FIELD_AS, NullAs::Error)?;
         let null_field_as = NullAs::parse(null_field_as, MISSING_FIELD_AS, NullAs::Null)?;
@@ -605,6 +622,7 @@ impl NdJsonFileFormatParams {
             compression,
             missing_field_as,
             null_field_as,
+            null_if,
         })
     }
 }
@@ -615,6 +633,7 @@ impl Default for NdJsonFileFormatParams {
             compression: StageFileCompression::None,
             missing_field_as: NullAs::Error,
             null_field_as: NullAs::FieldDefault,
+            null_if: vec![],
         }
     }
 }

--- a/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
@@ -327,6 +327,7 @@ impl FromToProto for mt::principal::NdJsonFileFormatParams {
             compression,
             p.missing_field_as.as_deref(),
             p.null_field_as.as_deref(),
+            p.null_if,
         )
         .map_err(|e| Incompatible {
             reason: format!("{e}"),
@@ -342,6 +343,7 @@ impl FromToProto for mt::principal::NdJsonFileFormatParams {
             compression,
             missing_field_as: Some(self.missing_field_as.to_string()),
             null_field_as: Some(self.null_field_as.to_string()),
+            null_if: self.null_if.clone(),
         })
     }
 }

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -111,7 +111,8 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (79, "2024-01-31: Add: udf.proto/UserDefinedFunction add created_on field", ),
     (80, "2024-02-01: Add: datatype.proto/DataType Geometry type"),
     (81, "2024-03-04: Add: udf.udf_script"),
-    (82, "2024-03-08: Add: table.inverted_index")
+    (82, "2024-03-08: Add: table.inverted_index"),
+    (83, "2024-03-14: Add: null_if in user.proto/NDJSONFileFormatParams")
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -85,3 +85,4 @@ mod v078_grantentry;
 mod v079_udf_created_on;
 mod v081_udf_script;
 mod v082_table_index;
+mod v083_ndjson_format_params;

--- a/src/meta/proto-conv/tests/it/v032_file_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v032_file_format_params.rs
@@ -93,6 +93,7 @@ fn test_decode_v32_ndjson_file_format_params() -> anyhow::Result<()> {
             compression: StageFileCompression::Gzip,
             missing_field_as: NullAs::Error,
             null_field_as: NullAs::Null,
+            null_if: vec![],
         })
     };
     common::test_pb_from_to(func_name!(), want())?;

--- a/src/meta/proto-conv/tests/it/v083_ndjson_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v083_ndjson_format_params.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_meta_app as mt;
 use databend_common_meta_app::principal::NdJsonFileFormatParams;
 use databend_common_meta_app::principal::NullAs;
 use databend_common_meta_app::principal::StageFileCompression;
@@ -21,6 +20,7 @@ use minitrace::func_name;
 use crate::common;
 
 // These bytes are built when a new version in introduced,
+
 // and are kept for backward compatibility test.
 //
 // *************************************************************
@@ -30,21 +30,23 @@ use crate::common;
 // *************************************************************
 //
 #[test]
-fn test_decode_v64_ndjson_file_format_params() -> anyhow::Result<()> {
-    let file_format_params_v64 = vec![
-        42, 29, 8, 1, 18, 13, 102, 105, 101, 108, 100, 95, 100, 101, 102, 97, 117, 108, 116, 26, 4,
-        110, 117, 108, 108, 160, 6, 64, 168, 6, 24,
+fn test_decode_v83_ndjson_file_format_params() -> anyhow::Result<()> {
+    let nd_json_file_format_params_v83 = vec![
+        8, 1, 18, 13, 70, 73, 69, 76, 68, 95, 68, 69, 70, 65, 85, 76, 84, 26, 13, 70, 73, 69, 76,
+        68, 95, 68, 69, 70, 65, 85, 76, 84, 34, 0, 160, 6, 83, 168, 6, 24,
     ];
-
-    let want = || {
-        mt::principal::FileFormatParams::NdJson(NdJsonFileFormatParams {
-            compression: StageFileCompression::Gzip,
-            missing_field_as: NullAs::FieldDefault,
-            null_field_as: NullAs::Null,
-            null_if: vec![],
-        })
+    let want = || NdJsonFileFormatParams {
+        compression: StageFileCompression::Gzip,
+        missing_field_as: NullAs::FieldDefault,
+        null_field_as: NullAs::FieldDefault,
+        null_if: vec!["".to_string()],
     };
+    common::test_load_old(
+        func_name!(),
+        nd_json_file_format_params_v83.as_slice(),
+        83,
+        want(),
+    )?;
     common::test_pb_from_to(func_name!(), want())?;
-    common::test_load_old(func_name!(), file_format_params_v64.as_slice(), 0, want())?;
     Ok(())
 }

--- a/src/meta/protos/proto/file_format.proto
+++ b/src/meta/protos/proto/file_format.proto
@@ -138,6 +138,7 @@ message NdJsonFileFormatParams {
   StageFileCompression compression = 1;
   optional string missing_field_as = 2;
   optional string null_field_as = 3;
+  repeated string null_if = 4;
 }
 
 message JsonFileFormatParams {

--- a/src/query/ast/Cargo.toml
+++ b/src/query/ast/Cargo.toml
@@ -30,6 +30,7 @@ nom-rule = "0.3.0"
 ordered-float = { workspace = true }
 pratt = "0.4.0"
 pretty = "0.11.3"
+serde_json = { workspace = true }
 strsim = "0.10"
 strum = "0.24"
 strum_macros = "0.24"

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -133,6 +133,16 @@ pub fn format_options(i: Input) -> IResult<BTreeMap<String, String>> {
         |(k, _, v)| (k.text().to_string(), v.text().to_string()),
     );
 
+    let null_if = map(
+        rule! { NULL_IF ~ ^"=" ~ ^"(" ~ ^#comma_separated_list0(literal_string) ~ ^")" },
+        |(_, _, _, values, _)| {
+            (
+                "null_if".to_string(),
+                serde_json::to_string(&values).unwrap(),
+            )
+        },
+    );
+
     map(
         rule! { ((
         #option_type
@@ -141,7 +151,9 @@ pub fn format_options(i: Input) -> IResult<BTreeMap<String, String>> {
         | #string_options
         | #int_options
         | #bool_options
-        | #none_options) ~ ","?)* },
+        | #none_options
+        | #null_if
+        ) ~ ","?)* },
         |opts| BTreeMap::from_iter(opts.iter().map(|((k, v), _)| (k.to_lowercase(), v.clone()))),
     )(i)
 }

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -566,6 +566,8 @@ pub enum TokenKind {
     NAN_DISPLAY,
     #[token("NULL_DISPLAY", ignore(ascii_case))]
     NULL_DISPLAY,
+    #[token("NULL_IF", ignore(ascii_case))]
+    NULL_IF,
     #[token("FILE_FORMAT", ignore(ascii_case))]
     FILE_FORMAT,
     #[token("FILE", ignore(ascii_case))]

--- a/tests/data/ndjson/null_if.ndjson
+++ b/tests/data/ndjson/null_if.ndjson
@@ -1,0 +1,2 @@
+{"a": "", "b": "Null", "c": "Null"}
+{"a": 1, "b": "null", "c": null}

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_null_if.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_null_if.test
@@ -1,0 +1,42 @@
+statement ok
+drop table if exists v
+
+statement ok
+create table v (a variant, b string, c int)
+
+query 
+copy into v from @data/ndjson/null_if.ndjson file_format = (type = 'ndjson') on_error = continue
+----
+ndjson/null_if.ndjson 1 1 Invalid value '"Null"' for column 2 (c Int32 NULL): BadBytes. Code: 1046, Text = Incorrect json value, must be number. 1
+
+query 
+select * from v order by b
+----
+1 null NULL
+
+statement ok
+truncate table v
+
+query 
+copy into v from @data/ndjson/null_if.ndjson file_format = (type = 'ndjson' null_if = ()) force=true  on_error = continue
+----
+ndjson/null_if.ndjson 1 1 Invalid value '"Null"' for column 2 (c Int32 NULL): BadBytes. Code: 1046, Text = Incorrect json value, must be number. 1
+
+query 
+select * from v order by b
+----
+1 null NULL
+
+statement ok
+truncate table v
+
+query 
+copy into v from @data/ndjson/null_if.ndjson file_format = (type = 'ndjson' null_if = ('', 'Null')) force=true
+----
+ndjson/null_if.ndjson 2 0 NULL NULL
+
+query 
+select * from v order by b
+----
+1 null NULL
+NULL NULL NULL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

e.g.

```
copy into v from @data/ndjson/null_if.ndjson file_format = (type = 'ndjson' null_if = ('', 'Null')) force=true
```

all nullable field will check for `null_if` first ( e.g. `{"a_int_field":  ""}` will load `a_int_field` as null instead of report error
note this is diff from snowflake which apply t `null_if` to varchar field only.

cc @wubx 


- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14938)
<!-- Reviewable:end -->
