### PR TITLE
feat: time travel support at stream

### DIFF
--- a/src/query/ast/src/ast/format/ast_format.rs
+++ b/src/query/ast/src/ast/format/ast_format.rs
@@ -1755,8 +1755,8 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
         children.push(self.children.pop().unwrap());
         self.visit_table_ref(&None, &stmt.table_database, &stmt.table);
         children.push(self.children.pop().unwrap());
-        if let Some(point) = &stmt.stream_point {
-            self.visit_stream_point(point);
+        if let Some(point) = &stmt.travel_point {
+            self.visit_time_travel_point(point);
             children.push(self.children.pop().unwrap());
         }
         if let Some(comment) = &stmt.comment {
@@ -3286,13 +3286,11 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
                 let node = FormatTreeNode::with_children(format_ctx, vec![child]);
                 self.children.push(node);
             }
-        }
-    }
-
-    fn visit_stream_point(&mut self, point: &'ast StreamPoint) {
-        match point {
-            StreamPoint::AtStream { database, name } => self.visit_table_ref(&None, database, name),
-            StreamPoint::AtPoint(point) => self.visit_time_travel_point(point),
+            TimeTravelPoint::Stream {
+                catalog,
+                database,
+                name,
+            } => self.visit_table_ref(catalog, database, name),
         }
     }
 

--- a/src/query/ast/src/ast/format/syntax/query.rs
+++ b/src/query/ast/src/ast/format/syntax/query.rs
@@ -348,6 +348,29 @@ pub(crate) fn pretty_table(table: TableReference) -> RcDoc<'static> {
             RcDoc::text(format!(" AT (SNAPSHOT => '{sid}')"))
         } else if let Some(TimeTravelPoint::Timestamp(ts)) = travel_point {
             RcDoc::text(format!(" AT (TIMESTAMP => {ts})"))
+        } else if let Some(TimeTravelPoint::Stream {
+            catalog,
+            database,
+            name,
+        }) = travel_point
+        {
+            RcDoc::space()
+                .append(RcDoc::text("AT (STREAM => "))
+                .append(
+                    RcDoc::space()
+                        .append(if let Some(catalog) = catalog {
+                            RcDoc::text(catalog.to_string()).append(RcDoc::text("."))
+                        } else {
+                            RcDoc::nil()
+                        })
+                        .append(if let Some(database) = database {
+                            RcDoc::text(database.to_string()).append(RcDoc::text("."))
+                        } else {
+                            RcDoc::nil()
+                        })
+                        .append(RcDoc::text(name.to_string())),
+                )
+                .append(RcDoc::text(")"))
         } else {
             RcDoc::nil()
         })
@@ -355,6 +378,29 @@ pub(crate) fn pretty_table(table: TableReference) -> RcDoc<'static> {
             RcDoc::text(format!(" SINCE (SNAPSHOT => '{sid}')"))
         } else if let Some(TimeTravelPoint::Timestamp(ts)) = since_point {
             RcDoc::text(format!(" SINCE (TIMESTAMP => {ts})"))
+        } else if let Some(TimeTravelPoint::Stream {
+            catalog,
+            database,
+            name,
+        }) = since_point
+        {
+            RcDoc::space()
+                .append(RcDoc::text("SINCE (STREAM => "))
+                .append(
+                    RcDoc::space()
+                        .append(if let Some(catalog) = catalog {
+                            RcDoc::text(catalog.to_string()).append(RcDoc::text("."))
+                        } else {
+                            RcDoc::nil()
+                        })
+                        .append(if let Some(database) = database {
+                            RcDoc::text(database.to_string()).append(RcDoc::text("."))
+                        } else {
+                            RcDoc::nil()
+                        })
+                        .append(RcDoc::text(name.to_string())),
+                )
+                .append(RcDoc::text(")"))
         } else {
             RcDoc::nil()
         })

