### PR TITLE
chore: add log about presign elapsed

### DIFF
--- a/src/query/service/src/interpreters/interpreter_presign.rs
+++ b/src/query/service/src/interpreters/interpreter_presign.rs
@@ -24,6 +24,7 @@ use databend_common_expression::Value;
 use databend_common_storages_stage::StageTable;
 use jsonb::Value as JsonbValue;
 use log::debug;
+use log::info;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -79,7 +80,7 @@ impl Interpreter for PresignInterpreter {
         };
         info!(
             "query_id" = self.ctx.get_id();
-            "presign {:?} {} success in {}ms", self.plan.action, path, start_time.elapsed().as_millis()
+            "presign {:?} {} success in {}ms", self.plan.action, self.plan.path, start_time.elapsed().as_millis()
         );
 
         let header = JsonbValue::Object(

--- a/src/query/service/src/interpreters/interpreter_presign.rs
+++ b/src/query/service/src/interpreters/interpreter_presign.rs
@@ -66,6 +66,7 @@ impl Interpreter for PresignInterpreter {
             ));
         }
 
+        let start_time = std::time::Instant::now();
         let presigned_req = match self.plan.action {
             PresignAction::Download => op.presign_read(&self.plan.path, self.plan.expire).await?,
             PresignAction::Upload => {
@@ -76,6 +77,10 @@ impl Interpreter for PresignInterpreter {
                 fut.await?
             }
         };
+        info!(
+            "query_id" = self.ctx.get_id();
+            "presign {:?} {} success in {}ms", self.plan.action, path, start_time.elapsed().as_millis()
+        );
 
         let header = JsonbValue::Object(
             presigned_req


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

this pr add a small log about how many time got elapsed during the presign operation.

presign is expected to be an io-free operation, but sometimes it has a latency of 100+ms.

## Tests

- [x] No Test  - simple logs

## Type of change

- [x] Other (please describe): simple logs
