### PR TITLE
fix(query): verify_privilege need check privilege one by one

### DIFF
--- a/src/meta/app/src/principal/user_grant.rs
+++ b/src/meta/app/src/principal/user_grant.rs
@@ -310,21 +310,13 @@ impl GrantEntry {
         &self.privileges
     }
 
-    pub fn verify_privilege(
-        &self,
-        object: &GrantObject,
-        privileges: Vec<UserPrivilegeType>,
-    ) -> bool {
+    pub fn verify_privilege(&self, object: &GrantObject, privilege: UserPrivilegeType) -> bool {
         // the verified object should be smaller than the object inside my grant entry.
         if !self.object.contains(object) {
             return false;
         }
 
-        let mut priv_set = UserPrivilegeSet::empty();
-        for privilege in privileges {
-            priv_set.set_privilege(privilege)
-        }
-        self.privileges.contains(BitFlags::from(priv_set))
+        self.privileges.contains(BitFlags::from(privilege))
     }
 
     pub fn matches_entry(&self, object: &GrantObject) -> bool {
@@ -384,14 +376,10 @@ impl UserGrantSet {
         self.roles.remove(role);
     }
 
-    pub fn verify_privilege(
-        &self,
-        object: &GrantObject,
-        privilege: Vec<UserPrivilegeType>,
-    ) -> bool {
+    pub fn verify_privilege(&self, object: &GrantObject, privilege: UserPrivilegeType) -> bool {
         self.entries
             .iter()
-            .any(|e| e.verify_privilege(object, privilege.clone()))
+            .any(|e| e.verify_privilege(object, privilege))
     }
 
     pub fn grant_privileges(&mut self, object: &GrantObject, privileges: UserPrivilegeSet) {

--- a/src/meta/app/tests/it/user_grant.rs
+++ b/src/meta/app/tests/it/user_grant.rs
@@ -129,15 +129,15 @@ fn test_user_grant_entry() -> Result<()> {
     );
     assert!(grant.verify_privilege(
         &GrantObject::Database("default".into(), "db1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
     assert!(!grant.verify_privilege(
         &GrantObject::Database("default".into(), "db1".into()),
-        vec![UserPrivilegeType::Insert]
+        UserPrivilegeType::Insert
     ));
     assert!(grant.verify_privilege(
         &GrantObject::Database("default".into(), "db2".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
 
     let grant = GrantEntry::new(
@@ -146,15 +146,15 @@ fn test_user_grant_entry() -> Result<()> {
     );
     assert!(grant.verify_privilege(
         &GrantObject::Table("default".into(), "db1".into(), "table1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
     assert!(!grant.verify_privilege(
         &GrantObject::Table("default".into(), "db2".into(), "table1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
     assert!(grant.verify_privilege(
         &GrantObject::Database("default".into(), "db1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
 
     let grant = GrantEntry::new(
@@ -163,19 +163,19 @@ fn test_user_grant_entry() -> Result<()> {
     );
     assert!(grant.verify_privilege(
         &GrantObject::Table("default".into(), "db1".into(), "table1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
     assert!(!grant.verify_privilege(
         &GrantObject::Table("default".into(), "db2".into(), "table1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
     assert!(!grant.verify_privilege(
         &GrantObject::Table("default".into(), "db1".into(), "table1".into()),
-        vec![UserPrivilegeType::Insert]
+        UserPrivilegeType::Insert
     ));
     assert!(grant.verify_privilege(
         &GrantObject::Table("default".into(), "db1".into(), "table1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
 
     Ok(())
@@ -216,23 +216,23 @@ fn test_user_grant_set() -> Result<()> {
 
     assert!(grants.verify_privilege(
         &GrantObject::Database("default".into(), "db1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
     assert!(!grants.verify_privilege(
         &GrantObject::Database("default".into(), "db1".into()),
-        vec![UserPrivilegeType::Select]
+        UserPrivilegeType::Select
     ));
     assert!(grants.verify_privilege(
         &GrantObject::Table("default".into(), "db1".into(), "table1".into()),
-        vec![UserPrivilegeType::Create]
+        UserPrivilegeType::Create
     ));
     assert!(!grants.verify_privilege(
         &GrantObject::Table("default".into(), "db1".into(), "table1".into()),
-        vec![UserPrivilegeType::Insert]
+        UserPrivilegeType::Insert
     ));
     assert!(grants.verify_privilege(
         &GrantObject::Table("default".into(), "db1".into(), "table1".into()),
-        vec![UserPrivilegeType::Select]
+        UserPrivilegeType::Select
     ));
     Ok(())
 }

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -149,14 +149,14 @@ impl PrivilegeAccess {
         &self,
         catalog_name: &str,
         db_name: &str,
-        privileges: Vec<UserPrivilegeType>,
+        privileges: UserPrivilegeType,
         if_exists: bool,
     ) -> Result<()> {
         let tenant = self.ctx.get_tenant();
         match self
             .validate_access(
                 &GrantObject::Database(catalog_name.to_string(), db_name.to_string()),
-                privileges.clone(),
+                privileges,
             )
             .await
         {
@@ -177,7 +177,7 @@ impl PrivilegeAccess {
                         if let Err(err) = self
                             .validate_access(
                                 &GrantObject::DatabaseById(catalog_name.to_string(), db_id),
-                                privileges.clone(),
+                                privileges,
                             )
                             .await
                         {
@@ -194,7 +194,7 @@ impl PrivilegeAccess {
                                 .collect::<Vec<_>>()
                                 .join(",");
                             return Err(ErrorCode::PermissionDenied(format!(
-                                "Permission denied: privilege {:?} is required on '{}'.'{}'.* for user {} with roles [{}]",
+                                "Permission denied: privilege [{:?}] is required on '{}'.'{}'.* for user {} with roles [{}]",
                                 privileges,
                                 catalog_name,
                                 db_name,
@@ -224,13 +224,13 @@ impl PrivilegeAccess {
         catalog_name: &str,
         db_name: &str,
         table_name: &str,
-        privileges: Vec<UserPrivilegeType>,
+        privilege: UserPrivilegeType,
         if_exists: bool,
     ) -> Result<()> {
         // skip checking the privilege on system tables.
         if ((db_name == "system" && SYSTEM_TABLES_ALLOW_LIST.iter().any(|x| x == &table_name))
             || db_name == "information_schema")
-            && privileges == [UserPrivilegeType::Select]
+            && privilege == UserPrivilegeType::Select
         {
             return Ok(());
         }
@@ -252,7 +252,7 @@ impl PrivilegeAccess {
                             db_name.to_string(),
                             table_name.to_string(),
                         ),
-                        privileges.clone(),
+                        privilege,
                     )
                     .await
                 {
@@ -274,7 +274,7 @@ impl PrivilegeAccess {
                                             db_id,
                                             table_id.unwrap(),
                                         ),
-                                        privileges.clone(),
+                                        privilege,
                                     )
                                     .await
                                 {
@@ -291,8 +291,8 @@ impl PrivilegeAccess {
                                         .collect::<Vec<_>>()
                                         .join(",");
                                     return Err(ErrorCode::PermissionDenied(format!(
-                                        "Permission denied: privilege {:?} is required on '{}'.'{}'.'{}' for user {} with roles [{}]",
-                                        privileges,
+                                        "Permission denied: privilege [{:?}] is required on '{}'.'{}'.'{}' for user {} with roles [{}]",
+                                        privilege,
                                         catalog_name,
                                         db_name,
                                         table_name,
@@ -355,7 +355,7 @@ impl PrivilegeAccess {
     async fn validate_access(
         &self,
         grant_object: &GrantObject,
-        privileges: Vec<UserPrivilegeType>,
+        privilege: UserPrivilegeType,
     ) -> Result<()> {
         let session = self.ctx.get_current_session();
 
@@ -374,10 +374,7 @@ impl PrivilegeAccess {
         }
 
         // wrap an user-facing error message with table/db names on cases like TableByID / DatabaseByID
-        match session
-            .validate_privilege(grant_object, privileges.clone())
-            .await
-        {
+        match session.validate_privilege(grant_object, privilege).await {
             Ok(_) => Ok(()),
             Err(err) => {
                 if err.code() != ErrorCode::PermissionDenied("").code() {
@@ -400,8 +397,8 @@ impl PrivilegeAccess {
                     | GrantObject::Stage(_)
                     | GrantObject::Database(_, _)
                     | GrantObject::Table(_, _, _) => Err(ErrorCode::PermissionDenied(format!(
-                        "Permission denied: privilege {:?} is required on {} for user {} with roles [{}]",
-                        privileges.clone(),
+                        "Permission denied: privilege [{:?}] is required on {} for user {} with roles [{}]",
+                        privilege,
                         grant_object,
                         &current_user.identity(),
                         roles_name,
@@ -439,17 +436,15 @@ impl PrivilegeAccess {
 
         self.validate_access(
             &GrantObject::Stage(stage_info.stage_name.to_string()),
-            vec![privilege],
+            privilege,
         )
         .await
     }
 
     async fn validate_udf_access(&self, udf_names: HashSet<&String>) -> Result<()> {
         for udf in udf_names {
-            self.validate_access(&GrantObject::UDF(udf.clone()), vec![
-                UserPrivilegeType::Usage,
-            ])
-            .await?;
+            self.validate_access(&GrantObject::UDF(udf.clone()), UserPrivilegeType::Usage)
+                .await?;
         }
         Ok(())
     }
@@ -605,7 +600,7 @@ impl AccessChecker for PrivilegeAccess {
                     // like this sql: copy into t from (select * from @s3); will bind a mock table with name `system.read_parquet(s3)`
                     // this is no means to check table `system.read_parquet(s3)` privilege
                     if !table.is_source_of_stage() {
-                        self.validate_table_access(catalog_name, table.database(), table.name(), vec![UserPrivilegeType::Select], false).await?
+                        self.validate_table_access(catalog_name, table.database(), table.name(), UserPrivilegeType::Select, false).await?
                     }
                 }
             }
@@ -615,21 +610,21 @@ impl AccessChecker for PrivilegeAccess {
 
             // Database.
             Plan::ShowCreateDatabase(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Select], false).await?
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Select, false).await?
             }
             Plan::CreateDatabase(_) => {
-                self.validate_access(&GrantObject::Global, vec![UserPrivilegeType::CreateDatabase])
+                self.validate_access(&GrantObject::Global, UserPrivilegeType::CreateDatabase)
                     .await?;
             }
             Plan::DropDatabase(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Drop], plan.if_exists).await?;
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Drop, plan.if_exists).await?;
             }
             Plan::UndropDatabase(_)
             | Plan::DropUDF(_)
             | Plan::DropIndex(_)
             | Plan::DropTableIndex(_) => {
                 // undroptable/db need convert name to id. But because of drop, can not find the id. Upgrade Object to Database.
-                self.validate_access(&GrantObject::Global, vec![UserPrivilegeType::Drop])
+                self.validate_access(&GrantObject::Global, UserPrivilegeType::Drop)
                     .await?;
             }
             Plan::UseDatabase(plan) => {
@@ -658,65 +653,68 @@ impl AccessChecker for PrivilegeAccess {
 
             // Virtual Column.
             Plan::CreateVirtualColumn(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Create], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Create, false).await?
             }
             Plan::AlterVirtualColumn(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter], plan.if_exists).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, plan.if_exists).await?
             }
             Plan::DropVirtualColumn(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Drop], plan.if_exists).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Drop, plan.if_exists).await?
             }
             Plan::RefreshVirtualColumn(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Super], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Super, false).await?
             }
 
             // Table.
             Plan::ShowCreateTable(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Select], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Select, false).await?
             }
             Plan::DescribeTable(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Select], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Select, false).await?
             }
             Plan::CreateTable(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Create], false).await?;
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Create, false).await?;
                 if let Some(query) = &plan.as_select {
                     self.check(ctx, query).await?;
                 }
             }
             Plan::DropTable(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Drop], plan.if_exists).await?;
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Drop, plan.if_exists).await?;
             }
             Plan::UndropTable(plan) => {
                 // undroptable/db need convert name to id. But because of drop, can not find the id. Upgrade Object to Database.
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Drop], false).await?;
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Drop, false).await?;
 
             }
             Plan::RenameTable(plan) => {
                 // You must have ALTER and DROP privileges for the original table,
                 // and CREATE for the new db.
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter, UserPrivilegeType::Drop], plan.if_exists).await?;
-                self.validate_db_access(&plan.catalog, &plan.new_database, vec![UserPrivilegeType::Create], false).await?;
+                let privileges = vec![UserPrivilegeType::Alter, UserPrivilegeType::Drop];
+                for privilege in privileges {
+                    self.validate_table_access(&plan.catalog, &plan.database, &plan.table, privilege, plan.if_exists).await?;
+                }
+                self.validate_db_access(&plan.catalog, &plan.new_database, UserPrivilegeType::Create, false).await?;
             }
             Plan::SetOptions(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false).await?
             }
             Plan::AddTableColumn(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false).await?
             }
             Plan::RenameTableColumn(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false).await?
             }
             Plan::ModifyTableColumn(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false).await?
             }
             Plan::DropTableColumn(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false).await?
             }
             Plan::AlterTableClusterKey(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false).await?
             }
             Plan::DropTableClusterKey(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Drop], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Drop, false).await?
             }
             Plan::ReclusterTable(plan) => {
                 if enable_experimental_rbac_check {
@@ -725,25 +723,25 @@ impl AccessChecker for PrivilegeAccess {
                         self.validate_udf_access(udf).await?;
                     }
                 }
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Alter], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false).await?
             }
             Plan::TruncateTable(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Delete], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Delete, false).await?
             }
             Plan::OptimizeTable(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Super], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Super, false).await?
             }
             Plan::VacuumTable(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Super], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Super, false).await?
             }
             Plan::VacuumDropTable(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Super], false).await?
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Super, false).await?
             }
             Plan::VacuumTemporaryFiles(_) => {
-                self.validate_access(&GrantObject::Global, vec![UserPrivilegeType::Super]).await?
+                self.validate_access(&GrantObject::Global, UserPrivilegeType::Super).await?
             }
             Plan::AnalyzeTable(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Super], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Super, false).await?
             }
             // Others.
             Plan::Insert(plan) => {
@@ -752,7 +750,9 @@ impl AccessChecker for PrivilegeAccess {
                 } else {
                     vec![UserPrivilegeType::Insert]
                 };
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, target_table_privileges, false).await?;
+                for privilege in target_table_privileges {
+                    self.validate_table_access(&plan.catalog, &plan.database, &plan.table, privilege, false).await?;
+                }
                 match &plan.source {
                     InsertInputSource::SelectPlan(plan) => {
                         self.check(ctx, plan).await?;
@@ -767,7 +767,10 @@ impl AccessChecker for PrivilegeAccess {
             }
             Plan::Replace(plan) => {
                 //plan.delete_when is Expr no need to check privileges.
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Insert, UserPrivilegeType::Delete], false).await?;
+                let privileges = vec![UserPrivilegeType::Insert, UserPrivilegeType::Delete];
+                for privilege in privileges {
+                    self.validate_table_access(&plan.catalog, &plan.database, &plan.table, privilege, false).await?;
+                }
                 match &plan.source {
                     InsertInputSource::SelectPlan(plan) => {
                         self.check(ctx, plan).await?;
@@ -818,7 +821,10 @@ impl AccessChecker for PrivilegeAccess {
                         }
                     }
                 }
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Insert, UserPrivilegeType::Delete], false).await?;
+                let privileges = vec![UserPrivilegeType::Insert, UserPrivilegeType::Delete];
+                for privilege in privileges {
+                    self.validate_table_access(&plan.catalog, &plan.database, &plan.table, privilege, false).await?;
+                }
             }
             Plan::Delete(plan) => {
                 if enable_experimental_rbac_check {
@@ -839,7 +845,7 @@ impl AccessChecker for PrivilegeAccess {
                         }
                     }
                 }
-                self.validate_table_access(&plan.catalog_name, &plan.database_name, &plan.table_name, vec![UserPrivilegeType::Delete], false).await?
+                self.validate_table_access(&plan.catalog_name, &plan.database_name, &plan.table_name, UserPrivilegeType::Delete, false).await?
             }
             Plan::Update(plan) => {
                 if enable_experimental_rbac_check {
@@ -864,7 +870,7 @@ impl AccessChecker for PrivilegeAccess {
                         }
                     }
                 }
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, vec![UserPrivilegeType::Update], false).await?;
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Update, false).await?;
             }
             Plan::CreateView(plan) => {
                 let mut planner = Planner::new(self.ctx.clone());
@@ -872,48 +878,48 @@ impl AccessChecker for PrivilegeAccess {
                 self.check(ctx, &plan).await?
             }
             Plan::AlterView(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Alter], false).await?;
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Alter, false).await?;
                 let mut planner = Planner::new(self.ctx.clone());
                 let (plan, _) = planner.plan_sql(&plan.subquery).await?;
                 self.check(ctx, &plan).await?
             }
             Plan::DropView(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Drop], plan.if_exists).await?
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Drop, plan.if_exists).await?
             }
             Plan::DescribeView(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.view_name, vec![UserPrivilegeType::Select], false).await?
