### PR TITLE
refactor: use type `Tenant` for `BackgroundJobIdent.tenant`

### DIFF
--- a/src/meta/api/src/background_api_impl.rs
+++ b/src/meta/api/src/background_api_impl.rs
@@ -94,7 +94,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> BackgroundApi for KV {
                 } else {
                     Err(KVAppError::AppError(AppError::BackgroundJobAlreadyExists(
                         BackgroundJobAlreadyExists::new(
-                            &name_key.name,
+                            name_key.name(),
                             format!("create background job: {:?}", req.job_name),
                         ),
                     )))
@@ -220,7 +220,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> BackgroundApi for KV {
             let r = get_background_job_by_id(self, &BackgroundJobId { id: job_id.0 }).await?;
             // filter none and get the task info
             if let Some(task_info) = r.1 {
-                res.push((r.0, ident.name, task_info));
+                res.push((r.0, ident.name().to_string(), task_info));
             }
         }
         Ok(res)
@@ -326,7 +326,7 @@ pub fn background_job_has_to_exist(
     if seq == 0 {
         debug!(seq = seq, name_ident :? =(name_ident); "background job does not exist");
         Err(KVAppError::AppError(AppError::UnknownBackgroundJob(
-            UnknownBackgroundJob::new(&name_ident.name, format!("{:?}", name_ident)),
+            UnknownBackgroundJob::new(name_ident.name(), format!("{:?}", name_ident)),
         )))
     } else {
         Ok(())

--- a/src/meta/app/src/background/job_ident.rs
+++ b/src/meta/app/src/background/job_ident.rs
@@ -1,0 +1,75 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tenant_key::TIdent;
+
+/// Defines the meta-service key for background job.
+pub type BackgroundJobIdent = TIdent<Resource>;
+
+pub use kvapi_impl::Resource;
+
+mod kvapi_impl {
+
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::background::BackgroundJobId;
+    use crate::tenant_key::TenantResource;
+
+    pub struct Resource;
+    impl TenantResource for Resource {
+        const PREFIX: &'static str = "__fd_background_job";
+        type ValueType = BackgroundJobId;
+    }
+
+    impl kvapi::Value for BackgroundJobId {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
+
+    // impl From<ExistError<Resource>> for ErrorCode {
+    //     fn from(err: ExistError<Resource>) -> Self {
+    //         ErrorCode::ConnectionAlreadyExists(err.to_string())
+    //     }
+    // }
+    //
+    // impl From<UnknownError<Resource>> for ErrorCode {
+    //     fn from(err: UnknownError<Resource>) -> Self {
+    //         // Special case: use customized message to keep backward compatibility.
+    //         // TODO: consider using the default message in the future(`err.to_string()`)
+    //         ErrorCode::UnknownConnection(format!("Connection '{}' does not exist.", err.name()))
+    //             .add_message_back(err.ctx())
+    //     }
+    // }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use super::BackgroundJobIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_connection_ident() {
+        let tenant = Tenant::new_literal("test");
+        let ident = BackgroundJobIdent::new(tenant, "test1");
+
+        let key = ident.to_string_key();
+        assert_eq!(key, "__fd_background_job/test/test1");
+
+        assert_eq!(ident, BackgroundJobIdent::from_str_key(&key).unwrap());
+    }
+}

--- a/src/meta/app/src/background/mod.rs
+++ b/src/meta/app/src/background/mod.rs
@@ -14,10 +14,10 @@
 
 mod background_job;
 mod background_task;
+pub mod job_ident;
 pub mod task_creator;
 
 pub use background_job::BackgroundJobId;
-pub use background_job::BackgroundJobIdent;
 pub use background_job::BackgroundJobInfo;
 pub use background_job::BackgroundJobParams;
 pub use background_job::BackgroundJobState;
@@ -46,3 +46,4 @@ pub use background_task::ListBackgroundTasksReq;
 pub use background_task::UpdateBackgroundTaskReply;
 pub use background_task::UpdateBackgroundTaskReq;
 pub use background_task::VacuumStats;
+pub use job_ident::BackgroundJobIdent;

--- a/src/meta/app/src/background/task_creator.rs
+++ b/src/meta/app/src/background/task_creator.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 
 use crate::background::BackgroundJobIdent;
+use crate::KeyWithTenant;
 
 /// Same as [`BackgroundJobIdent`] but provide serde support for use in a record value.
 /// [`BackgroundJobIdent`] is a kvapi::Key that does not need to be `serde`
@@ -26,6 +27,15 @@ pub struct BackgroundTaskCreator {
     pub name: String,
 }
 
+impl BackgroundTaskCreator {
+    pub fn new(tenant: impl ToString, name: impl ToString) -> Self {
+        Self {
+            tenant: tenant.to_string(),
+            name: name.to_string(),
+        }
+    }
+}
+
 impl fmt::Display for BackgroundTaskCreator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.tenant, self.name)
@@ -34,9 +44,6 @@ impl fmt::Display for BackgroundTaskCreator {
 
 impl From<BackgroundJobIdent> for BackgroundTaskCreator {
     fn from(ident: BackgroundJobIdent) -> Self {
-        Self {
-            tenant: ident.tenant,
-            name: ident.name,
-        }
+        Self::new(ident.tenant_name(), ident.name())
     }
 }

--- a/src/query/ee/src/background_service/job_scheduler.rs
+++ b/src/query/ee/src/background_service/job_scheduler.rs
@@ -79,11 +79,11 @@ impl JobScheduler {
         match info.job_params.as_ref().unwrap().job_type {
             BackgroundJobType::ONESHOT => {
                 self.one_shot_jobs
-                    .insert(job.get_name().name, Box::new(job) as BoxedJob);
+                    .insert(job.get_name().name().to_string(), Box::new(job) as BoxedJob);
             }
             BackgroundJobType::CRON | BackgroundJobType::INTERVAL => {
                 self.scheduled_jobs
-                    .insert(job.get_name().name, Box::new(job) as BoxedJob);
+                    .insert(job.get_name().name().to_string(), Box::new(job) as BoxedJob);
             }
         }
         Ok(())

--- a/src/query/ee/tests/it/background_service/job_scheduler.rs
+++ b/src/query/ee/tests/it/background_service/job_scheduler.rs
@@ -28,6 +28,7 @@ use databend_common_meta_app::background::BackgroundJobInfo;
 use databend_common_meta_app::background::BackgroundJobParams;
 use databend_common_meta_app::background::BackgroundJobStatus;
 use databend_common_meta_app::principal::UserIdentity;
+use databend_common_meta_app::tenant::Tenant;
 use databend_enterprise_query::background_service::Job;
 use databend_enterprise_query::background_service::JobScheduler;
 
@@ -64,10 +65,7 @@ impl Job for TestJob {
     }
 
     fn get_name(&self) -> BackgroundJobIdent {
-        BackgroundJobIdent {
-            tenant: "test".to_string(),
-            name: "test".to_string(),
-        }
+        BackgroundJobIdent::new(Tenant::new_literal("test"), "test")
     }
 
     async fn update_job_status(&mut self, _status: BackgroundJobStatus) -> Result<()> {

--- a/src/query/ee_features/background_service/src/background_service.rs
+++ b/src/query/ee_features/background_service/src/background_service.rs
@@ -18,6 +18,7 @@ use arrow_array::RecordBatch;
 use databend_common_base::base::GlobalInstance;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::UserIdentity;
+use databend_common_meta_app::tenant::Tenant;
 
 #[async_trait::async_trait]
 pub trait BackgroundServiceHandler: Sync + Send {
@@ -25,7 +26,7 @@ pub trait BackgroundServiceHandler: Sync + Send {
 
     async fn execute_scheduled_job(
         &self,
-        tenant: String,
+        tenant: Tenant,
         user: UserIdentity,
         name: String,
     ) -> Result<()>;
@@ -53,7 +54,7 @@ impl BackgroundServiceHandlerWrapper {
     #[async_backtrace::framed]
     pub async fn execute_scheduled_job(
         &self,
-        tenant: String,
+        tenant: Tenant,
         user: UserIdentity,
         name: String,
     ) -> Result<()> {

--- a/src/query/service/src/table_functions/others/execute_background_job.rs
+++ b/src/query/service/src/table_functions/others/execute_background_job.rs
@@ -32,6 +32,7 @@ use databend_common_expression::TableSchemaRefExt;
 use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_pipeline_core::Pipeline;
@@ -153,9 +154,13 @@ impl AsyncSource for ExecuteBackgroundJobSource {
     #[async_backtrace::framed]
     async fn generate(&mut self) -> Result<Option<DataBlock>> {
         let background_handler = get_background_service_handler();
+
+        let non_empty = self.ctx.get_tenant();
+        let tenant = Tenant::new_nonempty(non_empty);
+
         background_handler
             .execute_scheduled_job(
-                self.ctx.get_tenant().to_string(),
+                tenant,
                 self.ctx.get_current_user()?.identity(),
                 self.job_name.clone(),
             )


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: use type `Tenant` for `BackgroundJobIdent.tenant`

Define BackgroundJobIdent with `TIdent`, make
`BackgroundJobIdent.tenant` a `Tenant` instead of a plain `String`.

- Part of #14719

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues