### PR TITLE
chore: use Tenant::new_literal() and new_nonempty() to avoid creating empty Tenant

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -126,6 +126,7 @@ use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
+use databend_common_meta_types::NonEmptyString;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::UpsertKV;
 use log::debug;
@@ -3605,7 +3606,7 @@ impl SchemaApiTestSuite {
         mt: &MT,
     ) -> anyhow::Result<()> {
         let tenant_name = "db_table_gc_out_of_retention_time";
-        let tenant = Tenant::new(tenant_name);
+        let tenant = Tenant::new_nonempty(NonEmptyString::new(tenant_name).unwrap());
         let db1_name = "db1";
         let tb1_name = "tb1";
         let idx1_name = "idx1";
@@ -5914,7 +5915,7 @@ impl SchemaApiTestSuite {
     async fn index_create_list_drop<MT>(&self, mt: &MT) -> anyhow::Result<()>
     where MT: SchemaApi + kvapi::AsKVApi<Error = MetaError> {
         let tenant_name = "tenant1";
-        let tenant = Tenant::new(tenant_name);
+        let tenant = Tenant::new_nonempty(NonEmptyString::new(tenant_name).unwrap());
 
         let mut util = Util::new(mt, tenant_name, "db1", "tb1", "eng1");
         let table_id;

--- a/src/meta/app/src/background/background_job.rs
+++ b/src/meta/app/src/background/background_job.rs
@@ -182,7 +182,7 @@ impl BackgroundJobStatus {
     }
 }
 
-// Ident
+// Serde is required by `BackgroundTaskInfo.creator`
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct BackgroundJobIdent {
     // The user this job belongs to

--- a/src/meta/app/src/background/background_task.rs
+++ b/src/meta/app/src/background/background_task.rs
@@ -109,6 +109,7 @@ impl Display for VacuumStats {
     }
 }
 
+// Serde is required by `ListBackgroundTasksResponse.task_infos`
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct BackgroundTaskInfo {
     pub last_updated: Option<DateTime<Utc>>,

--- a/src/meta/app/src/principal/connection_ident.rs
+++ b/src/meta/app/src/principal/connection_ident.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_connection_ident() {
-        let tenant = Tenant::new("test".to_string());
+        let tenant = Tenant::new_literal("test");
         let ident = ConnectionIdent::new(tenant, "test1");
 
         let key = ident.to_string_key();

--- a/src/meta/app/src/principal/network_policy_ident.rs
+++ b/src/meta/app/src/principal/network_policy_ident.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_network_policy_ident() {
-        let tenant = Tenant::new("test".to_string());
+        let tenant = Tenant::new_literal("test");
         let ident = NetworkPolicyIdent::new(tenant, "test1");
 
         let key = ident.to_string_key();

--- a/src/meta/app/src/principal/password_policy_ident.rs
+++ b/src/meta/app/src/principal/password_policy_ident.rs
@@ -69,7 +69,7 @@ mod tests {
     use crate::tenant::Tenant;
     #[test]
     fn test_password_policy_ident() {
-        let tenant = Tenant::new("test");
+        let tenant = Tenant::new_literal("test");
         let ident = PasswordPolicyIdent::new(tenant.clone(), "test2");
 
         assert_eq!(ident.to_string_key(), "__fd_password_policies/test/test2");

--- a/src/meta/app/src/principal/role_ident.rs
+++ b/src/meta/app/src/principal/role_ident.rs
@@ -59,11 +59,11 @@ mod kvapi_key_impl {
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
             let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-            let tenant = p.next_str()?;
+            let tenant = p.next_nonempty()?;
             let role_name = p.next_str()?;
             p.done()?;
 
-            Ok(RoleIdent::new(Tenant::new(tenant), role_name))
+            Ok(RoleIdent::new(Tenant::new_nonempty(tenant), role_name))
         }
     }
 
@@ -90,13 +90,13 @@ mod tests {
 
     #[test]
     fn test_role_ident_tenant_prefix() {
-        let r = RoleIdent::new(Tenant::new("tenant"), "role");
+        let r = RoleIdent::new(Tenant::new_literal("tenant"), "role");
         assert_eq!("__fd_roles/tenant/", r.tenant_prefix());
     }
 
     #[test]
     fn test_role_ident_key() {
-        let r = RoleIdent::new(Tenant::new("tenant"), "role");
+        let r = RoleIdent::new(Tenant::new_literal("tenant"), "role");
         assert_eq!("__fd_roles/tenant/role", r.to_string_key());
         assert_eq!(Ok(r), RoleIdent::from_str_key("__fd_roles/tenant/role"));
     }

--- a/src/meta/app/src/principal/user_defined_file_format_ident.rs
+++ b/src/meta/app/src/principal/user_defined_file_format_ident.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_file_format_ident() {
-        let tenant = Tenant::new("test".to_string());
+        let tenant = Tenant::new_literal("test");
         let ident = UserDefinedFileFormatIdent::new(tenant, "test1");
 
         let key = ident.to_string_key();

--- a/src/meta/app/src/principal/user_grant.rs
+++ b/src/meta/app/src/principal/user_grant.rs
@@ -494,12 +494,12 @@ mod kvapi_key_impl {
         fn from_str_key(s: &str) -> Result<Self, KeyError> {
             let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
 
-            let tenant = p.next_str()?;
+            let tenant = p.next_nonempty()?;
             let subject = OwnershipObject::parse_key(&mut p)?;
             p.done()?;
 
             Ok(TenantOwnershipObject {
-                tenant: Tenant::new(tenant),
+                tenant: Tenant::new_nonempty(tenant),
                 object: subject,
             })
         }
@@ -529,10 +529,11 @@ mod tests {
 
     #[test]
     fn test_tenant_ownership_object_tenant_prefix() {
-        let r = TenantOwnershipObject::new(Tenant::new("tenant"), OwnershipObject::Database {
-            catalog_name: "cat".to_string(),
-            db_id: 1,
-        });
+        let r =
+            TenantOwnershipObject::new(Tenant::new_literal("tenant"), OwnershipObject::Database {
+                catalog_name: "cat".to_string(),
+                db_id: 1,
+            });
 
         assert_eq!("__fd_object_owners/tenant/", r.tenant_prefix());
     }
@@ -542,7 +543,7 @@ mod tests {
         // db with default catalog
         {
             let role_grantee = TenantOwnershipObject::new_unchecked(
-                Tenant::new("test"),
+                Tenant::new_literal("test"),
                 OwnershipObject::Database {
                     catalog_name: "default".to_string(),
                     db_id: 1,
@@ -559,7 +560,7 @@ mod tests {
         // db with catalog
         {
             let role_grantee = TenantOwnershipObject::new_unchecked(
-                Tenant::new("test"),
+                Tenant::new_literal("test"),
                 OwnershipObject::Database {
                     catalog_name: "cata/foo".to_string(),
                     db_id: 1,
@@ -578,35 +579,42 @@ mod tests {
 
         // table with default catalog
         {
-            let obj =
-                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Table {
+            let obj = TenantOwnershipObject::new_unchecked(
+                Tenant::new_literal("test"),
+                OwnershipObject::Table {
                     catalog_name: "default".to_string(),
                     db_id: 1,
                     table_id: 2,
-                });
+                },
+            );
 
             let key = obj.to_string_key();
             assert_eq!("__fd_object_owners/test/table-by-id/2", key);
 
             let parsed = TenantOwnershipObject::from_str_key(&key).unwrap();
             assert_eq!(
-                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Table {
-                    catalog_name: "default".to_string(),
-                    db_id: 0, // db_id is not encoded into key
-                    table_id: 2,
-                }),
+                TenantOwnershipObject::new_unchecked(
+                    Tenant::new_literal("test"),
+                    OwnershipObject::Table {
+                        catalog_name: "default".to_string(),
+                        db_id: 0, // db_id is not encoded into key
+                        table_id: 2,
+                    }
+                ),
                 parsed
             );
         }
 
         // table with catalog
         {
-            let obj =
-                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Table {
+            let obj = TenantOwnershipObject::new_unchecked(
+                Tenant::new_literal("test"),
+                OwnershipObject::Table {
                     catalog_name: "cata/foo".to_string(),
                     db_id: 1,
                     table_id: 2,
-                });
+                },
+            );
 
             let key = obj.to_string_key();
             assert_eq!(
@@ -616,21 +624,26 @@ mod tests {
 
             let parsed = TenantOwnershipObject::from_str_key(&key).unwrap();
             assert_eq!(
-                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Table {
-                    catalog_name: "cata/foo".to_string(),
-                    db_id: 0, // db_id is not encoded into key
-                    table_id: 2,
-                }),
+                TenantOwnershipObject::new_unchecked(
+                    Tenant::new_literal("test"),
+                    OwnershipObject::Table {
+                        catalog_name: "cata/foo".to_string(),
+                        db_id: 0, // db_id is not encoded into key
+                        table_id: 2,
+                    }
+                ),
                 parsed
             );
         }
 
         // stage
         {
-            let role_grantee =
-                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::Stage {
+            let role_grantee = TenantOwnershipObject::new_unchecked(
+                Tenant::new_literal("test"),
+                OwnershipObject::Stage {
                     name: "foo".to_string(),
-                });
+                },
+            );
 
             let key = role_grantee.to_string_key();
             assert_eq!("__fd_object_owners/test/stage-by-name/foo", key);
@@ -641,10 +654,12 @@ mod tests {
 
         // udf
         {
-            let role_grantee =
-                TenantOwnershipObject::new_unchecked(Tenant::new("test"), OwnershipObject::UDF {
+            let role_grantee = TenantOwnershipObject::new_unchecked(
+                Tenant::new_literal("test"),
+                OwnershipObject::UDF {
                     name: "foo".to_string(),
-                });
+                },
+            );
 
             let key = role_grantee.to_string_key();
             assert_eq!("__fd_object_owners/test/udf-by-name/foo", key);

--- a/src/meta/app/src/principal/user_identity.rs
+++ b/src/meta/app/src/principal/user_identity.rs
@@ -143,13 +143,14 @@ mod kvapi_key_impl {
 #[cfg(test)]
 mod tests {
     use databend_common_meta_kvapi::kvapi::Key;
+    use databend_common_meta_types::NonEmptyString;
 
     use crate::principal::user_identity::TenantUserIdent;
     use crate::principal::UserIdentity;
     use crate::tenant::Tenant;
 
     fn test_format_parse(user: &str, host: &str, expect: &str) {
-        let tenant = Tenant::new("test_tenant");
+        let tenant = Tenant::new_nonempty(NonEmptyString::new("test_tenant").unwrap());
         let user_ident = UserIdentity::new(user, host);
         let tenant_user_ident = TenantUserIdent {
             tenant,

--- a/src/meta/app/src/principal/user_setting_ident.rs
+++ b/src/meta/app/src/principal/user_setting_ident.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn test_setting_ident() {
-        let tenant = Tenant::new("tenant1");
+        let tenant = Tenant::new_literal("tenant1");
         let ident = SettingIdent::new(tenant.clone(), "test");
         assert_eq!("__fd_settings/tenant1/test", ident.to_string_key());
 

--- a/src/meta/app/src/principal/user_stage_file_ident.rs
+++ b/src/meta/app/src/principal/user_stage_file_ident.rs
@@ -79,6 +79,7 @@ mod kvapi_key_impl {
 #[cfg(test)]
 mod tests {
     use databend_common_meta_kvapi::kvapi::Key;
+    use databend_common_meta_types::NonEmptyString;
 
     use crate::principal::user_stage_file_ident::StageFileIdent;
     use crate::principal::StageIdent;
@@ -86,7 +87,7 @@ mod tests {
 
     #[test]
     fn test_kvapi_key_for_stage_file_ident() {
-        let tenant = Tenant::new("tenant1");
+        let tenant = Tenant::new_nonempty(NonEmptyString::new("tenant1").unwrap());
         let stage = StageIdent::new(tenant, "stage1");
         let sfi = StageFileIdent::new(stage, "file1");
 

--- a/src/meta/app/src/principal/user_stage_ident.rs
+++ b/src/meta/app/src/principal/user_stage_ident.rs
@@ -42,13 +42,14 @@ mod kvapi_impl {
 #[cfg(test)]
 mod tests {
     use databend_common_meta_kvapi::kvapi::Key;
+    use databend_common_meta_types::NonEmptyString;
 
     use crate::principal::user_stage_ident::StageIdent;
     use crate::tenant::Tenant;
 
     #[test]
     fn test_kvapi_key_for_stage_ident() {
-        let tenant = Tenant::new("test");
+        let tenant = Tenant::new_nonempty(NonEmptyString::new("test").unwrap());
         let stage = StageIdent::new(tenant, "stage");
 
         let key = stage.to_string_key();

--- a/src/meta/app/src/tenant/tenant.rs
+++ b/src/meta/app/src/tenant/tenant.rs
@@ -31,6 +31,14 @@ impl Tenant {
         }
     }
 
+    pub fn new_literal(tenant: &str) -> Self {
+        debug_assert!(!tenant.is_empty());
+        Self {
+            tenant: tenant.to_string(),
+        }
+    }
+
+    /// Create from a non-empty literal string, for testing purpose only.
     pub fn new_nonempty(tenant: NonEmptyString) -> Self {
         Self {
             tenant: tenant.as_str().to_string(),

--- a/src/meta/app/src/tenant/tenant_quota_ident.rs
+++ b/src/meta/app/src/tenant/tenant_quota_ident.rs
@@ -69,12 +69,13 @@ mod kvapi_key_impl {
 #[cfg(test)]
 mod tests {
     use databend_common_meta_kvapi::kvapi::Key;
+    use databend_common_meta_types::NonEmptyString;
 
     use super::*;
 
     #[test]
     fn test_quota_ident() {
-        let tenant = Tenant::new("test");
+        let tenant = Tenant::new_nonempty(NonEmptyString::new("test").unwrap());
         let ident = TenantQuotaIdent::new(tenant.clone());
 
         let key = ident.to_string_key();

--- a/src/meta/app/src/tenant_key.rs
+++ b/src/meta/app/src/tenant_key.rs
@@ -139,6 +139,7 @@ mod tests {
     use std::convert::Infallible;
 
     use databend_common_meta_kvapi::kvapi::Key;
+    use databend_common_meta_types::NonEmptyString;
 
     use crate::tenant::Tenant;
     use crate::tenant_key::TIdent;
@@ -153,7 +154,7 @@ mod tests {
             type ValueType = Infallible;
         }
 
-        let tenant = Tenant::new("test".to_string());
+        let tenant = Tenant::new_nonempty(NonEmptyString::new("test").unwrap());
         let ident = TIdent::<Foo>::new(tenant, "test1");
 
         let key = ident.to_string_key();

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -117,17 +117,20 @@ impl RoleMgr {
         let dummy = OwnershipObject::UDF {
             name: "dummy".to_string(),
         };
-        let grantee = TenantOwnershipObject::new(Tenant::new(self.tenant.as_str()), dummy);
+        let grantee = TenantOwnershipObject::new(Tenant::new_nonempty(self.tenant.clone()), dummy);
         grantee.tenant_prefix()
     }
 
     fn role_key(&self, role: &str) -> String {
-        let r = RoleIdent::new(Tenant::new(self.tenant.as_str()), role.to_string());
+        let r = RoleIdent::new(Tenant::new_nonempty(self.tenant.clone()), role.to_string());
         r.to_string_key()
     }
 
     fn role_prefix(&self) -> String {
-        let r = RoleIdent::new(Tenant::new(self.tenant.as_str()), "dummy".to_string());
+        let r = RoleIdent::new(
+            Tenant::new_nonempty(self.tenant.clone()),
+            "dummy".to_string(),
+        );
         r.tenant_prefix()
     }
 }

--- a/src/query/service/src/api/http/v1/background_tasks.rs
+++ b/src/query/service/src/api/http/v1/background_tasks.rs
@@ -36,6 +36,7 @@ pub struct BackgroundTaskQuery {
     task_type: Option<BackgroundTaskType>,
 }
 
+/// Required to be json serde by: [`list_background_tasks`]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListBackgroundTasksResponse {
     task_infos: Vec<(String, BackgroundTaskInfo)>,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: use Tenant::new_literal() and new_nonempty() to avoid creating empty Tenant


##### chore: add comment

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues