### PR TITLE
chore(query): errorcode use snake shape format

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -619,7 +619,7 @@ impl SchemaApiTestSuite {
             info!("create database res: {:?}", res);
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::DatabaseAlreadyExists("").code(),
+                ErrorCode::DATABASE_ALREADY_EXISTS,
                 ErrorCode::from(err).code()
             );
         }
@@ -721,10 +721,7 @@ impl SchemaApiTestSuite {
                 .get_database(GetDatabaseReq::new(tenant.clone(), "db2"))
                 .await;
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownDatabase("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, ErrorCode::from(err).code());
         }
 
         info!("--- drop db2 with if_exists=true returns no error");
@@ -852,7 +849,7 @@ impl SchemaApiTestSuite {
                 .await;
             assert!(res.is_err());
             assert_eq!(
-                ErrorCode::UndropDbHasNoHistory("").code(),
+                ErrorCode::UNDROP_DB_HAS_NO_HISTORY,
                 ErrorCode::from(res.unwrap_err()).code()
             );
         }
@@ -951,7 +948,7 @@ impl SchemaApiTestSuite {
             let err = res.unwrap_err();
             let err = ErrorCode::from(err);
 
-            assert_eq!(ErrorCode::UnknownDatabase("").code(), err.code());
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, err.code());
             assert!(err.message().contains("absent"));
         }
 
@@ -963,7 +960,7 @@ impl SchemaApiTestSuite {
             let res = res.unwrap_err();
             let err = ErrorCode::from(res);
 
-            assert_eq!(ErrorCode::UnknownDatabase("").code(), err.code());
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, err.code());
             assert_eq!("Unknown database 'db2'".to_string(), err.message());
         }
 