+                self.validate_table_access(&plan.catalog, &plan.database, &plan.view_name, UserPrivilegeType::Select, false).await?
             }
             Plan::CreateStream(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Create], false).await?
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Create, false).await?
             }
             Plan::DropStream(plan) => {
-                self.validate_db_access(&plan.catalog, &plan.database, vec![UserPrivilegeType::Drop], plan.if_exists).await?
+                self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Drop, plan.if_exists).await?
             }
             Plan::CreateUser(_) => {
                 self.validate_access(
                     &GrantObject::Global,
-                    vec![UserPrivilegeType::CreateUser],
+                    UserPrivilegeType::CreateUser,
                 )
                     .await?;
             }
             Plan::DropUser(_) => {
                 self.validate_access(
                     &GrantObject::Global,
-                    vec![UserPrivilegeType::DropUser],
+                    UserPrivilegeType::DropUser,
                 )
                     .await?;
             }
             Plan::CreateRole(_) => {
                 self.validate_access(
                     &GrantObject::Global,
-                    vec![UserPrivilegeType::CreateRole],
+                    UserPrivilegeType::CreateRole,
                 )
                     .await?;
             }
             Plan::DropRole(_) => {
                 self.validate_access(
                     &GrantObject::Global,
-                    vec![UserPrivilegeType::DropRole],
+                    UserPrivilegeType::DropRole,
                 )
                     .await?;
             }
