### PR TITLE
refactor: use TIdent to unify kvapi key def for MaskPolicyTableIdListIdent and DataMaskNameIdent

### DIFF
--- a/src/meta/app/src/data_mask/data_mask_name_ident.rs
+++ b/src/meta/app/src/data_mask/data_mask_name_ident.rs
@@ -1,0 +1,58 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tenant_key::TIdent;
+
+pub type DataMaskNameIdent = TIdent<Resource>;
+
+pub use kvapi_impl::Resource;
+
+mod kvapi_impl {
+
+    use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::data_mask::DatamaskId;
+    use crate::tenant_key::TenantResource;
+
+    pub struct Resource;
+    impl TenantResource for Resource {
+        const PREFIX: &'static str = "__fd_datamask";
+        type ValueType = DatamaskId;
+    }
+
+    impl kvapi::Value for DatamaskId {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            [self.to_string_key()]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::data_mask::DataMaskNameIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_ident() {
+        let tenant = Tenant::new_literal("tenant1");
+        let ident = DataMaskNameIdent::new(tenant.clone(), "test");
+        assert_eq!("__fd_datamask/tenant1/test", ident.to_string_key());
+
+        let got = DataMaskNameIdent::from_str_key(&ident.to_string_key()).unwrap();
+        assert_eq!(ident, got);
+    }
+}

--- a/src/meta/app/src/data_mask/mask_policy_table_id_list_ident.rs
+++ b/src/meta/app/src/data_mask/mask_policy_table_id_list_ident.rs
@@ -1,0 +1,57 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tenant_key::TIdent;
+
+pub type MaskPolicyTableIdListIdent = TIdent<Resource>;
+
+pub use kvapi_impl::Resource;
+
+mod kvapi_impl {
+
+    use databend_common_meta_kvapi::kvapi;
+
+    use crate::data_mask::MaskpolicyTableIdList;
+    use crate::tenant_key::TenantResource;
+
+    pub struct Resource;
+    impl TenantResource for Resource {
+        const PREFIX: &'static str = "__fd_datamask_id_list";
+        type ValueType = MaskpolicyTableIdList;
+    }
+
+    impl kvapi::Value for MaskpolicyTableIdList {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::data_mask::mask_policy_table_id_list_ident::MaskPolicyTableIdListIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_ident() {
+        let tenant = Tenant::new_literal("tenant1");
+        let ident = MaskPolicyTableIdListIdent::new(tenant.clone(), "test");
+        assert_eq!("__fd_datamask_id_list/tenant1/test", ident.to_string_key());
+
+        let got = MaskPolicyTableIdListIdent::from_str_key(&ident.to_string_key()).unwrap();
+        assert_eq!(ident, got);
+    }
+}

--- a/src/meta/app/src/data_mask/mod.rs
+++ b/src/meta/app/src/data_mask/mod.rs
@@ -12,26 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod data_mask_name_ident;
+pub mod mask_policy_table_id_list_ident;
 use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
 use chrono::DateTime;
 use chrono::Utc;
+pub use data_mask_name_ident::DataMaskNameIdent;
+pub use mask_policy_table_id_list_ident::MaskPolicyTableIdListIdent;
 
 use crate::schema::CreateOption;
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct DatamaskNameIdent {
-    pub tenant: String,
-    pub name: String,
-}
-
-impl Display for DatamaskNameIdent {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "'{}'/'{}'", self.tenant, self.name)
-    }
-}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatamaskId {
@@ -71,7 +63,7 @@ impl From<CreateDatamaskReq> for DatamaskMeta {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateDatamaskReq {
     pub create_option: CreateOption,
-    pub name: DatamaskNameIdent,
+    pub name: DataMaskNameIdent,
     pub args: Vec<(String, String)>,
     pub return_type: String,
     pub body: String,
@@ -87,7 +79,7 @@ pub struct CreateDatamaskReply {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DropDatamaskReq {
     pub if_exists: bool,
-    pub name: DatamaskNameIdent,
+    pub name: DataMaskNameIdent,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -95,33 +87,12 @@ pub struct DropDatamaskReply {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GetDatamaskReq {
-    pub name: DatamaskNameIdent,
+    pub name: DataMaskNameIdent,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct GetDatamaskReply {
     pub policy: DatamaskMeta,
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct MaskpolicyTableIdListKey {
-    pub tenant: String,
-    pub name: String,
-}
-
-impl MaskpolicyTableIdListKey {
-    pub fn new(tenant: impl ToString, name: impl ToString) -> Self {
-        MaskpolicyTableIdListKey {
-            tenant: tenant.to_string(),
-            name: name.to_string(),
-        }
-    }
-}
-
-impl Display for MaskpolicyTableIdListKey {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "'{}'/'{}'", self.tenant, self.name)
-    }
 }
 
 /// A list of table ids
@@ -132,43 +103,9 @@ pub struct MaskpolicyTableIdList {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
-    use databend_common_meta_kvapi::kvapi::Key;
 
     use super::DatamaskId;
-    use super::DatamaskNameIdent;
-    use super::MaskpolicyTableIdListKey;
     use crate::data_mask::DatamaskMeta;
-    use crate::data_mask::MaskpolicyTableIdList;
-    use crate::tenant::Tenant;
-
-    /// __fd_database/<tenant>/<name> -> <data_mask_id>
-    impl kvapi::Key for DatamaskNameIdent {
-        const PREFIX: &'static str = "__fd_datamask";
-
-        type ValueType = DatamaskId;
-
-        /// It belongs to a tenant
-        fn parent(&self) -> Option<String> {
-            Some(Tenant::new(&self.tenant).to_string_key())
-        }
-
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_str(&self.tenant)
-                .push_str(&self.name)
-                .done()
-        }
-
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let tenant = p.next_str()?;
-            let name = p.next_str()?;
-            p.done()?;
-
-            Ok(DatamaskNameIdent { tenant, name })
-        }
-    }
 
     /// "__fd_datamask_by_id/<id>"
     impl kvapi::Key for DatamaskId {
@@ -196,48 +133,7 @@ mod kvapi_key_impl {
         }
     }
 
-    impl kvapi::Key for MaskpolicyTableIdListKey {
-        const PREFIX: &'static str = "__fd_datamask_id_list";
-
-        type ValueType = MaskpolicyTableIdList;
-
-        /// It belongs to a tenant
-        fn parent(&self) -> Option<String> {
-            Some(Tenant::new(&self.tenant).to_string_key())
-        }
-
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_str(&self.tenant)
-                .push_str(&self.name)
-                .done()
-        }
-
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let tenant = p.next_str()?;
-            let name = p.next_str()?;
-            p.done()?;
-
-            Ok(MaskpolicyTableIdListKey { tenant, name })
-        }
-    }
-
-    impl kvapi::Value for DatamaskId {
-        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
-            [self.to_string_key()]
-        }
-    }
-
     impl kvapi::Value for DatamaskMeta {
-        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
-            []
-        }
-    }
-
-    impl kvapi::Value for MaskpolicyTableIdList {
-        /// It contains table ids but it does not own these table in the meta-data hierarchy.
         fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
             []
         }

--- a/src/meta/app/src/tenant/mod.rs
+++ b/src/meta/app/src/tenant/mod.rs
@@ -19,4 +19,5 @@ mod tenant_quota_ident;
 
 pub use quota::TenantQuota;
 pub use tenant::Tenant;
+pub use tenant::ToTenant;
 pub use tenant_quota_ident::TenantQuotaIdent;

--- a/src/meta/app/src/tenant/tenant.rs
+++ b/src/meta/app/src/tenant/tenant.rs
@@ -73,6 +73,22 @@ impl Tenant {
     }
 }
 
