### PR TITLE
fix(query): fix incorrect agg spill in new agg hashtable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,9 @@ name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+dependencies = [
+ "backtrace 0.3.69 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "apache-avro"
@@ -238,6 +241,16 @@ name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "ariadne"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd002a6223f12c7a95cdd4b1cb3a0149d22d37f7a9ecdb2cb691a071fe236c29"
+dependencies = [
+ "unicode-width",
+ "yansi 0.5.1",
+]
 
 [[package]]
 name = "array-init-cursor"
@@ -1760,6 +1773,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.3",
+ "stacker",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1873,48 @@ dependencies = [
  "anstyle",
  "clap_lex 0.7.0",
  "strsim 0.11.0",
+ "terminal_size 0.3.0",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
+dependencies = [
+ "clap 4.5.1",
+]
+
+[[package]]
+name = "clap_complete_command"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d"
+dependencies = [
+ "clap 4.5.1",
+ "clap_complete",
+ "clap_complete_fig",
+ "clap_complete_nushell",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110"
+dependencies = [
+ "clap 4.5.1",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e"
+dependencies = [
+ "clap 4.5.1",
+ "clap_complete",
 ]
 
 [[package]]
@@ -1891,6 +1956,21 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "clio"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7fc6734af48458f72f5a3fa7b840903606427d98a710256e808f76a965047d9"
+dependencies = [
+ "cfg-if",
+ "clap 4.5.1",
+ "is-terminal",
+ "libc",
+ "tempfile",
+ "walkdir",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "clipboard-win"
@@ -1939,10 +2019,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace 0.3.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colorchoice-clap"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe9ad5d064caf028aeb50818a5c7857c28f746ad04111652b85d9bca8b0d0be"
+dependencies = [
+ "clap 4.5.1",
+ "colorchoice",
+]
 
 [[package]]
 name = "comfy-table"
@@ -2885,7 +3002,7 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "strength_reduce",
- "terminal_size",
+ "terminal_size 0.2.6",
  "tonic 0.10.2",
  "typetag",
  "unicode-segmentation",
@@ -3605,6 +3722,7 @@ dependencies = [
  "ordered-float 4.2.0",
  "parking_lot 0.12.1",
  "percent-encoding",
+ "prqlc",
  "regex",
  "roaring",
  "serde",
@@ -5408,6 +5526,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5713,6 +5841,15 @@ checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
 dependencies = [
  "rustix 0.38.31",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7825,6 +7962,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7887,6 +8030,26 @@ dependencies = [
  "quick-xml 0.26.0",
  "rgb",
  "str_stack",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -8165,6 +8328,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac6ea8c376b6e208a81cf39b8e82bebf49652454d98a4829e907dac16ef1790"
 dependencies = [
  "typewit",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -8789,6 +8972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minijinja"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673d1ece89f7e166f43270800d78f9b1a9d21fda92dbcfa3b98b21213cdccbbc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9158,6 +9350,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ntapi"
@@ -10672,6 +10883,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "prqlc"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beb05b6b71ce096fa56d73006ab1c42a8d11bf190d193fa511a134f7730ec43"
+dependencies = [
+ "anstream",
+ "anyhow",
+ "ariadne",
+ "atty",
+ "chrono",
+ "clap 4.5.1",
+ "clap_complete",
+ "clap_complete_command",
+ "clio",
+ "color-eyre",
+ "colorchoice-clap",
+ "csv",
+ "enum-as-inner 0.6.0",
+ "env_logger",
+ "itertools 0.12.1",
+ "log",
+ "minijinja",
+ "notify",
+ "once_cell",
+ "prqlc-ast",
+ "prqlc-parser",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sqlformat",
+ "sqlparser",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
+ "walkdir",
+]
+
+[[package]]
+name = "prqlc-ast"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98923b046bc48046e3846b14a5fde5a059f681c7c367bd0ab96ebd3ecc33a71"
+dependencies = [
+ "anyhow",
+ "enum-as-inner 0.6.0",
+ "semver",
+ "serde",
+ "strum 0.26.2",
+]
+
+[[package]]
+name = "prqlc-parser"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "855ad9aba599ef608efc88a30ebd731155997d9bbe780639eb175de060b6cddc"
+dependencies = [
+ "chumsky",
+ "itertools 0.12.1",
+ "prqlc-ast",
+ "semver",
+ "stacker",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12080,6 +12365,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+dependencies = [
+ "indexmap 2.2.5",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serfig"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12421,6 +12719,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+dependencies = [
+ "itertools 0.12.1",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
 name = "sqllogictest"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12445,10 +12754,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95c4bae5aba7cd30bd506f7140026ade63cff5afd778af8854026f9606bf5d4"
+dependencies = [
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "state"
@@ -12541,6 +12873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros 0.26.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12558,6 +12899,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -12985,6 +13339,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix 0.37.27",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
@@ -13467,6 +13831,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13720,6 +14094,12 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -14227,6 +14607,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
 dependencies = [
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/src/query/expression/src/aggregate/aggregate_hashtable.rs
+++ b/src/query/expression/src/aggregate/aggregate_hashtable.rs
@@ -68,6 +68,26 @@ impl AggregateHashTable {
         Self::new_with_capacity(group_types, aggrs, config, capacity, arena)
     }
 
+    pub fn new_with_max_radix_bits(
+        group_types: Vec<DataType>,
+        aggrs: Vec<AggregateFunctionRef>,
+        config: HashTableConfig,
+        arena: Arc<Bump>,
+    ) -> Self {
+        let capacity = Self::initial_capacity();
+        Self {
+            entries: vec![0u64; capacity],
+            count: 0,
+            direct_append: false,
+            current_radix_bits: config.max_radix_bits,
+            payload: PartitionedPayload::new(group_types, aggrs, 1 << config.max_radix_bits, vec![
+                arena,
+            ]),
+            capacity,
+            config,
+        }
+    }
+
     pub fn new_with_capacity(
         group_types: Vec<DataType>,
         aggrs: Vec<AggregateFunctionRef>,

--- a/src/query/expression/src/aggregate/mod.rs
+++ b/src/query/expression/src/aggregate/mod.rs
@@ -103,15 +103,15 @@ impl HashTableConfig {
         self
     }
 
-    pub fn update_max_radix_bits(mut self, new_radix_bits: u64) -> Self {
+    pub fn update_current_max_radix_bits(self) -> Self {
         loop {
             let current_max_radix_bits = self.current_max_radix_bits.load(Ordering::SeqCst);
-            if current_max_radix_bits < new_radix_bits
+            if current_max_radix_bits < self.max_radix_bits
                 && self
                     .current_max_radix_bits
                     .compare_exchange(
                         current_max_radix_bits,
-                        new_radix_bits,
+                        self.max_radix_bits,
                         Ordering::SeqCst,
                         Ordering::SeqCst,
                     )
@@ -121,7 +121,6 @@ impl HashTableConfig {
             }
             break;
         }
-        self.initial_radix_bits = new_radix_bits;
         self
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
@@ -58,19 +58,15 @@ impl SerializedPayload {
         group_types: Vec<DataType>,
         aggrs: Vec<Arc<dyn AggregateFunction>>,
         radix_bits: u64,
+        arena: Arc<Bump>,
     ) -> Result<PartitionedPayload> {
         let rows_num = self.data_block.num_rows();
         let config = HashTableConfig::default().with_initial_radix_bits(radix_bits);
         let mut state = ProbeState::default();
         let agg_len = aggrs.len();
         let group_len = group_types.len();
-        let mut hashtable = AggregateHashTable::new_with_capacity(
-            group_types,
-            aggrs,
-            config,
-            rows_num,
-            Arc::new(Bump::new()),
-        );
+        let mut hashtable =
+            AggregateHashTable::new_with_capacity(group_types, aggrs, config, rows_num, arena);
         hashtable.direct_append = true;
 
         let agg_states = (0..agg_len)

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
@@ -57,9 +57,9 @@ impl SerializedPayload {
         &self,
         group_types: Vec<DataType>,
         aggrs: Vec<Arc<dyn AggregateFunction>>,
+        radix_bits: u64,
     ) -> Result<PartitionedPayload> {
         let rows_num = self.data_block.num_rows();
-        let radix_bits = self.max_partition_count.trailing_zeros() as u64;
         let config = HashTableConfig::default().with_initial_radix_bits(radix_bits);
         let mut state = ProbeState::default();
         let agg_len = aggrs.len();

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -93,19 +93,23 @@ impl<Method: HashMethodBounds> TransformFinalAggregate<Method> {
                     AggregateMeta::Serialized(payload) => match agg_hashtable.as_mut() {
                         Some(ht) => {
                             debug_assert!(bucket == payload.bucket);
+                            let arena = Arc::new(Bump::new());
                             let payload = payload.convert_to_partitioned_payload(
                                 self.params.group_data_types.clone(),
                                 self.params.aggregate_functions.clone(),
                                 0,
+                                arena,
                             )?;
                             ht.combine_payloads(&payload, &mut self.flush_state)?;
                         }
                         None => {
                             debug_assert!(bucket == payload.bucket);
+                            let arena = Arc::new(Bump::new());
                             let payload = payload.convert_to_partitioned_payload(
                                 self.params.group_data_types.clone(),
                                 self.params.aggregate_functions.clone(),
                                 0,
+                                arena,
                             )?;
                             let capacity =
                                 AggregateHashTable::get_capacity_for_count(payload.len());

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -68,7 +68,7 @@ impl<Method: HashMethodBounds> TransformFinalAggregate<Method> {
 
     fn transform_agg_hashtable(&mut self, meta: AggregateMeta<Method, usize>) -> Result<DataBlock> {
         let mut agg_hashtable: Option<AggregateHashTable> = None;
-        if let AggregateMeta::Partitioned { bucket: _, data } = meta {
+        if let AggregateMeta::Partitioned { bucket, data } = meta {
             for bucket_data in data {
                 match bucket_data {
                     AggregateMeta::AggregateHashTable(payload) => match agg_hashtable.as_mut() {
@@ -92,16 +92,20 @@ impl<Method: HashMethodBounds> TransformFinalAggregate<Method> {
                     },
                     AggregateMeta::Serialized(payload) => match agg_hashtable.as_mut() {
                         Some(ht) => {
+                            debug_assert!(bucket == payload.bucket);
                             let payload = payload.convert_to_partitioned_payload(
                                 self.params.group_data_types.clone(),
                                 self.params.aggregate_functions.clone(),
+                                0,
                             )?;
                             ht.combine_payloads(&payload, &mut self.flush_state)?;
                         }
                         None => {
+                            debug_assert!(bucket == payload.bucket);
                             let payload = payload.convert_to_partitioned_payload(
                                 self.params.group_data_types.clone(),
                                 self.params.aggregate_functions.clone(),
+                                0,
                             )?;
                             let capacity =
                                 AggregateHashTable::get_capacity_for_count(payload.len());

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
@@ -402,13 +402,14 @@ impl<Method: HashMethodBounds> AccumulatingTransform for TransformPartialAggrega
 
                     let group_types = v.payload.group_types.clone();
                     let aggrs = v.payload.aggrs.clone();
-                    let config = v.config.clone();
+                    let max_radix_bits = v.config.max_radix_bits;
+                    let config = v.config.update_max_radix_bits(max_radix_bits);
+
                     let mut state = PayloadFlushState::default();
 
                     // repartition to max for normalization
-                    let partitioned_payload = v
-                        .payload
-                        .repartition(1 << config.max_radix_bits, &mut state);
+                    let partitioned_payload =
+                        v.payload.repartition(1 << max_radix_bits, &mut state);
 
                     let blocks = vec![DataBlock::empty_with_meta(
                         AggregateMeta::<Method, usize>::create_agg_spilling(partitioned_payload),

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
@@ -402,26 +402,27 @@ impl<Method: HashMethodBounds> AccumulatingTransform for TransformPartialAggrega
 
                     let group_types = v.payload.group_types.clone();
                     let aggrs = v.payload.aggrs.clone();
-                    let max_radix_bits = v.config.max_radix_bits;
-                    let config = v.config.update_max_radix_bits(max_radix_bits);
+                    let config = v.config.update_current_max_radix_bits();
 
                     let mut state = PayloadFlushState::default();
 
                     // repartition to max for normalization
-                    let partitioned_payload =
-                        v.payload.repartition(1 << max_radix_bits, &mut state);
+                    let partitioned_payload = v
+                        .payload
+                        .repartition(1 << config.max_radix_bits, &mut state);
 
                     let blocks = vec![DataBlock::empty_with_meta(
                         AggregateMeta::<Method, usize>::create_agg_spilling(partitioned_payload),
                     )];
 
                     let arena = Arc::new(Bump::new());
-                    self.hash_table = HashTable::AggregateHashTable(AggregateHashTable::new(
-                        group_types,
-                        aggrs,
-                        config,
-                        arena,
-                    ));
+                    self.hash_table =
+                        HashTable::AggregateHashTable(AggregateHashTable::new_with_max_radix_bits(
+                            group_types,
+                            aggrs,
+                            config,
+                            arena,
+                        ));
                     return Ok(blocks);
                 }
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_final.rs
@@ -86,19 +86,23 @@ impl<Method: HashMethodBounds> TransformFinalGroupBy<Method> {
                     AggregateMeta::Serialized(payload) => match agg_hashtable.as_mut() {
                         Some(ht) => {
                             debug_assert!(bucket == payload.bucket);
+                            let arena = Arc::new(Bump::new());
                             let payload = payload.convert_to_partitioned_payload(
                                 self.params.group_data_types.clone(),
                                 self.params.aggregate_functions.clone(),
                                 0,
+                                arena,
                             )?;
                             ht.combine_payloads(&payload, &mut self.flush_state)?;
                         }
                         None => {
                             debug_assert!(bucket == payload.bucket);
+                            let arena = Arc::new(Bump::new());
                             let payload = payload.convert_to_partitioned_payload(
                                 self.params.group_data_types.clone(),
                                 self.params.aggregate_functions.clone(),
                                 0,
+                                arena,
                             )?;
                             let capacity =
                                 AggregateHashTable::get_capacity_for_count(payload.len());

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_partial.rs
@@ -237,13 +237,14 @@ impl<Method: HashMethodBounds> AccumulatingTransform for TransformPartialGroupBy
                     if let HashTable::AggregateHashTable(v) = std::mem::take(&mut self.hash_table) {
                         let group_types = v.payload.group_types.clone();
                         let aggrs = v.payload.aggrs.clone();
-                        let config = v.config.clone();
+                        let max_radix_bits = v.config.max_radix_bits;
+                        let config = v.config.update_max_radix_bits(max_radix_bits);
+
                         let mut state = PayloadFlushState::default();
 
                         // repartition to max for normalization
-                        let partitioned_payload = v
-                            .payload
-                            .repartition(1 << config.max_radix_bits, &mut state);
+                        let partitioned_payload =
+                            v.payload.repartition(1 << max_radix_bits, &mut state);
 
                         let blocks = vec![DataBlock::empty_with_meta(
                             AggregateMeta::<Method, ()>::create_agg_spilling(partitioned_payload),

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_group_by_partial.rs
@@ -26,6 +26,7 @@ use databend_common_expression::AggregateHashTable;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::HashTableConfig;
+use databend_common_expression::PayloadFlushState;
 use databend_common_expression::ProbeState;
 use databend_common_hashtable::HashtableLike;
 use databend_common_pipeline_core::processors::InputPort;
@@ -237,8 +238,15 @@ impl<Method: HashMethodBounds> AccumulatingTransform for TransformPartialGroupBy
                         let group_types = v.payload.group_types.clone();
                         let aggrs = v.payload.aggrs.clone();
                         let config = v.config.clone();
+                        let mut state = PayloadFlushState::default();
+
+                        // repartition to max for normalization
+                        let partitioned_payload = v
+                            .payload
+                            .repartition(1 << config.max_radix_bits, &mut state);
+
                         let blocks = vec![DataBlock::empty_with_meta(
-                            AggregateMeta::<Method, ()>::create_agg_spilling(v.payload),
+                            AggregateMeta::<Method, ()>::create_agg_spilling(partitioned_payload),
                         )];
 
                         let arena = Arc::new(Bump::new());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In PR https://github.com/datafuselabs/databend/pull/14905, we add spill for new agg hashtable ,but we found data loss caused by incorrect handling. this pr fix it by normalizing the data.

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
