### PR TITLE
refactor: change PartInfo is_lazy to LazyLevel 

### DIFF
--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -28,6 +28,7 @@ use sha2::Digest;
 use crate::table_context::TableContext;
 
 /// Partition information.
+#[derive(PartialEq)]
 pub enum PartInfoType {
     // Block level partition information.
     // Read the data from the block level.
@@ -99,28 +100,11 @@ pub enum PartitionsShuffleKind {
 pub struct Partitions {
     pub kind: PartitionsShuffleKind,
     pub partitions: Vec<PartInfoPtr>,
-    pub is_lazy: bool,
 }
 
 impl Partitions {
-    pub fn create(
-        kind: PartitionsShuffleKind,
-        partitions: Vec<PartInfoPtr>,
-        is_lazy: bool,
-    ) -> Self {
-        Partitions {
-            kind,
-            partitions,
-            is_lazy,
-        }
-    }
-
-    pub fn create_nolazy(kind: PartitionsShuffleKind, partitions: Vec<PartInfoPtr>) -> Self {
-        Partitions {
-            kind,
-            partitions,
-            is_lazy: false,
-        }
+    pub fn create(kind: PartitionsShuffleKind, partitions: Vec<PartInfoPtr>) -> Self {
+        Partitions { kind, partitions }
     }
 
     pub fn len(&self) -> usize {
@@ -159,11 +143,7 @@ impl Partitions {
                 for executor in executors_sorted.iter() {
                     executor_part.insert(
                         executor.clone(),
-                        Partitions::create(
-                            PartitionsShuffleKind::Seq,
-                            self.partitions.clone(),
-                            self.is_lazy,
-                        ),
+                        Partitions::create(PartitionsShuffleKind::Seq, self.partitions.clone()),
                     );
                 }
 
@@ -192,7 +172,7 @@ impl Partitions {
 
             executor_part.insert(
                 executor,
-                Partitions::create(PartitionsShuffleKind::Seq, parts, self.is_lazy),
+                Partitions::create(PartitionsShuffleKind::Seq, parts),
             );
         }
 
@@ -221,7 +201,6 @@ impl Default for Partitions {
         Self {
             kind: PartitionsShuffleKind::Seq,
             partitions: vec![],
-            is_lazy: false,
         }
     }
 }

--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -52,6 +52,7 @@ pub trait PartInfo: Send + Sync {
 
     /// Get the partition type.
     /// Default is block level.
+    /// You must override this method if the partition is segment level.
     fn part_type(&self) -> PartInfoType {
         PartInfoType::BlockLevel
     }

--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -33,11 +33,10 @@ pub enum PartInfoType {
     // Block level partition information.
     // Read the data from the block level.
     BlockLevel,
-    // Segment level partition information.
-    // Need to read the block location information from the segment.
-    // Then read the data from the block level.
-    // Formerly, we treat this as a lazy part.
-    SegmentLevel,
+    // In lazy level, we need:
+    // 1. read the block location information from the segment.
+    // 2. read the block data from the block level.
+    LazyLevel,
 }
 
 #[typetag::serde(tag = "type")]
@@ -52,7 +51,7 @@ pub trait PartInfo: Send + Sync {
 
     /// Get the partition type.
     /// Default is block level.
-    /// You must override this method if the partition is segment level.
+    /// If the partition is lazy level, it should be override.
     fn part_type(&self) -> PartInfoType {
         PartInfoType::BlockLevel
     }

--- a/src/query/catalog/tests/it/partitions.rs
+++ b/src/query/catalog/tests/it/partitions.rs
@@ -54,7 +54,7 @@ impl PartInfo for TestPartInfo {
     }
 
     fn part_type(&self) -> PartInfoType {
-        PartInfoType::SegmentLevel
+        PartInfoType::LazyLevel
     }
 }
 

--- a/src/query/catalog/tests/it/partitions.rs
+++ b/src/query/catalog/tests/it/partitions.rs
@@ -24,6 +24,7 @@ use databend_common_catalog::plan::compute_row_id_prefix;
 use databend_common_catalog::plan::split_prefix;
 use databend_common_catalog::plan::PartInfo;
 use databend_common_catalog::plan::PartInfoPtr;
+use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::plan::PartitionsShuffleKind;
 use databend_storages_common_table_meta::meta::NUM_BLOCK_ID_BITS;
@@ -51,6 +52,10 @@ impl PartInfo for TestPartInfo {
         self.loc.hash(&mut s);
         s.finish()
     }
+
+    fn part_type(&self) -> PartInfoType {
+        PartInfoType::SegmentLevel
+    }
 }
 
 impl TestPartInfo {
@@ -65,7 +70,7 @@ fn gen_parts(kind: PartitionsShuffleKind, size: usize) -> Partitions {
         parts.push(TestPartInfo::create(format!("{}", i)));
     }
 
-    Partitions::create(kind, parts, true)
+    Partitions::create(kind, parts)
 }
 
 #[test]

--- a/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
+++ b/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
@@ -1,25 +1,25 @@
 PartitionsShuffleKind::Seq : 11 partitions of 3 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"6"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"6"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
 PartitionsShuffleKind::Seq : 2 partitions of 3 executors
-Partitions { kind: Seq, partitions: [], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"1"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"1"}] }
 PartitionsShuffleKind::Mod : 10 partitions of 3 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}] }
 PartitionsShuffleKind::Mod : 11 partitions of 3 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"10"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"10"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}] }
 PartitionsShuffleKind::Mod : 11 partitions of 2 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
 PartitionsShuffleKind::Rand: 11 partitions of 2 executors
 5
 6
 PartitionsShuffleKind::Broadcast: 3 partitions of 2 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}], is_lazy: true }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}], is_lazy: true }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}] }

