### PR TITLE
refactor: `QueryFragmentsPlanPacket` should include just setting changes

### DIFF
--- a/src/query/service/src/api/rpc/packets/packet_executor.rs
+++ b/src/query/service/src/api/rpc/packets/packet_executor.rs
@@ -15,12 +15,13 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use dashmap::DashMap;
 use databend_common_catalog::query_kind::QueryKind;
 use databend_common_config::InnerConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_types::NodeInfo;
-use databend_common_settings::Settings;
+use databend_common_settings::ChangeValue;
 
 use crate::api::rpc::flight_actions::InitQueryFragmentsPlan;
 use crate::api::rpc::packets::packet::create_client;
@@ -35,7 +36,7 @@ pub struct QueryFragmentsPlanPacket {
     pub executor: String,
     pub request_executor: String,
     pub fragments: Vec<FragmentPlanPacket>,
-    pub changed_settings: Arc<Settings>,
+    pub changed_settings: Arc<DashMap<String, ChangeValue>>,
     // We send nodes info for each node. This is a bad choice
     pub executors_info: HashMap<String, Arc<NodeInfo>>,
 }
@@ -48,7 +49,7 @@ impl QueryFragmentsPlanPacket {
         executor: String,
         fragments: Vec<FragmentPlanPacket>,
         executors_info: HashMap<String, Arc<NodeInfo>>,
-        changed_settings: Arc<Settings>,
+        changed_settings: Arc<DashMap<String, ChangeValue>>,
         request_executor: String,
     ) -> QueryFragmentsPlanPacket {
         QueryFragmentsPlanPacket {

--- a/src/query/service/src/schedulers/fragments/query_fragment_actions.rs
+++ b/src/query/service/src/schedulers/fragments/query_fragment_actions.rs
@@ -179,7 +179,7 @@ impl QueryFragmentsActions {
             cluster.local_id.clone(),
             fragments_packets.remove(&cluster.local_id).unwrap(),
             nodes_info.clone(),
-            settings.clone(),
+            settings.changes().clone(),
             cluster.local_id(),
         );
 
@@ -194,7 +194,7 @@ impl QueryFragmentsActions {
                 executor,
                 fragments,
                 executors_info,
-                settings.clone(),
+                settings.changes().clone(),
                 cluster.local_id(),
             ));
         }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -645,7 +645,7 @@ impl TableContext for QueryContext {
         if !self.query_settings.is_changed() {
             unsafe {
                 self.query_settings
-                    .unchecked_apply_changes(&self.shared.get_settings());
+                    .unchecked_apply_changes(self.shared.get_settings().changes());
             }
         }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: `QueryFragmentsPlanPacket` should include just setting changes

There is no need to have the entire `Settings` in `QueryFragmentsPlanPacket`.
Only the `Settings.changes` is used.

And `Settings.tenant` can not be `serde` in future, ths
`QueryFragmentsPlanPacket` can not include a `Tenant` in it.

- Part of #14719

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues