### PR TITLE
chore(http): tune log on getting /v1/query/:id/kill

### DIFF
--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -218,7 +218,7 @@ async fn query_final_handler(
     async {
         info!(
             "{}: got /v1/query/{}/final request, this query is going to be finally completed.",
-            query_id
+            query_id, query_id
         );
         let http_query_manager = HttpQueryManager::instance();
         match http_query_manager

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -216,7 +216,10 @@ async fn query_final_handler(
     let _t = SlowRequestLogTracker::new(ctx);
 
     async {
-        info!("{}: final http query", query_id);
+        info!(
+            "{}: got /v1/query/{}/final request, this query is going to be finally completed.",
+            query_id
+        );
         let http_query_manager = HttpQueryManager::instance();
         match http_query_manager
             .remove_query(&query_id, RemoveReason::Finished)
@@ -258,7 +261,10 @@ async fn query_cancel_handler(
     let _t = SlowRequestLogTracker::new(ctx);
 
     async {
-        info!("{}: http query is killed", query_id);
+        info!(
+            "{}: got /v1/query/{}/kill request, cancel the query",
+            query_id, query_id
+        );
         let http_query_manager = HttpQueryManager::instance();
         match http_query_manager.try_get_query(&query_id).await {
             Ok(query) => {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

this pr made a small modificaton on logs, make it more clear about what is actually happening.

## Tests

- [x] No Test  - log text modification

## Type of change

- [x] Other (please describe): small log modification
