### PR TITLE
refactor: Add ExistError and UnknownError, TenantResource does not need to define error type any more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,9 @@ name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+dependencies = [
+ "backtrace 0.3.69 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "apache-avro"
@@ -238,6 +241,16 @@ name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "ariadne"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd002a6223f12c7a95cdd4b1cb3a0149d22d37f7a9ecdb2cb691a071fe236c29"
+dependencies = [
+ "unicode-width",
+ "yansi 0.5.1",
+]
 
 [[package]]
 name = "array-init-cursor"
@@ -1760,6 +1773,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.3",
+ "stacker",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1873,48 @@ dependencies = [
  "anstyle",
  "clap_lex 0.7.0",
  "strsim 0.11.0",
+ "terminal_size 0.3.0",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
+dependencies = [
+ "clap 4.5.1",
+]
+
+[[package]]
+name = "clap_complete_command"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d"
+dependencies = [
+ "clap 4.5.1",
+ "clap_complete",
+ "clap_complete_fig",
+ "clap_complete_nushell",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110"
+dependencies = [
+ "clap 4.5.1",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e"
+dependencies = [
+ "clap 4.5.1",
+ "clap_complete",
 ]
 
 [[package]]
@@ -1891,6 +1956,21 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "clio"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7fc6734af48458f72f5a3fa7b840903606427d98a710256e808f76a965047d9"
+dependencies = [
+ "cfg-if",
+ "clap 4.5.1",
+ "is-terminal",
+ "libc",
+ "tempfile",
+ "walkdir",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "clipboard-win"
@@ -1939,10 +2019,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace 0.3.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colorchoice-clap"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe9ad5d064caf028aeb50818a5c7857c28f746ad04111652b85d9bca8b0d0be"
+dependencies = [
+ "clap 4.5.1",
+ "colorchoice",
+]
 
 [[package]]
 name = "comfy-table"
@@ -2885,7 +3002,7 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "strength_reduce",
- "terminal_size",
+ "terminal_size 0.2.6",
  "tonic 0.10.2",
  "typetag",
  "unicode-segmentation",
@@ -3605,6 +3722,7 @@ dependencies = [
  "ordered-float 4.2.0",
  "parking_lot 0.12.1",
  "percent-encoding",
+ "prqlc",
  "regex",
  "roaring",
  "serde",
@@ -4126,6 +4244,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-grpc",
  "databend-common-management",
+ "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-kvapi",
  "databend-common-meta-store",
@@ -5408,6 +5527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5713,6 +5842,15 @@ checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
 dependencies = [
  "rustix 0.38.31",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7825,6 +7963,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7887,6 +8031,26 @@ dependencies = [
  "quick-xml 0.26.0",
  "rgb",
  "str_stack",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -8165,6 +8329,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac6ea8c376b6e208a81cf39b8e82bebf49652454d98a4829e907dac16ef1790"
 dependencies = [
  "typewit",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -8789,6 +8973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minijinja"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673d1ece89f7e166f43270800d78f9b1a9d21fda92dbcfa3b98b21213cdccbbc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9158,6 +9351,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ntapi"
@@ -10672,6 +10884,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "prqlc"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beb05b6b71ce096fa56d73006ab1c42a8d11bf190d193fa511a134f7730ec43"
+dependencies = [
+ "anstream",
+ "anyhow",
+ "ariadne",
+ "atty",
+ "chrono",
+ "clap 4.5.1",
+ "clap_complete",
+ "clap_complete_command",
+ "clio",
+ "color-eyre",
+ "colorchoice-clap",
+ "csv",
+ "enum-as-inner 0.6.0",
+ "env_logger",
+ "itertools 0.12.1",
+ "log",
+ "minijinja",
+ "notify",
+ "once_cell",
+ "prqlc-ast",
+ "prqlc-parser",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sqlformat",
+ "sqlparser",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
+ "walkdir",
+]
+
+[[package]]
+name = "prqlc-ast"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98923b046bc48046e3846b14a5fde5a059f681c7c367bd0ab96ebd3ecc33a71"
+dependencies = [
+ "anyhow",
+ "enum-as-inner 0.6.0",
+ "semver",
+ "serde",
+ "strum 0.26.2",
+]
+
+[[package]]
+name = "prqlc-parser"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "855ad9aba599ef608efc88a30ebd731155997d9bbe780639eb175de060b6cddc"
+dependencies = [
+ "chumsky",
+ "itertools 0.12.1",
+ "prqlc-ast",
+ "semver",
+ "stacker",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12080,6 +12366,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+dependencies = [
+ "indexmap 2.2.5",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serfig"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12421,6 +12720,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+dependencies = [
+ "itertools 0.12.1",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
 name = "sqllogictest"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12445,10 +12755,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95c4bae5aba7cd30bd506f7140026ade63cff5afd778af8854026f9606bf5d4"
+dependencies = [
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "state"
@@ -12541,6 +12874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros 0.26.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12558,6 +12900,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -12985,6 +13340,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix 0.37.27",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
@@ -13467,6 +13832,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13720,6 +14095,12 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -14227,6 +14608,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
 dependencies = [
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/src/meta/api/src/crud/errors.rs
+++ b/src/meta/api/src/crud/errors.rs
@@ -1,0 +1,81 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+
+use databend_common_exception::ErrorCode;
+use databend_common_meta_app::tenant_key::TenantResource;
+use databend_common_meta_app::tenant_key_errors::ExistError;
+use databend_common_meta_app::tenant_key_errors::UnknownError;
+use databend_common_meta_types::MetaError;
+
+/// CRUD Error that can be an API level error or a business error.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum CrudError<E>
+where E: Error + 'static
+{
+    #[error(transparent)]
+    ApiError(#[from] MetaError),
+
+    #[error(transparent)]
+    Business(E),
+}
+
+impl<E> CrudError<E>
+where E: Error + 'static
+{
+    pub fn is_business_error(&self) -> bool {
+        match self {
+            CrudError::ApiError(_e) => false,
+            CrudError::Business(_e) => true,
+        }
+    }
+
+    /// Convert the error into a layered result.
+    pub fn into_result(self) -> Result<Result<(), E>, MetaError> {
+        match self {
+            CrudError::ApiError(meta_err) => Err(meta_err),
+            CrudError::Business(e) => Ok(Err(e)),
+        }
+    }
+}
+
+impl<R> From<ExistError<R>> for CrudError<ExistError<R>>
+where R: TenantResource + 'static
+{
+    fn from(e: ExistError<R>) -> Self {
+        CrudError::Business(e)
+    }
+}
+
+impl<R> From<UnknownError<R>> for CrudError<UnknownError<R>>
+where R: TenantResource + 'static
+{
+    fn from(e: UnknownError<R>) -> Self {
+        CrudError::Business(e)
+    }
+}
+
+impl<E> From<CrudError<E>> for ErrorCode
+where
+    E: Into<ErrorCode>,
+    E: Error,
+{
+    fn from(value: CrudError<E>) -> Self {
+        match value {
+            CrudError::ApiError(meta_err) => meta_err.into(),
+            CrudError::Business(e) => e.into(),
+        }
+    }
+}

--- a/src/meta/api/src/crud/mod.rs
+++ b/src/meta/api/src/crud/mod.rs
@@ -14,6 +14,7 @@
 
 //! A generic CRUD interface for meta data operations.
 
+mod errors;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -21,6 +22,8 @@ use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_app::tenant_key::TIdent;
 use databend_common_meta_app::tenant_key::TenantResource;
+use databend_common_meta_app::tenant_key_errors::ExistError;
+use databend_common_meta_app::tenant_key_errors::UnknownError;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_kvapi::kvapi::ValueWithName;
@@ -29,8 +32,10 @@ use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::NonEmptyString;
 use databend_common_meta_types::SeqV;
+use databend_common_meta_types::SeqValue;
 use databend_common_meta_types::With;
 use databend_common_proto_conv::FromToProto;
+pub use errors::CrudError;
 use futures::TryStreamExt;
 
 use crate::kv_pb_api::KVPbApi;
@@ -76,8 +81,6 @@ type ValueOf<R> = <TIdent<R> as kvapi::Key>::ValueType;
 impl<R> CrudMgr<R>
 where
     R: TenantResource + Send + 'static,
-    R::UnknownError: From<MetaError>,
-    R::ExistError: From<MetaError>,
     // As a kvapi::Key, the corresponding value contains a name.
     ValueOf<R>: ValueWithName + FromToProto + Clone,
 {
@@ -87,7 +90,7 @@ where
         &self,
         value: ValueOf<R>,
         create_option: &CreateOption,
-    ) -> Result<(), R::ExistError> {
+    ) -> Result<(), CrudError<ExistError<R>>> {
         let ident = self.ident(value.name());
 
         let seq = MatchSeq::from(*create_option);
@@ -97,11 +100,7 @@ where
 
         if let CreateOption::Create = create_option {
             if res.prev.is_some() {
-                return Err(R::error_exist(
-                    &self.tenant,
-                    value.name(),
-                    || "Exist when add",
-                ));
+                return Err(ExistError::new(value.name(), "Exist when add").into());
             }
         }
 
@@ -114,7 +113,7 @@ where
         &self,
         value: ValueOf<R>,
         match_seq: MatchSeq,
-    ) -> Result<u64, R::UnknownError> {
+    ) -> Result<u64, CrudError<UnknownError<R>>> {
         let ident = self.ident(value.name());
         let upsert = UpsertPB::update(ident, value.clone()).with(match_seq);
 
@@ -122,24 +121,27 @@ where
 
         match res.result {
             Some(SeqV { seq, .. }) => Ok(seq),
-            None => Err(R::error_unknown(
-                &self.tenant,
-                value.name(),
-                || "NotFound when update",
-            )),
+            None => Err(UnknownError::new(value.name(), "NotFound when update").into()),
         }
     }
 
     #[async_backtrace::framed]
     #[minitrace::trace]
-    pub async fn remove(&self, name: &str, seq: MatchSeq) -> Result<(), R::UnknownError> {
+    pub async fn remove(
+        &self,
+        name: &str,
+        seq: MatchSeq,
+    ) -> Result<(), CrudError<UnknownError<R>>> {
         let ident = self.ident(name);
 
         let upsert = UpsertPB::delete(ident).with(seq);
 
         let res = self.kv_api.upsert_pb(&upsert).await?;
         res.removed_or_else(|e| {
-            R::error_unknown(&self.tenant, name, || format!("Exist when remove: {:?}", e))
+            UnknownError::new(
+                name,
+                format_args!("NotFound when remove, seq of existing record: {}", e.seq()),
+            )
         })?;
 
         Ok(())
@@ -151,17 +153,16 @@ where
         &self,
         name: &str,
         seq: MatchSeq,
-    ) -> Result<SeqV<ValueOf<R>>, R::UnknownError> {
+    ) -> Result<SeqV<ValueOf<R>>, CrudError<UnknownError<R>>> {
         let ident = self.ident(name);
 
         let res = self.kv_api.get_pb(&ident).await?;
 
-        let seq_value =
-            res.ok_or_else(|| R::error_unknown(&self.tenant, name, || "NotFound when get"))?;
+        let seq_value = res.ok_or_else(|| UnknownError::new(name, "NotFound when get"))?;
 
         match seq.match_seq(&seq_value) {
             Ok(_) => Ok(seq_value),
-            Err(e) => Err(R::error_unknown(&self.tenant, name, || e)),
+            Err(e) => Err(UnknownError::new(name, format_args!("NotFound when get: {}", e)).into()),
         }
     }
 

--- a/src/meta/app/src/lib.rs
+++ b/src/meta/app/src/lib.rs
@@ -31,6 +31,7 @@ pub mod share;
 pub mod storage;
 pub mod tenant;
 pub mod tenant_key;
+pub mod tenant_key_errors;
 
 mod key_with_tenant;
 pub use key_with_tenant::KeyWithTenant;

--- a/src/meta/app/src/principal/user_setting_ident.rs
+++ b/src/meta/app/src/principal/user_setting_ident.rs
@@ -18,38 +18,16 @@ use crate::tenant_key::TIdent;
 pub type SettingIdent = TIdent<kvapi_impl::Resource>;
 
 mod kvapi_impl {
-    use std::fmt::Display;
 
-    use databend_common_exception::ErrorCode;
     use databend_common_meta_kvapi::kvapi;
 
     use crate::principal::UserSetting;
-    use crate::tenant::Tenant;
     use crate::tenant_key::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {
         const PREFIX: &'static str = "__fd_settings";
         type ValueType = UserSetting;
-        type UnknownError = ErrorCode;
-
-        fn error_unknown<D: Display>(
-            _tenant: &Tenant,
-            _name: &str,
-            _ctx: impl FnOnce() -> D,
-        ) -> Self::UnknownError {
-            todo!()
-        }
-
-        type ExistError = ErrorCode;
-
-        fn error_exist<D: Display>(
-            _tenant: &Tenant,
-            _name: &str,
-            _ctx: impl FnOnce() -> D,
-        ) -> Self::ExistError {
-            todo!()
-        }
     }
 
     impl kvapi::Value for UserSetting {

--- a/src/meta/app/src/principal/user_stage_ident.rs
+++ b/src/meta/app/src/principal/user_stage_ident.rs
@@ -18,39 +18,16 @@ use crate::tenant_key::TIdent;
 pub type StageIdent = TIdent<kvapi_impl::Resource>;
 
 mod kvapi_impl {
-    use std::fmt::Display;
 
-    use databend_common_exception::ErrorCode;
     use databend_common_meta_kvapi::kvapi;
 
     use crate::principal::StageInfo;
-    use crate::tenant::Tenant;
     use crate::tenant_key::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {
         const PREFIX: &'static str = "__fd_stages";
         type ValueType = StageInfo;
-
-        type UnknownError = ErrorCode;
-
-        fn error_unknown<D: Display>(
-            _tenant: &Tenant,
-            _name: &str,
-            _ctx: impl FnOnce() -> D,
-        ) -> Self::UnknownError {
-            todo!()
-        }
-
-        type ExistError = ErrorCode;
-
-        fn error_exist<D: Display>(
-            _tenant: &Tenant,
-            _name: &str,
-            _ctx: impl FnOnce() -> D,
-        ) -> Self::ExistError {
-            todo!()
-        }
     }
 
     impl kvapi::Value for StageInfo {

--- a/src/meta/app/src/tenant_key.rs
+++ b/src/meta/app/src/tenant_key.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::fmt::Debug;
-use std::fmt::Display;
-use std::fmt::Formatter;
 use std::hash::Hash;
 use std::hash::Hasher;
 
@@ -33,30 +32,6 @@ pub trait TenantResource {
 
     /// The type of the value for the key [`TIdent<R: TenantResource>`](TIdent).
     type ValueType: kvapi::Value;
-
-    /// The error to return when the value is not found for a key.
-    type UnknownError: std::error::Error + Send + 'static;
-
-    /// Make an error when the value is not found for a key.
-    ///
-    /// Additional context can be provided by `ctx`.
-    fn error_unknown<D: Display>(
-        tenant: &Tenant,
-        name: &str,
-        ctx: impl FnOnce() -> D,
-    ) -> Self::UnknownError;
-
-    /// The error to return when the value already exists.
-    type ExistError: std::error::Error + Send + 'static;
-
-    /// Make an error when the value already exists.
-    ///
-    /// Additional context can be provided by `ctx`.
-    fn error_exist<D: Display>(
-        tenant: &Tenant,
-        name: &str,
-        ctx: impl FnOnce() -> D,
-    ) -> Self::ExistError;
 }
 
 /// `[T]enant[Ident]` is a common meta-service key structure in form of `<PREFIX>/<TENANT>/<NAME>`.
@@ -68,7 +43,7 @@ pub struct TIdent<R> {
 
 /// `TIdent` to be Debug does not require `R` to be Debug.
 impl<R> Debug for TIdent<R> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TenantResourceIdent")
             .field("tenant", &self.tenant)
             .field("name", &self.name)
@@ -162,7 +137,6 @@ mod kvapi_key_impl {
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
-    use std::fmt::Display;
 
     use databend_common_meta_kvapi::kvapi::Key;
 
@@ -177,26 +151,6 @@ mod tests {
         impl TenantResource for Foo {
             const PREFIX: &'static str = "foo";
             type ValueType = Infallible;
-
-            type UnknownError = std::io::Error;
-
-            fn error_unknown<D: Display>(
-                _tenant: &Tenant,
-                _name: &str,
-                _ctx: impl FnOnce() -> D,
-            ) -> Self::UnknownError {
-                todo!()
-            }
-
-            type ExistError = std::io::Error;
-
-            fn error_exist<D: Display>(
-                _tenant: &Tenant,
-                _name: &str,
-                _ctx: impl FnOnce() -> D,
-            ) -> Self::ExistError {
-                todo!()
-            }
         }
 
         let tenant = Tenant::new("test".to_string());

--- a/src/meta/app/src/tenant_key_errors.rs
+++ b/src/meta/app/src/tenant_key_errors.rs
@@ -1,0 +1,135 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::fmt::Formatter;
+
+use crate::tenant_key::TenantResource;
+
+/// Error occurred when a record already exists for a key.
+#[derive(Clone, PartialEq, Eq, thiserror::Error)]
+pub struct ExistError<R> {
+    name: String,
+    ctx: String,
+    _p: std::marker::PhantomData<R>,
+}
+
+impl<R> ExistError<R> {
+    pub fn new(name: impl ToString, ctx: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            ctx: ctx.to_string(),
+            _p: Default::default(),
+        }
+    }
+}
+
+impl<R> fmt::Debug for ExistError<R>
+where R: TenantResource
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let typ = type_name::<R>();
+
+        f.debug_struct("ExistError")
+            .field("type", &typ)
+            .field("name", &self.name)
+            .field("ctx", &self.ctx)
+            .finish()
+    }
+}
+
+impl<R> fmt::Display for ExistError<R>
+where R: TenantResource
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let typ = type_name::<R>();
+        write!(f, "{typ} '{}' already exists: {}", self.name, self.ctx)
+    }
+}
+
+/// Error occurred when a record not found for a key.
+#[derive(Clone, PartialEq, Eq, thiserror::Error)]
+pub struct UnknownError<R> {
+    name: String,
+    ctx: String,
+    _p: std::marker::PhantomData<R>,
+}
+
+impl<R> UnknownError<R> {
+    pub fn new(name: impl ToString, ctx: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            ctx: ctx.to_string(),
+            _p: Default::default(),
+        }
+    }
+}
+
+impl<R> fmt::Debug for UnknownError<R>
+where R: TenantResource
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let typ = type_name::<R>();
+
+        f.debug_struct("UnknownError")
+            .field("type", &typ)
+            .field("name", &self.name)
+            .field("ctx", &self.ctx)
+            .finish()
+    }
+}
+
+impl<R> fmt::Display for UnknownError<R>
+where R: TenantResource
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let typ = type_name::<R>();
+        write!(f, "Unknown {typ} '{}': {}", self.name, self.ctx)
+    }
+}
+
+fn type_name<R: TenantResource>() -> &'static str {
+    let full_name = std::any::type_name::<R::ValueType>();
+    let mut segs = full_name.rsplitn(2, "::");
+    segs.next().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::principal::network_policy_ident;
+
+    #[test]
+    fn test_exist_error() {
+        let err = super::ExistError::<network_policy_ident::Resource> {
+            name: "foo".to_string(),
+            ctx: "bar".to_string(),
+            _p: Default::default(),
+        };
+
+        let got = err.to_string();
+        assert_eq!(got, "NetworkPolicy 'foo' already exists: bar")
+    }
+
+    #[test]
+    fn test_unknown_error() {
+        let err = super::UnknownError::<network_policy_ident::Resource> {
+            name: "foo".to_string(),
+            ctx: "bar".to_string(),
+            _p: Default::default(),
+        };
+
+        let got = err.to_string();
+        assert_eq!(got, "Unknown NetworkPolicy 'foo': bar")
+    }
+}

--- a/src/query/users/Cargo.toml
+++ b/src/query/users/Cargo.toml
@@ -20,6 +20,7 @@ databend-common-base = { path = "../../common/base" }
 databend-common-exception = { path = "../../common/exception" }
 databend-common-grpc = { path = "../../common/grpc" }
 databend-common-management = { path = "../management" }
+databend-common-meta-api = { path = "../../meta/api" }
 databend-common-meta-app = { path = "../../meta/app" }
 databend-common-meta-kvapi = { path = "../../meta/kvapi" }
 databend-common-meta-store = { path = "../../meta/store" }

--- a/src/query/users/src/password_policy.rs
+++ b/src/query/users/src/password_policy.rs
@@ -19,6 +19,7 @@ use chrono::Utc;
 use databend_common_ast::ast::AuthOption;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_meta_api::crud::CrudError;
 use databend_common_meta_app::principal::AuthInfo;
 use databend_common_meta_app::principal::PasswordPolicy;
 use databend_common_meta_app::principal::UserIdentity;
@@ -71,7 +72,8 @@ impl UserApiProvider {
         check_password_policy(&password_policy)?;
 
         let client = self.password_policy_api(tenant);
-        client.add(password_policy, create_option).await
+        client.add(password_policy, create_option).await?;
+        Ok(())
     }
 
     // Update password policy.
@@ -98,13 +100,20 @@ impl UserApiProvider {
         let client = self.password_policy_api(tenant);
         let seq_password_policy = match client.get(name, MatchSeq::GE(0)).await {
             Ok(seq_password_policy) => seq_password_policy,
-            Err(e) => {
-                if if_exists && e.code() == ErrorCode::UNKNOWN_PASSWORD_POLICY {
-                    return Ok(None);
-                } else {
-                    return Err(e.add_message_back(" (while alter password policy)"));
+            Err(e) => match e {
+                CrudError::ApiError(meta_err) => {
+                    return Err(ErrorCode::from(meta_err)
+                        .add_message_back(" (while alter password policy)"));
                 }
-            }
+                CrudError::Business(unknown) => {
+                    if if_exists {
+                        return Ok(None);
+                    } else {
+                        return Err(ErrorCode::from(unknown)
+                            .add_message_back(" (while alter password policy)"));
+                    }
+                }
+            },
         };
 
         let seq = seq_password_policy.seq;
@@ -151,7 +160,7 @@ impl UserApiProvider {
 
         match client.update(password_policy, MatchSeq::Exact(seq)).await {
             Ok(res) => Ok(Some(res)),
-            Err(e) => Err(e.add_message_back(" (while alter password policy).")),
+            Err(e) => Err(ErrorCode::from(e).add_message_back(" (while alter password policy).")),
         }
     }
 
@@ -178,13 +187,21 @@ impl UserApiProvider {
         let client = self.password_policy_api(tenant);
         match client.remove(name, MatchSeq::GE(1)).await {
             Ok(res) => Ok(res),
-            Err(e) => {
-                if if_exists && e.code() == ErrorCode::UNKNOWN_PASSWORD_POLICY {
-                    Ok(())
-                } else {
-                    Err(e.add_message_back(" (while drop password policy)"))
+            Err(e) => match e {
+                CrudError::ApiError(meta_err) => {
+                    return Err(
+                        ErrorCode::from(meta_err).add_message_back(" (while drop password policy)")
+                    );
                 }
-            }
+                CrudError::Business(unknown) => {
+                    if if_exists {
+                        return Ok(());
+                    } else {
+                        return Err(ErrorCode::from(unknown)
+                            .add_message_back(" (while drop password policy)"));
+                    }
+                }
+            },
         }
     }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Add ExistError and UnknownError, TenantResource does not need to define error type any more

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring


## Related Issues