### PR TITLE
chore: default enable aggregate/sort/join spill

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -273,7 +273,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
                 ("join_spilling_memory_ratio", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
+                    value: UserSettingValue::UInt64(60),
                     desc: "Sets the maximum memory ratio in bytes that hash join can use before spilling data to storage during query execution, 0 is unlimited",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=100)),
@@ -412,7 +412,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
                 ("aggregate_spilling_memory_ratio", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
+                    value: UserSettingValue::UInt64(60),
                     desc: "Sets the maximum memory ratio in bytes that an aggregator can use before spilling data to storage during query execution.",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=100)),
@@ -424,7 +424,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
                 ("sort_spilling_memory_ratio", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
+                    value: UserSettingValue::UInt64(60),
                     desc: "Sets the maximum memory ratio in bytes that a sorter can use before spilling data to storage during query execution.",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=100)),

--- a/tests/sqllogictests/suites/mode/standalone/explain/sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/sort.test
@@ -67,6 +67,8 @@ Sort
 statement ok
 set max_threads = 4;
 
+statement ok
+set sort_spilling_memory_ratio = 0;
 
 # Sort without pre-projection
 query T
@@ -81,6 +83,25 @@ CompoundBlockOperator(Project) × 1 processor
             SyncReadParquetDataSource × 1 processor
 
 
+# Sort spilling
+statement ok
+set sort_spilling_memory_ratio = 60;
+
+query T
+explain pipeline select a, b from t1 order by a;
+----
+CompoundBlockOperator(Project) × 1 processor
+  Merge (TransformSortSpill × 4 processors) to (CompoundBlockOperator(Project) × 1)
+    TransformSortSpill × 4 processors
+      TransformSortMerge × 4 processors
+        SortPartialTransform × 4 processors
+          Merge (DeserializeDataTransform × 1 processor) to (SortPartialTransform × 4)
+            DeserializeDataTransform × 1 processor
+              SyncReadParquetDataSource × 1 processor
+
+statement ok
+set sort_spilling_memory_ratio = 0;
+
 # Sort with pre-projection
 query T
 explain pipeline select a + 1, b from t1 order by a + 1;
@@ -94,6 +115,23 @@ CompoundBlockOperator(Project) × 1 processor
             DeserializeDataTransform × 1 processor
               SyncReadParquetDataSource × 1 processor
 
+
+# Sort spilling
+statement ok
+set sort_spilling_memory_ratio = 60;
+
+query T
+explain pipeline select a + 1, b from t1 order by a + 1;
+----
+CompoundBlockOperator(Project) × 1 processor
+  Merge (TransformSortSpill × 4 processors) to (CompoundBlockOperator(Project) × 1)
+    TransformSortSpill × 4 processors
+      TransformSortMerge × 4 processors
+        SortPartialTransform × 4 processors
+          Merge (CompoundBlockOperator(Map) × 1 processor) to (SortPartialTransform × 4)
+            CompoundBlockOperator(Map) × 1 processor
+              DeserializeDataTransform × 1 processor
+                SyncReadParquetDataSource × 1 processor
 
 statement ok
 drop table if exists t1;

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -36,6 +36,10 @@ Sort
 statement ok
 set max_threads=4;
 
+# Disable sort spilling
+statement ok
+set sort_spilling_memory_ratio = 0;
+
 query T
 explain pipeline SELECT depname, empno, salary, sum(salary) OVER (PARTITION BY depname ORDER BY empno) FROM empsalary ORDER BY depname, empno;
 ----
@@ -51,6 +55,30 @@ CompoundBlockOperator(Project) × 1 processor
                   Merge (DeserializeDataTransform × 1 processor) to (SortPartialTransform × 4)
                     DeserializeDataTransform × 1 processor
                       SyncReadParquetDataSource × 1 processor
+
+
+# Enable sort spilling
+statement ok
+set sort_spilling_memory_ratio = 60;
+
+query T
+explain pipeline SELECT depname, empno, salary, sum(salary) OVER (PARTITION BY depname ORDER BY empno) FROM empsalary ORDER BY depname, empno;
+----
+CompoundBlockOperator(Project) × 1 processor
+  Merge (TransformSortSpill × 4 processors) to (CompoundBlockOperator(Project) × 1)
+    TransformSortSpill × 4 processors
+      TransformSortMerge × 4 processors
+        SortPartialTransform × 4 processors
+          Merge (Transform Window × 1 processor) to (SortPartialTransform × 4)
+            Transform Window × 1 processor
+              Merge (TransformSortSpill × 4 processors) to (Transform Window × 1)
+                TransformSortSpill × 4 processors
+                  TransformSortMerge × 4 processors
+                    SortPartialTransform × 4 processors
+                      Merge (DeserializeDataTransform × 1 processor) to (SortPartialTransform × 4)
+                        DeserializeDataTransform × 1 processor
+                          SyncReadParquetDataSource × 1 processor
+
 
 statement ok
 DROP TABLE IF EXISTS Test
@@ -292,6 +320,11 @@ drop table if exists t
 statement ok
 create table t (a int, b int, c string, d int, e int, f string)
 
+
+# Disable sort spilling
+statement ok
+set sort_spilling_memory_ratio = 0;
+
 # range frame (can not push down limit)
 query T
 explain pipeline select a, sum(a) over (partition by a order by a desc) from t limit 3
@@ -305,6 +338,30 @@ CompoundBlockOperator(Project) × 1 processor
             Merge (DeserializeDataTransform × 1 processor) to (SortPartialTransform × 4)
               DeserializeDataTransform × 1 processor
                 SyncReadParquetDataSource × 1 processor
+
+# Enable sort spilling
+statement ok
+set sort_spilling_memory_ratio = 60;
+
+# range frame (can not push down limit)
+query T
+explain pipeline select a, sum(a) over (partition by a order by a desc) from t limit 3
+----
+CompoundBlockOperator(Project) × 1 processor
+  LimitTransform × 1 processor
+   Transform Window × 1 processor
+     Merge (TransformSortSpill × 4 processors) to (Transform Window × 1)
+       TransformSortSpill × 4 processors
+         TransformSortMerge × 4 processors
+           SortPartialTransform × 4 processors
+             Merge (DeserializeDataTransform × 1 processor) to (SortPartialTransform × 4)
+               DeserializeDataTransform × 1 processor
+                 SyncReadParquetDataSource × 1 processor
+
+
+# Disable sort spilling
+statement ok
+set sort_spilling_memory_ratio = 0;
 
 # range frame with ranking function (can push down limit)
 query T


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR default enable spill in the settings:
1. `join_spilling_memory_ratio=60`
2. `aggregate_spilling_memory_ratio=60`
3. `sort_spilling_memory_ratio=60`
4. Add test for the spill enabled https://github.com/datafuselabs/databend/pull/15038/commits/e9b5f2e42553924646cdab029e1a493aa1fcfdd1

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - Exists Tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
