### PR TITLE
feat(query): add statement_queued_timeout_in_seconds setting for queries queue

### DIFF
--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -149,6 +149,7 @@ build_exceptions! {
     UnknownCatalog(1119),
     UnknownCatalogType(1120),
     UnmatchMaskPolicyReturnType(1121),
+    Timeout(1122),
 
     // Data Related Errors
 

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -1399,7 +1399,7 @@ pub struct QueryConfig {
     #[clap(long, value_name = "VALUE", default_value = "256")]
     pub max_active_sessions: u64,
 
-    #[clap(long, value_name = "VALUE", default_value = "0")]
+    #[clap(long, value_name = "VALUE", default_value = "8")]
     pub max_running_queries: u64,
 
     /// The max total memory in bytes that can be used by this process.

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -247,7 +247,7 @@ impl Default for QueryConfig {
             mysql_tls_server_cert: "".to_string(),
             mysql_tls_server_key: "".to_string(),
             max_active_sessions: 256,
-            max_running_queries: 0,
+            max_running_queries: 8,
             max_server_memory_usage: 0,
             max_memory_limit_enabled: false,
             clickhouse_http_handler_host: "127.0.0.1".to_string(),

--- a/src/query/service/tests/it/sessions/queue_mgr.rs
+++ b/src/query/service/tests/it/sessions/queue_mgr.rs
@@ -36,6 +36,10 @@ impl QueueData for TestData {
     fn remove_error_message(key: Option<Self::Key>) -> ErrorCode {
         ErrorCode::Internal(format!("{:?}", key))
     }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(1000)
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -99,7 +99,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | 'query'   | 'max_active_sessions'                      | '256'                                                          | ''       |
 | 'query'   | 'max_memory_limit_enabled'                 | 'false'                                                        | ''       |
 | 'query'   | 'max_query_log_size'                       | '10000'                                                        | ''       |
-| 'query'   | 'max_running_queries'                      | '0'                                                            | ''       |
+| 'query'   | 'max_running_queries'                      | '8'                                                            | ''       |
 | 'query'   | 'max_server_memory_usage'                  | '0'                                                            | ''       |
 | 'query'   | 'max_storage_io_requests'                  | 'null'                                                         | ''       |
 | 'query'   | 'metric_api_address'                       | '127.0.0.1:7070'                                               | ''       |

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -709,6 +709,12 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: None,
                 }),
+                ("statement_queued_timeout_in_seconds", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "The maximum waiting seconds in the queue. The default value is 0(no limit).",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
+                })
             ]);
 
             Ok(Arc::new(DefaultSettings {

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -626,4 +626,8 @@ impl Settings {
     pub fn get_enable_experimental_queries_executor(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_experimental_queries_executor")? == 1)
     }
+
+    pub fn get_statement_queued_timeout(&self) -> Result<u64> {
+        self.try_get_u64("statement_queued_timeout_in_seconds")
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

feat(query): add statement_queued_timeout_in_seconds setting for queries queue

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14945)
<!-- Reviewable:end -->
