### PR TITLE
feat(query): add query_result_cache_min_execute_secs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,6 +4097,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tokio",
  "uuid",
 ]
 

--- a/src/query/service/src/interpreters/interpreter_select.rs
+++ b/src/query/service/src/interpreters/interpreter_select.rs
@@ -263,6 +263,7 @@ impl Interpreter for SelectInterpreter {
             self.ctx.get_id(),
             query_plan
         );
+
         if self.ctx.get_settings().get_enable_query_result_cache()? && self.ctx.get_cacheable() {
             let key = gen_result_cache_key(self.formatted_ast.as_ref().unwrap());
             // 1. Try to get result from cache.

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -132,7 +132,7 @@ impl Debug for HttpQueryRequest {
 
 const DEFAULT_MAX_ROWS_IN_BUFFER: usize = 5 * 1000 * 1000;
 const DEFAULT_MAX_ROWS_PER_PAGE: usize = 10000;
-const DEFAULT_WAIT_TIME_SECS: u32 = 1;
+const DEFAULT_WAIT_TIME_SECS: u32 = 10;
 
 fn default_max_rows_in_buffer() -> usize {
     DEFAULT_MAX_ROWS_IN_BUFFER

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -380,6 +380,12 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
+                ("query_result_cache_min_execute_secs", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1),
+                    desc: "For a query to be cached, it must take at least this many seconds to fetch the first block. It helps to avoid caching queries that are too fast to execute or queries with streaming scan.",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
+                }),
                 ("query_result_cache_ttl_secs", DefaultSettingValue {
                     value: UserSettingValue::UInt64(300), // seconds
                     desc: "Sets the time-to-live (TTL) in seconds for cached query results. \

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -346,6 +346,10 @@ impl Settings {
         Ok(self.try_get_u64("query_result_cache_max_bytes")? as usize)
     }
 
+    pub fn get_query_result_cache_min_execute_secs(&self) -> Result<usize> {
+        Ok(self.try_get_u64("query_result_cache_min_execute_secs")? as usize)
+    }
+
     pub fn get_http_handler_result_timeout_secs(&self) -> Result<u64> {
         self.try_get_u64("http_handler_result_timeout_secs")
     }

--- a/src/query/storages/result_cache/Cargo.toml
+++ b/src/query/storages/result_cache/Cargo.toml
@@ -27,8 +27,8 @@ databend-storages-common-table-meta = { path = "../common/table_meta" }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 opendal = { workspace = true }
-tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
+tokio = { workspace = true }
 uuid = { workspace = true }

--- a/src/query/storages/result_cache/Cargo.toml
+++ b/src/query/storages/result_cache/Cargo.toml
@@ -27,6 +27,7 @@ databend-storages-common-table-meta = { path = "../common/table_meta" }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 opendal = { workspace = true }
+tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"

--- a/src/query/storages/result_cache/src/write/sink.rs
+++ b/src/query/storages/result_cache/src/write/sink.rs
@@ -27,6 +27,7 @@ use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_pipeline_sinks::AsyncMpscSink;
 use databend_common_pipeline_sinks::AsyncMpscSinker;
 use databend_common_storage::DataOperator;
+use tokio::time::Instant;
 
 use super::writer::ResultCacheWriter;
 use crate::common::gen_result_cache_dir;
@@ -42,6 +43,13 @@ pub struct WriteResultCacheSink {
     meta_mgr: ResultCacheMetaManager,
     meta_key: String,
     cache_writer: ResultCacheWriter,
+
+    // The time when the sink is created.
+    create_time: Instant,
+
+    // A flag indicates at least one block has been consumed.
+    consumed_one_block: bool,
+    terminated: bool,
 }
 
 #[async_trait::async_trait]
@@ -51,10 +59,24 @@ impl AsyncMpscSink for WriteResultCacheSink {
     #[async_trait::unboxed_simple]
     #[async_backtrace::framed]
     async fn consume(&mut self, block: DataBlock) -> Result<bool> {
+        if self.terminated {
+            return Ok(true);
+        }
+
+        if !self.consumed_one_block {
+            if self.cache_writer.not_over_time(&self.create_time) {
+                // Skip the cache writing if the query execution time is less than the min_execute_secs.
+                self.terminated = true;
+                return Ok(true);
+            }
+            self.consumed_one_block = true;
+        }
+
         if !self.cache_writer.over_limit() {
             self.cache_writer.append_block(block);
             Ok(false)
         } else {
+            self.terminated = true;
             // Finish the cache writing pipeline.
             Ok(true)
         }
@@ -62,7 +84,7 @@ impl AsyncMpscSink for WriteResultCacheSink {
 
     #[async_backtrace::framed]
     async fn on_finish(&mut self) -> Result<()> {
-        if self.cache_writer.over_limit() {
+        if self.terminated {
             return Ok(());
         }
 
@@ -103,6 +125,7 @@ impl WriteResultCacheSink {
     ) -> Result<ProcessorPtr> {
         let settings = ctx.get_settings();
         let max_bytes = settings.get_query_result_cache_max_bytes()?;
+        let min_execute_secs = settings.get_query_result_cache_min_execute_secs()?;
         let ttl = settings.get_query_result_cache_ttl_secs()?;
         let tenant = ctx.get_tenant();
         let sql = ctx.get_query_str();
@@ -112,8 +135,14 @@ impl WriteResultCacheSink {
         let location = gen_result_cache_dir(key);
 
         let operator = DataOperator::instance().operator();
-        let cache_writer =
-            ResultCacheWriter::create(schema, location, operator, max_bytes, ctx.clone());
+        let cache_writer = ResultCacheWriter::create(
+            schema,
+            location,
+            operator,
+            max_bytes,
+            min_execute_secs,
+            ctx.clone(),
+        );
 
         Ok(ProcessorPtr::create(Box::new(AsyncMpscSinker::create(
             inputs,
@@ -124,6 +153,9 @@ impl WriteResultCacheSink {
                 meta_mgr: ResultCacheMetaManager::create(kv_store, ttl),
                 meta_key,
                 cache_writer,
+                create_time: Instant::now(),
+                consumed_one_block: false,
+                terminated: false,
             },
         ))))
     }

--- a/tests/sqllogictests/suites/base/01_system/01_0011_system_query_cache.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0011_system_query_cache.test
@@ -17,6 +17,20 @@ statement ok
 SET enable_query_result_cache = 1;
 
 statement ok
+SET query_result_cache_min_execute_secs = 5;
+
+statement ok
+SELECT * FROM t1;
+
+query I
+SELECT count() FROM system.query_cache;
+----
+0
+
+statement ok
+SET query_result_cache_min_execute_secs = 0;
+
+statement ok
 SELECT * FROM t1;
 
 query I

--- a/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache.test
+++ b/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache.test
@@ -46,6 +46,9 @@ select block_count as c from fuse_snapshot('db20_13','t1') order by c;
 statement ok
 SET enable_query_result_cache = 1;
 
+statement ok
+SET query_result_cache_min_execute_secs = 0;
+
 # Write cache
 
 query I
@@ -202,6 +205,10 @@ statement ok
 SET enable_query_result_cache = 1;
 
 statement ok
+SET query_result_cache_min_execute_secs = 0;
+
+
+statement ok
 SET query_result_cache_allow_inconsistent = 1;
 
 query I
@@ -291,6 +298,9 @@ insert into a values( 1 ), ( 2 )
 
 statement ok
 SET enable_query_result_cache = 1;
+
+statement ok
+SET query_result_cache_min_execute_secs = 0;
 
 query I
 select 3, a as price from a union all select a, b from ab order by price

--- a/tests/sqllogictests/suites/base/20+_others/20_0014_result_scan.test
+++ b/tests/sqllogictests/suites/base/20+_others/20_0014_result_scan.test
@@ -23,6 +23,9 @@ SELECT * FROM t1 ORDER BY a;
 statement ok
 SET enable_query_result_cache = 1;
 
+statement ok
+SET query_result_cache_min_execute_secs = 0;
+
 statement error `RESULT_SCAN` failed: No cache key found in current session for query ID '.*'\.
 SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary



1. add query_result_cache_min_execute_secs settings. For a query to be cached, it must take at least this many seconds to fetch the first block. It helps to avoid caching queries that are too fast to execute or queries with streaming scan.

2. Increase wait_time_secs to be 10 secs.


- Fixes #15097

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