@@ -985,10 +982,7 @@ impl SchemaApiTestSuite {
                 .get_database(GetDatabaseReq::new(tenant1.clone(), "db2"))
                 .await;
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownDatabase("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, ErrorCode::from(err).code());
         }
 
         info!("--- tenant1 drop db2 with if_exists=true returns no error");
@@ -1118,7 +1112,7 @@ impl SchemaApiTestSuite {
             info!("rename database res: {:?}", res);
             assert!(res.is_err());
             assert_eq!(
-                ErrorCode::UnknownDatabase("").code(),
+                ErrorCode::UNKNOWN_DATABASE,
                 ErrorCode::from(res.unwrap_err()).code()
             );
         }
@@ -1144,7 +1138,7 @@ impl SchemaApiTestSuite {
                 info!("rename database res: {:?}", res);
                 assert!(res.is_err());
                 assert_eq!(
-                    ErrorCode::UnknownDatabase("").code(),
+                    ErrorCode::UNKNOWN_DATABASE,
                     ErrorCode::from(res.unwrap_err()).code()
                 );
             }
@@ -1169,7 +1163,7 @@ impl SchemaApiTestSuite {
             info!("rename database res: {:?}", res);
             assert!(res.is_err());
             assert_eq!(
-                ErrorCode::DatabaseAlreadyExists("").code(),
+                ErrorCode::DATABASE_ALREADY_EXISTS,
                 ErrorCode::from(res.unwrap_err()).code()
             );
         }
@@ -1201,10 +1195,7 @@ impl SchemaApiTestSuite {
             {
                 let res = mt.get_database(GetDatabaseReq::new(tenant, db_name)).await;
                 let err = res.err().unwrap();
-                assert_eq!(
-                    ErrorCode::UnknownDatabase("").code(),
-                    ErrorCode::from(err).code()
-                );
+                assert_eq!(ErrorCode::UNKNOWN_DATABASE, ErrorCode::from(err).code());
             }
         }
 
@@ -1694,7 +1685,7 @@ impl SchemaApiTestSuite {
             ..TableMeta::default()
         };
 
-        let unknown_database_code = ErrorCode::UnknownDatabase("").code();
+        let unknown_database_code = ErrorCode::UNKNOWN_DATABASE;
 
         info!("--- create or get table on unknown db");
         {
@@ -1959,7 +1950,7 @@ impl SchemaApiTestSuite {
                 let res = mt.drop_table_by_id(plan).await;
                 let err = res.unwrap_err();
                 assert_eq!(
-                    ErrorCode::UnknownTable("").code(),
+                    ErrorCode::UNKNOWN_TABLE,
                     ErrorCode::from(err).code(),
                     "drop table {} with if_exists=false again",
                     tbl_name
@@ -2247,7 +2238,7 @@ impl SchemaApiTestSuite {
 
             assert!(got.is_err());
             assert_eq!(
-                ErrorCode::UnknownDatabase("").code(),
+                ErrorCode::UNKNOWN_DATABASE,
                 ErrorCode::from(got.unwrap_err()).code()
             );
         }
@@ -2339,7 +2330,7 @@ impl SchemaApiTestSuite {
             let res = mt.rename_table(rename_db1tb2_to_db1tb3(false)).await;
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::UnknownTable("").code(),
+                ErrorCode::UNKNOWN_TABLE,
                 ErrorCode::from(err).code(),
                 "rename table {} again",
                 tb2_name
@@ -2375,7 +2366,7 @@ impl SchemaApiTestSuite {
             let res = mt.rename_table(rename_db1tb2_to_db1tb3(false)).await;
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::TableAlreadyExists("").code(),
+                ErrorCode::TABLE_ALREADY_EXISTS,
                 ErrorCode::from(err).code(),
                 "rename table {} again after recreate",
                 tb2_name
@@ -2387,7 +2378,7 @@ impl SchemaApiTestSuite {
             let res = mt.rename_table(rename_db1tb2_to_db1tb3(true)).await;
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::TableAlreadyExists("").code(),
+                ErrorCode::TABLE_ALREADY_EXISTS,
                 ErrorCode::from(err).code(),
                 "rename table {} again after recreate",
                 tb2_name
@@ -2411,7 +2402,7 @@ impl SchemaApiTestSuite {
 
             assert!(res.is_err());
             assert_eq!(
-                ErrorCode::UnknownDatabase("").code(),
+                ErrorCode::UNKNOWN_DATABASE,
                 ErrorCode::from(res.unwrap_err()).code()
             );
         }
@@ -2731,7 +2722,7 @@ impl SchemaApiTestSuite {
                     .await;
                 let err = result.unwrap_err();
                 let err = ErrorCode::from(err);
-                assert_eq!(ErrorCode::DuplicatedUpsertFiles("").code(), err.code());
+                assert_eq!(ErrorCode::DUPLICATED_UPSERT_FILES, err.code());
             }
         }
         Ok(())
@@ -3223,7 +3214,7 @@ impl SchemaApiTestSuite {
                 let err = got.unwrap_err();
                 let err = ErrorCode::from(err);
 
-                assert_eq!(ErrorCode::TableVersionMismatched("").code(), err.code());
+                assert_eq!(ErrorCode::TABLE_VERSION_MISMATCHED, err.code());
 
                 // table is not affected.
                 let table = mt.get_table((tenant, "db1", "tb2").into()).await.unwrap();
@@ -3248,7 +3239,7 @@ impl SchemaApiTestSuite {
                 let err = got.unwrap_err();
                 let err = ErrorCode::from(err);
 
-                assert_eq!(ErrorCode::UnknownTableId("").code(), err.code());
+                assert_eq!(ErrorCode::UNKNOWN_TABLE_ID, err.code());
 
                 // table is not affected.
                 let table = mt.get_table((tenant, "db1", "tb2").into()).await.unwrap();
@@ -4903,7 +4894,7 @@ impl SchemaApiTestSuite {
                 .await;
             assert!(res.is_err());
             let code = ErrorCode::from(res.unwrap_err()).code();
-            let undrop_table_already_exists = ErrorCode::UndropTableAlreadyExists("").code();
+            let undrop_table_already_exists = ErrorCode::UNDROP_TABLE_ALREADY_EXISTS;
             assert_eq!(undrop_table_already_exists, code);
         }
 
@@ -5158,7 +5149,7 @@ impl SchemaApiTestSuite {
                 let err = got.unwrap_err();
                 let err = ErrorCode::from(err);
 
-                assert_eq!(ErrorCode::UnknownTableId("").code(), err.code());
+                assert_eq!(ErrorCode::UNKNOWN_TABLE_ID, err.code());
             }
         }
         Ok(())
@@ -5255,7 +5246,7 @@ impl SchemaApiTestSuite {
                 let err = got.unwrap_err();
                 let err = ErrorCode::from(err);
 
-                assert_eq!(ErrorCode::UnknownTableId("").code(), err.code());
+                assert_eq!(ErrorCode::UNKNOWN_TABLE_ID, err.code());
             }
         }
         Ok(())
@@ -5314,7 +5305,7 @@ impl SchemaApiTestSuite {
                 let err = got.unwrap_err();
                 let err = ErrorCode::from(err);
 
-                assert_eq!(ErrorCode::UnknownDatabaseId("").code(), err.code());
+                assert_eq!(ErrorCode::UNKNOWN_DATABASE_ID, err.code());
             }
         }
         Ok(())
@@ -5657,7 +5648,7 @@ impl SchemaApiTestSuite {
             assert!(got.is_err());
             assert_eq!(
                 ErrorCode::from(got.unwrap_err()).code(),
-                ErrorCode::WrongShareObject("").code()
+                ErrorCode::WRONG_SHARE_OBJECT
             );
         }
 
@@ -5677,7 +5668,7 @@ impl SchemaApiTestSuite {
             assert!(res.is_err());
 
             let code = ErrorCode::from(res.unwrap_err()).code();
-            assert_eq!(ErrorCode::UnknownDatabase("").code(), code);
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, code);
         }
 
         info!("--- prepare db");
@@ -5971,7 +5962,7 @@ impl SchemaApiTestSuite {
             let status = res.err().unwrap();
             let err_code = ErrorCode::from(status);
 
-            assert_eq!(ErrorCode::IndexAlreadyExists("").code(), err_code.code());
+            assert_eq!(ErrorCode::INDEX_ALREADY_EXISTS, err_code.code());
         }
 
         {
@@ -6157,7 +6148,7 @@ impl SchemaApiTestSuite {
             let status = res.err().unwrap();
             let err_code = ErrorCode::from(status);
 
-            assert_eq!(ErrorCode::IndexAlreadyExists("").code(), err_code.code());
+            assert_eq!(ErrorCode::INDEX_ALREADY_EXISTS, err_code.code());
         }
 
         {
@@ -6825,7 +6816,7 @@ impl SchemaApiTestSuite {
             debug!("get present database res: {:?}", res);
             let err = res.unwrap_err();
             let err = ErrorCode::from(err);
-            assert_eq!(ErrorCode::UnknownDatabase("").code(), err.code());
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, err.code());
             assert_eq!("Unknown database 'nonexistent'", err.message());
             assert_eq!(
                 "UnknownDatabase. Code: 1003, Text = Unknown database 'nonexistent'.",
@@ -7043,10 +7034,7 @@ impl SchemaApiTestSuite {
                 .await;
             debug!("get present table res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownTable("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_TABLE, ErrorCode::from(err).code());
         }
 
         Ok(())
@@ -7182,7 +7170,7 @@ impl SchemaApiTestSuite {
             let result = mt.update_table_meta(req).await;
             let err = result.unwrap_err();
             let err = ErrorCode::from(err);
-            assert_eq!(ErrorCode::DuplicatedUpsertFiles("").code(), err.code());
+            assert_eq!(ErrorCode::DUPLICATED_UPSERT_FILES, err.code());
 
             let req = GetTableCopiedFileReq {
                 table_id,

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -248,7 +248,7 @@ impl ShareApiTestSuite {
             assert!(res.is_err());
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::ShareEndpointAlreadyExists("").code(),
+                ErrorCode::SHARE_ENDPOINT_ALREADY_EXISTS,
                 ErrorCode::from(err).code()
             );
 
@@ -521,10 +521,7 @@ impl ShareApiTestSuite {
             let res = mt.add_share_tenants(req).await;
             assert!(res.is_err());
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownShare("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_SHARE, ErrorCode::from(err).code());
 
             let req = RemoveShareAccountsReq {
                 share_name: share_name.clone(),
@@ -535,10 +532,7 @@ impl ShareApiTestSuite {
             let res = mt.remove_share_tenants(req).await;
             assert!(res.is_err());
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownShare("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_SHARE, ErrorCode::from(err).code());
         }
 
         info!("--- prepare share1 share2 share3");
@@ -687,7 +681,7 @@ impl ShareApiTestSuite {
             info!("add share account res: {:?}", res);
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::ShareAccountsAlreadyExists("").code(),
+                ErrorCode::SHARE_ACCOUNTS_ALREADY_EXISTS,
                 ErrorCode::from(err).code()
             );
         }
@@ -735,7 +729,7 @@ impl ShareApiTestSuite {
             let res = get_share_account_meta_or_err(mt.as_kv_api(), &share_account_name, "").await;
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::UnknownShareAccounts("").code(),
+                ErrorCode::UNKNOWN_SHARE_ACCOUNTS,
                 ErrorCode::from(err).code()
             );
         }
@@ -758,7 +752,7 @@ impl ShareApiTestSuite {
             let res = get_share_account_meta_or_err(mt.as_kv_api(), &share_account_name, "").await;
             let err = res.unwrap_err();
             assert_eq!(
-                ErrorCode::UnknownShareAccounts("").code(),
+                ErrorCode::UNKNOWN_SHARE_ACCOUNTS,
                 ErrorCode::from(err).code()
             );
         }
@@ -890,10 +884,7 @@ impl ShareApiTestSuite {
             let res = mt.grant_share_object(req).await;
             info!("grant object res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownDatabase("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, ErrorCode::from(err).code());
 
             let req = GrantShareObjectReq {
                 share_name: share_name.clone(),
@@ -908,10 +899,7 @@ impl ShareApiTestSuite {
             let res = mt.grant_share_object(req).await;
             info!("grant object res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownTable("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_TABLE, ErrorCode::from(err).code());
         }
 
         info!("--- grant unknown share2");
@@ -929,10 +917,7 @@ impl ShareApiTestSuite {
             let res = mt.grant_share_object(req).await;
             info!("grant object res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownShare("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_SHARE, ErrorCode::from(err).code());
         }
 
         info!("--- grant table2 on a unbound database share");
@@ -947,10 +932,7 @@ impl ShareApiTestSuite {
             let res = mt.grant_share_object(req).await;
             info!("grant object res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::WrongShareObject("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::WRONG_SHARE_OBJECT, ErrorCode::from(err).code());
         }
 
         info!("--- grant db object and table object");
@@ -1037,10 +1019,7 @@ impl ShareApiTestSuite {
             let res = mt.grant_share_object(req).await;
             info!("grant object res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::WrongShareObject("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::WRONG_SHARE_OBJECT, ErrorCode::from(err).code());
 
             let req = GrantShareObjectReq {
                 share_name: share_name.clone(),
@@ -1052,10 +1031,7 @@ impl ShareApiTestSuite {
             let res = mt.grant_share_object(req).await;
             info!("grant object res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::WrongShareObject("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::WRONG_SHARE_OBJECT, ErrorCode::from(err).code());
         }
 
         info!("--- check db and table shared_by field");
@@ -1226,10 +1202,7 @@ impl ShareApiTestSuite {
             let res = mt.get_share_grant_objects(req).await;
             info!("get_share_grant_objects res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownShare("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_SHARE, ErrorCode::from(err).code());
         }
 
         info!("--- create share1");
@@ -1370,10 +1343,7 @@ impl ShareApiTestSuite {
             let res = mt.get_grant_privileges_of_object(req).await;
             info!("get_share_grant_objects res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownDatabase("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, ErrorCode::from(err).code());
 
             let req = GetObjectGrantPrivilegesReq {
                 tenant: tenant_name.to_string(),
@@ -1383,10 +1353,7 @@ impl ShareApiTestSuite {
             let res = mt.get_grant_privileges_of_object(req).await;
             info!("get_share_grant_objects res: {:?}", res);
             let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::UnknownDatabase("").code(),
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(ErrorCode::UNKNOWN_DATABASE, ErrorCode::from(err).code());
         }
 
         info!("--- create share1 and share2");
@@ -1563,7 +1530,7 @@ impl ShareApiTestSuite {
                 assert!(res.is_err());
                 let err = res.unwrap_err();
                 assert_eq!(
-                    ErrorCode::CannotShareDatabaseCreatedFromShare("").code(),
+                    ErrorCode::CANNOT_SHARE_DATABASE_CREATED_FROM_SHARE,
                     ErrorCode::from(err).code()
                 );
             }

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -152,10 +152,7 @@ mod add {
 
             let res = user_mgr.add_user(user_info, &CreateOption::Create).await;
 
-            assert_eq!(
-                res.unwrap_err().code(),
-                ErrorCode::UserAlreadyExists("").code()
-            );
+            assert_eq!(res.unwrap_err().code(), ErrorCode::USER_ALREADY_EXISTS);
         }
 
         Ok(())
@@ -243,7 +240,7 @@ mod get {
             )
             .await;
         assert!(res.is_err());
-        assert_eq!(res.unwrap_err().code(), ErrorCode::UnknownUser("").code());
+        assert_eq!(res.unwrap_err().code(), ErrorCode::UNKNOWN_USER);
         Ok(())
     }
 
@@ -271,7 +268,7 @@ mod get {
             )
             .await;
         assert!(res.is_err());
-        assert_eq!(res.unwrap_err().code(), ErrorCode::UnknownUser("").code());
+        assert_eq!(res.unwrap_err().code(), ErrorCode::UNKNOWN_USER);
         Ok(())
     }
 
@@ -298,7 +295,7 @@ mod get {
         );
         assert_eq!(
             res.await.unwrap_err().code(),
-            ErrorCode::IllegalUserInfoFormat("").code()
+            ErrorCode::ILLEGAL_USER_INFO_FORMAT
         );
 
         Ok(())
@@ -389,7 +386,7 @@ mod get_users {
         let res = user_mgr.get_users();
         assert_eq!(
             res.await.unwrap_err().code(),
-            ErrorCode::IllegalUserInfoFormat("").code()
+            ErrorCode::ILLEGAL_USER_INFO_FORMAT
         );
 
         Ok(())
@@ -448,10 +445,7 @@ mod drop {
         let kv = Arc::new(kv);
         let user_mgr = UserMgr::create(kv, &Tenant::new_literal("tenant1"));
         let res = user_mgr.drop_user(UserIdentity::new(test_user, test_hostname), MatchSeq::GE(1));
-        assert_eq!(
-            res.await.unwrap_err().code(),
-            ErrorCode::UnknownUser("").code()
-        );
+        assert_eq!(res.await.unwrap_err().code(), ErrorCode::UNKNOWN_USER);
         Ok(())
     }
 }
@@ -559,10 +553,7 @@ mod update {
             MatchSeq::GE(0),
             |ui: &mut UserInfo| ui.update_auth_option(Some(new_test_auth_info(false)), None),
         );
-        assert_eq!(
-            res.await.unwrap_err().code(),
-            ErrorCode::UnknownUser("").code()
-        );
+        assert_eq!(res.await.unwrap_err().code(), ErrorCode::UNKNOWN_USER);
         Ok(())
     }
 

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -181,7 +181,7 @@ impl PrivilegeAccess {
                             )
                             .await
                         {
-                            if err.code() != ErrorCode::PermissionDenied("").code() {
+                            if err.code() != ErrorCode::PERMISSION_DENIED {
                                 return Err(err);
                             }
                             let current_user = self.ctx.get_current_user()?;
@@ -278,7 +278,7 @@ impl PrivilegeAccess {
                                     )
                                     .await
                                 {
-                                    if err.code() != ErrorCode::PermissionDenied("").code() {
+                                    if err.code() != ErrorCode::PERMISSION_DENIED {
                                         return Err(err);
                                     }
                                     let current_user = self.ctx.get_current_user()?;
@@ -377,7 +377,7 @@ impl PrivilegeAccess {
         match session.validate_privilege(grant_object, privilege).await {
             Ok(_) => Ok(()),
             Err(err) => {
-                if err.code() != ErrorCode::PermissionDenied("").code() {
+                if err.code() != ErrorCode::PERMISSION_DENIED {
                     return Err(err);
                 }
                 let current_user = self.ctx.get_current_user()?;

--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -37,7 +37,7 @@ fn error_fields(log_type: LogType, err: Option<ErrorCode>) -> (LogType, i32, Str
     match err {
         None => (log_type, 0, "".to_string(), "".to_string()),
         Some(e) => {
-            if e.code() == ErrorCode::AbortedQuery("").code() {
+            if e.code() == ErrorCode::ABORTED_QUERY {
                 (
                     LogType::Aborted,
                     e.code().into(),

--- a/src/query/service/src/interpreters/interpreter_data_mask_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_data_mask_desc.rs
@@ -72,7 +72,7 @@ impl Interpreter for DescDataMaskInterpreter {
             Ok(policy) => policy,
             Err(err) => {
                 warn!("DescDataMaskInterpreter err: {}", err);
-                if err.code() != ErrorCode::UnknownDatamask("").code() {
+                if err.code() != ErrorCode::UNKNOWN_DATAMASK {
                     return Err(err);
                 }
                 return Ok(PipelineBuildResult::create());

--- a/src/query/service/tests/it/api/rpc_service.rs
+++ b/src/query/service/tests/it/api/rpc_service.rs
@@ -81,7 +81,7 @@ async fn test_tls_rpc_server_invalid_server_config() -> Result<()> {
         .await;
     assert!(r.is_err());
     let e = r.unwrap_err();
-    assert_eq!(e.code(), ErrorCode::TLSConfigurationFailure("").code());
+    assert_eq!(e.code(), ErrorCode::T_L_S_CONFIGURATION_FAILURE);
     Ok(())
 }
 

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -802,7 +802,7 @@ async fn test_query_log() -> Result<()> {
     );
     assert_eq!(
         result.data[0][1].as_str().unwrap(),
-        ErrorCode::TableAlreadyExists("").code().to_string(),
+        ErrorCode::TABLE_ALREADY_EXISTS.to_string(),
         "{:?}",
         result
     );
@@ -858,7 +858,7 @@ async fn test_query_log_killed() -> Result<()> {
     );
     assert_eq!(
         result.data[0][1].as_str().unwrap(),
-        ErrorCode::AbortedQuery("").code().to_string(),
+        ErrorCode::ABORTED_QUERY.to_string(),
         "{:?}",
         result
     );

--- a/src/query/storages/fuse/src/operations/analyze.rs
+++ b/src/query/storages/fuse/src/operations/analyze.rs
@@ -203,7 +203,7 @@ impl AsyncSink for SinkAnalyzeState {
     #[unboxed_simple]
     #[async_backtrace::framed]
     async fn consume(&mut self, data_block: DataBlock) -> Result<bool> {
-        let mismatch_code = ErrorCode::TableVersionMismatched("").code();
+        let mismatch_code = ErrorCode::TABLE_VERSION_MISMATCHED;
 
         loop {
             if let Err(e) = self.merge_analyze_states(data_block.clone()).await {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

errorcode use snake shape format

We have macro `build_exceptions` can expand code. Use macro keep code clean.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Modify error code assert eq.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
