### PR TITLE
feat(query): check view's inner table privilege when create or alter view

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -862,7 +862,6 @@ impl AccessChecker for PrivilegeAccess {
                 self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Update], false).await?;
             }
             Plan::CreateView(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Create], false).await?;
                 let mut planner = Planner::new(self.ctx.clone());
                 let (plan, _) = planner.plan_sql(&plan.subquery).await?;
                 self.check(ctx, &plan).await?

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -32,6 +32,7 @@ use databend_common_sql::optimizer::get_udf_names;
 use databend_common_sql::plans::InsertInputSource;
 use databend_common_sql::plans::PresignAction;
 use databend_common_sql::plans::RewriteKind;
+use databend_common_sql::Planner;
 use databend_common_users::RoleCacheManager;
 
 use crate::interpreters::access::AccessChecker;
@@ -861,10 +862,16 @@ impl AccessChecker for PrivilegeAccess {
                 self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Update], false).await?;
             }
             Plan::CreateView(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Create], false).await?
+                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Create], false).await?;
+                let mut planner = Planner::new(self.ctx.clone());
+                let (plan, _) = planner.plan_sql(&plan.subquery).await?;
+                self.check(ctx, &plan).await?
             }
             Plan::AlterView(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Alter], false).await?
+                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Alter], false).await?;
+                let mut planner = Planner::new(self.ctx.clone());
+                let (plan, _) = planner.plan_sql(&plan.subquery).await?;
+                self.check(ctx, &plan).await?
             }
             Plan::DropView(plan) => {
                 self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Drop], plan.if_exists).await?

--- a/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.result
+++ b/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.result
@@ -1,0 +1,38 @@
+>>>> drop user if exists 'owner'
+>>>> drop role if exists role1
+>>>> create user 'owner' IDENTIFIED BY 'password' with DEFAULT_ROLE='role1'
+>>>> create role role1
+>>>> grant role role1 to owner
+>>>> grant create on default.* to role role1
+>>>> drop table if exists t
+>>>> drop view if exists v_t
+>>>> drop table if exists t_owner
+>>>> drop view if exists v_t_owner
+>>>> drop view if exists v_t_union
+>>>> create table t(id int)
+>>>> insert into t values(1)
+need failed: with 1063
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'t' for user 'owner'@'%' with roles [public,role1]
+need failed: with 1063
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'t' for user 'owner'@'%' with roles [public,role1]
+>>>> grant ownership on default.v_t_owner to role role1
+>>>> create view v_t as select * from t
+>>>> create view v_t_union as select * from t union all select * from t_owner
+'select * from v_t order by id' failed.
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'v_t' for user 'owner'@'%' with roles [public,role1]
+>>>> grant select on default.v_t to owner
+>>>> grant select on default.v_t_union to owner
+1
+2
+1
+2
+>>>> select * from v_t order by id
+1
+<<<<
+>>>> select * from v_t_owner order by c1
+2
+<<<<
+>>>> select * from v_t_union order by id
+1
+2
+<<<<

--- a/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.result
+++ b/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.result
@@ -9,8 +9,10 @@
 >>>> drop table if exists t_owner
 >>>> drop view if exists v_t_owner
 >>>> drop view if exists v_t_union
+>>>> drop view if exists v_t1
 >>>> create table t(id int)
 >>>> insert into t values(1)
+>>>> revoke create on default.* from role role1
 need failed: with 1063
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'t' for user 'owner'@'%' with roles [public,role1]
 need failed: with 1063
@@ -36,3 +38,19 @@ Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] 
 1
 2
 <<<<
+=== create view as select view ===
+>>>> revoke select on default.v_t from owner
+>>>> grant select on default.t to owner
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'v_t' for user 'owner'@'%' with roles [public,role1]
+>>>> grant select on default.v_t to owner
+>>>> grant select on default.t to owner
+>>>> grant select on default.v_t1 to owner
+1
+>>>> drop table if exists t
+>>>> drop view if exists v_t
+>>>> drop table if exists t_owner
+>>>> drop view if exists v_t_owner
+>>>> drop view if exists v_t_union
+>>>> drop view if exists v_t1
+>>>> drop user if exists owner
+>>>> drop role if exists role1