+pub trait ToTenant {
+    fn to_tenant(self) -> Tenant;
+}
+
+impl ToTenant for Tenant {
+    fn to_tenant(self) -> Tenant {
+        self
+    }
+}
+
+impl ToTenant for &Tenant {
+    fn to_tenant(self) -> Tenant {
+        self.clone()
+    }
+}
+
 mod kvapi_key_impl {
     use std::convert::Infallible;
 

--- a/src/meta/app/src/tenant_key.rs
+++ b/src/meta/app/src/tenant_key.rs
@@ -20,6 +20,7 @@ use std::hash::Hasher;
 use databend_common_meta_kvapi::kvapi;
 
 use crate::tenant::Tenant;
+use crate::tenant::ToTenant;
 
 /// Defines the in-meta-service data for some resource that belongs to a tenant.
 /// Such as `PasswordPolicy`.
@@ -80,19 +81,24 @@ impl<R> Hash for TIdent<R> {
 }
 
 impl<R> TIdent<R> {
-    pub fn new(tenant: Tenant, name: impl ToString) -> Self {
+    pub fn new(tenant: impl ToTenant, name: impl ToString) -> Self {
         Self {
-            tenant,
+            tenant: tenant.to_tenant(),
             name: name.to_string(),
             _p: Default::default(),
         }
+    }
+
+    /// Create a new instance from TIdent of different resource definition.
+    pub fn new_from<T>(other: TIdent<T>) -> Self {
+        Self::new(other.tenant, other.name)
     }
 
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    //
+    /// Create a display-able instance.
     pub fn display(&self) -> impl fmt::Display + '_ {
         format!("'{}'/'{}'", self.tenant.name(), self.name)
     }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -25,6 +25,7 @@ use databend_common_meta_app::share::ShareGrantObjectName;
 use databend_common_meta_app::share::ShareGrantObjectPrivilege;
 use databend_common_meta_app::share::ShareNameIdent;
 use databend_common_meta_app::tenant::Tenant;
+use minitrace::func_name;
 use nom::branch::alt;
 use nom::combinator::consumed;
 use nom::combinator::map;
@@ -3608,34 +3609,26 @@ pub fn create_database_option(i: Input) -> IResult<CreateDatabaseOption> {
         |(_, _, option)| CreateDatabaseOption::DatabaseEngine(option),
     );
 
-    let share_from = map(
+    let share_from = map_res(
         rule! {
             FROM ~ SHARE ~ #ident ~ "." ~ #ident
         },
-        |(_x, _y, tenant, _z, share_name)| {
-            CreateDatabaseOption::FromShare(ShareNameIdent {
-                // TODO: non-safe new() that does not return an error
-                tenant: Tenant::new(tenant.to_string()),
-                share_name: share_name.to_string(),
-            })
+        |(_, _, tenant, _, share_name)| {
+            Tenant::new_or_err(tenant.to_string(), func_name!())
+                .map_err(|e| nom::Err::Error(ErrorKind::Other("tenant can not be empty string")))
+                .and_then(|tenant| {
+                    Ok(CreateDatabaseOption::FromShare(ShareNameIdent {
+                        tenant,
+                        share_name: share_name.to_string(),
+                    }))
+                })
         },
     );
 
-    let (i, opt) = rule!(
+    rule!(
         #create_db_engine
         | #share_from
-    )(i)?;
-
-    if let CreateDatabaseOption::FromShare(ident) = &opt {
-        if ident.tenant.name().is_empty() {
-            return Err(nom::Err::Error(Error::from_error_kind(
-                i,
-                ErrorKind::Other("tenant is empty string"),
-            )));
-        }
-    }
-
-    Ok((i, opt))
+    )(i)
 }
 
 pub fn catalog_type(i: Input) -> IResult<CatalogType> {

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -3615,12 +3615,12 @@ pub fn create_database_option(i: Input) -> IResult<CreateDatabaseOption> {
         },
         |(_, _, tenant, _, share_name)| {
             Tenant::new_or_err(tenant.to_string(), func_name!())
-                .map_err(|e| nom::Err::Error(ErrorKind::Other("tenant can not be empty string")))
-                .and_then(|tenant| {
-                    Ok(CreateDatabaseOption::FromShare(ShareNameIdent {
+                .map_err(|_e| nom::Err::Error(ErrorKind::Other("tenant can not be empty string")))
+                .map(|tenant| {
+                    CreateDatabaseOption::FromShare(ShareNameIdent {
                         tenant,
                         share_name: share_name.to_string(),
-                    }))
+                    })
                 })
         },
     );

--- a/src/query/ee/src/data_mask/data_mask_handler.rs
+++ b/src/query/ee/src/data_mask/data_mask_handler.rs
@@ -18,10 +18,11 @@ use databend_common_base::base::GlobalInstance;
 use databend_common_exception::Result;
 use databend_common_meta_api::DatamaskApi;
 use databend_common_meta_app::data_mask::CreateDatamaskReq;
+use databend_common_meta_app::data_mask::DataMaskNameIdent;
 use databend_common_meta_app::data_mask::DatamaskMeta;
-use databend_common_meta_app::data_mask::DatamaskNameIdent;
 use databend_common_meta_app::data_mask::DropDatamaskReq;
 use databend_common_meta_app::data_mask::GetDatamaskReq;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_store::MetaStore;
 use databend_enterprise_data_mask_feature::data_mask_handler::DatamaskHandler;
 use databend_enterprise_data_mask_feature::data_mask_handler::DatamaskHandlerWrapper;
@@ -49,12 +50,12 @@ impl DatamaskHandler for RealDatamaskHandler {
     async fn get_data_mask(
         &self,
         meta_api: Arc<MetaStore>,
-        tenant: String,
+        tenant: &Tenant,
         name: String,
     ) -> Result<DatamaskMeta> {
         let resp = meta_api
             .get_data_mask(GetDatamaskReq {
-                name: DatamaskNameIdent { tenant, name },
+                name: DataMaskNameIdent::new(tenant, name),
             })
             .await?;
         Ok(resp.policy)

--- a/src/query/ee_features/data_mask/src/data_mask_handler.rs
+++ b/src/query/ee_features/data_mask/src/data_mask_handler.rs
@@ -33,6 +33,7 @@ use databend_common_exception::Result;
 use databend_common_meta_app::data_mask::CreateDatamaskReq;
 use databend_common_meta_app::data_mask::DatamaskMeta;
 use databend_common_meta_app::data_mask::DropDatamaskReq;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_store::MetaStore;
 
 #[async_trait::async_trait]
@@ -48,7 +49,7 @@ pub trait DatamaskHandler: Sync + Send {
     async fn get_data_mask(
         &self,
         meta_api: Arc<MetaStore>,
-        tenant: String,
+        tenant: &Tenant,
         name: String,
     ) -> Result<DatamaskMeta>;
 }
@@ -81,7 +82,7 @@ impl DatamaskHandlerWrapper {
     pub async fn get_data_mask(
         &self,
         meta_api: Arc<MetaStore>,
-        tenant: String,
+        tenant: &Tenant,
         name: String,
     ) -> Result<DatamaskMeta> {
         self.handler.get_data_mask(meta_api, tenant, name).await

--- a/src/query/service/src/interpreters/interpreter_data_mask_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_data_mask_desc.rs
@@ -61,11 +61,7 @@ impl Interpreter for DescDataMaskInterpreter {
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let handler = get_datamask_handler();
         let policy = handler
-            .get_data_mask(
-                meta_api,
-                self.ctx.get_tenant().name().to_string(),
-                self.plan.name.clone(),
-            )
+            .get_data_mask(meta_api, &self.ctx.get_tenant(), self.plan.name.clone())
             .await;
 
         let policy = match policy {

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -85,11 +85,7 @@ impl ModifyTableColumnInterpreter {
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let handler = get_datamask_handler();
         let policy = handler
-            .get_data_mask(
-                meta_api,
-                self.ctx.get_tenant().name().to_string(),
-                mask_name.clone(),
-            )
+            .get_data_mask(meta_api, &self.ctx.get_tenant(), mask_name.clone())
             .await?;
 
         // check if column type match to the input type

--- a/src/query/sql/src/executor/table_read_plan.rs
+++ b/src/query/sql/src/executor/table_read_plan.rs
@@ -210,11 +210,7 @@ impl ToReadDataSourcePlan for dyn Table {
                                 start.elapsed())
                             );
                             if let Ok(policy) = handler
-                                .get_data_mask(
-                                    meta_api.clone(),
-                                    tenant.name().to_string(),
-                                    mask_policy.clone(),
-                                )
+                                .get_data_mask(meta_api.clone(), &tenant, mask_policy.clone())
                                 .await
                             {
                                 let args = &policy.args;

--- a/src/query/sql/src/planner/binder/ddl/data_mask.rs
+++ b/src/query/sql/src/planner/binder/ddl/data_mask.rs
@@ -47,7 +47,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = CreateDatamaskPolicyPlan {
             create_option: *create_option,
-            tenant: tenant.name().to_string(),
+            tenant,
             name: name.to_string(),
             policy: policy.clone(),
         };
@@ -64,7 +64,7 @@ impl Binder {
         let tenant = self.ctx.get_tenant();
         let plan = DropDatamaskPolicyPlan {
             if_exists: *if_exists,
-            tenant: tenant.name().to_string(),
+            tenant,
             name: name.to_string(),
         };
         Ok(Plan::DropDatamaskPolicy(Box::new(plan)))

--- a/src/query/sql/src/planner/plans/data_mask.rs
+++ b/src/query/sql/src/planner/plans/data_mask.rs
@@ -21,14 +21,15 @@ use databend_common_expression::DataField;
 use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
 use databend_common_meta_app::data_mask::CreateDatamaskReq;
-use databend_common_meta_app::data_mask::DatamaskNameIdent;
+use databend_common_meta_app::data_mask::DataMaskNameIdent;
 use databend_common_meta_app::data_mask::DropDatamaskReq;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_app::tenant::Tenant;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CreateDatamaskPolicyPlan {
     pub create_option: CreateOption,
-    pub tenant: String,
+    pub tenant: Tenant,
     pub name: String,
     pub policy: DataMaskPolicy,
 }
@@ -43,10 +44,7 @@ impl From<CreateDatamaskPolicyPlan> for CreateDatamaskReq {
     fn from(p: CreateDatamaskPolicyPlan) -> Self {
         CreateDatamaskReq {
             create_option: p.create_option,
-            name: DatamaskNameIdent {
-                tenant: p.tenant.clone(),
-                name: p.name.clone(),
-            },
+            name: DataMaskNameIdent::new(p.tenant.clone(), &p.name),
             args: p
                 .policy
                 .args
@@ -64,7 +62,7 @@ impl From<CreateDatamaskPolicyPlan> for CreateDatamaskReq {
 #[derive(Clone, Debug, PartialEq)]
 pub struct DropDatamaskPolicyPlan {
     pub if_exists: bool,
-    pub tenant: String,
+    pub tenant: Tenant,
     pub name: String,
 }
 
@@ -78,10 +76,7 @@ impl From<DropDatamaskPolicyPlan> for DropDatamaskReq {
     fn from(p: DropDatamaskPolicyPlan) -> Self {
         DropDatamaskReq {
             if_exists: p.if_exists,
-            name: DatamaskNameIdent {
-                tenant: p.tenant.clone(),
-                name: p.name,
-            },
+            name: DataMaskNameIdent::new(&p.tenant, &p.name),
         }
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: use TIdent to unify kvapi key def for MaskPolicyTableIdListIdent and DataMaskNameIdent

- Part of #14719


##### refactor: use map_res() to emit an sql error

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues