### PR TITLE
chore: adjust stack size of flaky ut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6163,6 +6163,7 @@ source = "git+https://github.com/georust/geozero?rev=1d78b36#1d78b3604ea6d082980
 dependencies = [
  "geo-types",
  "geojson",
+ "geos",
  "log",
  "scroll",
  "serde_json",

--- a/src/query/ee/tests/it/aggregating_index/index_scan.rs
+++ b/src/query/ee/tests/it/aggregating_index/index_scan.rs
@@ -73,10 +73,14 @@ fn test_fuzz() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_fuzz_with_spill() -> Result<()> {
-    test_fuzz_impl("parquet", true).await?;
-    test_fuzz_impl("native", true).await
+#[test]
+fn test_fuzz_with_spill() -> Result<()> {
+    let runtime = Runtime::with_worker_threads(2, None)?;
+    runtime.block_on(async {
+        test_fuzz_impl("parquet", true).await?;
+        test_fuzz_impl("native", true).await
+    })?;
+    Ok(())
 }
 
 async fn plan_sql(ctx: Arc<QueryContext>, sql: &str) -> Result<Plan> {

--- a/src/query/ee/tests/it/aggregating_index/index_scan.rs
+++ b/src/query/ee/tests/it/aggregating_index/index_scan.rs
@@ -17,6 +17,7 @@ use std::fmt::Display;
 use std::sync::Arc;
 
 use databend_common_base::base::tokio;
+use databend_common_base::runtime::Runtime;
 use databend_common_exception::Result;
 use databend_common_expression::block_debug::pretty_format_blocks;
 use databend_common_expression::DataBlock;
@@ -62,10 +63,14 @@ async fn test_index_scan_agg_args_are_expression() -> Result<()> {
     test_index_scan_agg_args_are_expression_impl("native").await
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_fuzz() -> Result<()> {
-    test_fuzz_impl("parquet", false).await?;
-    test_fuzz_impl("native", false).await
+#[test]
+fn test_fuzz() -> Result<()> {
+    let runtime = Runtime::with_worker_threads(2, None)?;
+    runtime.block_on(async {
+        test_fuzz_impl("parquet", false).await?;
+        test_fuzz_impl("native", false).await
+    })?;
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Increase the test stack from the default 2M to 20M to avoid stack overflow.


- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):