--- a/src/query/ast/src/ast/statements/stream.rs
+++ b/src/query/ast/src/ast/statements/stream.rs
@@ -25,28 +25,6 @@ use crate::ast::ShowLimit;
 use crate::ast::TimeTravelPoint;
 
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
-pub enum StreamPoint {
-    AtStream {
-        database: Option<Identifier>,
-        name: Identifier,
-    },
-    AtPoint(TimeTravelPoint),
-}
-
-impl Display for StreamPoint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StreamPoint::AtStream { database, name } => {
-                write!(f, " AT (STREAM => ")?;
-                write_dot_separated_list(f, database.iter().chain(Some(name)))?;
-                write!(f, ")")
-            }
-            StreamPoint::AtPoint(point) => write!(f, " AT {}", point),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
 pub struct CreateStreamStmt {
     #[drive(skip)]
     pub create_option: CreateOption,
@@ -55,7 +33,7 @@ pub struct CreateStreamStmt {
     pub stream: Identifier,
     pub table_database: Option<Identifier>,
     pub table: Identifier,
-    pub stream_point: Option<StreamPoint>,
+    pub travel_point: Option<TimeTravelPoint>,
     #[drive(skip)]
     pub append_only: bool,
     #[drive(skip)]
@@ -81,8 +59,8 @@ impl Display for CreateStreamStmt {
         )?;
         write!(f, " ON TABLE ")?;
         write_dot_separated_list(f, self.table_database.iter().chain(Some(&self.table)))?;
-        if let Some(stream_point) = &self.stream_point {
-            write!(f, "{}", stream_point)?;
+        if let Some(travel_point) = &self.travel_point {
+            write!(f, " AT {}", travel_point)?;
         }
         if !self.append_only {
             write!(f, " APPEND_ONLY = false")?;

--- a/src/query/ast/src/ast/visitors/visitor.rs
+++ b/src/query/ast/src/ast/visitors/visitor.rs
@@ -26,7 +26,6 @@ use super::walk::walk_select_target;
 use super::walk::walk_set_expr;
 use super::walk::walk_statement;
 use super::walk::walk_table_reference;
-use super::walk_stream_point;
 use super::walk_time_travel_point;
 use crate::ast::visitors::walk_window_definition;
 use crate::ast::*;
@@ -811,10 +810,6 @@ pub trait Visitor<'ast>: Sized {
 
     fn visit_time_travel_point(&mut self, time: &'ast TimeTravelPoint) {
         walk_time_travel_point(self, time);
-    }
-
-    fn visit_stream_point(&mut self, stream: &'ast StreamPoint) {
-        walk_stream_point(self, stream)
     }
 
     fn visit_join(&mut self, join: &'ast Join) {

--- a/src/query/ast/src/ast/visitors/visitor_mut.rs
+++ b/src/query/ast/src/ast/visitors/visitor_mut.rs
@@ -26,7 +26,6 @@ use super::walk_mut::walk_select_target_mut;
 use super::walk_mut::walk_set_expr_mut;
 use super::walk_mut::walk_statement_mut;
 use super::walk_mut::walk_table_reference_mut;
-use super::walk_stream_point_mut;
 use super::walk_time_travel_point_mut;
 use super::walk_window_definition_mut;
 use crate::ast::visitors::walk_column_id_mut;
@@ -826,10 +825,6 @@ pub trait VisitorMut: Sized {
 
     fn visit_time_travel_point(&mut self, time: &mut TimeTravelPoint) {
         walk_time_travel_point_mut(self, time);
-    }
-
-    fn visit_stream_point(&mut self, stream: &mut StreamPoint) {
-        walk_stream_point_mut(self, stream);
     }
 
     fn visit_join(&mut self, join: &mut Join) {

--- a/src/query/ast/src/ast/visitors/walk.rs
+++ b/src/query/ast/src/ast/visitors/walk.rs
@@ -310,20 +310,20 @@ pub fn walk_time_travel_point<'a, V: Visitor<'a>>(visitor: &mut V, time: &'a Tim
     match time {
         TimeTravelPoint::Snapshot(_) => {}
         TimeTravelPoint::Timestamp(expr) => visitor.visit_expr(expr),
-    }
-}
+        TimeTravelPoint::Stream {
+            catalog,
+            database,
+            name,
+        } => {
+            if let Some(catalog) = catalog {
+                visitor.visit_identifier(catalog);
+            }
 
-pub fn walk_stream_point<'a, V: Visitor<'a>>(visitor: &mut V, point: &'a StreamPoint) {
-    match point {
-        StreamPoint::AtStream { database, name } => {
             if let Some(database) = database {
                 visitor.visit_identifier(database);
             }
 
             visitor.visit_identifier(name);
-        }
-        StreamPoint::AtPoint(point) => {
-            visitor.visit_time_travel_point(point);
         }
     }
 }

--- a/src/query/ast/src/ast/visitors/walk_mut.rs
+++ b/src/query/ast/src/ast/visitors/walk_mut.rs
@@ -334,19 +334,21 @@ pub fn walk_time_travel_point_mut<V: VisitorMut>(visitor: &mut V, time: &mut Tim
     match time {
         TimeTravelPoint::Snapshot(_) => {}
         TimeTravelPoint::Timestamp(expr) => visitor.visit_expr(expr),
-    }
-}
+        TimeTravelPoint::Stream {
+            catalog,
+            database,
+            name,
+        } => {
+            if let Some(catalog) = catalog {
+                visitor.visit_identifier(catalog);
+            }
 
-pub fn walk_stream_point_mut<V: VisitorMut>(visitor: &mut V, stream: &mut StreamPoint) {
-    match stream {
-        StreamPoint::AtStream { database, name } => {
             if let Some(database) = database {
                 visitor.visit_identifier(database);
             }
 
             visitor.visit_identifier(name);
         }
-        StreamPoint::AtPoint(point) => visitor.visit_time_travel_point(point),
     }
 }
 

--- a/src/query/ast/src/parser/query.rs
+++ b/src/query/ast/src/parser/query.rs
@@ -508,9 +508,17 @@ pub fn travel_point(i: Input) -> IResult<TimeTravelPoint> {
         rule! { "(" ~ TIMESTAMP ~ "=>" ~ #expr ~ ")" },
         |(_, _, _, e, _)| TimeTravelPoint::Timestamp(Box::new(e)),
     );
+    let at_stream = map(
+        rule! { "(" ~ STREAM ~ "=>" ~  #dot_separated_idents_1_to_3 ~ ")" },
+        |(_, _, _, (catalog, database, name), _)| TimeTravelPoint::Stream {
+            catalog,
+            database,
+            name,
+        },
+    );
 
     rule!(
-        #at_snapshot | #at_timestamp
+        #at_stream | #at_snapshot | #at_timestamp
     )(i)
 }
 

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -3610,7 +3610,7 @@ CreateStream(
             quote: None,
             is_hole: false,
         },
-        stream_point: None,
+        travel_point: None,
         append_only: false,
         comment: None,
     },
@@ -3662,8 +3662,9 @@ CreateStream(
             quote: None,
             is_hole: false,
         },
-        stream_point: Some(
-            AtStream {
+        travel_point: Some(
+            Stream {
+                catalog: None,
                 database: Some(
                     Identifier {
                         span: Some(
@@ -3737,25 +3738,23 @@ CreateStream(
             quote: None,
             is_hole: false,
         },
-        stream_point: Some(
-            AtPoint(
-                Timestamp(
-                    Cast {
+        travel_point: Some(
+            Timestamp(
+                Cast {
+                    span: Some(
+                        98..109,
+                    ),
+                    expr: Literal {
                         span: Some(
-                            98..109,
+                            70..98,
                         ),
-                        expr: Literal {
-                            span: Some(
-                                70..98,
-                            ),
-                            value: String(
-                                "2023-06-26 09:49:02.038483",
-                            ),
-                        },
-                        target_type: Timestamp,
-                        pg_style: true,
+                        value: String(
+                            "2023-06-26 09:49:02.038483",
+                        ),
                     },
-                ),
+                    target_type: Timestamp,
+                    pg_style: true,
+                },
             ),
         ),
         append_only: false,
@@ -3809,11 +3808,9 @@ CreateStream(
             quote: None,
             is_hole: false,
         },
-        stream_point: Some(
-            AtPoint(
-                Snapshot(
-                    "9828b23f74664ff3806f44bbc1925ea5",
-                ),
+        travel_point: Some(
+            Snapshot(
+                "9828b23f74664ff3806f44bbc1925ea5",
             ),
         ),
         append_only: true,
@@ -3867,7 +3864,7 @@ CreateStream(
             quote: None,
             is_hole: false,
         },
-        stream_point: None,
+        travel_point: None,
         append_only: false,
         comment: None,
     },

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -433,6 +433,7 @@ impl<T: ?Sized> TableExt for T where T: Table {}
 pub enum NavigationPoint {
     SnapshotID(String),
     TimePoint(DateTime<Utc>),
+    StreamInfo(TableInfo),
 }
 
 #[derive(Debug, Copy, Clone, Default)]

--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -31,11 +31,8 @@ use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_sql::plans::CreateStreamPlan;
 use databend_common_sql::plans::DropStreamPlan;
-use databend_common_sql::plans::StreamNavigation;
-use databend_common_storages_fuse::io::SnapshotsIO;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::TableContext;
-use databend_common_storages_stream::stream_table::StreamTable;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 use databend_enterprise_stream_handler::StreamHandler;
 use databend_enterprise_stream_handler::StreamHandlerWrapper;
@@ -74,14 +71,14 @@ impl StreamHandler for RealStreamHandler {
             )));
         }
 
-        let mut table_version = table_info.ident.seq;
         let table_id = table_info.ident.table_id;
         let schema = table_info.schema().clone();
         if !table.change_tracking_enabled() {
+            let table_seq = table_info.ident.seq;
             // enable change tracking.
             let req = UpsertTableOptionReq {
                 table_id,
-                seq: MatchSeq::Exact(table_version),
+                seq: MatchSeq::Exact(table_seq),
                 options: HashMap::from([
                     (
                         OPT_KEY_CHANGE_TRACKING.to_string(),
@@ -89,7 +86,7 @@ impl StreamHandler for RealStreamHandler {
                     ),
                     (
                         OPT_KEY_CHANGE_TRACKING_BEGIN_VER.to_string(),
-                        Some(table_version.to_string()),
+                        Some(table_seq.to_string()),
                     ),
                 ]),
             };
@@ -99,68 +96,19 @@ impl StreamHandler for RealStreamHandler {
                 .await?;
             // refreash table.
             table = table.refresh(ctx.as_ref()).await?;
-            table_version = table.get_table_info().ident.seq;
         }
 
-        let (version, snapshot_location) = match &plan.navigation {
-            Some(StreamNavigation::AtStream { database, name }) => {
-                let stream = catalog.get_table(tenant.name(), database, name).await?;
-                let stream = StreamTable::try_from_table(stream.as_ref())?;
-                let stream_opts = stream.get_table_info().options();
-                let stream_table_name = stream_opts
-                    .get(OPT_KEY_TABLE_NAME)
-                    .ok_or_else(|| ErrorCode::IllegalStream(format!("Illegal stream '{name}'")))?;
-                let stream_database_name = stream_opts
-                    .get(OPT_KEY_DATABASE_NAME)
-                    .ok_or_else(|| ErrorCode::IllegalStream(format!("Illegal stream '{name}'")))?;
-                let stream_table_id = stream_opts
-                    .get(OPT_KEY_TABLE_ID)
-                    .ok_or_else(|| ErrorCode::IllegalStream(format!("Illegal stream '{name}'")))?
-                    .parse::<u64>()?;
-                if stream_table_name != &plan.table_name
-                    || stream_database_name != &plan.table_database
-                    || stream_table_id != table_id
-                {
-                    return Err(ErrorCode::IllegalStream(format!(
-                        "The stream '{name}' is not match the table '{}.{}'",
-                        plan.table_database, plan.table_name
-                    )));
-                }
+        table = table.navigate_since_to(&None, &plan.navigation).await?;
+        let source = FuseTable::try_from_table(table.as_ref())?;
+        let version = source.get_table_info().ident.seq;
+        if version == 0 {
+            return Err(ErrorCode::IllegalStream(
+                "The stream navigation at point has not table version".to_string(),
+            ));
+        }
+        let snapshot_location = source.snapshot_loc().await?;
 
-                let version = stream_opts
-                    .get(OPT_KEY_TABLE_VER)
-                    .ok_or_else(|| ErrorCode::IllegalStream(format!("Illegal stream '{name}'")))?
-                    .parse::<u64>()?;
-                (version, stream_opts.get(OPT_KEY_SNAPSHOT_LOCATION).cloned())
-            }
-            Some(StreamNavigation::AtPoint(point)) => {
-                let fuse_table = FuseTable::try_from_table(table.as_ref())?;
-                let source = fuse_table.navigate_to(point).await?;
-                if let Some(snapshot_loc) = source.snapshot_loc().await? {
-                    let (snapshot, _) =
-                        SnapshotsIO::read_snapshot(snapshot_loc.clone(), fuse_table.get_operator())
-                            .await?;
-                    let Some(version) = snapshot.prev_table_seq else {
-                        return Err(ErrorCode::IllegalStream(
-                            "The stream navigation at point has not table version".to_string(),
-                        ));
-                    };
-
-                    // The table version is the version of the table when the snapshot was created.
-                    // We need make sure the version greater than the table version,
-                    // and less equal than the table version after the snapshot commit.
-                    (version + 1, Some(snapshot_loc))
-                } else {
-                    unreachable!()
-                }
-            }
-            None => {
-                let fuse_table = FuseTable::try_from_table(table.as_ref())?;
-                (table_version, fuse_table.snapshot_loc().await?)
-            }
-        };
-
-        if let Some(value) = table
+        if let Some(value) = source
             .get_table_info()
             .options()
             .get(OPT_KEY_CHANGE_TRACKING_BEGIN_VER)

--- a/src/query/sql/src/planner/binder/ddl/stream.rs
+++ b/src/query/sql/src/planner/binder/ddl/stream.rs
@@ -17,7 +17,6 @@ use databend_common_ast::ast::DescribeStreamStmt;
 use databend_common_ast::ast::DropStreamStmt;
 use databend_common_ast::ast::ShowLimit;
 use databend_common_ast::ast::ShowStreamsStmt;
-use databend_common_ast::ast::StreamPoint;
 use databend_common_exception::Result;
 use databend_common_license::license::Feature;
 use databend_common_license::license_manager::get_license_manager;
@@ -29,7 +28,6 @@ use crate::plans::CreateStreamPlan;
 use crate::plans::DropStreamPlan;
 use crate::plans::Plan;
 use crate::plans::RewriteKind;
-use crate::plans::StreamNavigation;
 use crate::BindContext;
 use crate::SelectBuilder;
 
@@ -47,7 +45,7 @@ impl Binder {
             stream,
             table_database,
             table,
-            stream_point,
+            travel_point,
             append_only,
             comment,
         } = stmt;
@@ -62,20 +60,10 @@ impl Binder {
             .unwrap_or_else(|| self.ctx.get_current_database());
         let table_name = normalize_identifier(table, &self.name_resolution_ctx).name;
 
-        let navigation = match stream_point {
-            Some(StreamPoint::AtStream { database, name }) => {
-                let database = database
-                    .as_ref()
-                    .map(|ident| normalize_identifier(ident, &self.name_resolution_ctx).name)
-                    .unwrap_or_else(|| self.ctx.get_current_database());
-                let name = normalize_identifier(name, &self.name_resolution_ctx).name;
-                Some(StreamNavigation::AtStream { database, name })
-            }
-            Some(StreamPoint::AtPoint(point)) => {
-                let point = self.resolve_data_travel_point(bind_context, point).await?;
-                Some(StreamNavigation::AtPoint(point))
-            }
-            None => None,
+        let navigation = if let Some(point) = travel_point {
+            Some(self.resolve_data_travel_point(bind_context, point).await?)
+        } else {
+            None
         };
 
         let plan = CreateStreamPlan {

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -1489,6 +1489,22 @@ impl Binder {
                     ))),
                 }
             }
+            TimeTravelPoint::Stream {
+                catalog,
+                database,
+                name,
+            } => {
+                let (catalog, database, name) =
+                    self.normalize_object_identifier_triple(catalog, database, name);
+                let stream = self.ctx.get_table(&catalog, &database, &name).await?;
+                if stream.engine() != "STREAM" {
+                    return Err(ErrorCode::TableEngineNotSupported(format!(
+                        "{database}.{name} is not STREAM",
+                    )));
+                }
+                let info = stream.get_table_info().clone();
+                Ok(NavigationPoint::StreamInfo(info))
+            }
         }
     }
 

--- a/src/query/sql/src/planner/plans/ddl/stream.rs
+++ b/src/query/sql/src/planner/plans/ddl/stream.rs
@@ -15,12 +15,6 @@
 use databend_common_catalog::table::NavigationPoint;
 use databend_common_meta_app::schema::CreateOption;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum StreamNavigation {
-    AtStream { database: String, name: String },
-    AtPoint(NavigationPoint),
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateStreamPlan {
     pub create_option: CreateOption,
@@ -30,7 +24,7 @@ pub struct CreateStreamPlan {
     pub stream_name: String,
     pub table_database: String,
     pub table_name: String,
-    pub navigation: Option<StreamNavigation>,
+    pub navigation: Option<NavigationPoint>,
     pub append_only: bool,
     pub comment: Option<String>,
 }

--- a/src/query/storages/fuse/src/operations/navigate.rs
+++ b/src/query/storages/fuse/src/operations/navigate.rs
@@ -21,10 +21,13 @@ use databend_common_catalog::table::NavigationPoint;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableStatistics;
 use databend_storages_common_cache::LoadParams;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
+use databend_storages_common_table_meta::table::OPT_KEY_TABLE_ID;
+use databend_storages_common_table_meta::table::OPT_KEY_TABLE_VER;
 use futures::TryStreamExt;
 use log::warn;
 use opendal::EntryMode;
@@ -32,11 +35,63 @@ use opendal::Metakey;
 
 use crate::io::MetaReaders;
 use crate::io::SnapshotHistoryReader;
+use crate::io::SnapshotsIO;
 use crate::io::TableMetaLocationGenerator;
 use crate::FuseTable;
 use crate::FUSE_TBL_SNAPSHOT_PREFIX;
 
 impl FuseTable {
+    #[minitrace::trace]
+    #[async_backtrace::framed]
+    pub async fn navigate_to(&self, point: &NavigationPoint) -> Result<Arc<FuseTable>> {
+        match point {
+            NavigationPoint::SnapshotID(snapshot_id) => {
+                self.navigate_to_snapshot(snapshot_id.as_str()).await
+            }
+            NavigationPoint::TimePoint(time_point) => {
+                let Some(location) = self.snapshot_loc().await? else {
+                    return Err(ErrorCode::TableHistoricalDataNotFound(
+                        "Empty Table has no historical data",
+                    ));
+                };
+                self.navigate_to_time_point(location, *time_point).await
+            }
+            NavigationPoint::StreamInfo(info) => self.navigate_to_stream(info).await,
+        }
+    }
+
+    #[async_backtrace::framed]
+    pub async fn navigate_to_stream(&self, stream_info: &TableInfo) -> Result<Arc<FuseTable>> {
+        let options = stream_info.options();
+        let stream_table_id = options
+            .get(OPT_KEY_TABLE_ID)
+            .ok_or_else(|| ErrorCode::Internal("table id must be set"))?
+            .parse::<u64>()?;
+        if stream_table_id != self.table_info.ident.table_id {
+            return Err(ErrorCode::IllegalStream(format!(
+                "The stream '{}' is not match the table '{}'",
+                stream_info.desc, self.table_info.desc
+            )));
+        }
+
+        let version = options
+            .get(OPT_KEY_TABLE_VER)
+            .ok_or_else(|| ErrorCode::Internal("table version must be set"))?
+            .parse::<u64>()?;
+
+        let Some(snapshot_loc) = options.get(OPT_KEY_SNAPSHOT_LOCATION) else {
+            let mut table_info = self.table_info.clone();
+            table_info.ident.seq = version;
+            table_info.meta.options.remove(OPT_KEY_SNAPSHOT_LOCATION);
+            table_info.meta.statistics = TableStatistics::default();
+            let table = FuseTable::do_create(table_info)?;
+            return Ok(table.into());
+        };
+        let (snapshot, format_version) =
+            SnapshotsIO::read_snapshot(snapshot_loc.clone(), self.get_operator()).await?;
+        self.load_table_by_snapshot(snapshot.as_ref(), format_version, Some(version))
+    }
+
     #[async_backtrace::framed]
     pub async fn navigate_to_time_point(
         &self,
@@ -53,34 +108,14 @@ impl FuseTable {
         .await
     }
 
-    #[minitrace::trace]
     #[async_backtrace::framed]
-    pub async fn navigate_to(&self, point: &NavigationPoint) -> Result<Arc<FuseTable>> {
-        let snapshot_location = if let Some(loc) = self.snapshot_loc().await? {
-            loc
-        } else {
-            // not an error?
+    pub async fn navigate_to_snapshot(&self, snapshot_id: &str) -> Result<Arc<FuseTable>> {
+        let Some(location) = self.snapshot_loc().await? else {
             return Err(ErrorCode::TableHistoricalDataNotFound(
                 "Empty Table has no historical data",
             ));
         };
 
-        match point {
-            NavigationPoint::SnapshotID(snapshot_id) => Ok(self
-                .navigate_to_snapshot(snapshot_location, snapshot_id.as_str())
-                .await?),
-            NavigationPoint::TimePoint(time_point) => Ok(self
-                .navigate_to_time_point(snapshot_location, *time_point)
-                .await?),
-        }
-    }
-
-    #[async_backtrace::framed]
-    pub async fn navigate_to_snapshot(
-        &self,
-        location: String,
-        snapshot_id: &str,
-    ) -> Result<Arc<FuseTable>> {
         self.find(location, |snapshot| {
             snapshot
                 .snapshot_id
@@ -115,48 +150,65 @@ impl FuseTable {
         }
 
         if let Some((snapshot, format_version)) = instant {
-            // Load the table instance by the snapshot
-
-            // The `seq` of ident that we cloned here is JUST a place holder
-            // we should NOT use it other than a pure place holder.
-            let mut table_info = self.table_info.clone();
-
-            // There are more to be kept in snapshot, like engine_options, ordering keys...
-            // or we could just keep a clone of TableMeta in the snapshot.
-            //
-            // currently, here are what we can recovery from the snapshot:
-
-            // 1. the table schema
-            table_info.meta.schema = Arc::new(snapshot.schema.clone());
-
-            // 2. the table option `snapshot_location`
-            let loc = self
-                .meta_location_generator
-                .snapshot_location_from_uuid(&snapshot.snapshot_id, format_version)?;
-            table_info
-                .meta
-                .options
-                .insert(OPT_KEY_SNAPSHOT_LOCATION.to_owned(), loc);
-
-            // 3. The statistics
-            let summary = &snapshot.summary;
-            table_info.meta.statistics = TableStatistics {
-                number_of_rows: summary.row_count,
-                data_bytes: summary.uncompressed_byte_size,
-                compressed_data_bytes: summary.compressed_byte_size,
-                index_data_bytes: summary.index_size,
-                number_of_segments: Some(snapshot.segments.len() as u64),
-                number_of_blocks: Some(summary.block_count),
-            };
-
-            // let's instantiate it
-            let table = FuseTable::do_create(table_info)?;
-            Ok(table.into())
+            self.load_table_by_snapshot(snapshot.as_ref(), format_version, None)
         } else {
             Err(ErrorCode::TableHistoricalDataNotFound(
                 "No historical data found at given point",
             ))
         }
+    }
+
+    /// Load the table instance by the snapshot
+    fn load_table_by_snapshot(
+        &self,
+        snapshot: &TableSnapshot,
+        format_version: u64,
+        table_seq: Option<u64>,
+    ) -> Result<Arc<FuseTable>> {
+        let mut table_info = self.table_info.clone();
+
+        // The `seq` of ident here is primarily JUST a place holder
+        // we should NOT use it outside of create stream.
+        table_info.ident.seq = if let Some(seq) = table_seq {
+            seq
+        } else {
+            // The table version is the version of the table when the snapshot was created.
+            // We need make sure the version greater than the table version,
+            // and less equal than the table version after the snapshot commit.
+            snapshot.prev_table_seq.map_or(0, |v| v + 1)
+        };
+
+        // There are more to be kept in snapshot, like engine_options, ordering keys...
+        // or we could just keep a clone of TableMeta in the snapshot.
+        //
+        // currently, here are what we can recovery from the snapshot:
+
+        // 1. the table schema
+        table_info.meta.schema = Arc::new(snapshot.schema.clone());
+
+        // 2. the table option `snapshot_location`
+        let loc = self
+            .meta_location_generator
+            .snapshot_location_from_uuid(&snapshot.snapshot_id, format_version)?;
+        table_info
+            .meta
+            .options
+            .insert(OPT_KEY_SNAPSHOT_LOCATION.to_owned(), loc);
+
+        // 3. The statistics
+        let summary = &snapshot.summary;
+        table_info.meta.statistics = TableStatistics {
+            number_of_rows: summary.row_count,
+            data_bytes: summary.uncompressed_byte_size,
+            compressed_data_bytes: summary.compressed_byte_size,
+            index_data_bytes: summary.index_size,
+            number_of_segments: Some(snapshot.segments.len() as u64),
+            number_of_blocks: Some(summary.block_count),
+        };
+
+        // let's instantiate it
+        let table = FuseTable::do_create(table_info)?;
+        Ok(table.into())
     }
 
     #[async_backtrace::framed]
@@ -187,6 +239,7 @@ impl FuseTable {
                 self.list_by_snapshot_id(snapshot_id.as_str(), time_point)
                     .await
             }
+            Some(NavigationPoint::StreamInfo(info)) => self.list_by_stream(info, time_point).await,
             None => self.list_by_time_point(time_point).await,
         }?;
 
@@ -266,6 +319,55 @@ impl FuseTable {
             ErrorCode::TableHistoricalDataNotFound("No historical data found at given point")
         })?;
         Ok((location, files))
+    }
+
+    #[async_backtrace::framed]
+    pub async fn list_by_stream(
+        &self,
+        stream_info: TableInfo,
+        retention_point: DateTime<Utc>,
+    ) -> Result<(String, Vec<String>)> {
+        let options = stream_info.options();
+        let stream_table_id = options
+            .get(OPT_KEY_TABLE_ID)
+            .ok_or_else(|| ErrorCode::Internal("table id must be set"))?
+            .parse::<u64>()?;
+        if stream_table_id != self.table_info.ident.table_id {
+            return Err(ErrorCode::IllegalStream(format!(
+                "The stream '{}' is not match the table '{}'",
+                stream_info.desc, self.table_info.desc
+            )));
+        }
+
+        let snapshot_loc = options
+            .get(OPT_KEY_SNAPSHOT_LOCATION)
+            .ok_or_else(|| {
+                ErrorCode::TableHistoricalDataNotFound("No historical data found at given point")
+            })?
+            .parse::<String>()?;
+
+        let mut found = false;
+        let prefix = format!(
+            "{}/{}/",
+            self.meta_location_generator().prefix(),
+            FUSE_TBL_SNAPSHOT_PREFIX,
+        );
+
+        let files = self
+            .list_files(prefix, |loc, modified| {
+                if loc == snapshot_loc {
+                    found = true;
+                }
+                modified <= retention_point
+            })
+            .await?;
+
+        if !found {
+            return Err(ErrorCode::TableHistoricalDataNotFound(
+                "No historical data found at given point",
+            ));
+        }
+        Ok((snapshot_loc, files))
     }
 
     #[async_backtrace::framed]

--- a/tests/suites/5_ee/05_stream/05_0002_ee_stream_create.result
+++ b/tests/suites/5_ee/05_stream/05_0002_ee_stream_create.result
@@ -1,7 +1,11 @@
 Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
 3	INSERT	false	true
+1
+2
 Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
 3	INSERT	false	true
 Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
 Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
 Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
+3
+2

--- a/tests/suites/5_ee/05_stream/05_0002_ee_stream_create.sh
+++ b/tests/suites/5_ee/05_stream/05_0002_ee_stream_create.sh
@@ -19,6 +19,7 @@ echo "create stream db_stream.s1 on table db_stream.base at (snapshot => '$SNAPS
 SNAPSHOT_ID_2=$(echo "select snapshot_id from fuse_snapshot('db_stream','base') where row_count=2 limit 1" | $BENDSQL_CLIENT_CONNECT)
 echo "create stream db_stream.s2 on table db_stream.base at (snapshot => '$SNAPSHOT_ID_2')" | $BENDSQL_CLIENT_CONNECT
 echo "select a, change\$action, change\$is_update, change\$row_id='$BASE_ROW_ID' from db_stream.s2" | $BENDSQL_CLIENT_CONNECT
+echo "select a from db_stream.base at (stream => db_stream.s2) order by a" | $BENDSQL_CLIENT_CONNECT
 
 TIMEPOINT_1=$(echo "select timestamp from fuse_snapshot('db_stream','base') where row_count=1 limit 1" | $BENDSQL_CLIENT_CONNECT)
 echo "create stream db_stream.t1 on table db_stream.base at (timestamp => '$TIMEPOINT_1'::TIMESTAMP)" | $BENDSQL_CLIENT_CONNECT
@@ -33,6 +34,10 @@ echo "create stream db_stream.s3 on table db_stream.base at (snapshot => '$SNAPS
 echo "alter table db_stream.base set options(change_tracking = true)" | $BENDSQL_CLIENT_CONNECT
 echo "create stream db_stream.s4 on table db_stream.base at (stream => db_stream.s2)" | $BENDSQL_CLIENT_CONNECT
 echo "select a from db_stream.s2" | $BENDSQL_CLIENT_CONNECT
+
+echo "select count(*) from fuse_snapshot('db_stream', 'base')" | $BENDSQL_CLIENT_CONNECT
+echo "set data_retention_time_in_days=0; optimize table db_stream.base purge before (stream => db_stream.s2)" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from fuse_snapshot('db_stream', 'base')" | $BENDSQL_CLIENT_CONNECT
 
 echo "drop stream if exists db_stream.s2" | $BENDSQL_CLIENT_CONNECT
 echo "drop stream if exists db_stream.t2" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```sql
SELECT ...
FROM ...
AT ( { SNAPSHOT => <snapshot_id> | TIMESTAMP => <timestamp> | (STREAM => '<name>')} );
```
```sql
OPTIMIZE TABLE <table_name> PURGE [BEFORE (SNAPSHOT => '<SNAPSHOT_ID>') 
| (STREAM => '<name>') | (TIMESTAMP => '<TIMESTAMP>'::TIMESTAMP)] 
[LIMIT <snapshot_count>]
```

```
mysql> create table t(a int);
Query OK, 0 rows affected (0.03 sec)

mysql> insert into t values(1);
Query OK, 1 row affected (0.04 sec)

mysql> insert into t values(2);
Query OK, 1 row affected (0.05 sec)

mysql> create or replace stream s on table t;
Query OK, 0 rows affected (0.05 sec)

mysql> insert into t values(3);
Query OK, 1 row affected (0.11 sec)

mysql> select * from t at(stream=>s);
+------+
| a    |
+------+
|    2 |
|    1 |
+------+
2 rows in set (0.19 sec)
Read 2 rows, 10.00 B in 0.070 sec., 28.55 rows/sec., 142.77 B/sec.

mysql> set data_retention_time_in_days=0;
Query OK, 0 rows affected (0.03 sec)

mysql> select count() from fuse_snapshot('default','t');
+---------+
| count() |
+---------+
|       3 |
+---------+
1 row in set (0.08 sec)
Read 3 rows, 603.00 B in 0.056 sec., 53.3 rows/sec., 10.46 KiB/sec.

mysql> optimize table t purge before(stream=>s);
Query OK, 0 rows affected (0.08 sec)

mysql> select count() from fuse_snapshot('default','t');
+---------+
| count() |
+---------+
|       2 |
+---------+
1 row in set (0.09 sec)
Read 2 rows, 432.00 B in 0.061 sec., 32.85 rows/sec., 6.93 KiB/sec.

mysql> create stream s1 on table t at(stream=>s) append_only=false;
Query OK, 0 rows affected (0.16 sec)

mysql> select * from s1;
+------+---------------+------------------+----------------------------------------+
| a    | change$action | change$is_update | change$row_id                          |
+------+---------------+------------------+----------------------------------------+
|    3 | INSERT        |                0 | 1a1b617249b546529ed072dff78faea2000000 |
+------+---------------+------------------+----------------------------------------+
1 row in set (0.20 sec)
Read 1 rows, 197.00 B in 0.016 sec., 62.86 rows/sec., 12.09 KiB/sec.

mysql> select * from s;
+------+---------------+------------------+----------------------------------------+
| a    | change$action | change$is_update | change$row_id                          |
+------+---------------+------------------+----------------------------------------+
|    3 | INSERT        |                0 | 1a1b617249b546529ed072dff78faea2000000 |
+------+---------------+------------------+----------------------------------------+
1 row in set (0.23 sec)
Read 1 rows, 197.00 B in 0.017 sec., 59.67 rows/sec., 11.48 KiB/sec.
```

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
