### PR TITLE
refactor: remove serde from kvapi::Key types

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -2206,7 +2206,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         let db_type = db_meta
             .from_share
             .map_or(DatabaseType::NormalDB, |share_ident| {
-                DatabaseType::ShareDB(share_ident)
+                DatabaseType::ShareDB(share_ident.into())
             });
 
         let tb_info = TableInfo {
@@ -2332,7 +2332,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                             .from_share
                             .clone()
                             .map_or(DatabaseType::NormalDB, |share_ident| {
-                                DatabaseType::ShareDB(share_ident)
+                                DatabaseType::ShareDB(share_ident.into())
                             });
 
                         let tb_info = TableInfo {

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -5507,7 +5507,7 @@ impl SchemaApiTestSuite {
             assert_eq!(table_info.name, tb1.to_string());
             assert_eq!(table_info.ident.table_id, share_table_id);
             assert_eq!(table_info.tenant, tenant2.to_string());
-            assert_eq!(table_info.db_type, DatabaseType::ShareDB(share_name));
+            assert_eq!(table_info.db_type, DatabaseType::ShareDB(share_name.into()));
         }
 
         info!("--- get tables from share db");

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -917,7 +917,7 @@ pub async fn list_tables_from_share_db(
         &ids,
         tenant_dbname,
         None,
-        DatabaseType::ShareDB(share),
+        DatabaseType::ShareDB(share.into()),
     )
     .await
 }
@@ -1112,7 +1112,7 @@ pub async fn remove_table_from_share(
                     .filter(|table_info| table_ids.contains(&table_info.ident.table_id))
                     .map(|table_info| {
                         let mut table_info = table_info.as_ref().clone();
-                        table_info.db_type = DatabaseType::ShareDB(share_name.to_owned());
+                        table_info.db_type = DatabaseType::ShareDB(share_name.clone().into());
                         (table_info.name.clone(), table_info)
                     })
                     .collect::<Vec<_>>(),
@@ -1170,7 +1170,7 @@ pub async fn get_share_table_info(
                     .filter(|table_info| table_ids.contains(&table_info.ident.table_id))
                     .map(|table_info| {
                         let mut table_info = table_info.as_ref().clone();
-                        table_info.db_type = DatabaseType::ShareDB(share_name.to_owned());
+                        table_info.db_type = DatabaseType::ShareDB(share_name.clone().into());
                         (table_info.name.clone(), table_info)
                     })
                     .collect::<Vec<_>>(),

--- a/src/meta/app/src/data_mask/mod.rs
+++ b/src/meta/app/src/data_mask/mod.rs
@@ -21,7 +21,7 @@ use chrono::Utc;
 
 use crate::schema::CreateOption;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatamaskNameIdent {
     pub tenant: String,
     pub name: String,
@@ -33,7 +33,7 @@ impl Display for DatamaskNameIdent {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatamaskId {
     pub id: u64,
 }
@@ -68,7 +68,7 @@ impl From<CreateDatamaskReq> for DatamaskMeta {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateDatamaskReq {
     pub create_option: CreateOption,
     pub name: DatamaskNameIdent,
@@ -84,7 +84,7 @@ pub struct CreateDatamaskReply {
     pub id: u64,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DropDatamaskReq {
     pub if_exists: bool,
     pub name: DatamaskNameIdent,
@@ -93,7 +93,7 @@ pub struct DropDatamaskReq {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DropDatamaskReply {}
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GetDatamaskReq {
     pub name: DatamaskNameIdent,
 }
@@ -103,7 +103,7 @@ pub struct GetDatamaskReply {
     pub policy: DatamaskMeta,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct MaskpolicyTableIdListKey {
     pub tenant: String,
     pub name: String,

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -186,7 +186,7 @@ impl Display for CatalogNameIdent {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CatalogIdToName {
     pub catalog_id: u64,
 }

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -26,7 +26,8 @@ use super::CreateOption;
 use crate::share::ShareNameIdent;
 use crate::share::ShareSpec;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+// serde is required by
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatabaseNameIdent {
     pub tenant: String,
     pub db_name: String,
@@ -60,9 +61,7 @@ pub struct DatabaseIdent {
     pub seq: u64,
 }
 
-#[derive(
-    serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord,
-)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct DatabaseId {
     pub db_id: u64,
 }
@@ -85,7 +84,7 @@ impl Display for DatabaseId {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatabaseIdToName {
     pub db_id: u64,
 }
@@ -102,7 +101,7 @@ impl DatabaseIdToName {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DbIdListKey {
     pub tenant: String,
     pub db_name: String,
@@ -240,7 +239,7 @@ pub struct CreateDatabaseReply {
     pub spec_vec: Option<Vec<ShareSpec>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RenameDatabaseReq {
     pub if_exists: bool,
     pub name_ident: DatabaseNameIdent,
@@ -260,7 +259,7 @@ impl Display for RenameDatabaseReq {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct RenameDatabaseReply {}
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DropDatabaseReq {
     pub if_exists: bool,
     pub name_ident: DatabaseNameIdent,
@@ -281,7 +280,7 @@ pub struct DropDatabaseReply {
     pub spec_vec: Option<Vec<ShareSpec>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UndropDatabaseReq {
     pub name_ident: DatabaseNameIdent,
 }
@@ -308,7 +307,7 @@ impl UndropDatabaseReq {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct UndropDatabaseReply {}
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GetDatabaseReq {
     pub inner: DatabaseNameIdent,
 }

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -49,7 +49,7 @@ impl Display for IndexNameIdent {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct IndexIdToName {
     pub index_id: u64,
 }
@@ -60,7 +60,7 @@ impl Display for IndexIdToName {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct IndexId {
     pub index_id: u64,
 }

--- a/src/meta/app/src/schema/least_visible_time.rs
+++ b/src/meta/app/src/schema/least_visible_time.rs
@@ -43,7 +43,7 @@ pub struct GetLVTReply {
     pub time: Option<DateTime<Utc>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct LeastVisibleTimeKey {
     pub table_id: u64,
 }

--- a/src/meta/app/src/schema/lock.rs
+++ b/src/meta/app/src/schema/lock.rs
@@ -172,7 +172,7 @@ pub struct DeleteLockRevReq {
     pub revision: u64,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableLockKey {
     pub table_id: u64,
     pub revision: u64,

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -33,7 +33,6 @@ use maplit::hashmap;
 
 use super::CreateOption;
 use crate::schema::database::DatabaseNameIdent;
-use crate::share::ShareNameIdent;
 use crate::share::ShareSpec;
 use crate::share::ShareTableInfoMap;
 use crate::storage::StorageParams;
@@ -153,11 +152,30 @@ impl Display for TableIdListKey {
     }
 }
 
+// serde is required by [`TableInfo`]
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub enum DatabaseType {
     #[default]
     NormalDB,
-    ShareDB(ShareNameIdent),
+    ShareDB(database_type::ShareNameIdent),
+}
+
+mod database_type {
+    /// Same as  [`crate::share::ShareNameIdent`] but with serde support for being used as a value.
+    /// while [`crate::share::ShareNameIdent`] can only be used as key.
+    #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+    pub struct ShareNameIdent {
+        pub tenant: String,
+        pub share_name: String,
+    }
+    impl From<crate::share::ShareNameIdent> for ShareNameIdent {
+        fn from(value: crate::share::ShareNameIdent) -> Self {
+            Self {
+                tenant: value.tenant,
+                share_name: value.share_name,
+            }
+        }
+    }
 }
 
 impl Display for DatabaseType {

--- a/src/meta/app/src/schema/virtual_column.rs
+++ b/src/meta/app/src/schema/virtual_column.rs
@@ -22,7 +22,7 @@ use databend_common_meta_types::MetaId;
 
 use super::CreateOption;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct VirtualColumnNameIdent {
     pub tenant: String,
     pub table_id: u64,
@@ -56,7 +56,7 @@ pub struct VirtualColumnMeta {
     pub updated_on: Option<DateTime<Utc>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateVirtualColumnReq {
     pub create_option: CreateOption,
     pub name_ident: VirtualColumnNameIdent,
@@ -76,7 +76,7 @@ impl Display for CreateVirtualColumnReq {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateVirtualColumnReply {}
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UpdateVirtualColumnReq {
     pub if_exists: bool,
     pub name_ident: VirtualColumnNameIdent,
@@ -96,7 +96,7 @@ impl Display for UpdateVirtualColumnReq {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UpdateVirtualColumnReply {}
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DropVirtualColumnReq {
     pub if_exists: bool,
     pub name_ident: VirtualColumnNameIdent,

--- a/src/meta/app/src/share/share.rs
+++ b/src/meta/app/src/share/share.rs
@@ -30,8 +30,9 @@ use crate::schema::DatabaseMeta;
 use crate::schema::TableInfo;
 use crate::schema::TableMeta;
 
+// serde is required by `DatabaseType`
 /// A share that is created by `tenant` and is named with `share_name`.
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ShareNameIdent {
     pub tenant: String,
     pub share_name: String,
@@ -57,7 +58,7 @@ impl Display for ShareConsumer {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ShareEndpointIdent {
     pub tenant: String,
     pub endpoint: String,
@@ -74,7 +75,7 @@ pub struct ShowSharesReq {
     pub tenant: String,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ShareAccountReply {
     pub share_name: ShareNameIdent,
     pub database_name: Option<String>,
@@ -86,13 +87,13 @@ pub struct ShareAccountReply {
     pub comment: Option<String>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ShowSharesReply {
     // sharing to other accounts(outbound shares)
     pub outbound_accounts: Vec<ShareAccountReply>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateShareReq {
     pub if_not_exists: bool,
     pub share_name: ShareNameIdent,
@@ -107,7 +108,7 @@ pub struct CreateShareReply {
     pub spec_vec: Option<Vec<ShareSpec>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DropShareReq {
     pub share_name: ShareNameIdent,
     pub if_exists: bool,
@@ -119,7 +120,7 @@ pub struct DropShareReply {
     pub spec_vec: Option<Vec<ShareSpec>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AddShareAccountsReq {
     pub share_name: ShareNameIdent,
     pub if_exists: bool,
@@ -133,7 +134,7 @@ pub struct AddShareAccountsReply {
     pub spec_vec: Option<Vec<ShareSpec>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoveShareAccountsReq {
     pub share_name: ShareNameIdent,
     pub if_exists: bool,
@@ -146,7 +147,7 @@ pub struct RemoveShareAccountsReply {
     pub spec_vec: Option<Vec<ShareSpec>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ShowShareOfReq {
     pub share_name: ShareNameIdent,
 }
@@ -187,7 +188,7 @@ pub enum ShareGrantObjectSeqAndId {
 pub type TableInfoMap = BTreeMap<String, TableInfo>;
 pub type ShareTableInfoMap = (String, Option<TableInfoMap>);
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GrantShareObjectReq {
     pub share_name: ShareNameIdent,
     pub object: ShareGrantObjectName,
@@ -202,7 +203,7 @@ pub struct GrantShareObjectReply {
     pub share_table_info: ShareTableInfoMap,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RevokeShareObjectReq {
     pub share_name: ShareNameIdent,
     pub object: ShareGrantObjectName,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: remove serde from kvapi::Key types

CatalogIdToName
DatabaseId
DatabaseIdToName
DatabaseNameIdent
DatamaskId
DatamaskNameIdent
DbIdListKey
IndexId
IndexIdToName
LeastVisibleTimeKey
MaskpolicyTableIdListKey
MaskpolicyTableIdListKey
ShareEndpointIdent
ShareNameIdent
TableLockKey
VirtualColumnNameIdent

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues