### PR TITLE
fix(query): Need return error udf_name when derialize from pb  failed.

### DIFF
--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use databend_common_exception::ErrorCode;
 use databend_common_functions::is_builtin_function;
 use databend_common_meta_api::kv_pb_api::KVPbApi;
 use databend_common_meta_api::kv_pb_api::UpsertPB;
@@ -21,14 +22,13 @@ use databend_common_meta_app::principal::UdfName;
 use databend_common_meta_app::principal::UserDefinedFunction;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_kvapi::kvapi;
-use databend_common_meta_kvapi::kvapi::DirName;
+use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::NonEmptyStr;
 use databend_common_meta_types::NonEmptyString;
 use databend_common_meta_types::SeqV;
 use databend_common_meta_types::With;
-use futures::stream::TryStreamExt;
 
 use crate::udf::UdfApiError;
 use crate::udf::UdfError;
@@ -121,16 +121,24 @@ impl UdfMgr {
     /// Get all the UDFs for a tenant.
     #[async_backtrace::framed]
     #[minitrace::trace]
-    pub async fn list_udf(&self) -> Result<Vec<UserDefinedFunction>, UdfApiError> {
-        let key = DirName::new(UdfName::new(self.tenant.as_str(), ""));
-        let strm = self.kv_api.list_pb_values(&key).await?;
-        let udfs = strm
-            .try_collect()
-            .await
-            .map_err(|e| UdfApiError::MetaError {
-                meta_err: e,
-                context: "while list UDF".to_string(),
+    pub async fn list_udf(&self) -> Result<Vec<UserDefinedFunction>, ErrorCode> {
+        let key = UdfName::new(&self.tenant, "");
+        // TODO: use list_kv instead.
+        let values = self.kv_api.prefix_list_kv(&key.to_string_key()).await?;
+
+        let mut udfs = Vec::with_capacity(values.len());
+        // At begin udf is serialize to json. https://github.com/datafuselabs/databend/pull/12729/files#diff-9c992028e59caebc313d761b8488b17f142618fb89db64c51c1655689d68c41b
+        // But we can not deserialize the UserDefinedFunction from json now,
+        // because add a new field created_on and the field `definition` refactor to a ENUM type.
+        for (name, value) in values {
+            let udf = crate::deserialize_struct(&value.data, ErrorCode::IllegalUDFFormat, || {
+                format!(
+                    "Failed to deserialize UDF '{}': data format is corrupt or invalid.",
+                    name
+                )
             })?;
+            udfs.push(udf);
+        }
         Ok(udfs)
     }
 

--- a/src/query/storages/system/src/user_functions_table.rs
+++ b/src/query/storages/system/src/user_functions_table.rs
@@ -181,6 +181,6 @@ impl UserFunctionsTable {
     #[async_backtrace::framed]
     async fn get_udfs(ctx: Arc<dyn TableContext>) -> Result<Vec<UserDefinedFunction>> {
         let tenant = ctx.get_tenant();
-        UserApiProvider::instance().get_udfs(&tenant).await
+        UserApiProvider::instance().list_udf(&tenant).await
     }
 }

--- a/src/query/users/src/user_udf.rs
+++ b/src/query/users/src/user_udf.rs
@@ -75,10 +75,12 @@ impl UserApiProvider {
     pub async fn list_udf(&self, tenant: &NonEmptyString) -> Result<Vec<UserDefinedFunction>> {
         let udf_api = self.udf_api(tenant);
 
-        match udf_api.list_udf().await {
-            Err(e) => Err(e.add_message_back("(while list UDFs).")),
-            Ok(seq_udfs_info) => Ok(seq_udfs_info),
-        }
+        let udfs = udf_api
+            .list_udf()
+            .await
+            .map_err(|e| e.add_message_back("while list UDFs"))?;
+
+        Ok(udfs)
     }
 
     // Drop a UDF by name.

--- a/src/query/users/src/user_udf.rs
+++ b/src/query/users/src/user_udf.rs
@@ -72,15 +72,13 @@ impl UserApiProvider {
 
     // Get all UDFs for the tenant.
     #[async_backtrace::framed]
-    pub async fn get_udfs(&self, tenant: &NonEmptyString) -> Result<Vec<UserDefinedFunction>> {
+    pub async fn list_udf(&self, tenant: &NonEmptyString) -> Result<Vec<UserDefinedFunction>> {
         let udf_api = self.udf_api(tenant);
 
-        let udfs = udf_api
-            .list_udf()
-            .await
-            .map_err(|e| e.append_context("while get UDFs"))?;
-
-        Ok(udfs)
+        match udf_api.list_udf().await {
+            Err(e) => Err(e.add_message_back("(while list UDFs).")),
+            Ok(seq_udfs_info) => Ok(seq_udfs_info),
+        }
     }
 
     // Drop a UDF by name.

--- a/src/query/users/tests/it/user_udf.rs
+++ b/src/query/users/tests/it/user_udf.rs
@@ -57,7 +57,7 @@ async fn test_user_lambda_udf() -> Result<()> {
 
     // get all.
     {
-        let udfs = user_mgr.get_udfs(&tenant).await?;
+        let udfs = user_mgr.list_udf(&tenant).await?;
         assert_eq!(udfs, vec![isempty_udf.clone(), isnotempty_udf.clone()]);
     }
 
@@ -70,7 +70,7 @@ async fn test_user_lambda_udf() -> Result<()> {
     // drop.
     {
         user_mgr.drop_udf(&tenant, isnotempty, false).await??;
-        let udfs = user_mgr.get_udfs(&tenant).await?;
+        let udfs = user_mgr.list_udf(&tenant).await?;
         assert_eq!(udfs, vec![isempty_udf]);
     }
 
@@ -133,7 +133,7 @@ async fn test_user_udf_server() -> Result<()> {
 
     // get all.
     {
-        let udfs = user_mgr.get_udfs(&tenant).await?;
+        let udfs = user_mgr.list_udf(&tenant).await?;
         assert_eq!(udfs, vec![isempty_udf.clone(), isnotempty_udf.clone()]);
     }
 
@@ -146,7 +146,7 @@ async fn test_user_udf_server() -> Result<()> {
     // drop.
     {
         user_mgr.drop_udf(&tenant, isnotempty, false).await??;
-        let udfs = user_mgr.get_udfs(&tenant).await?;
+        let udfs = user_mgr.list_udf(&tenant).await?;
         assert_eq!(udfs, vec![isempty_udf]);
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

https://github.com/datafuselabs/databend/pull/12729/files#diff-9c992028e59caebc313d761b8488b17f142618fb89db64c51c1655689d68c41b

![image](https://github.com/datafuselabs/databend/assets/33082201/446ad6d2-0941-49e6-9595-a111f55a54aa)

I think we can not upgrade the old json to pb. The best way is return error udf when `select * from system.user_functions` and then user need to re-create the udf.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - rollback deserialize udf code. If the test can be passed the code is ok.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14964)
<!-- Reviewable:end -->
