### PR TITLE
fix: privilege check for insert statement

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -747,7 +747,12 @@ impl AccessChecker for PrivilegeAccess {
             }
             // Others.
             Plan::Insert(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Insert], false).await?;
+                let target_table_privileges = if plan.is_overwrite {
+                    vec![UserPrivilegeType::Insert, UserPrivilegeType::Delete]
+                } else {
+                    vec![UserPrivilegeType::Insert]
+                };
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, target_table_privileges, false).await?;
                 match &plan.source {
                     InsertInputSource::SelectPlan(plan) => {
                         self.check(ctx, plan).await?;

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -747,7 +747,7 @@ impl AccessChecker for PrivilegeAccess {
             }
             // Others.
             Plan::Insert(plan) => {
-                let target_table_privileges = if plan.is_overwrite {
+                let target_table_privileges = if plan.overwrite {
                     vec![UserPrivilegeType::Insert, UserPrivilegeType::Delete]
                 } else {
                     vec![UserPrivilegeType::Insert]

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
@@ -4,6 +4,9 @@ test -- insert
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Insert] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public]
 1
 2
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Insert, Delete] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
+1
+2
 test -- update
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Update] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 2
@@ -11,6 +14,9 @@ Error: APIError: ResponseError with 1063: Permission denied: privilege [Update] 
 test -- delete
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Delete] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 true
+test -- insert overwrite
+2
+3
 test -- optimize table
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Super] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 true

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
@@ -63,15 +63,14 @@ echo "delete from t20_0012 where c=2" | $TEST_USER_CONNECT
 echo "select count(*) = 0 from t20_0012 where c=2" | $TEST_USER_CONNECT
 
 ## insert overwrite
-echo "grant insert, delete on default.t20_0012 to 'test-user'" | $BENDSQL_CLIENT_CONNECT
 echo "select 'test -- insert overwrite'" | $TEST_USER_CONNECT
+echo "GRANT DELETE ON * TO role 'test-role1'" | $BENDSQL_CLIENT_CONNECT
 echo "insert overwrite t20_0012 values(2)" | $TEST_USER_CONNECT
 ## verify
 echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT
 echo "insert overwrite t20_0012 values(3)" | $TEST_USER_CONNECT
 ## verify
 echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT
-echo "revoke insert, delete on default.t20_0012 from 'test-user'" | $BENDSQL_CLIENT_CONNECT
 
 ## optimize table
 echo "select 'test -- optimize table'" | $TEST_USER_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
@@ -37,6 +37,10 @@ echo "GRANT ROLE \`test-role2\` TO 'test-user'" | $BENDSQL_CLIENT_CONNECT
 echo "insert into t20_0012 values(1),(2)" | $TEST_USER_CONNECT
 ## verify
 echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT
+## insert overwrite, but no delete privilege
+echo "insert overwrite t20_0012 values(3),(4)" | $TEST_USER_CONNECT
+## verify
+echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT
 
 ## update data
 echo "select 'test -- update'" | $TEST_USER_CONNECT
@@ -57,6 +61,16 @@ echo "GRANT DELETE ON * TO 'test-user'" | $BENDSQL_CLIENT_CONNECT
 echo "delete from t20_0012 where c=2" | $TEST_USER_CONNECT
 ## verify
 echo "select count(*) = 0 from t20_0012 where c=2" | $TEST_USER_CONNECT
+
+
+## insert overwrite
+echo "select 'test -- insert overwrite'" | $TEST_USER_CONNECT
+echo "insert overwrite t20_0012 values(2)" | $TEST_USER_CONNECT
+## verify
+echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT
+echo "insert overwrite t20_0012 values(3)" | $TEST_USER_CONNECT
+## verify
+echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT
 
 ## optimize table
 echo "select 'test -- optimize table'" | $TEST_USER_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
@@ -62,8 +62,8 @@ echo "delete from t20_0012 where c=2" | $TEST_USER_CONNECT
 ## verify
 echo "select count(*) = 0 from t20_0012 where c=2" | $TEST_USER_CONNECT
 
-
 ## insert overwrite
+echo "grant insert, delete on default.t20_0012 to 'test-user'" | $BENDSQL_CLIENT_CONNECT
 echo "select 'test -- insert overwrite'" | $TEST_USER_CONNECT
 echo "insert overwrite t20_0012 values(2)" | $TEST_USER_CONNECT
 ## verify
@@ -71,6 +71,7 @@ echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT
 echo "insert overwrite t20_0012 values(3)" | $TEST_USER_CONNECT
 ## verify
 echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT
+echo "revoke insert, delete on default.t20_0012 from 'test-user'" | $BENDSQL_CLIENT_CONNECT
 
 ## optimize table
 echo "select 'test -- optimize table'" | $TEST_USER_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

To use the OVERWRITE option on INSERT, you must use a role that has DELETE privilege on the table because OVERWRITE will delete the existing records in the table.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
