### PR TITLE
fix: sqllogicaltest datatype mismatch in `expr_in_window.test`

### DIFF
--- a/tests/sqllogictests/suites/query/window_function/expr_in_window.test
+++ b/tests/sqllogictests/suites/query/window_function/expr_in_window.test
@@ -247,7 +247,7 @@ SELECT enroll_date, salary, last_value(salary + 1) OVER (ORDER BY enroll_date) F
 2008-01-01 4500 4501
 
 # nth_value
-query III
+query TII
 SELECT depname, empno,
 	nth_value(empno + 1, 2) OVER (
 		PARTITION BY depname ORDER BY empno ASC
@@ -268,7 +268,7 @@ sales 3 5
 sales 4 NULL
 
 # nth_value
-query III
+query TII
 SELECT depname, empno,
 	nth_value(empno + 1, 2) OVER (
 		PARTITION BY depname ORDER BY empno ASC


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

sqllogicaltest datatype mismatch in `expr_in_window.test`. `depname` should be type T not I.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
