### PR TITLE
chore: disable table locking in ut `delete.test`

### DIFF
--- a/tests/sqllogictests/suites/crdb/delete.test
+++ b/tests/sqllogictests/suites/crdb/delete.test
@@ -1,3 +1,9 @@
+
+# Disables table lock, so that we can avoid the flakiness introduced
+# by "nondeterministic" locking timeout during unit testing.
+statement ok
+set enable_table_lock = 0;
+
 statement ok
 drop table if exists kv
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Disables table lock in the ut `delete.test`, so that we can avoid the flakiness introduced by "nondeterministic" locking timeout.



- Fixes #15050

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - "use existing test`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
