### PR TITLE
chore: tweak deletion batch size & log messages

### DIFF
--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Instant;
 
 use chrono_tz::Tz;
 use databend_common_ast::ast::format_statement;
@@ -34,6 +35,7 @@ use databend_common_expression::Expr;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::principal::StageFileFormatType;
 use indexmap::IndexMap;
+use log::info;
 use log::warn;
 
 use super::Finder;
@@ -129,10 +131,12 @@ impl<'a> Binder {
     #[async_backtrace::framed]
     #[minitrace::trace]
     pub async fn bind(mut self, stmt: &Statement) -> Result<Plan> {
+        let start = Instant::now();
         self.ctx.set_status_info("binding");
         let mut init_bind_context = BindContext::new();
         let plan = self.bind_statement(&mut init_bind_context, stmt).await?;
         self.bind_query_index(&mut init_bind_context, &plan).await?;
+        info!("bind stmt to plan, time used: {:?}", start.elapsed());
         Ok(plan)
     }
 

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::Literal;
@@ -68,6 +69,7 @@ impl Planner {
     #[async_backtrace::framed]
     #[minitrace::trace]
     pub async fn plan_sql(&mut self, sql: &str) -> Result<(Plan, PlanExtras)> {
+        let start = Instant::now();
         let settings = self.ctx.get_settings();
         let sql_dialect = settings.get_sql_dialect()?;
         // compile prql to sql for prql dialect
@@ -205,6 +207,7 @@ impl Planner {
                     tokens.extend(iter);
                 };
             } else {
+                info!("logical plan built, time used: {:?}", start.elapsed());
                 return res;
             }
         }

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -588,8 +588,7 @@ impl FuseTable {
         locations_to_be_purged: HashSet<String>,
     ) -> Result<()> {
         let fuse_file = Files::create(ctx.clone(), self.operator.clone());
-        let locations = Vec::from_iter(locations_to_be_purged);
-        fuse_file.remove_file_in_batch(&locations).await
+        fuse_file.remove_file_in_batch(locations_to_be_purged).await
     }
 
     // Purge file by location chunks.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- tweak the batch size used in `remove_file_in_batch`
Instead of setting a fixed batch size of 1000 for file deletion, adjust the batch size based on the `max_threads` setting to allow for more parallel deletion of files, i.e. take "(number of files) / max_threads" as the size of batch. 

In latency-sensitive scenarios, adjusting the  batch size of object storage file deletion, may improve performance significantly:


before this PR (with customized log)

_ec2 query node + s3 in the same region_

~~~
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 80, time used 774.073632ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 60, time used 648.507035ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 20, time used 264.455804ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 40, time used 510.963558ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 20, time used 273.607883ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 20, time used 266.098798ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 20, time used 294.253539ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 33, time used 426.443657ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 27, time used 406.260959ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 20, time used 274.669911ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 20, time used 341.166744ms
src/query/storages/fuse/src/io/files.rs:85 deleted files, # of files 37, time used 488.287495ms
~~~

with this PR:

~~~
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 80 files in 200.192256ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 29 files in 88.241821ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 31 files in 111.350945ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 20 files in 74.052776ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 18 files in 67.15381ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 12 files in 38.340867ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 10 files in 55.873557ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 20 files in 58.602681ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 19 files in 58.248392ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 3 files in 55.438356ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 18 files in 71.469202ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 20 files in 65.742636ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 16 files in 49.608766ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 4 files in 35.568428ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 20 files in 72.753463ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 20 files in 74.300976ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 18 files in 78.302705ms
src/query/service/src/pipelines/builders/builder_on_finished.rs:126 purge 13 files in 115.849776ms
~~~

- logs(info level) the time used in logical plan and binding phase

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):