--- a/src/query/service/src/interpreters/interpreter_delete.rs
+++ b/src/query/service/src/interpreters/interpreter_delete.rs
@@ -301,7 +301,7 @@ impl DeleteInterpreter {
         is_distributed: bool,
         query_row_id_col: bool,
     ) -> Result<PhysicalPlan> {
-        let merge_meta = partitions.partitions_type() == PartInfoType::SegmentLevel;
+        let merge_meta = partitions.partitions_type() == PartInfoType::LazyLevel;
         let mut root = PhysicalPlan::DeleteSource(Box::new(DeleteSource {
             parts: partitions,
             filters,

--- a/src/query/service/src/interpreters/interpreter_delete.rs
+++ b/src/query/service/src/interpreters/interpreter_delete.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use databend_common_base::base::ProgressValues;
 use databend_common_catalog::plan::Filters;
+use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::table::TableExt;
 use databend_common_exception::ErrorCode;
@@ -300,7 +301,7 @@ impl DeleteInterpreter {
         is_distributed: bool,
         query_row_id_col: bool,
     ) -> Result<PhysicalPlan> {
-        let merge_meta = partitions.is_lazy;
+        let merge_meta = partitions.partitions_type() == PartInfoType::SegmentLevel;
         let mut root = PhysicalPlan::DeleteSource(Box::new(DeleteSource {
             parts: partitions,
             filters,

--- a/src/query/service/src/interpreters/interpreter_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_index_refresh.rs
@@ -42,8 +42,8 @@ use databend_common_sql::plans::RefreshIndexPlan;
 use databend_common_sql::plans::RelOperator;
 use databend_common_storages_fuse::operations::AggIndexSink;
 use databend_common_storages_fuse::pruning::create_segment_location_vector;
-use databend_common_storages_fuse::FuseLazyPartInfo;
-use databend_common_storages_fuse::FusePartInfo;
+use databend_common_storages_fuse::FuseBlockPartInfo;
+use databend_common_storages_fuse::FuseSegmentPartInfo;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::SegmentLocation;
 use databend_enterprise_aggregating_index::get_agg_index_handler;
@@ -76,7 +76,7 @@ impl RefreshIndexInterpreter {
         let mut lazy_init_segments = Vec::with_capacity(plan.parts.len());
 
         for part in &plan.parts.partitions {
-            if let Some(lazy_part_info) = part.as_any().downcast_ref::<FuseLazyPartInfo>() {
+            if let Some(lazy_part_info) = part.as_any().downcast_ref::<FuseSegmentPartInfo>() {
                 lazy_init_segments.push(SegmentLocation {
                     segment_idx: lazy_part_info.segment_index,
                     location: lazy_part_info.segment_location.clone(),
@@ -176,8 +176,8 @@ impl RefreshIndexInterpreter {
 
             // first, sort the partitions by create_on.
             source.parts.partitions.sort_by(|p1, p2| {
-                let p1 = FusePartInfo::from_part(p1).unwrap();
-                let p2 = FusePartInfo::from_part(p2).unwrap();
+                let p1 = FuseBlockPartInfo::from_part(p1).unwrap();
+                let p2 = FuseBlockPartInfo::from_part(p2).unwrap();
                 p1.create_on.partial_cmp(&p2.create_on).unwrap()
             });
 
@@ -186,7 +186,7 @@ impl RefreshIndexInterpreter {
                 .parts
                 .partitions
                 .binary_search_by(|p| {
-                    let fp = FusePartInfo::from_part(p).unwrap();
+                    let fp = FuseBlockPartInfo::from_part(p).unwrap();
                     fp.create_on
                         .partial_cmp(&self.plan.index_meta.updated_on)
                         .unwrap()
@@ -211,7 +211,7 @@ impl RefreshIndexInterpreter {
     }
 
     fn update_index_meta(&self, read_source: &DataSourcePlan) -> Result<IndexMeta> {
-        let fuse_part = FusePartInfo::from_part(read_source.parts.partitions.last().unwrap())?;
+        let fuse_part = FuseBlockPartInfo::from_part(read_source.parts.partitions.last().unwrap())?;
         let mut index_meta = self.plan.index_meta.clone();
         index_meta.updated_on = fuse_part.create_on;
         Ok(index_meta)

--- a/src/query/service/src/interpreters/interpreter_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_index_refresh.rs
@@ -43,7 +43,7 @@ use databend_common_sql::plans::RelOperator;
 use databend_common_storages_fuse::operations::AggIndexSink;
 use databend_common_storages_fuse::pruning::create_segment_location_vector;
 use databend_common_storages_fuse::FuseBlockPartInfo;
-use databend_common_storages_fuse::FuseSegmentPartInfo;
+use databend_common_storages_fuse::FuseLazyPartInfo;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::SegmentLocation;
 use databend_enterprise_aggregating_index::get_agg_index_handler;
@@ -76,7 +76,7 @@ impl RefreshIndexInterpreter {
         let mut lazy_init_segments = Vec::with_capacity(plan.parts.len());
 
         for part in &plan.parts.partitions {
-            if let Some(lazy_part_info) = part.as_any().downcast_ref::<FuseSegmentPartInfo>() {
+            if let Some(lazy_part_info) = part.as_any().downcast_ref::<FuseLazyPartInfo>() {
                 lazy_init_segments.push(SegmentLocation {
                     segment_idx: lazy_part_info.segment_index,
                     location: lazy_part_info.segment_location.clone(),

--- a/src/query/service/src/interpreters/interpreter_table_optimize.rs
+++ b/src/query/service/src/interpreters/interpreter_table_optimize.rs
@@ -115,7 +115,7 @@ impl OptimizeTableInterpreter {
         is_distributed: bool,
         need_lock: bool,
     ) -> Result<PhysicalPlan> {
-        let merge_meta = parts.partitions_type() == PartInfoType::SegmentLevel;
+        let merge_meta = parts.partitions_type() == PartInfoType::LazyLevel;
         let mut root = PhysicalPlan::CompactSource(Box::new(CompactSource {
             parts,
             table_info: table_info.clone(),

--- a/src/query/service/src/interpreters/interpreter_table_optimize.rs
+++ b/src/query/service/src/interpreters/interpreter_table_optimize.rs
@@ -17,6 +17,7 @@ use std::time::SystemTime;
 
 use databend_common_base::runtime::GlobalIORuntime;
 use databend_common_catalog::catalog::Catalog;
+use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::table::CompactTarget;
 use databend_common_catalog::table::Table;
@@ -114,7 +115,7 @@ impl OptimizeTableInterpreter {
         is_distributed: bool,
         need_lock: bool,
     ) -> Result<PhysicalPlan> {
-        let merge_meta = parts.is_lazy;
+        let merge_meta = parts.partitions_type() == PartInfoType::SegmentLevel;
         let mut root = PhysicalPlan::CompactSource(Box::new(CompactSource {
             parts,
             table_info: table_info.clone(),

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -296,7 +296,7 @@ impl UpdateInterpreter {
         is_distributed: bool,
         ctx: Arc<QueryContext>,
     ) -> Result<PhysicalPlan> {
-        let merge_meta = partitions.partitions_type() == PartInfoType::SegmentLevel;
+        let merge_meta = partitions.partitions_type() == PartInfoType::LazyLevel;
         let mut root = PhysicalPlan::UpdateSource(Box::new(UpdateSource {
             parts: partitions,
             filters,

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -18,6 +18,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use databend_common_catalog::plan::Filters;
+use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::table::TableExt;
 use databend_common_exception::ErrorCode;
@@ -295,7 +296,7 @@ impl UpdateInterpreter {
         is_distributed: bool,
         ctx: Arc<QueryContext>,
     ) -> Result<PhysicalPlan> {
-        let merge_meta = partitions.is_lazy;
+        let merge_meta = partitions.partitions_type() == PartInfoType::SegmentLevel;
         let mut root = PhysicalPlan::UpdateSource(Box::new(UpdateSource {
             parts: partitions,
             filters,

--- a/src/query/service/src/pipelines/builders/builder_delete.rs
+++ b/src/query/service/src/pipelines/builders/builder_delete.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_base::runtime::Runtime;
+use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
@@ -53,7 +54,8 @@ impl PipelineBuilder {
             return self.main_pipeline.add_source(EmptySource::create, 1);
         }
 
-        if delete.parts.is_lazy {
+        let is_lazy = delete.parts.partitions_type() == PartInfoType::SegmentLevel;
+        if is_lazy {
             let ctx = self.ctx.clone();
             let projection = Projection::Columns(delete.col_indices.clone());
             let filters = delete.filters.clone();
@@ -104,6 +106,7 @@ impl PipelineBuilder {
             delete.query_row_id_col,
             &mut self.main_pipeline,
         )?;
+
         if table.change_tracking_enabled() {
             let stream_ctx = StreamContext::try_create(
                 self.ctx.get_function_context()?,
@@ -120,6 +123,7 @@ impl PipelineBuilder {
                     )
                 })?;
         }
+
         let cluster_stats_gen =
             table.get_cluster_stats_gen(self.ctx.clone(), 0, table.get_block_thresholds(), None)?;
         self.main_pipeline.add_transform(|input, output| {
@@ -133,8 +137,9 @@ impl PipelineBuilder {
             )?;
             proc.into_processor()
         })?;
+
         let ctx: Arc<dyn TableContext> = self.ctx.clone();
-        if delete.parts.is_lazy {
+        if is_lazy {
             table.chain_mutation_aggregator(
                 &ctx,
                 &mut self.main_pipeline,

--- a/src/query/service/src/pipelines/builders/builder_delete.rs
+++ b/src/query/service/src/pipelines/builders/builder_delete.rs
@@ -26,7 +26,7 @@ use databend_common_sql::executor::physical_plans::MutationKind;
 use databend_common_sql::StreamContext;
 use databend_common_storages_fuse::operations::MutationBlockPruningContext;
 use databend_common_storages_fuse::operations::TransformSerializeBlock;
-use databend_common_storages_fuse::FuseLazyPartInfo;
+use databend_common_storages_fuse::FuseSegmentPartInfo;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::SegmentLocation;
 use log::info;
@@ -63,7 +63,7 @@ impl PipelineBuilder {
             let mut segment_locations = Vec::with_capacity(delete.parts.partitions.len());
             for part in &delete.parts.partitions {
                 // Safe to downcast because we know the the partition is lazy
-                let part: &FuseLazyPartInfo = part.as_any().downcast_ref().unwrap();
+                let part: &FuseSegmentPartInfo = part.as_any().downcast_ref().unwrap();
                 segment_locations.push(SegmentLocation {
                     segment_idx: part.segment_index,
                     location: part.segment_location.clone(),

--- a/src/query/service/src/pipelines/builders/builder_delete.rs
+++ b/src/query/service/src/pipelines/builders/builder_delete.rs
@@ -26,7 +26,7 @@ use databend_common_sql::executor::physical_plans::MutationKind;
 use databend_common_sql::StreamContext;
 use databend_common_storages_fuse::operations::MutationBlockPruningContext;
 use databend_common_storages_fuse::operations::TransformSerializeBlock;
-use databend_common_storages_fuse::FuseSegmentPartInfo;
+use databend_common_storages_fuse::FuseLazyPartInfo;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::SegmentLocation;
 use log::info;
@@ -54,7 +54,7 @@ impl PipelineBuilder {
             return self.main_pipeline.add_source(EmptySource::create, 1);
         }
 
-        let is_lazy = delete.parts.partitions_type() == PartInfoType::SegmentLevel;
+        let is_lazy = delete.parts.partitions_type() == PartInfoType::LazyLevel;
         if is_lazy {
             let ctx = self.ctx.clone();
             let projection = Projection::Columns(delete.col_indices.clone());
@@ -63,7 +63,7 @@ impl PipelineBuilder {
             let mut segment_locations = Vec::with_capacity(delete.parts.partitions.len());
             for part in &delete.parts.partitions {
                 // Safe to downcast because we know the the partition is lazy
-                let part: &FuseSegmentPartInfo = part.as_any().downcast_ref().unwrap();
+                let part: &FuseLazyPartInfo = FuseLazyPartInfo::from_part(part)?;
                 segment_locations.push(SegmentLocation {
                     segment_idx: part.segment_index,
                     location: part.segment_location.clone(),

--- a/src/query/service/src/table_functions/numbers/numbers_part.rs
+++ b/src/query/service/src/table_functions/numbers/numbers_part.rs
@@ -84,5 +84,5 @@ pub fn generate_numbers_parts(start: u64, workers: u64, total: u64) -> Partition
         }
     }
 
-    Partitions::create_nolazy(PartitionsShuffleKind::Seq, partitions)
+    Partitions::create(PartitionsShuffleKind::Seq, partitions)
 }

--- a/src/query/service/tests/it/storages/fuse/operations/internal_column.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/internal_column.rs
@@ -27,7 +27,7 @@ use databend_common_expression::SNAPSHOT_NAME_COL_NAME;
 use databend_common_sql::binder::INTERNAL_COLUMN_FACTORY;
 use databend_common_sql::Planner;
 use databend_common_storages_fuse::io::MetaReaders;
-use databend_common_storages_fuse::FusePartInfo;
+use databend_common_storages_fuse::FuseBlockPartInfo;
 use databend_common_storages_fuse::FuseTable;
 use databend_query::interpreters::InterpreterFactory;
 use databend_query::test_kits::*;
@@ -44,7 +44,7 @@ fn expected_data_block(
 ) -> Result<Vec<DataBlock>> {
     let mut data_blocks = Vec::with_capacity(parts.partitions.len());
     for part in &parts.partitions {
-        let fuse_part = FusePartInfo::from_part(part)?;
+        let fuse_part = FuseBlockPartInfo::from_part(part)?;
         let num_rows = fuse_part.nums_rows;
         let block_meta = fuse_part.block_meta_index.as_ref().unwrap();
         let mut columns = Vec::with_capacity(internal_columns.len());
@@ -130,7 +130,7 @@ async fn check_partitions(parts: &Partitions, fixture: &TestFixture) -> Result<(
     }
 
     for part in &parts.partitions {
-        let fuse_part = FusePartInfo::from_part(part)?;
+        let fuse_part = FuseBlockPartInfo::from_part(part)?;
         let block_meta = fuse_part.block_meta_index.as_ref().unwrap();
         assert_eq!(
             block_meta.snapshot_location.clone().unwrap(),

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use databend_common_base::base::tokio;
+use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::table::Table;
 use databend_common_exception::Result;
 use databend_common_expression::BlockThresholds;
@@ -236,7 +237,7 @@ async fn test_safety() -> Result<()> {
             eprintln!("no target select");
             continue;
         }
-        assert!(!selections.is_lazy);
+        assert!(selections.partitions_type() != PartInfoType::SegmentLevel);
 
         let mut actual_blocks_number = 0;
         let mut compact_segment_indices = HashSet::new();

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -22,8 +22,8 @@ use databend_common_exception::Result;
 use databend_common_expression::BlockThresholds;
 use databend_common_storages_fuse::io::SegmentsIO;
 use databend_common_storages_fuse::operations::BlockCompactMutator;
+use databend_common_storages_fuse::operations::CompactBlockPartInfo;
 use databend_common_storages_fuse::operations::CompactOptions;
-use databend_common_storages_fuse::operations::CompactPartInfo;
 use databend_common_storages_fuse::statistics::reducers::merge_statistics_mut;
 use databend_query::interpreters::OptimizeTableInterpreter;
 use databend_query::pipelines::executor::ExecutorSettings;
@@ -243,9 +243,9 @@ async fn test_safety() -> Result<()> {
         let mut compact_segment_indices = HashSet::new();
         let mut actual_block_ids = HashSet::new();
         for part in selections.partitions.into_iter() {
-            let part = CompactPartInfo::from_part(&part)?;
+            let part = CompactBlockPartInfo::from_part(&part)?;
             match part {
-                CompactPartInfo::CompactExtraInfo(extra) => {
+                CompactBlockPartInfo::CompactExtraInfo(extra) => {
                     compact_segment_indices.insert(extra.segment_index);
                     compact_segment_indices.extend(extra.removed_segment_indexes.iter());
                     actual_blocks_number += extra.unchanged_blocks.len();
@@ -253,7 +253,7 @@ async fn test_safety() -> Result<()> {
                         actual_block_ids.insert(b.1.location.clone());
                     }
                 }
-                CompactPartInfo::CompactTaskInfo(task) => {
+                CompactBlockPartInfo::CompactTaskInfo(task) => {
                     compact_segment_indices.insert(task.index.segment_idx);
                     actual_blocks_number += task.blocks.len();
                     for b in &task.blocks {

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -237,7 +237,7 @@ async fn test_safety() -> Result<()> {
             eprintln!("no target select");
             continue;
         }
-        assert!(selections.partitions_type() != PartInfoType::SegmentLevel);
+        assert!(selections.partitions_type() != PartInfoType::LazyLevel);
 
         let mut actual_blocks_number = 0;
         let mut compact_segment_indices = HashSet::new();

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -31,7 +31,7 @@ use databend_common_storages_fuse::operations::ReclusterMutator;
 use databend_common_storages_fuse::pruning::create_segment_location_vector;
 use databend_common_storages_fuse::statistics::reducers::merge_statistics_mut;
 use databend_common_storages_fuse::statistics::reducers::reduce_block_metas;
-use databend_common_storages_fuse::FusePartInfo;
+use databend_common_storages_fuse::FuseBlockPartInfo;
 use databend_common_storages_fuse::FuseTable;
 use databend_query::sessions::TableContext;
 use databend_query::test_kits::*;
@@ -291,7 +291,7 @@ async fn test_safety_for_recluster() -> Result<()> {
                 let parts = task.parts.partitions;
                 assert!(task.total_bytes <= recluster_block_size);
                 for part in parts.into_iter() {
-                    let fuse_part = FusePartInfo::from_part(&part)?;
+                    let fuse_part = FuseBlockPartInfo::from_part(&part)?;
                     blocks.push(fuse_part.location.clone());
                 }
             }

--- a/src/query/service/tests/it/storages/fuse/operations/read_plan.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/read_plan.rs
@@ -28,7 +28,7 @@ use databend_common_expression::FieldIndex;
 use databend_common_expression::Scalar;
 use databend_common_storage::ColumnNode;
 use databend_common_storage::ColumnNodes;
-use databend_common_storages_fuse::FusePartInfo;
+use databend_common_storages_fuse::FuseBlockPartInfo;
 use databend_query::storages::fuse::FuseTable;
 use databend_query::test_kits::*;
 use databend_storages_common_table_meta::meta;
@@ -185,7 +185,7 @@ async fn test_fuse_table_exact_statistic() -> Result<()> {
         assert!(!parts.is_empty());
 
         let part = parts.partitions[0].clone();
-        let fuse_part = FusePartInfo::from_part(&part)?;
+        let fuse_part = FuseBlockPartInfo::from_part(&part)?;
         assert!(fuse_part.create_on.is_some())
     }
 

--- a/src/query/storages/delta/src/table.rs
+++ b/src/query/storages/delta/src/table.rs
@@ -304,22 +304,23 @@ impl DeltaTable {
                         (None, Some(s)) => {
                             let stats = serde_json::from_str::<Stats>(s.as_str()).unwrap();
                             Some(stats.num_records)
-                        },
-                        _ =>  None,
+                        }
+                        _ => None,
                     }
                     ).unwrap_or(1);
                 read_rows += num_records as usize;
                 read_bytes += add.size as usize;
                 let partition_values = get_partition_values(add, &partition_fields[..])?;
                 Ok(Arc::new(
-                    Box::new(DeltaPartInfo{
+                    Box::new(DeltaPartInfo {
                         partition_values,
                         data: ParquetPart::ParquetFiles(
                             ParquetFilesPart {
-                            files: vec![(add.path.clone(), add.size as u64)],
-                            estimated_uncompressed_size: add.size as u64, // This field is not used here.
-                        },
-                    )}) as Box<dyn PartInfo>
+                                files: vec![(add.path.clone(), add.size as u64)],
+                                estimated_uncompressed_size: add.size as u64, // This field is not used here.
+                            },
+                        ),
+                    }) as Box<dyn PartInfo>
                 ))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -333,7 +334,7 @@ impl DeltaTable {
                 total_files,
                 None,
             ),
-            Partitions::create_nolazy(PartitionsShuffleKind::Mod, parts),
+            Partitions::create(PartitionsShuffleKind::Mod, parts),
         ))
     }
 }

--- a/src/query/storages/fuse/src/fuse_part.rs
+++ b/src/query/storages/fuse/src/fuse_part.rs
@@ -24,6 +24,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use databend_common_catalog::plan::PartInfo;
 use databend_common_catalog::plan::PartInfoPtr;
+use databend_common_catalog::plan::PartInfoType;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
@@ -65,6 +66,10 @@ impl PartInfo for FusePartInfo {
         let mut s = DefaultHasher::new();
         self.location.hash(&mut s);
         s.finish()
+    }
+
+    fn part_type(&self) -> PartInfoType {
+        PartInfoType::BlockLevel
     }
 }
 
@@ -141,6 +146,10 @@ impl PartInfo for FuseLazyPartInfo {
         let mut s = DefaultHasher::new();
         self.segment_location.0.hash(&mut s);
         s.finish()
+    }
+
+    fn part_type(&self) -> PartInfoType {
+        PartInfoType::SegmentLevel
     }
 }
 

--- a/src/query/storages/fuse/src/fuse_part.rs
+++ b/src/query/storages/fuse/src/fuse_part.rs
@@ -37,7 +37,7 @@ use databend_storages_common_table_meta::meta::Location;
 
 /// Fuse table partition information.
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
-pub struct FusePartInfo {
+pub struct FuseBlockPartInfo {
     pub location: String,
 
     pub create_on: Option<DateTime<Utc>>,
@@ -51,14 +51,14 @@ pub struct FusePartInfo {
 }
 
 #[typetag::serde(name = "fuse")]
-impl PartInfo for FusePartInfo {
+impl PartInfo for FuseBlockPartInfo {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn equals(&self, info: &Box<dyn PartInfo>) -> bool {
         info.as_any()
-            .downcast_ref::<FusePartInfo>()
+            .downcast_ref::<FuseBlockPartInfo>()
             .is_some_and(|other| self == other)
     }
 
@@ -73,7 +73,7 @@ impl PartInfo for FusePartInfo {
     }
 }
 
-impl FusePartInfo {
+impl FuseBlockPartInfo {
     #[allow(clippy::too_many_arguments)]
     pub fn create(
         location: String,
@@ -85,7 +85,7 @@ impl FusePartInfo {
         block_meta_index: Option<BlockMetaIndex>,
         create_on: Option<DateTime<Utc>>,
     ) -> Arc<Box<dyn PartInfo>> {
-        Arc::new(Box::new(FusePartInfo {
+        Arc::new(Box::new(FuseBlockPartInfo {
             location,
             create_on,
             columns_meta,
@@ -97,9 +97,9 @@ impl FusePartInfo {
         }))
     }
 
-    pub fn from_part(info: &PartInfoPtr) -> Result<&FusePartInfo> {
+    pub fn from_part(info: &PartInfoPtr) -> Result<&FuseBlockPartInfo> {
         info.as_any()
-            .downcast_ref::<FusePartInfo>()
+            .downcast_ref::<FuseBlockPartInfo>()
             .ok_or_else(|| ErrorCode::Internal("Cannot downcast from PartInfo to FusePartInfo."))
     }
 
@@ -125,20 +125,20 @@ impl FusePartInfo {
 /// Lazy partition is a partition that only contains the partition location.
 /// The partition data will be loaded when the partition is used.
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct FuseLazyPartInfo {
+pub struct FuseSegmentPartInfo {
     pub segment_index: usize,
     pub segment_location: Location,
 }
 
 #[typetag::serde(name = "fuse_lazy")]
-impl PartInfo for FuseLazyPartInfo {
+impl PartInfo for FuseSegmentPartInfo {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn equals(&self, info: &Box<dyn PartInfo>) -> bool {
         info.as_any()
-            .downcast_ref::<FuseLazyPartInfo>()
+            .downcast_ref::<FuseSegmentPartInfo>()
             .is_some_and(|other| self == other)
     }
 
@@ -153,9 +153,9 @@ impl PartInfo for FuseLazyPartInfo {
     }
 }
 
-impl FuseLazyPartInfo {
+impl FuseSegmentPartInfo {
     pub fn create(idx: usize, segment_location: Location) -> PartInfoPtr {
-        Arc::new(Box::new(FuseLazyPartInfo {
+        Arc::new(Box::new(FuseSegmentPartInfo {
             segment_index: idx,
             segment_location,
         }))

--- a/src/query/storages/fuse/src/fuse_part.rs
+++ b/src/query/storages/fuse/src/fuse_part.rs
@@ -100,7 +100,9 @@ impl FuseBlockPartInfo {
     pub fn from_part(info: &PartInfoPtr) -> Result<&FuseBlockPartInfo> {
         info.as_any()
             .downcast_ref::<FuseBlockPartInfo>()
-            .ok_or_else(|| ErrorCode::Internal("Cannot downcast from PartInfo to FusePartInfo."))
+            .ok_or_else(|| {
+                ErrorCode::Internal("Cannot downcast from PartInfo to FuseBlockPartInfo.")
+            })
     }
 
     pub fn range(&self) -> Option<&Range<usize>> {
@@ -125,20 +127,20 @@ impl FuseBlockPartInfo {
 /// Lazy partition is a partition that only contains the partition location.
 /// The partition data will be loaded when the partition is used.
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct FuseSegmentPartInfo {
+pub struct FuseLazyPartInfo {
     pub segment_index: usize,
     pub segment_location: Location,
 }
 
 #[typetag::serde(name = "fuse_lazy")]
-impl PartInfo for FuseSegmentPartInfo {
+impl PartInfo for FuseLazyPartInfo {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn equals(&self, info: &Box<dyn PartInfo>) -> bool {
         info.as_any()
-            .downcast_ref::<FuseSegmentPartInfo>()
+            .downcast_ref::<FuseLazyPartInfo>()
             .is_some_and(|other| self == other)
     }
 
@@ -149,15 +151,23 @@ impl PartInfo for FuseSegmentPartInfo {
     }
 
     fn part_type(&self) -> PartInfoType {
-        PartInfoType::SegmentLevel
+        PartInfoType::LazyLevel
     }
 }
 
-impl FuseSegmentPartInfo {
+impl FuseLazyPartInfo {
     pub fn create(idx: usize, segment_location: Location) -> PartInfoPtr {
-        Arc::new(Box::new(FuseSegmentPartInfo {
+        Arc::new(Box::new(FuseLazyPartInfo {
             segment_index: idx,
             segment_location,
         }))
+    }
+
+    pub fn from_part(info: &PartInfoPtr) -> Result<&FuseLazyPartInfo> {
+        info.as_any()
+            .downcast_ref::<FuseLazyPartInfo>()
+            .ok_or_else(|| {
+                ErrorCode::Internal("Cannot downcast from PartInfo to FuseLazyPartInfo.")
+            })
     }
 }

--- a/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader_native.rs
+++ b/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader_native.rs
@@ -24,7 +24,7 @@ use log::debug;
 use super::AggIndexReader;
 use crate::io::BlockReader;
 use crate::io::NativeSourceData;
-use crate::FusePartInfo;
+use crate::FuseBlockPartInfo;
 
 impl AggIndexReader {
     pub fn sync_read_native_data(&self, loc: &str) -> Option<NativeSourceData> {
@@ -46,7 +46,7 @@ impl AggIndexReader {
                     .enumerate()
                     .map(|(i, c)| (i as u32, ColumnMeta::Native(c)))
                     .collect();
-                let part = FusePartInfo::create(
+                let part = FuseBlockPartInfo::create(
                     loc.to_string(),
                     num_rows,
                     columns_meta,
@@ -98,7 +98,7 @@ impl AggIndexReader {
                     .enumerate()
                     .map(|(i, c)| (i as u32, ColumnMeta::Native(c)))
                     .collect();
-                let part = FusePartInfo::create(
+                let part = FuseBlockPartInfo::create(
                     loc.to_string(),
                     num_rows,
                     columns_meta,

--- a/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader_parquet.rs
@@ -24,7 +24,7 @@ use super::AggIndexReader;
 use crate::io::read::utils::build_columns_meta;
 use crate::io::ReadSettings;
 use crate::io::UncompressedBuffer;
-use crate::FusePartInfo;
+use crate::FuseBlockPartInfo;
 use crate::MergeIOReadResult;
 
 impl AggIndexReader {
@@ -43,7 +43,7 @@ impl AggIndexReader {
                 debug_assert_eq!(metadata.row_groups.len(), 1);
                 let row_group = &metadata.row_groups[0];
                 let columns_meta = build_columns_meta(row_group);
-                let part = FusePartInfo::create(
+                let part = FuseBlockPartInfo::create(
                     loc.to_string(),
                     row_group.num_rows() as u64,
                     columns_meta,
@@ -93,7 +93,7 @@ impl AggIndexReader {
                     .await
                     .inspect_err(|e| debug!("Read aggregating index `{loc}` failed: {e}"))
                     .ok()?;
-                let part = FusePartInfo::create(
+                let part = FuseBlockPartInfo::create(
                     loc.to_string(),
                     row_group.num_rows() as u64,
                     columns_meta,
@@ -123,7 +123,7 @@ impl AggIndexReader {
         buffer: Arc<UncompressedBuffer>,
     ) -> Result<DataBlock> {
         let columns_chunks = data.columns_chunks()?;
-        let part = FusePartInfo::from_part(&part)?;
+        let part = FuseBlockPartInfo::from_part(&part)?;
         let block = self.reader.deserialize_parquet_chunks_with_buffer(
             &part.location,
             part.nums_rows,

--- a/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
@@ -30,7 +30,7 @@ use super::BlockReader;
 use crate::io::read::block::block_reader_merge_io::DataItem;
 use crate::io::ReadSettings;
 use crate::io::UncompressedBuffer;
-use crate::FusePartInfo;
+use crate::FuseBlockPartInfo;
 use crate::FuseStorageFormat;
 use crate::MergeIOReadResult;
 
@@ -57,7 +57,7 @@ impl BlockReader {
         chunks: HashMap<ColumnId, DataItem>,
         storage_format: &FuseStorageFormat,
     ) -> Result<DataBlock> {
-        let part = FusePartInfo::from_part(&part)?;
+        let part = FuseBlockPartInfo::from_part(&part)?;
 
         self.deserialize_chunks(
             &part.location,

--- a/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_sync.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_sync.rs
@@ -28,7 +28,7 @@ use databend_storages_common_cache::TableDataCacheKey;
 use databend_storages_common_cache_manager::CacheManager;
 use opendal::Operator;
 
-use crate::fuse_part::FusePartInfo;
+use crate::fuse_part::FuseBlockPartInfo;
 use crate::io::read::block::block_reader_merge_io::OwnerMemory;
 use crate::io::read::ReadSettings;
 use crate::io::BlockReader;
@@ -83,7 +83,7 @@ impl BlockReader {
             let column_range = raw_range.start..raw_range.end;
 
             // Find the range index and Range from merged ranges.
-            let (merged_range_idx, merged_range) = range_merger.get(column_range.clone()).ok_or_else(||ErrorCode::Internal(format!(
+            let (merged_range_idx, merged_range) = range_merger.get(column_range.clone()).ok_or_else(|| ErrorCode::Internal(format!(
                 "It's a terrible bug, not found raw range:[{:?}], path:{} from merged ranges\n: {:?}",
                 column_range, path, merged_ranges
             )))?;
@@ -103,7 +103,7 @@ impl BlockReader {
         part: &PartInfoPtr,
         ignore_column_ids: &Option<HashSet<ColumnId>>,
     ) -> Result<MergeIOReadResult> {
-        let part = FusePartInfo::from_part(part)?;
+        let part = FuseBlockPartInfo::from_part(part)?;
         let column_array_cache = CacheManager::instance().get_table_data_array_cache();
 
         let mut ranges = vec![];

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
@@ -36,13 +36,14 @@ use databend_common_metrics::storage::*;
 use databend_storages_common_table_meta::meta::ColumnMeta;
 use opendal::Operator;
 
-use crate::fuse_part::FusePartInfo;
+use crate::fuse_part::FuseBlockPartInfo;
 use crate::io::BlockReader;
 use crate::io::ReadSettings;
 
 // Native storage format
 
 pub trait NativeReaderExt: NativeReadBuf + std::io::Seek + Send + Sync {}
+
 impl<T: NativeReadBuf + std::io::Seek + Send + Sync> NativeReaderExt for T {}
 
 pub type Reader = Box<dyn NativeReaderExt>;
@@ -62,7 +63,7 @@ impl BlockReader {
             metrics_inc_remote_io_read_parts(1);
         }
 
-        let part = FusePartInfo::from_part(part)?;
+        let part = FuseBlockPartInfo::from_part(part)?;
         let settings = ReadSettings::from_ctx(ctx)?;
         let read_res = self
             .read_columns_data_by_merge_io(
@@ -140,7 +141,7 @@ impl BlockReader {
         part: &PartInfoPtr,
         ignore_column_ids: &Option<HashSet<ColumnId>>,
     ) -> Result<NativeSourceData> {
-        let part = FusePartInfo::from_part(part)?;
+        let part = FuseBlockPartInfo::from_part(part)?;
 
         let mut results: BTreeMap<usize, Vec<NativeReader<Reader>>> = BTreeMap::new();
         for (index, column_node) in self.project_column_nodes.iter().enumerate() {

--- a/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
@@ -42,7 +42,7 @@ use crate::io::read::utils::build_columns_meta;
 use crate::io::BlockReader;
 use crate::io::ReadSettings;
 use crate::io::UncompressedBuffer;
-use crate::FusePartInfo;
+use crate::FuseBlockPartInfo;
 use crate::MergeIOReadResult;
 
 pub struct VirtualMergeIOReadResult {
@@ -87,7 +87,7 @@ impl VirtualColumnReader {
         let (ranges, ignore_column_ids) = self.read_columns_meta(&schema, &columns_meta);
 
         if !ranges.is_empty() {
-            let part = FusePartInfo::create(
+            let part = FuseBlockPartInfo::create(
                 loc.to_string(),
                 row_group.num_rows() as u64,
                 columns_meta,
@@ -129,7 +129,7 @@ impl VirtualColumnReader {
         let (ranges, ignore_column_ids) = self.read_columns_meta(&schema, &columns_meta);
 
         if !ranges.is_empty() {
-            let part = FusePartInfo::create(
+            let part = FuseBlockPartInfo::create(
                 loc.to_string(),
                 row_group.num_rows() as u64,
                 columns_meta,
@@ -202,7 +202,7 @@ impl VirtualColumnReader {
         let mut virtual_values = HashMap::new();
         if let Some(virtual_data) = virtual_data {
             let columns_chunks = virtual_data.data.columns_chunks()?;
-            let part = FusePartInfo::from_part(&virtual_data.part)?;
+            let part = FuseBlockPartInfo::from_part(&virtual_data.part)?;
             let schema = virtual_data.schema;
 
             let table_schema = TableSchema::try_from(&schema).unwrap();

--- a/src/query/storages/fuse/src/lib.rs
+++ b/src/query/storages/fuse/src/lib.rs
@@ -41,7 +41,7 @@ use databend_common_catalog::table::TableStatistics;
 pub use databend_common_catalog::table_context::TableContext;
 pub use fuse_column::FuseTableColumnStatisticsProvider;
 pub use fuse_part::FuseBlockPartInfo;
-pub use fuse_part::FuseSegmentPartInfo;
+pub use fuse_part::FuseLazyPartInfo;
 pub use fuse_table::FuseTable;
 pub use fuse_type::FuseStorageFormat;
 pub use fuse_type::FuseTableType;

--- a/src/query/storages/fuse/src/lib.rs
+++ b/src/query/storages/fuse/src/lib.rs
@@ -40,8 +40,8 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table::TableStatistics;
 pub use databend_common_catalog::table_context::TableContext;
 pub use fuse_column::FuseTableColumnStatisticsProvider;
-pub use fuse_part::FuseLazyPartInfo;
-pub use fuse_part::FusePartInfo;
+pub use fuse_part::FuseBlockPartInfo;
+pub use fuse_part::FuseSegmentPartInfo;
 pub use fuse_table::FuseTable;
 pub use fuse_type::FuseStorageFormat;
 pub use fuse_type::FuseTableType;
@@ -51,4 +51,5 @@ pub use pruning::SegmentLocation;
 mod sessions {
     pub use databend_common_catalog::table_context::TableContext;
 }
+
 pub use databend_storages_common_index as index;

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -34,7 +34,7 @@ use databend_storages_common_table_meta::meta::TableSnapshot;
 use crate::operations::common::TableMutationAggregator;
 use crate::operations::common::TransformSerializeBlock;
 use crate::operations::mutation::BlockCompactMutator;
-use crate::operations::mutation::CompactLazyPartInfo;
+use crate::operations::mutation::CompactSegmentPartInfo;
 use crate::operations::mutation::CompactSource;
 use crate::operations::mutation::SegmentCompactMutator;
 use crate::FuseTable;
@@ -133,7 +133,7 @@ impl FuseTable {
                 .into_iter()
                 .map(|v| {
                     v.as_any()
-                        .downcast_ref::<CompactLazyPartInfo>()
+                        .downcast_ref::<CompactSegmentPartInfo>()
                         .unwrap()
                         .clone()
                 })

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -34,7 +34,7 @@ use databend_storages_common_table_meta::meta::TableSnapshot;
 use crate::operations::common::TableMutationAggregator;
 use crate::operations::common::TransformSerializeBlock;
 use crate::operations::mutation::BlockCompactMutator;
-use crate::operations::mutation::CompactSegmentPartInfo;
+use crate::operations::mutation::CompactLazyPartInfo;
 use crate::operations::mutation::CompactSource;
 use crate::operations::mutation::SegmentCompactMutator;
 use crate::FuseTable;
@@ -120,7 +120,7 @@ impl FuseTable {
         column_ids: HashSet<ColumnId>,
         pipeline: &mut Pipeline,
     ) -> Result<()> {
-        let is_lazy = parts.partitions_type() == PartInfoType::SegmentLevel;
+        let is_lazy = parts.partitions_type() == PartInfoType::LazyLevel;
         let thresholds = self.get_block_thresholds();
         let cluster_key_id = self.cluster_key_id();
         let mut max_threads = ctx.get_settings().get_max_threads()? as usize;
@@ -133,7 +133,7 @@ impl FuseTable {
                 .into_iter()
                 .map(|v| {
                     v.as_any()
-                        .downcast_ref::<CompactSegmentPartInfo>()
+                        .downcast_ref::<CompactLazyPartInfo>()
                         .unwrap()
                         .clone()
                 })

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -55,7 +55,7 @@ use crate::operations::mutation::MutationPartInfo;
 use crate::operations::mutation::MutationSource;
 use crate::pruning::create_segment_location_vector;
 use crate::pruning::FusePruner;
-use crate::FuseLazyPartInfo;
+use crate::FuseSegmentPartInfo;
 use crate::FuseTable;
 use crate::SegmentLocation;
 
@@ -201,7 +201,7 @@ impl FuseTable {
         let partitions = if is_lazy {
             let mut segments = Vec::with_capacity(snapshot.segments.len());
             for (idx, segment_location) in snapshot.segments.iter().enumerate() {
-                segments.push(FuseLazyPartInfo::create(idx, segment_location.clone()));
+                segments.push(FuseSegmentPartInfo::create(idx, segment_location.clone()));
             }
             Partitions::create(PartitionsShuffleKind::Mod, segments)
         } else {

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -203,7 +203,7 @@ impl FuseTable {
             for (idx, segment_location) in snapshot.segments.iter().enumerate() {
                 segments.push(FuseLazyPartInfo::create(idx, segment_location.clone()));
             }
-            Partitions::create(PartitionsShuffleKind::Mod, segments, true)
+            Partitions::create(PartitionsShuffleKind::Mod, segments)
         } else {
             let projection = Projection::Columns(col_indices.clone());
             let prune_ctx = MutationBlockPruningContext {
@@ -312,7 +312,7 @@ impl FuseTable {
             PruningStatistics::default(),
         )?;
 
-        let mut parts = Partitions::create_nolazy(
+        let mut parts = Partitions::create(
             PartitionsShuffleKind::Mod,
             block_metas
                 .into_iter()

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -55,7 +55,7 @@ use crate::operations::mutation::MutationPartInfo;
 use crate::operations::mutation::MutationSource;
 use crate::pruning::create_segment_location_vector;
 use crate::pruning::FusePruner;
-use crate::FuseSegmentPartInfo;
+use crate::FuseLazyPartInfo;
 use crate::FuseTable;
 use crate::SegmentLocation;
 
@@ -201,7 +201,7 @@ impl FuseTable {
         let partitions = if is_lazy {
             let mut segments = Vec::with_capacity(snapshot.segments.len());
             for (idx, segment_location) in snapshot.segments.iter().enumerate() {
-                segments.push(FuseSegmentPartInfo::create(idx, segment_location.clone()));
+                segments.push(FuseLazyPartInfo::create(idx, segment_location.clone()));
             }
             Partitions::create(PartitionsShuffleKind::Mod, segments)
         } else {

--- a/src/query/storages/fuse/src/operations/mutation/meta/compact_part.rs
+++ b/src/query/storages/fuse/src/operations/mutation/meta/compact_part.rs
@@ -18,7 +18,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 
-use databend_common_catalog::plan::PartInfo;
+use databend_common_catalog::plan::{PartInfo, PartInfoType};
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -53,6 +53,10 @@ impl PartInfo for CompactSegmentPartInfo {
         let mut s = DefaultHasher::new();
         self.segment_indices.hash(&mut s);
         s.finish()
+    }
+
+    fn part_type(&self) -> PartInfoType {
+        PartInfoType::SegmentLevel
     }
 }
 

--- a/src/query/storages/fuse/src/operations/mutation/meta/compact_part.rs
+++ b/src/query/storages/fuse/src/operations/mutation/meta/compact_part.rs
@@ -30,21 +30,22 @@ use crate::operations::common::BlockMetaIndex;
 use crate::operations::mutation::BlockIndex;
 use crate::operations::mutation::SegmentIndex;
 
+/// Compact segment part information.
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone)]
-pub struct CompactLazyPartInfo {
+pub struct CompactSegmentPartInfo {
     pub segment_indices: Vec<SegmentIndex>,
     pub compact_segments: Vec<Arc<CompactSegmentInfo>>,
 }
 
 #[typetag::serde(name = "compact_lazy")]
-impl PartInfo for CompactLazyPartInfo {
+impl PartInfo for CompactSegmentPartInfo {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn equals(&self, info: &Box<dyn PartInfo>) -> bool {
         info.as_any()
-            .downcast_ref::<CompactLazyPartInfo>()
+            .downcast_ref::<CompactSegmentPartInfo>()
             .is_some_and(|other| self == other)
     }
 
@@ -55,33 +56,34 @@ impl PartInfo for CompactLazyPartInfo {
     }
 }
 
-impl CompactLazyPartInfo {
+impl CompactSegmentPartInfo {
     pub fn create(
         segment_indices: Vec<SegmentIndex>,
         compact_segments: Vec<Arc<CompactSegmentInfo>>,
     ) -> PartInfoPtr {
-        Arc::new(Box::new(CompactLazyPartInfo {
+        Arc::new(Box::new(CompactSegmentPartInfo {
             segment_indices,
             compact_segments,
         }))
     }
 }
 
+/// Compact block part information.
 #[derive(serde::Serialize, serde::Deserialize, PartialEq)]
-pub enum CompactPartInfo {
+pub enum CompactBlockPartInfo {
     CompactExtraInfo(CompactExtraInfo),
     CompactTaskInfo(CompactTaskInfo),
 }
 
 #[typetag::serde(name = "compact_part_info")]
-impl PartInfo for CompactPartInfo {
+impl PartInfo for CompactBlockPartInfo {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn equals(&self, info: &Box<dyn PartInfo>) -> bool {
         info.as_any()
-            .downcast_ref::<CompactPartInfo>()
+            .downcast_ref::<CompactBlockPartInfo>()
             .is_some_and(|other| self == other)
     }
 
@@ -93,10 +95,10 @@ impl PartInfo for CompactPartInfo {
     }
 }
 
-impl CompactPartInfo {
-    pub fn from_part(info: &PartInfoPtr) -> Result<&CompactPartInfo> {
+impl CompactBlockPartInfo {
+    pub fn from_part(info: &PartInfoPtr) -> Result<&CompactBlockPartInfo> {
         info.as_any()
-            .downcast_ref::<CompactPartInfo>()
+            .downcast_ref::<CompactBlockPartInfo>()
             .ok_or_else(|| ErrorCode::Internal("Cannot downcast from PartInfo to CompactPartInfo."))
     }
 }

--- a/src/query/storages/fuse/src/operations/mutation/meta/mod.rs
+++ b/src/query/storages/fuse/src/operations/mutation/meta/mod.rs
@@ -18,7 +18,7 @@ mod mutation_part;
 
 pub use compact_part::CompactBlockPartInfo;
 pub use compact_part::CompactExtraInfo;
-pub use compact_part::CompactSegmentPartInfo;
+pub use compact_part::CompactLazyPartInfo;
 pub use compact_part::CompactTaskInfo;
 pub use mutation_meta::ClusterStatsGenType;
 pub use mutation_meta::SerializeBlock;

--- a/src/query/storages/fuse/src/operations/mutation/meta/mod.rs
+++ b/src/query/storages/fuse/src/operations/mutation/meta/mod.rs
@@ -16,9 +16,9 @@ mod compact_part;
 mod mutation_meta;
 mod mutation_part;
 
+pub use compact_part::CompactBlockPartInfo;
 pub use compact_part::CompactExtraInfo;
-pub use compact_part::CompactLazyPartInfo;
-pub use compact_part::CompactPartInfo;
+pub use compact_part::CompactSegmentPartInfo;
 pub use compact_part::CompactTaskInfo;
 pub use mutation_meta::ClusterStatsGenType;
 pub use mutation_meta::SerializeBlock;

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -40,7 +40,7 @@ use crate::operations::common::BlockMetaIndex;
 use crate::operations::mutation::BlockIndex;
 use crate::operations::mutation::CompactBlockPartInfo;
 use crate::operations::mutation::CompactExtraInfo;
-use crate::operations::mutation::CompactSegmentPartInfo;
+use crate::operations::mutation::CompactLazyPartInfo;
 use crate::operations::mutation::CompactTaskInfo;
 use crate::operations::mutation::SegmentIndex;
 use crate::operations::mutation::MAX_BLOCK_COUNT;
@@ -194,7 +194,7 @@ impl BlockCompactMutator {
                 .into_iter()
                 .map(|v| {
                     v.as_any()
-                        .downcast_ref::<CompactSegmentPartInfo>()
+                        .downcast_ref::<CompactLazyPartInfo>()
                         .unwrap()
                         .clone()
                 })
@@ -222,7 +222,7 @@ impl BlockCompactMutator {
         column_ids: HashSet<ColumnId>,
         cluster_key_id: Option<u32>,
         thresholds: BlockThresholds,
-        mut lazy_parts: Vec<CompactSegmentPartInfo>,
+        mut lazy_parts: Vec<CompactLazyPartInfo>,
     ) -> Result<Vec<PartInfoPtr>> {
         let start = Instant::now();
 
@@ -300,7 +300,7 @@ impl BlockCompactMutator {
                 compact_segments.push(segment);
             }
 
-            let lazy_part = CompactSegmentPartInfo::create(segment_indices, compact_segments);
+            let lazy_part = CompactLazyPartInfo::create(segment_indices, compact_segments);
             parts.push(lazy_part);
         }
     }

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -38,9 +38,9 @@ use crate::io::SegmentsIO;
 use crate::operations::acquire_task_permit;
 use crate::operations::common::BlockMetaIndex;
 use crate::operations::mutation::BlockIndex;
+use crate::operations::mutation::CompactBlockPartInfo;
 use crate::operations::mutation::CompactExtraInfo;
-use crate::operations::mutation::CompactLazyPartInfo;
-use crate::operations::mutation::CompactPartInfo;
+use crate::operations::mutation::CompactSegmentPartInfo;
 use crate::operations::mutation::CompactTaskInfo;
 use crate::operations::mutation::SegmentIndex;
 use crate::operations::mutation::MAX_BLOCK_COUNT;
@@ -194,7 +194,7 @@ impl BlockCompactMutator {
                 .into_iter()
                 .map(|v| {
                     v.as_any()
-                        .downcast_ref::<CompactLazyPartInfo>()
+                        .downcast_ref::<CompactSegmentPartInfo>()
                         .unwrap()
                         .clone()
                 })
@@ -222,7 +222,7 @@ impl BlockCompactMutator {
         column_ids: HashSet<ColumnId>,
         cluster_key_id: Option<u32>,
         thresholds: BlockThresholds,
-        mut lazy_parts: Vec<CompactLazyPartInfo>,
+        mut lazy_parts: Vec<CompactSegmentPartInfo>,
     ) -> Result<Vec<PartInfoPtr>> {
         let start = Instant::now();
 
@@ -300,7 +300,7 @@ impl BlockCompactMutator {
                 compact_segments.push(segment);
             }
 
-            let lazy_part = CompactLazyPartInfo::create(segment_indices, compact_segments);
+            let lazy_part = CompactSegmentPartInfo::create(segment_indices, compact_segments);
             parts.push(lazy_part);
         }
     }
@@ -572,7 +572,7 @@ impl CompactTaskBuilder {
         let segment_idx = removed_segment_indexes.pop().unwrap();
         let mut partitions: Vec<PartInfoPtr> = Vec::with_capacity(tasks.len() + 1);
         for (block_idx, blocks) in tasks.into_iter() {
-            partitions.push(Arc::new(Box::new(CompactPartInfo::CompactTaskInfo(
+            partitions.push(Arc::new(Box::new(CompactBlockPartInfo::CompactTaskInfo(
                 CompactTaskInfo::create(blocks, BlockMetaIndex {
                     segment_idx,
                     block_idx,
@@ -580,7 +580,7 @@ impl CompactTaskBuilder {
             ))));
         }
 
-        partitions.push(Arc::new(Box::new(CompactPartInfo::CompactExtraInfo(
+        partitions.push(Arc::new(Box::new(CompactBlockPartInfo::CompactExtraInfo(
             CompactExtraInfo::create(
                 segment_idx,
                 unchanged_blocks,

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -199,7 +199,7 @@ impl BlockCompactMutator {
                         .clone()
                 })
                 .collect::<Vec<_>>();
-            Partitions::create_nolazy(
+            Partitions::create(
                 PartitionsShuffleKind::Mod,
                 BlockCompactMutator::build_compact_tasks(
                     self.ctx.clone(),
@@ -211,7 +211,7 @@ impl BlockCompactMutator {
                 .await?,
             )
         } else {
-            Partitions::create(PartitionsShuffleKind::Mod, parts, true)
+            Partitions::create(PartitionsShuffleKind::Mod, parts)
         };
         Ok(partitions)
     }

--- a/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
@@ -34,7 +34,7 @@ use databend_storages_common_table_meta::meta::BlockMeta;
 use crate::io::BlockReader;
 use crate::io::ReadSettings;
 use crate::operations::mutation::ClusterStatsGenType;
-use crate::operations::mutation::CompactPartInfo;
+use crate::operations::mutation::CompactBlockPartInfo;
 use crate::operations::mutation::SerializeBlock;
 use crate::operations::mutation::SerializeDataMeta;
 use crate::operations::BlockMetaIndex;
@@ -187,14 +187,14 @@ impl Processor for CompactSource {
 
                 // block read tasks.
                 let mut task_futures = Vec::new();
-                let part = CompactPartInfo::from_part(&part)?;
+                let part = CompactBlockPartInfo::from_part(&part)?;
                 match part {
-                    CompactPartInfo::CompactExtraInfo(extra) => {
+                    CompactBlockPartInfo::CompactExtraInfo(extra) => {
                         let meta = Box::new(SerializeDataMeta::CompactExtras(extra.clone()));
                         let block = DataBlock::empty_with_meta(meta);
                         self.state = State::Output(self.ctx.get_partition(), block);
                     }
-                    CompactPartInfo::CompactTaskInfo(task) => {
+                    CompactBlockPartInfo::CompactTaskInfo(task) => {
                         for block in &task.blocks {
                             let settings = ReadSettings::from_ctx(&self.ctx)?;
                             // read block in parallel.

--- a/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
@@ -42,7 +42,7 @@ use databend_common_pipeline_core::processors::Processor;
 use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_sql::evaluator::BlockOperator;
 
-use crate::fuse_part::FusePartInfo;
+use crate::fuse_part::FuseBlockPartInfo;
 use crate::io::BlockReader;
 use crate::io::ReadSettings;
 use crate::operations::common::BlockMetaIndex;
@@ -184,7 +184,7 @@ impl Processor for MutationSource {
                 )?;
                 let num_rows = data_block.num_rows();
 
-                let fuse_part = FusePartInfo::from_part(&part)?;
+                let fuse_part = FuseBlockPartInfo::from_part(&part)?;
                 if let Some(filter) = self.filter.as_ref() {
                     if self.query_row_id_col {
                         // Add internal column to data block
@@ -319,7 +319,7 @@ impl Processor for MutationSource {
                 mut data_block,
                 filter,
             } => {
-                let path = FusePartInfo::from_part(&part)?.location.clone();
+                let path = FuseBlockPartInfo::from_part(&part)?.location.clone();
                 if let Some(remain_reader) = self.remain_reader.as_ref() {
                     let chunks = merged_io_read_result.columns_chunks()?;
                     let remain_block = remain_reader.deserialize_chunks_with_part_info(
@@ -395,7 +395,7 @@ impl Processor for MutationSource {
                         }
 
                         let inner_part = part.inner_part.clone();
-                        let fuse_part = FusePartInfo::from_part(&inner_part)?;
+                        let fuse_part = FuseBlockPartInfo::from_part(&inner_part)?;
 
                         if part.whole_block_mutation
                             && matches!(self.action, MutationAction::Deletion)
@@ -434,7 +434,7 @@ impl Processor for MutationSource {
                 filter,
             } => {
                 if let Some(remain_reader) = self.remain_reader.as_ref() {
-                    let fuse_part = FusePartInfo::from_part(&part)?;
+                    let fuse_part = FuseBlockPartInfo::from_part(&part)?;
 
                     let settings = ReadSettings::from_ctx(&self.ctx)?;
                     let read_res = remain_reader

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -229,7 +229,7 @@ pub fn dispatch_partitions(
 ) -> Vec<VecDeque<PartInfoPtr>> {
     let mut results = Vec::with_capacity(max_streams);
     // Lazy part, we can dispatch them now.
-    if plan.parts.partitions_type() == PartInfoType::SegmentLevel {
+    if plan.parts.partitions_type() == PartInfoType::LazyLevel {
         return results;
     }
 

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::PartInfoPtr;
+use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::plan::StealablePartitions;
 use databend_common_catalog::plan::TopK;
 use databend_common_catalog::table_context::TableContext;
@@ -228,7 +229,7 @@ pub fn dispatch_partitions(
 ) -> Vec<VecDeque<PartInfoPtr>> {
     let mut results = Vec::with_capacity(max_streams);
     // Lazy part, we can dispatch them now.
-    if plan.parts.is_lazy {
+    if plan.parts.partitions_type() == PartInfoType::SegmentLevel {
         return results;
     }
 
@@ -260,7 +261,7 @@ pub fn adjust_threads_and_request(
     mut max_io_requests: usize,
     plan: &DataSourcePlan,
 ) -> (usize, usize) {
-    if !plan.parts.is_lazy {
+    if plan.parts.partitions_type() == PartInfoType::BlockLevel {
         let mut block_nums = plan.parts.partitions.len();
 
         // If the read bytes of a partition is small enough, less than 16k rows

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -28,7 +28,7 @@ use databend_common_pipeline_core::Pipeline;
 use databend_common_pipeline_core::SourcePipeBuilder;
 use log::info;
 
-use crate::fuse_part::FusePartInfo;
+use crate::fuse_part::FuseBlockPartInfo;
 use crate::io::AggIndexReader;
 use crate::io::BlockReader;
 use crate::io::VirtualColumnReader;
@@ -270,7 +270,7 @@ pub fn adjust_threads_and_request(
         static MIN_ROWS_READ_PER_THREAD: u64 = 16 * 1024;
         if is_native {
             plan.parts.partitions.iter().for_each(|part| {
-                if let Some(part) = part.as_any().downcast_ref::<FusePartInfo>() {
+                if let Some(part) = part.as_any().downcast_ref::<FuseBlockPartInfo>() {
                     let to_read_rows = part
                         .columns_meta
                         .values()

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -46,7 +46,7 @@ use xorf::BinaryFuse16;
 use super::parquet_data_source::ParquetDataSource;
 use super::util::add_data_block_meta;
 use super::util::need_reserve_block_info;
-use crate::fuse_part::FusePartInfo;
+use crate::fuse_part::FuseBlockPartInfo;
 use crate::io::AggIndexReader;
 use crate::io::BlockReader;
 use crate::io::UncompressedBuffer;
@@ -261,7 +261,7 @@ impl Processor for DeserializeDataTransform {
                 ParquetDataSource::Normal((data, virtual_data)) => {
                     let start = Instant::now();
                     let columns_chunks = data.columns_chunks()?;
-                    let part = FusePartInfo::from_part(&part)?;
+                    let part = FuseBlockPartInfo::from_part(&part)?;
 
                     let mut data_block = self.block_reader.deserialize_parquet_chunks_with_buffer(
                         &part.location,

--- a/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
@@ -38,7 +38,7 @@ use crate::io::CompactSegmentInfoReader;
 use crate::io::MetaReaders;
 use crate::io::ReadSettings;
 use crate::io::UncompressedBuffer;
-use crate::FusePartInfo;
+use crate::FuseBlockPartInfo;
 use crate::FuseTable;
 use crate::MergeIOReadResult;
 
@@ -233,7 +233,7 @@ impl<const BLOCKING_IO: bool> ParquetRowsFetcher<BLOCKING_IO> {
             }
         } else {
             for part in parts.iter() {
-                let part = FusePartInfo::from_part(part)?;
+                let part = FuseBlockPartInfo::from_part(part)?;
                 let chunk = reader
                     .read_columns_data_by_merge_io(
                         &settings,
@@ -263,7 +263,7 @@ impl<const BLOCKING_IO: bool> ParquetRowsFetcher<BLOCKING_IO> {
         uncompressed_buffer: Arc<UncompressedBuffer>,
     ) -> Result<DataBlock> {
         let columns_chunks = chunk.columns_chunks()?;
-        let part = FusePartInfo::from_part(part)?;
+        let part = FuseBlockPartInfo::from_part(part)?;
         reader.deserialize_parquet_chunks_with_buffer(
             &part.location,
             part.nums_rows,

--- a/src/query/storages/fuse/src/operations/read/runtime_filter_prunner.rs
+++ b/src/query/storages/fuse/src/operations/read/runtime_filter_prunner.rs
@@ -40,7 +40,7 @@ use log::info;
 use xorf::BinaryFuse16;
 use xorf::Filter;
 
-use crate::FusePartInfo;
+use crate::FuseBlockPartInfo;
 
 pub fn runtime_filter_pruner(
     table_schema: Arc<TableSchema>,
@@ -51,7 +51,7 @@ pub fn runtime_filter_pruner(
     if filters.is_empty() {
         return Ok(false);
     }
-    let part = FusePartInfo::from_part(part)?;
+    let part = FuseBlockPartInfo::from_part(part)?;
     let pruned = filters.iter().any(|filter| {
         let column_refs = filter.column_refs();
         // Currently only support filter with one column(probe key).

--- a/src/query/storages/fuse/src/operations/read/util.rs
+++ b/src/query/storages/fuse/src/operations/read/util.rs
@@ -24,7 +24,7 @@ use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
 
 use crate::operations::BlockMetaIndex;
-use crate::FusePartInfo;
+use crate::FuseBlockPartInfo;
 
 pub fn need_reserve_block_info(ctx: Arc<dyn TableContext>, table_idx: usize) -> (bool, bool) {
     let merge_into_join = ctx.get_merge_into_join();
@@ -39,7 +39,7 @@ pub fn need_reserve_block_info(ctx: Arc<dyn TableContext>, table_idx: usize) -> 
 
 pub(crate) fn add_data_block_meta(
     block: DataBlock,
-    fuse_part: &FusePartInfo,
+    fuse_part: &FuseBlockPartInfo,
     offsets: Option<Vec<usize>>,
     base_block_ids: Option<Scalar>,
     update_stream_columns: bool,

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -36,7 +36,7 @@ use crate::operations::read::build_fuse_parquet_source_pipeline;
 use crate::operations::read::fuse_source::build_fuse_native_source_pipeline;
 use crate::pruning::InvertedIndexPruner;
 use crate::pruning::SegmentLocation;
-use crate::FuseSegmentPartInfo;
+use crate::FuseLazyPartInfo;
 use crate::FuseStorageFormat;
 use crate::FuseTable;
 
@@ -153,7 +153,7 @@ impl FuseTable {
         let mut lazy_init_segments = Vec::with_capacity(plan.parts.len());
 
         for part in &plan.parts.partitions {
-            if let Some(lazy_part_info) = part.as_any().downcast_ref::<FuseSegmentPartInfo>() {
+            if let Some(lazy_part_info) = part.as_any().downcast_ref::<FuseLazyPartInfo>() {
                 lazy_init_segments.push(SegmentLocation {
                     segment_idx: lazy_part_info.segment_index,
                     location: lazy_part_info.segment_location.clone(),

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -36,7 +36,7 @@ use crate::operations::read::build_fuse_parquet_source_pipeline;
 use crate::operations::read::fuse_source::build_fuse_native_source_pipeline;
 use crate::pruning::InvertedIndexPruner;
 use crate::pruning::SegmentLocation;
-use crate::FuseLazyPartInfo;
+use crate::FuseSegmentPartInfo;
 use crate::FuseStorageFormat;
 use crate::FuseTable;
 
@@ -153,7 +153,7 @@ impl FuseTable {
         let mut lazy_init_segments = Vec::with_capacity(plan.parts.len());
 
         for part in &plan.parts.partitions {
-            if let Some(lazy_part_info) = part.as_any().downcast_ref::<FuseLazyPartInfo>() {
+            if let Some(lazy_part_info) = part.as_any().downcast_ref::<FuseSegmentPartInfo>() {
                 lazy_init_segments.push(SegmentLocation {
                     segment_idx: lazy_part_info.segment_index,
                     location: lazy_part_info.segment_location.clone(),

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -51,7 +51,7 @@ use crate::pruning::create_segment_location_vector;
 use crate::pruning::FusePruner;
 use crate::pruning::InvertedIndexPruner;
 use crate::pruning::SegmentLocation;
-use crate::FuseSegmentPartInfo;
+use crate::FuseLazyPartInfo;
 use crate::FuseTable;
 
 impl FuseTable {
@@ -95,7 +95,7 @@ impl FuseTable {
                 if (!dry_run && snapshot.segments.len() > nodes_num) || is_lazy {
                     let mut segments = Vec::with_capacity(snapshot.segments.len());
                     for (idx, segment_location) in snapshot.segments.iter().enumerate() {
-                        segments.push(FuseSegmentPartInfo::create(idx, segment_location.clone()))
+                        segments.push(FuseLazyPartInfo::create(idx, segment_location.clone()))
                     }
 
                     return Ok((

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -107,7 +107,7 @@ impl FuseTable {
                             snapshot.segments.len(),
                             snapshot.index_info_locations.clone(),
                         ),
-                        Partitions::create(PartitionsShuffleKind::Mod, segments, true),
+                        Partitions::create(PartitionsShuffleKind::Mod, segments),
                     ));
                 }
 
@@ -430,7 +430,7 @@ impl FuseTable {
         limit: usize,
     ) -> (PartStatistics, Partitions) {
         let mut statistics = PartStatistics::default_exact();
-        let mut partitions = Partitions::create_nolazy(PartitionsShuffleKind::Mod, vec![]);
+        let mut partitions = Partitions::create(PartitionsShuffleKind::Mod, vec![]);
 
         if limit == 0 {
             return (statistics, partitions);

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -45,13 +45,13 @@ use sha2::Digest;
 use sha2::Sha256;
 
 use super::collect_incremental_blocks;
-use crate::fuse_part::FusePartInfo;
+use crate::fuse_part::FuseBlockPartInfo;
 use crate::io::SegmentsIO;
 use crate::pruning::create_segment_location_vector;
 use crate::pruning::FusePruner;
 use crate::pruning::InvertedIndexPruner;
 use crate::pruning::SegmentLocation;
-use crate::FuseLazyPartInfo;
+use crate::FuseSegmentPartInfo;
 use crate::FuseTable;
 
 impl FuseTable {
@@ -95,7 +95,7 @@ impl FuseTable {
                 if (!dry_run && snapshot.segments.len() > nodes_num) || is_lazy {
                     let mut segments = Vec::with_capacity(snapshot.segments.len());
                     for (idx, segment_location) in snapshot.segments.iter().enumerate() {
-                        segments.push(FuseLazyPartInfo::create(idx, segment_location.clone()))
+                        segments.push(FuseSegmentPartInfo::create(idx, segment_location.clone()))
                     }
 
                     return Ok((
@@ -552,7 +552,7 @@ impl FuseTable {
                 .unwrap_or((default.clone(), default.clone()))
         });
 
-        FusePartInfo::create(
+        FuseBlockPartInfo::create(
             location,
             rows_count,
             columns_meta,
@@ -600,7 +600,7 @@ impl FuseTable {
         // TODO
         // row_count should be a hint value of  LIMIT,
         // not the count the rows in this partition
-        FusePartInfo::create(
+        FuseBlockPartInfo::create(
             location,
             rows_count,
             columns_meta,

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -531,7 +531,7 @@ impl HiveTable {
 
         Ok((
             Default::default(),
-            Partitions::create_nolazy(PartitionsShuffleKind::Seq, partitions),
+            Partitions::create(PartitionsShuffleKind::Seq, partitions),
         ))
     }
 }

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -320,7 +320,7 @@ impl IcebergTable {
                 total_files,
                 None,
             ),
-            Partitions::create_nolazy(PartitionsShuffleKind::Mod, parts),
+            Partitions::create(PartitionsShuffleKind::Mod, parts),
         ))
     }
 }

--- a/src/query/storages/memory/src/memory_table.rs
+++ b/src/query/storages/memory/src/memory_table.rs
@@ -134,7 +134,7 @@ impl MemoryTable {
             }
         }
 
-        Partitions::create_nolazy(PartitionsShuffleKind::Seq, partitions)
+        Partitions::create(PartitionsShuffleKind::Seq, partitions)
     }
 }
 

--- a/src/query/storages/parquet/src/parquet_rs/copy_into_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_rs/copy_into_table/table.rs
@@ -107,10 +107,7 @@ impl ParquetTableForCopy {
         stats.partitions_total = parts.len();
         stats.read_bytes = total_size;
 
-        Ok((
-            stats,
-            Partitions::create_nolazy(PartitionsShuffleKind::Mod, parts),
-        ))
+        Ok((stats, Partitions::create(PartitionsShuffleKind::Mod, parts)))
     }
 
     pub fn do_read_data(

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/partition.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/partition.rs
@@ -285,7 +285,7 @@ async fn prune_metas_in_parallel(
     if files.is_empty() {
         return Ok((
             PartStatistics::default_exact(),
-            Partitions::create_nolazy(PartitionsShuffleKind::Mod, vec![]),
+            Partitions::create(PartitionsShuffleKind::Mod, vec![]),
         ));
     }
 
@@ -455,5 +455,5 @@ fn create_partitions(mut parts: Vec<ParquetRSRowGroupPart>, topk: &Option<TopK>)
         .map(|p| Arc::new(Box::new(ParquetPart::ParquetRSRowGroup(p)) as Box<dyn PartInfo>))
         .collect();
 
-    Partitions::create_nolazy(PartitionsShuffleKind::Mod, parts)
+    Partitions::create(PartitionsShuffleKind::Mod, parts)
 }

--- a/src/query/storages/random/src/random_table.rs
+++ b/src/query/storages/random/src/random_table.rs
@@ -76,7 +76,7 @@ impl RandomTable {
                 partitions.push(RandomPartInfo::create(rows));
             }
         }
-        Partitions::create_nolazy(PartitionsShuffleKind::Seq, partitions)
+        Partitions::create(PartitionsShuffleKind::Seq, partitions)
     }
 }
 

--- a/src/query/storages/stage/src/input_context_bridge.rs
+++ b/src/query/storages/stage/src/input_context_bridge.rs
@@ -68,7 +68,7 @@ impl StageTable {
             .collect::<Vec<_>>();
         Ok((
             PartStatistics::default(),
-            Partitions::create_nolazy(PartitionsShuffleKind::Seq, partitions),
+            Partitions::create(PartitionsShuffleKind::Seq, partitions),
         ))
     }
 

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -118,7 +118,7 @@ impl StageTable {
 
         Ok((
             statistics,
-            Partitions::create_nolazy(PartitionsShuffleKind::Seq, partitions),
+            Partitions::create(PartitionsShuffleKind::Seq, partitions),
         ))
     }
 }

--- a/src/query/storages/stream/src/stream_table.rs
+++ b/src/query/storages/stream/src/stream_table.rs
@@ -292,9 +292,11 @@ impl StreamTable {
             pruning_stats,
         )?;
         if let Some(base_block_ids_scalar) = base_block_ids_scalar {
-            let wrapper = Partitions::create_nolazy(PartitionsShuffleKind::Seq, vec![
-                StreamTablePart::create(parts, base_block_ids_scalar),
-            ]);
+            let wrapper =
+                Partitions::create(PartitionsShuffleKind::Seq, vec![StreamTablePart::create(
+                    parts,
+                    base_block_ids_scalar,
+                )]);
             Ok((stats, wrapper))
         } else {
             Ok((stats, parts))

--- a/src/query/storages/system/src/log_queue.rs
+++ b/src/query/storages/system/src/log_queue.rs
@@ -168,7 +168,7 @@ impl<Event: SystemLogElement + 'static> Table for SystemLogTable<Event> {
         Ok((
             PartStatistics::default(),
             // Make the table in distributed.
-            Partitions::create_nolazy(PartitionsShuffleKind::Broadcast, vec![Arc::new(Box::new(
+            Partitions::create(PartitionsShuffleKind::Broadcast, vec![Arc::new(Box::new(
                 SystemTablePart,
             ))]),
         ))

--- a/src/query/storages/system/src/one_table.rs
+++ b/src/query/storages/system/src/one_table.rs
@@ -60,7 +60,7 @@ impl SyncSystemTable for OneTable {
     ) -> Result<(PartStatistics, Partitions)> {
         Ok((
             PartStatistics::new_exact(1, 1, 1, 1),
-            Partitions::create_nolazy(PartitionsShuffleKind::Seq, vec![Arc::new(Box::new(
+            Partitions::create(PartitionsShuffleKind::Seq, vec![Arc::new(Box::new(
                 SystemTablePart,
             ))]),
         ))

--- a/src/query/storages/system/src/table.rs
+++ b/src/query/storages/system/src/table.rs
@@ -71,15 +71,15 @@ pub trait SyncSystemTable: Send + Sync {
         match Self::IS_LOCAL {
             true => Ok((
                 PartStatistics::default(),
-                Partitions::create_nolazy(PartitionsShuffleKind::Seq, vec![Arc::new(Box::new(
+                Partitions::create(PartitionsShuffleKind::Seq, vec![Arc::new(Box::new(
                     SystemTablePart,
                 ))]),
             )),
             false => Ok((
                 PartStatistics::default(),
-                Partitions::create_nolazy(PartitionsShuffleKind::Broadcast, vec![Arc::new(
-                    Box::new(SystemTablePart),
-                )]),
+                Partitions::create(PartitionsShuffleKind::Broadcast, vec![Arc::new(Box::new(
+                    SystemTablePart,
+                ))]),
             )),
         }
     }
@@ -215,15 +215,15 @@ pub trait AsyncSystemTable: Send + Sync {
         match Self::IS_LOCAL {
             true => Ok((
                 PartStatistics::default(),
-                Partitions::create_nolazy(PartitionsShuffleKind::Seq, vec![Arc::new(Box::new(
+                Partitions::create(PartitionsShuffleKind::Seq, vec![Arc::new(Box::new(
                     SystemTablePart,
                 ))]),
             )),
             false => Ok((
                 PartStatistics::default(),
-                Partitions::create_nolazy(PartitionsShuffleKind::Broadcast, vec![Arc::new(
-                    Box::new(SystemTablePart),
-                )]),
+                Partitions::create(PartitionsShuffleKind::Broadcast, vec![Arc::new(Box::new(
+                    SystemTablePart,
+                ))]),
             )),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Instead of declaring with is_lazy, use the PartInfo type itself to determine whether it's a Lazy(Segment) or Block level.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Exists Tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
