### PR TITLE
fix: cluster table with change tracking enabled append panic

### DIFF
--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -72,8 +72,9 @@ impl FuseTable {
             }
         }
 
+        let schema = DataSchema::from(self.schema()).into();
         let cluster_stats_gen =
-            self.cluster_gen_for_append(ctx.clone(), pipeline, block_thresholds, None)?;
+            self.cluster_gen_for_append(ctx.clone(), pipeline, block_thresholds, Some(schema))?;
         pipeline.add_transform(|input, output| {
             let proc = TransformSerializeBlock::try_create(
                 ctx.clone(),

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
@@ -135,6 +135,66 @@ select a, _origin_version is null, _origin_block_id is null, _origin_block_row_n
 7 0 0 1 0
 8 0 0 0 0
 
+###############
+# issue 14955 #
+###############
+
+statement ok
+create table t3(a int, b int) cluster by(a+1) change_tracking=true
+
+statement ok
+insert into t3 values(1, 1), (3, 3), (2, 3)
+
+statement ok
+update t3 set b = 2 where a = 2
+
+statement ok
+delete from t3 where a = 3
+
+statement ok
+insert into t3 values(4, 4)
+
+statement ok
+alter table t3 recluster
+
+statement ok
+insert into t3 values(0, 0)
+
+statement ok
+optimize table t3 compact
+
+statement ok
+create table t4(a int, b int, c int)
+
+statement ok
+insert into t4 values(0, 1, 0), (3, 4, 3), (4, 5, 4)
+
+statement ok
+replace into t3 on(a) delete when c = 0 select * from t4
+
+query III
+merge into t3 using t4 on t3.a = t4.a when matched and t4.a = 4 then delete when matched then update set t3.b = t4.c when not matched then insert values(t4.a, t4.c)
+----
+1 1 1
+
+query IIBBII
+select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t3
+----
+0 0 0 0 0 0
+1 1 0 0 0 0
+2 2 0 0 1 1
+3 3 0 0 0 1
+
+statement ok
+drop table t4 all
+
+statement ok
+drop table t3 all
+
+######################
+# end of issue 14955 #
+######################
+
 statement ok
 set enable_experimental_merge_into = 0
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When append and replace generating cluster stats, specify the data schema.

When generating cluster stats during append and replace operations, specify the data schema. 
This is because append and replace operations will ignore the change tracking field [when serialize block](https://github.com/datafuselabs/databend/blob/main/src/query/storages/fuse/src/operations/common/processors/transform_serialize_block.rs#L91-L95).

- Fixes #14955

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14956)
<!-- Reviewable:end -->
