### PR TITLE
chore: max_running_queries from 8 to 0, disable the max running queries

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -87,7 +87,7 @@ const CATALOG_HIVE: &str = "hive";
 /// Only adding new fields is allowed.
 /// This same rules should be applied to all fields of this struct.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Parser)]
-#[clap(name = "databend-query", about, version = &**DATABEND_COMMIT_VERSION, author)]
+#[clap(name = "databend-query", about, version = & * * DATABEND_COMMIT_VERSION, author)]
 #[serde(default)]
 pub struct Config {
     /// Run a command and quit
@@ -1399,14 +1399,14 @@ pub struct QueryConfig {
     #[clap(long, value_name = "VALUE", default_value = "256")]
     pub max_active_sessions: u64,
 
-    #[clap(long, value_name = "VALUE", default_value = "8")]
+    #[clap(long, value_name = "VALUE", default_value = "0")]
     pub max_running_queries: u64,
 
     /// The max total memory in bytes that can be used by this process.
     #[clap(long, value_name = "VALUE", default_value = "0")]
     pub max_server_memory_usage: u64,
 
-    #[clap(long,  value_name = "VALUE",value_parser = clap::value_parser!(bool), default_value = "false")]
+    #[clap(long, value_name = "VALUE", value_parser = clap::value_parser!(bool), default_value = "false")]
     pub max_memory_limit_enabled: bool,
 
     #[deprecated(note = "clickhouse tcp support is deprecated")]
@@ -1490,7 +1490,7 @@ pub struct QueryConfig {
     pub rpc_client_timeout_secs: u64,
 
     /// Table engine memory enabled
-    #[clap(long,  value_name = "VALUE",value_parser = clap::value_parser!(bool), default_value = "true")]
+    #[clap(long, value_name = "VALUE", value_parser = clap::value_parser!(bool), default_value = "true")]
     pub table_engine_memory_enabled: bool,
 
     #[clap(long, value_name = "VALUE", default_value = "5000")]

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -247,7 +247,7 @@ impl Default for QueryConfig {
             mysql_tls_server_cert: "".to_string(),
             mysql_tls_server_key: "".to_string(),
             max_active_sessions: 256,
-            max_running_queries: 8,
+            max_running_queries: 0,
             max_server_memory_usage: 0,
             max_memory_limit_enabled: false,
             clickhouse_http_handler_host: "127.0.0.1".to_string(),

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -99,7 +99,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | 'query'   | 'max_active_sessions'                      | '256'                                                          | ''       |
 | 'query'   | 'max_memory_limit_enabled'                 | 'false'                                                        | ''       |
 | 'query'   | 'max_query_log_size'                       | '10000'                                                        | ''       |
-| 'query'   | 'max_running_queries'                      | '8'                                                            | ''       |
+| 'query'   | 'max_running_queries'                      | '0'                                                            | ''       |
 | 'query'   | 'max_server_memory_usage'                  | '0'                                                            | ''       |
 | 'query'   | 'max_storage_io_requests'                  | 'null'                                                         | ''       |
 | 'query'   | 'metric_api_address'                       | '127.0.0.1:7070'                                               | ''       |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* Change the config `max_running_queries` from `8` to `0`, disabled by default.
* Some codes are formatted by `make fmt`

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): disable the config by default
