### PR TITLE
fix: enable runtime filter when `join_spilling_memory_ratio` !=0

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -150,9 +150,7 @@ impl HashJoinBuildState {
         let mut enable_bloom_runtime_filter = false;
         let mut enable_inlist_runtime_filter = false;
         let mut enable_min_max_runtime_filter = false;
-        if supported_join_type_for_runtime_filter(&hash_join_state.hash_join_desc.join_type)
-            && ctx.get_settings().get_join_spilling_memory_ratio()? == 0
-        {
+        if supported_join_type_for_runtime_filter(&hash_join_state.hash_join_desc.join_type) {
             let is_cluster = !ctx.get_cluster().is_empty();
             // For cluster, only support runtime filter for broadcast join.
             let is_broadcast_join = hash_join_state.hash_join_desc.broadcast;
@@ -324,7 +322,10 @@ impl HashJoinBuildState {
                     .clone()
             };
 
-            self.add_runtime_filter(&build_chunks, build_num_rows)?;
+            // If spilling happened, skip adding runtime filter, because probe data is ready and spilled.
+            if self.spilled_partition_set.read().is_empty() {
+                self.add_runtime_filter(&build_chunks, build_num_rows)?;
+            }
 
             if self.hash_join_state.hash_join_desc.join_type == JoinType::Cross {
                 return Ok(());

--- a/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
@@ -543,7 +543,7 @@ async fn adjust_bloom_runtime_filter(
                     .derive_cardinality()?
                     .cardinality;
                 // If the filtered data reduces to less than 1/1000 of the original dataset, we will enable bloom runtime filter.
-                return Ok(join_cardinality <= (num_rows / 1000) as f64);
+                return Ok(join_cardinality <= (num_rows / 500) as f64);
             }
         }
     }

--- a/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
@@ -543,7 +543,7 @@ async fn adjust_bloom_runtime_filter(
                     .derive_cardinality()?
                     .cardinality;
                 // If the filtered data reduces to less than 1/1000 of the original dataset, we will enable bloom runtime filter.
-                return Ok(join_cardinality <= (num_rows / 500) as f64);
+                return Ok(join_cardinality <= (num_rows / 100) as f64);
             }
         }
     }

--- a/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
@@ -543,7 +543,7 @@ async fn adjust_bloom_runtime_filter(
                     .derive_cardinality()?
                     .cardinality;
                 // If the filtered data reduces to less than 1/1000 of the original dataset, we will enable bloom runtime filter.
-                return Ok(join_cardinality <= (num_rows / 100) as f64);
+                return Ok(join_cardinality <= (num_rows / 1000) as f64);
             }
         }
     }

--- a/tests/sqllogictests/suites/tpch/queries.test
+++ b/tests/sqllogictests/suites/tpch/queries.test
@@ -802,6 +802,7 @@ Brand#13 LARGE BURNISHED COPPER 45 8
 Brand#13 MEDIUM ANODIZED STEEL 23 8
 
 #Q17
+
 query I
 select
         truncate(sum(l_extendedprice) / 7.0,8) as avg_yearly


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Due to the join spilling opened by default which makes `runtime filter` closed.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14959)
<!-- Reviewable:end -->