@@ -926,11 +932,11 @@ impl AccessChecker for PrivilegeAccess {
             | Plan::GrantPriv(_)
             | Plan::RevokePriv(_)
             | Plan::RevokeRole(_) => {
-                self.validate_access(&GrantObject::Global, vec![UserPrivilegeType::Grant])
+                self.validate_access(&GrantObject::Global, UserPrivilegeType::Grant)
                     .await?;
             }
             Plan::SetVariable(_) | Plan::UnSetVariable(_) | Plan::Kill(_) => {
-                self.validate_access(&GrantObject::Global, vec![UserPrivilegeType::Super])
+                self.validate_access(&GrantObject::Global, UserPrivilegeType::Super)
                     .await?;
             }
             Plan::AlterUser(_)
@@ -940,12 +946,12 @@ impl AccessChecker for PrivilegeAccess {
             | Plan::AlterShareTenants(_)
             | Plan::RefreshIndex(_)
             | Plan::RefreshTableIndex(_) => {
-                self.validate_access(&GrantObject::Global, vec![UserPrivilegeType::Alter])
+                self.validate_access(&GrantObject::Global, UserPrivilegeType::Alter)
                     .await?;
             }
             Plan::CopyIntoTable(plan) => {
                 self.validate_stage_access(&plan.stage_table_info.stage_info, UserPrivilegeType::Read).await?;
-                self.validate_table_access(plan.catalog_info.catalog_name(), &plan.database_name, &plan.table_name, vec![UserPrivilegeType::Insert], false).await?;
+                self.validate_table_access(plan.catalog_info.catalog_name(), &plan.database_name, &plan.table_name, UserPrivilegeType::Insert, false).await?;
                 if let Some(query) = &plan.query {
                     self.check(ctx, query).await?;
                 }
@@ -999,13 +1005,13 @@ impl AccessChecker for PrivilegeAccess {
             | Plan::ExecuteTask(_)  // TODO: need to build ownership info for task
             | Plan::DropTask(_)     // TODO: need to build ownership info for task
             | Plan::AlterTask(_) => {
-                self.validate_access(&GrantObject::Global, vec![UserPrivilegeType::Super])
+                self.validate_access(&GrantObject::Global, UserPrivilegeType::Super)
                     .await?;
             }
             Plan::CreateDatamaskPolicy(_) | Plan::DropDatamaskPolicy(_) => {
                 self.validate_access(
                     &GrantObject::Global,
-                    vec![UserPrivilegeType::CreateDataMask],
+                    UserPrivilegeType::CreateDataMask,
                 )
                     .await?;
             }

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -270,7 +270,7 @@ impl Session {
     pub async fn validate_privilege(
         self: &Arc<Self>,
         object: &GrantObject,
-        privilege: Vec<UserPrivilegeType>,
+        privilege: UserPrivilegeType,
     ) -> Result<()> {
         if matches!(self.get_type(), SessionType::Local) {
             return Ok(());

--- a/src/query/service/src/sessions/session_privilege_mgr.rs
+++ b/src/query/service/src/sessions/session_privilege_mgr.rs
@@ -61,7 +61,7 @@ pub trait SessionPrivilegeManager {
     async fn validate_privilege(
         &self,
         object: &GrantObject,
-        privilege: Vec<UserPrivilegeType>,
+        privilege: UserPrivilegeType,
     ) -> Result<()>;
 
     async fn has_ownership(&self, object: &OwnershipObject) -> Result<bool>;
@@ -241,13 +241,11 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl {
     async fn validate_privilege(
         &self,
         object: &GrantObject,
-        privilege: Vec<UserPrivilegeType>,
+        privilege: UserPrivilegeType,
     ) -> Result<()> {
         // 1. check user's privilege set
         let current_user = self.get_current_user()?;
-        let user_verified = current_user
-            .grants
-            .verify_privilege(object, privilege.clone());
+        let user_verified = current_user.grants.verify_privilege(object, privilege);
         if user_verified {
             return Ok(());
         }
@@ -257,7 +255,7 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl {
         let effective_roles = self.get_all_effective_roles().await?;
         let role_verified = &effective_roles
             .iter()
-            .any(|r| r.grants.verify_privilege(object, privilege.clone()));
+            .any(|r| r.grants.verify_privilege(object, privilege));
         if *role_verified {
             return Ok(());
         }

--- a/src/query/users/tests/it/role_mgr.rs
+++ b/src/query/users/tests/it/role_mgr.rs
@@ -85,7 +85,7 @@ async fn test_role_manager() -> Result<()> {
         let role = role_mgr.get_role(&tenant, role_name.clone()).await?;
         assert!(
             role.grants
-                .verify_privilege(&GrantObject::Global, vec![UserPrivilegeType::Alter])
+                .verify_privilege(&GrantObject::Global, UserPrivilegeType::Alter)
         );
     }
 

--- a/src/query/users/tests/it/user_mgr.rs
+++ b/src/query/users/tests/it/user_mgr.rs
@@ -135,12 +135,12 @@ async fn test_user_manager() -> Result<()> {
         assert!(
             new_user
                 .grants
-                .verify_privilege(&GrantObject::Global, vec![UserPrivilegeType::Set])
+                .verify_privilege(&GrantObject::Global, UserPrivilegeType::Set)
         );
         assert!(
             !new_user
                 .grants
-                .verify_privilege(&GrantObject::Global, vec![UserPrivilegeType::Create])
+                .verify_privilege(&GrantObject::Global, UserPrivilegeType::Create)
         );
         user_mgr
             .drop_user(tenant.clone(), new_user.identity(), true)

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
@@ -13,7 +13,7 @@ test -- insert
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Insert] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public]
 1
 2
-Error: APIError: ResponseError with 1063: Permission denied: privilege [Insert, Delete] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Delete] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 1
 2
 test -- update

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
@@ -70,7 +70,9 @@ echo "select count(*) = 0 from t20_0012 where c=2" | $TEST_USER_CONNECT
 
 ## insert overwrite
 echo "select 'test -- insert overwrite'" | $TEST_USER_CONNECT
-echo "GRANT DELETE ON * TO role 'test-role1'" | $BENDSQL_CLIENT_CONNECT
+# now, user test-user has delete on default.t20_0012, role test-role1 has insert on default
+# insert overwrite should pass privilege check.
+echo "GRANT DELETE ON default.t20_0012 TO 'test-user'" | $BENDSQL_CLIENT_CONNECT
 echo "insert overwrite t20_0012 values(2)" | $TEST_USER_CONNECT
 ## verify
 echo "select * from t20_0012 order by c" | $TEST_USER_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

verify_privilege need fold same GrantEntry

E.g.

```sql
grant insert on default.* to role role1;
grant delete on default.t to u1;
grant role role1 to u1;

-- login in with u1; -- need success.
insert overwrite t values(100) 

```

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
