### PR TITLE
fix: trim leading '/'s for files specified in copy opt

### DIFF
--- a/src/common/storage/src/stage.rs
+++ b/src/common/storage/src/stage.rs
@@ -121,6 +121,7 @@ impl StageFilesInfo {
                 let full_path = Path::new(&self.path)
                     .join(file)
                     .to_string_lossy()
+                    .trim_start_matches('/')
                     .to_string();
                 let meta = operator.stat(&full_path).await?;
                 if meta.mode().is_file() {
@@ -177,6 +178,7 @@ impl StageFilesInfo {
                 let full_path = Path::new(&self.path)
                     .join(file)
                     .to_string_lossy()
+                    .trim_start_matches('/')
                     .to_string();
                 let meta = operator.blocking().stat(&full_path)?;
                 if meta.mode().is_file() {

--- a/tests/suites/1_stateful/00_stage/00_0002_copy_purge.result
+++ b/tests/suites/1_stateful/00_stage/00_0002_copy_purge.result
@@ -12,7 +12,7 @@ i0.csv	2	0	NULL	NULL
 2	2
 >>>> truncate table ii
 >>>> copy into ii from @s_ii file_format = (type = CSV) files = ('i1.csv') purge = true
-/i1.csv	2	0	NULL	NULL
+i1.csv	2	0	NULL	NULL
 <<<<
 >>>> list @s_ii
 <<<<

--- a/tests/suites/1_stateful/00_stage/00_0002_copy_purge_issue_15039.result
+++ b/tests/suites/1_stateful/00_stage/00_0002_copy_purge_issue_15039.result
@@ -1,0 +1,22 @@
+>>>> drop table if exists ii
+>>>> create table ii(a int, b int)
+>>>> drop stage if exists s_ii
+>>>> create stage s_ii url='fs:///tmp/00_0002_issue_15039/';
+>>>> copy into ii from @s_ii file_format = (type = CSV) purge = true
+i0.csv	2	0	NULL	NULL
+<<<<
+>>>> list @s_ii
+<<<<
+>>>> select * from ii
+1	1
+2	2
+>>>> copy into ii from @s_ii file_format = (type = CSV) files = ('i0.csv') purge = true
+<<<<
+>>>>
+i0.csv
+<<<<
+>>>> select * from ii
+1	1
+2	2
+>>>> drop table if exists ii
+>>>> drop stage if exists s_ii

--- a/tests/suites/1_stateful/00_stage/00_0002_copy_purge_issue_15039.sh
+++ b/tests/suites/1_stateful/00_stage/00_0002_copy_purge_issue_15039.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+# https://github.com/datafuselabs/databend/issues/15039
+
+rm -rf /tmp/00_0002_issue_15039
+mkdir -p /tmp/00_0002_issue_15039
+cat << EOF > /tmp/00_0002_issue_15039/i0.csv
+1,1
+2,2
+EOF
+
+stmt "drop table if exists ii"
+stmt "create table ii(a int, b int)"
+
+stmt "drop stage if exists s_ii"
+stmt "create stage s_ii url='fs:///tmp/00_0002_issue_15039/';"
+
+query "copy into ii from @s_ii file_format = (type = CSV) purge = true"
+
+query "list @s_ii"
+
+stmt "select * from ii"
+
+# put file i0 into the stage again
+cat << EOF > /tmp/00_0002_issue_15039/i0.csv
+1,1
+2,2
+EOF
+
+# since purge_duplicated_files_in_copy is disabled by default, the file i0 should be listed
+# but data of i0 should not be copied into table ii
+
+query "copy into ii from @s_ii file_format = (type = CSV) files = ('i0.csv') purge = true"
+
+query "list @s_ii" | awk '{print $1}'
+
+stmt "select * from ii"
+
+stmt "drop table if exists ii"
+stmt "drop stage if exists s_ii"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


This PR introduces a modification to the handling of file paths in COPY INTO table statements. Specifically, when using statements like (files are explicitly specified by copy-option `files`):

~~~
copy into t from  @ts file_format = (type = CSV) files =('///a.csv') purge = true force = false;
~~~
The leading slashes in the file path (e.g., `///a.csv`) will now be trimmed before the file names are stored in the meta server (in this case `a.csv`). This change aligns with the behavior observed when using COPY INTO table statements that copy data from a location without specifying individual file names, such as:
~~~
copy into t from  @ts file_format = (type = CSV)  purge = true force = false;
~~~

With this update, the file names recorded in the meta server will be consistent across different COPY INTO usage patterns, ensuring uniformity when the same files are copied.


- Fixes #15039

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
