### PR TITLE
fix: csv read error with skip_header.

### DIFF
--- a/src/query/storages/stage/src/read/row_based/formats/csv/separator.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/csv/separator.rs
@@ -208,12 +208,17 @@ impl CsvReader {
         let mut buf_out = vec![0u8; buf_in.len()];
 
         // skip headers
-        while self.rows_to_skip > 0 {
+        // be careful not passing empty input to reader, which indicates eof
+        while self.rows_to_skip > 0 && !buf_in.is_empty() {
             let (res, n_in) = self.read_record(buf_in, &mut buf_out, &mut file_status)?;
             buf_in = &buf_in[n_in..];
             if matches!(res, ReadRecordOutput::Record { .. }) {
                 self.rows_to_skip -= 1;
             }
+        }
+
+        if self.rows_to_skip > 0 {
+            return Ok((vec![], file_status));
         }
 
         // prepare for reading data

--- a/src/query/storages/stage/src/read/row_based/processors/reader.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/reader.rs
@@ -17,6 +17,9 @@ use std::sync::Arc;
 
 use databend_common_base::base::tokio::io::AsyncRead;
 use databend_common_base::base::tokio::io::AsyncReadExt;
+use databend_common_base::base::ProgressValues;
+use databend_common_base::runtime::profile::Profile;
+use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -71,6 +74,11 @@ impl BytesReader {
                 )));
             };
             buffer.truncate(n);
+
+            Profile::record_usize_profile(ProfileStatisticsName::ScanBytes, n);
+            self.table_ctx
+                .get_scan_progress()
+                .incr(&ProgressValues { rows: 0, bytes: n });
 
             debug!("read {} bytes", n);
             let offset = state.offset;

--- a/src/query/storages/stage/src/read/row_based/processors/separator.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/separator.rs
@@ -15,8 +15,6 @@
 use std::sync::Arc;
 
 use databend_common_base::base::ProgressValues;
-use databend_common_base::runtime::profile::Profile;
-use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::DataBlock;
@@ -59,7 +57,6 @@ impl AccumulatingTransform for Separator {
         });
         let mut process_values = ProgressValues { rows: 0, bytes: 0 };
 
-        process_values.bytes += batch.data.len();
         let batch_meta = batch.meta();
         let (row_batches, file_status) = state.append(batch)?;
         let row_batches = row_batches
@@ -81,7 +78,6 @@ impl AccumulatingTransform for Separator {
             for b in row_batches.iter() {
                 process_values.rows += b.rows();
             }
-            Profile::record_usize_profile(ProfileStatisticsName::ScanBytes, process_values.bytes);
             self.ctx
                 .table_context
                 .get_scan_progress()

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_select.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_select.test
@@ -17,3 +17,16 @@ select * from @data/csv (files=>('select.csv'), file_format=>'csv')
 
 query error 1065.*select \* from file only support Parquet format
 select *, $1 from @data/csv (files=>('select.csv'), file_format=>'csv')
+----
+
+
+statement ok
+drop file format if exists csv1
+
+statement ok
+create file format csv1 type = 'CSV' field_delimiter = ',' skip_header = 1 compression= 'auto'
+
+query
+select /*+ set_var(input_read_buffer_size=100) */ count($1) from @data/ontime_200.csv (file_format=>'csv1' pattern=>'') limit 1
+----
+199


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fortunately, this bug only happen when header is longer than the `input_read_buffer_size` (1M by default),  which rarely happen.


also fix progress by the way  https://github.com/datafuselabs/databend/issues/14973#issuecomment-2001999581

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/14981)
<!-- Reviewable:end -->
