### PR TITLE
fix: fix plan_sql error can not write query_log

### DIFF
--- a/src/query/service/src/interpreters/mod.rs
+++ b/src/query/service/src/interpreters/mod.rs
@@ -146,6 +146,7 @@ mod interpreter_virtual_column_refresh;
 pub use access::ManagementModeAccess;
 pub use common::InterpreterQueryLog;
 pub use hook::HookOperator;
+pub use interpreter::interpreter_plan_sql;
 pub use interpreter::Interpreter;
 pub use interpreter::InterpreterPtr;
 pub use interpreter_cluster_key_alter::AlterTableClusterKeyInterpreter;

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -58,6 +58,7 @@ use poem::Route;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::interpreters::interpreter_plan_sql;
 use crate::interpreters::InterpreterFactory;
 use crate::interpreters::InterpreterPtr;
 use crate::servers::http::middleware::sanitize_request_headers;
@@ -266,9 +267,8 @@ pub async fn clickhouse_handler_get(
             .map_err(BadRequest)?;
         let default_format = get_default_format(&params, headers).map_err(BadRequest)?;
         let sql = params.query();
-        let mut planner = Planner::new(context.clone());
-        let (plan, extras) = planner
-            .plan_sql(&sql)
+        // Use interpreter_plan_sql, we can write the query log if an error occurs.
+        let (plan, extras) = interpreter_plan_sql(context.clone(), &sql)
             .await
             .map_err(|err| err.display_with_sql(&sql))
             .map_err(BadRequest)?;

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -27,9 +27,6 @@ use databend_common_expression::DataSchemaRef;
 use databend_common_expression::Scalar;
 use databend_common_io::prelude::FormatSettings;
 use databend_common_settings::Settings;
-use databend_common_sql::plans::Plan;
-use databend_common_sql::PlanExtras;
-use databend_common_sql::Planner;
 use databend_storages_common_txn::TxnManagerRef;
 use futures::StreamExt;
 use log::error;
@@ -39,6 +36,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use ExecuteState::*;
 
+use crate::interpreters::interpreter_plan_sql;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterFactory;
 use crate::interpreters::InterpreterQueryLog;
@@ -293,12 +291,6 @@ impl Executor {
 
 impl ExecuteState {
     #[async_backtrace::framed]
-    pub(crate) async fn plan_sql(sql: &str, ctx: Arc<QueryContext>) -> Result<(Plan, PlanExtras)> {
-        let mut planner = Planner::new(ctx.clone());
-        planner.plan_sql(sql).await
-    }
-
-    #[async_backtrace::framed]
     pub(crate) async fn try_start_query(
         executor: Arc<RwLock<Executor>>,
         sql: String,
@@ -310,7 +302,8 @@ impl ExecuteState {
         let entry = QueryEntry::create(&ctx)?;
         let queue_guard = QueriesQueueManager::instance().acquire(entry).await?;
 
-        let (plan, _) = ExecuteState::plan_sql(&sql, ctx.clone())
+        // Use interpreter_plan_sql, we can write the query log if an error occurs.
+        let (plan, _) = interpreter_plan_sql(ctx.clone(), &sql)
             .await
             .map_err(|err| err.display_with_sql(&sql))?;
 

--- a/src/query/service/src/table_functions/others/suggested_background_tasks.rs
+++ b/src/query/service/src/table_functions/others/suggested_background_tasks.rs
@@ -47,13 +47,13 @@ use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_pipeline_core::Pipeline;
 use databend_common_pipeline_sources::AsyncSource;
 use databend_common_pipeline_sources::AsyncSourcer;
-use databend_common_sql::Planner;
 use databend_common_storages_factory::Table;
 use databend_enterprise_background_service::Suggestion;
 use futures_util::StreamExt;
 use log::error;
 use log::info;
 
+use crate::interpreters::interpreter_plan_sql;
 use crate::interpreters::InterpreterFactory;
 use crate::sessions::QueryContext;
 
@@ -163,8 +163,9 @@ impl SuggestedBackgroundTasksSource {
         ctx: Arc<QueryContext>,
         sql: String,
     ) -> Result<Option<RecordBatch>> {
-        let mut planner = Planner::new(ctx.clone());
-        let (plan, _) = planner.plan_sql(sql.as_str()).await?;
+        // Use interpreter_plan_sql, we can write the query log if an error occurs.
+        let (plan, _) = interpreter_plan_sql(ctx.clone(), sql.as_str()).await?;
+
         let data_schema = plan.schema();
         let interpreter = InterpreterFactory::get(ctx.clone(), &plan).await?;
         let stream = interpreter.execute(ctx.clone()).await?;

--- a/src/query/service/tests/it/api/http/status.rs
+++ b/src/query/service/tests/it/api/http/status.rs
@@ -21,12 +21,12 @@ use databend_common_meta_types::NonEmptyString;
 use databend_common_users::UserApiProvider;
 use databend_query::api::http::v1::instance_status::instance_status_handler;
 use databend_query::api::http::v1::instance_status::InstanceStatus;
+use databend_query::interpreters::interpreter_plan_sql;
 use databend_query::interpreters::Interpreter;
 use databend_query::interpreters::InterpreterFactory;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::SessionManager;
 use databend_query::sessions::SessionType;
-use databend_query::sql::Planner;
 use databend_query::test_kits::*;
 use poem::get;
 use poem::http::header;
@@ -67,8 +67,8 @@ async fn run_query(query_ctx: &Arc<QueryContext>) -> Result<Arc<dyn Interpreter>
         .get_current_session()
         .set_authed_user(user, None)
         .await?;
-    let mut planner = Planner::new(query_ctx.clone());
-    let (plan, _) = planner.plan_sql(sql).await?;
+    let (plan, _) = interpreter_plan_sql(query_ctx.clone(), sql).await?;
+
     InterpreterFactory::get(query_ctx.clone(), &plan).await
 }
 

--- a/tests/sqllogictests/suites/base/01_system/01_0002_system_query_log.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0002_system_query_log.test
@@ -45,3 +45,13 @@ select count(*) from tbl_01_0002 where a > 1
 statement ok
 drop table tbl_01_0002
 
+
+# https://github.com/datafuselabs/databend/issues/15065
+
+statement error 1025
+select * from table_not_exitst;
+
+query B
+select count(*) > 0 from system.query_log where log_type_name = 'Error'
+----
+1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

There are two steps to execute a query:
1. Plan the SQL -- here error we can not write query_log
2. Execute the plan -- interpreter

This PR add a new function: `interpreter_plan_sql`, it's a wrap of `plan_sql`,  If `plan_sql` error occurs, we will log the query start and finished.

Where is use `interpreter_plan_sql`:
1. http handler
2. ClickHouse handler
3. MySQL handler
4. suggested_background_tasks.rs


- Fixes #15065

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