--- a/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+export TEST_USER_NAME="owner"
+export TEST_USER_PASSWORD="password"
+export TEST_USER_CONNECT="bendsql --user=owner --password=password --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
+
+stmt "drop user if exists 'owner'"
+stmt "drop role if exists role1"
+stmt "create user 'owner' IDENTIFIED BY '$TEST_USER_PASSWORD' with DEFAULT_ROLE='role1'"
+stmt 'create role role1'
+
+stmt 'grant role role1 to owner'
+stmt 'grant create on default.* to role role1'
+stmt 'drop table if exists t'
+stmt 'drop view if exists v_t'
+stmt 'drop table if exists t_owner'
+stmt 'drop view if exists v_t_owner'
+stmt 'drop view if exists v_t_union'
+stmt 'create table t(id int)'
+stmt 'insert into t values(1)'
+echo 'create table t_owner(c1 int)' | $TEST_USER_CONNECT
+echo 'insert into t_owner values(2)' | $TEST_USER_CONNECT
+
+echo 'need failed: with 1063'
+echo 'create view v_t as select * from t' | $TEST_USER_CONNECT
+echo 'need failed: with 1063'
+echo 'create view v_t_union as select * from t union all select * from t_owner' | $TEST_USER_CONNECT
+echo 'create view v_t_owner as select * from t_owner' | $TEST_USER_CONNECT
+stmt 'grant ownership on default.v_t_owner to role role1'
+
+stmt 'create view v_t as select * from t'
+stmt 'create view v_t_union as select * from t union all select * from t_owner'
+
+echo "'select * from v_t order by id' failed."
+echo "select * from v_t order by id" | $TEST_USER_CONNECT
+stmt 'grant select on default.v_t to owner'
+stmt 'grant select on default.v_t_union to owner'
+echo "select * from v_t order by id" | $TEST_USER_CONNECT
+echo "select * from v_t_owner order by c1" | $TEST_USER_CONNECT
+echo "select * from v_t_union order by id" | $TEST_USER_CONNECT
+
+query "select * from v_t order by id"
+query "select * from v_t_owner order by c1"
+query "select * from v_t_union order by id"
+
+

--- a/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.sh
@@ -19,10 +19,12 @@ stmt 'drop view if exists v_t'
 stmt 'drop table if exists t_owner'
 stmt 'drop view if exists v_t_owner'
 stmt 'drop view if exists v_t_union'
+stmt 'drop view if exists v_t1'
 stmt 'create table t(id int)'
 stmt 'insert into t values(1)'
 echo 'create table t_owner(c1 int)' | $TEST_USER_CONNECT
 echo 'insert into t_owner values(2)' | $TEST_USER_CONNECT
+stmt 'revoke create on default.* from role role1'
 
 echo 'need failed: with 1063'
 echo 'create view v_t as select * from t' | $TEST_USER_CONNECT
@@ -46,4 +48,22 @@ query "select * from v_t order by id"
 query "select * from v_t_owner order by c1"
 query "select * from v_t_union order by id"
 
+echo "=== create view as select view ==="
 
+stmt 'revoke select on default.v_t from owner'
+stmt 'grant select on default.t to owner'
+echo 'create view v_t1 as select * from t union select * from v_t' | $TEST_USER_CONNECT
+stmt 'grant select on default.v_t to owner'
+stmt 'grant select on default.t to owner'
+echo 'create view v_t1 as select * from t union select * from v_t' | $TEST_USER_CONNECT
+stmt 'grant select on default.v_t1 to owner'
+echo "select * from v_t1 order by id" | $TEST_USER_CONNECT
+
+stmt 'drop table if exists t'
+stmt 'drop view if exists v_t'
+stmt 'drop table if exists t_owner'
+stmt 'drop view if exists v_t_owner'
+stmt 'drop view if exists v_t_union'
+stmt 'drop view if exists v_t1'
+stmt 'drop user if exists owner'
+stmt 'drop role if exists role1'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Note:

Select view no need to check the inner table privilege.

Because the user only can query view when the admin user grant select on the view to the user.

So the admin user needs to know why the user need access this view.

This pr is avoid that:

User only has create or alter on db. And then the user can query table as create or alter view. Like this:

```sql
--root
grant create on default.* to a;
--user a
create view v_t1 as select * from t1; -- If it can be success, the user can query table t1 according to query view v_t1. It maybe dangerous.
```

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
