### PR TITLE
chore: to avoid UT stackoverflow, disable async_backtrace of `TypeChecker::resolve`

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -215,7 +215,7 @@ impl<'a> TypeChecker<'a> {
     }
 
     #[async_recursion::async_recursion]
-    #[async_backtrace::framed]
+    //#[async_backtrace::framed]
     pub async fn resolve(&mut self, expr: &Expr) -> Result<Box<(ScalarExpr, DataType)>> {
         if let Some(scalar) = self.bind_context.srfs.get(&expr.to_string()) {
             if !matches!(self.bind_context.expr_context, ExprContext::SelectClause) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

to avoid stackoverflow of UT 
- aggregating_index::index_scan::test_fuzz_with_spill
- aggregating_index::index_scan::test_fuzz

disables the async_backtrace of method `TypeChecker::resolve`.


-----
A grep of gdb bt of aborted execution (before this PR)
~~~
home-dev:~/workspace/fuse-query$ grep src/query/ gdb.txt
#2  0x0000555560bf5d77 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:218
#4  0x0000555560c2790d in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_function::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2185
#12 0x0000555560c27163 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_function::{async_fn#0} () at src/query/sql/src/planner/semantic/type_check.rs:2165
#13 0x0000555560c2b310 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_binary_op::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2366
#21 0x0000555560c28cd5 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_binary_op::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2312
#23 0x0000555560c04d48 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:561
#31 0x0000555560bf5cc9 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:218
#33 0x0000555560c1c7b6 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_aggregate_function::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:1702
#41 0x0000555560c1bf87 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_aggregate_function::{async_fn#0} () at src/query/sql/src/planner/semantic/type_check.rs:1652
#42 0x0000555560c0a904 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:876
#50 0x0000555560bf5cc9 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:218
#52 0x0000555560c2790d in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_function::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2185
#60 0x0000555560c27163 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_function::{async_fn#0} () at src/query/sql/src/planner/semantic/type_check.rs:2165
#61 0x0000555560c2b310 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_binary_op::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2366
#69 0x0000555560c28cd5 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_binary_op::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2312
#71 0x0000555560c04d48 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:561
#79 0x0000555560bf5cc9 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:218
#81 0x0000555560c2790d in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_function::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2185
#89 0x0000555560c27163 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_function::{async_fn#0} () at src/query/sql/src/planner/semantic/type_check.rs:2165
#90 0x0000555560c0c62e in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:922
#98 0x0000555560bf5cc9 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:218
#100 0x0000555560c2790d in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_function::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2185
#108 0x0000555560c27163 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_function::{async_fn#0} () at src/query/sql/src/planner/semantic/type_check.rs:2165
#109 0x0000555560c2b310 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_binary_op::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2366
#117 0x0000555560c28cd5 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve_binary_op::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:2312
#119 0x0000555560c04d48 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:561
#127 0x0000555560bf5cc9 in databend_common_sql::planner::semantic::type_check::{impl#0}::resolve::{async_block#0} () at src/query/sql/src/planner/semantic/type_check.rs:218
#129 0x00005555611e0f64 in databend_common_sql::planner::binder::scalar::{impl#0}::bind::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/binder/scalar.rs:94
#137 0x00005555611e08cf in databend_common_sql::planner::binder::scalar::{impl#0}::bind::{async_fn#0} () at src/query/sql/src/planner/binder/scalar.rs:82
#138 0x00005555611d91a4 in databend_common_sql::planner::binder::project::{impl#1}::normalize_select_list::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/binder/project.rs:261
#146 0x00005555611d8d07 in databend_common_sql::planner::binder::project::{impl#1}::normalize_select_list::{async_fn#0} () at src/query/sql/src/planner/binder/project.rs:215
#147 0x00005555610eef77 in databend_common_sql::planner::binder::select::{impl#0}::bind_select_stmt::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/binder/select.rs:172
#155 0x00005555610ed166 in databend_common_sql::planner::binder::select::{impl#0}::bind_select_stmt::{async_fn#0} () at src/query/sql/src/planner/binder/select.rs:98
#156 0x00005555610f4f19 in databend_common_sql::planner::binder::select::{impl#0}::bind_set_expr::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/binder/select.rs:342
#164 0x00005555610f48b5 in databend_common_sql::planner::binder::select::{impl#0}::bind_set_expr::{async_block#0} () at src/query/sql/src/planner/binder/select.rs:331
#166 0x00005555610f6bad in databend_common_sql::planner::binder::select::{impl#0}::bind_query::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/binder/select.rs:414
#174 0x00005555610f570b in databend_common_sql::planner::binder::select::{impl#0}::bind_query::{async_block#0} () at src/query/sql/src/planner/binder/select.rs:360
#176 0x00005555610b61b0 in databend_common_sql::planner::binder::binder::{impl#0}::bind_statement::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/binder/binder.rs:195
#184 0x00005555610ae1b8 in databend_common_sql::planner::binder::binder::{impl#0}::bind_statement::{async_block#0} () at src/query/sql/src/planner/binder/binder.rs:187
#186 0x00005555610ad400 in databend_common_sql::planner::binder::binder::{impl#0}::bind::{async_fn#0}::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/binder/binder.rs:137
#194 0x00005555610acf69 in databend_common_sql::planner::binder::binder::{impl#0}::bind::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/binder/binder.rs:131
#196 0x00005555610aca6d in databend_common_sql::planner::binder::binder::{impl#0}::bind::{async_fn#0} () at src/query/sql/src/planner/binder/binder.rs:131
#197 0x0000555560e63660 in databend_common_sql::planner::planner::{impl#0}::plan_sql::{async_fn#0}::{async_block#0}::{async_block#0}::{async_block#3} () at src/query/sql/src/planner/planner.rs:165
#198 0x0000555560e61d5a in databend_common_sql::planner::planner::{impl#0}::plan_sql::{async_fn#0}::{async_block#0}::{async_block#0} () at src/query/sql/src/planner/planner.rs:185
#206 0x0000555560e60b2f in databend_common_sql::planner::planner::{impl#0}::plan_sql::{async_fn#0}::{async_block#0} () at src/query/sql/src/planner/planner.rs:69
#208 0x0000555560e606db in databend_common_sql::planner::planner::{impl#0}::plan_sql::{async_fn#0} () at src/query/sql/src/planner/planner.rs:69
#209 0x000055555be5c72a in it::aggregating_index::index_scan::plan_sql::{async_fn#0} () at src/query/ee/tests/it/aggregating_index/index_scan.rs:88
#210 0x000055555be5cdb7 in it::aggregating_index::index_scan::execute_sql::{async_fn#0} () at src/query/ee/tests/it/aggregating_index/index_scan.rs:94
#211 0x000055555be76a93 in it::aggregating_index::index_scan::fuzz::{async_fn#0} () at src/query/ee/tests/it/aggregating_index/index_scan.rs:660
#212 0x000055555be7d11e in it::aggregating_index::index_scan::test_fuzz_impl::{async_fn#0} () at src/query/ee/tests/it/aggregating_index/index_scan.rs:1130
#213 0x000055555be80e09 in it::aggregating_index::index_scan::test_fuzz_with_spill::{async_block#0} () at src/query/ee/tests/it/aggregating_index/index_scan.rs:80
#245 0x000055555be80ab6 in it::aggregating_index::index_scan::test_fuzz_with_spill () at src/query/ee/tests/it/aggregating_index/index_scan.rs:79
#246 0x000055555be80923 in it::aggregating_index::index_scan::test_fuzz_with_spill::{closure#0} () at src/query/ee/tests/it/aggregating_index/index_scan.rs:77
~~~


the "bt full" of this aborted execution

[gdb.txt](https://github.com/datafuselabs/databend/files/14809970/gdb.txt)

-----

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - using previous ut

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): tuning
