### PR TITLE
refactor: use Tenat in VirtualColumnNameIdent

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -6191,9 +6191,10 @@ impl SchemaApiTestSuite {
     #[minitrace::trace]
     async fn virtual_column_create_list_drop<MT>(&self, mt: &MT) -> anyhow::Result<()>
     where MT: SchemaApi + kvapi::AsKVApi<Error = MetaError> {
-        let tenant = "tenant1";
+        let tenant_name = "tenant1";
+        let tenant = Tenant::new_literal(tenant_name);
 
-        let mut util = Util::new(mt, tenant, "db1", "tb1", "eng1");
+        let mut util = Util::new(mt, tenant_name, "db1", "tb1", "eng1");
         let table_id;
 
         info!("--- prepare db and table");
@@ -6203,17 +6204,11 @@ impl SchemaApiTestSuite {
             table_id = tid;
         }
 
-        let name_ident = VirtualColumnNameIdent {
-            tenant: tenant.to_string(),
-            table_id,
-        };
+        let name_ident = VirtualColumnNameIdent::new(&tenant, table_id);
 
         {
             info!("--- list virtual columns with no create before");
-            let req = ListVirtualColumnsReq {
-                tenant: tenant.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListVirtualColumnsReq::new(&tenant, Some(table_id));
 
             let res = mt.list_virtual_columns(req).await?;
             assert!(res.is_empty())
@@ -6242,10 +6237,7 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- list virtual columns");
-            let req = ListVirtualColumnsReq {
-                tenant: tenant.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListVirtualColumnsReq::new(&tenant, Some(table_id));
 
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());
@@ -6254,10 +6246,7 @@ impl SchemaApiTestSuite {
                 "variant[1]".to_string(),
             ]);
 
-            let req = ListVirtualColumnsReq {
-                tenant: tenant.to_string(),
-                table_id: Some(u64::MAX),
-            };
+            let req = ListVirtualColumnsReq::new(&tenant, Some(u64::MAX));
 
             let res = mt.list_virtual_columns(req).await?;
             assert!(res.is_empty())
@@ -6276,10 +6265,7 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- list virtual columns after update");
-            let req = ListVirtualColumnsReq {
-                tenant: tenant.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListVirtualColumnsReq::new(&tenant, Some(table_id));
 
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());
@@ -6301,10 +6287,7 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- list virtual columns after drop");
-            let req = ListVirtualColumnsReq {
-                tenant: tenant.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListVirtualColumnsReq::new(&tenant, Some(table_id));
 
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(0, res.len());
@@ -6332,10 +6315,7 @@ impl SchemaApiTestSuite {
 
             let _res = mt.create_virtual_column(req.clone()).await?;
 
-            let req = ListVirtualColumnsReq {
-                tenant: tenant.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListVirtualColumnsReq::new(&tenant, Some(table_id));
 
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());
@@ -6352,10 +6332,7 @@ impl SchemaApiTestSuite {
 
             let _res = mt.create_virtual_column(req.clone()).await?;
 
-            let req = ListVirtualColumnsReq {
-                tenant: tenant.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListVirtualColumnsReq::new(&tenant, Some(table_id));
 
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -1231,7 +1231,8 @@ pub async fn get_virtual_column_by_id_or_err(
                 name_ident.table_id,
                 format!(
                     "get virtual column with tenant: {} table_id: {}",
-                    name_ident.tenant, name_ident.table_id
+                    name_ident.tenant.name(),
+                    name_ident.table_id
                 ),
             ),
         )));

--- a/src/query/service/src/interpreters/hook/refresh_hook.rs
+++ b/src/query/service/src/interpreters/hook/refresh_hook.rs
@@ -301,12 +301,8 @@ async fn generate_refresh_virtual_column_plan(
         .get_table(&desc.catalog, &desc.database, &desc.table)
         .await?;
     let catalog = ctx.get_catalog(&desc.catalog).await?;
-    let res = catalog
-        .list_virtual_columns(ListVirtualColumnsReq {
-            tenant: ctx.get_tenant().name().to_string(),
-            table_id: Some(table_info.get_id()),
-        })
-        .await?;
+    let req = ListVirtualColumnsReq::new(ctx.get_tenant(), Some(table_info.get_id()));
+    let res = catalog.list_virtual_columns(req).await?;
 
     if res.is_empty() || res[0].virtual_columns.is_empty() {
         return Ok(None);

--- a/src/query/service/src/interpreters/interpreter_virtual_column_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_alter.rs
@@ -73,10 +73,7 @@ impl Interpreter for AlterVirtualColumnInterpreter {
 
         let update_virtual_column_req = UpdateVirtualColumnReq {
             if_exists: self.plan.if_exists,
-            name_ident: VirtualColumnNameIdent {
-                tenant: tenant.name().to_string(),
-                table_id,
-            },
+            name_ident: VirtualColumnNameIdent::new(&tenant, table_id),
             virtual_columns: self.plan.virtual_columns.clone(),
         };
 

--- a/src/query/service/src/interpreters/interpreter_virtual_column_create.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_create.rs
@@ -73,10 +73,7 @@ impl Interpreter for CreateVirtualColumnInterpreter {
 
         let create_virtual_column_req = CreateVirtualColumnReq {
             create_option: self.plan.create_option,
-            name_ident: VirtualColumnNameIdent {
-                tenant: tenant.name().to_string(),
-                table_id,
-            },
+            name_ident: VirtualColumnNameIdent::new(tenant, table_id),
             virtual_columns: self.plan.virtual_columns.clone(),
         };
 

--- a/src/query/service/src/interpreters/interpreter_virtual_column_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_virtual_column_drop.rs
@@ -73,10 +73,7 @@ impl Interpreter for DropVirtualColumnInterpreter {
 
         let drop_virtual_column_req = DropVirtualColumnReq {
             if_exists: self.plan.if_exists,
-            name_ident: VirtualColumnNameIdent {
-                tenant: tenant.name().to_string(),
-                table_id,
-            },
+            name_ident: VirtualColumnNameIdent::new(tenant, table_id),
         };
 
         let handler = get_virtual_column_handler();

--- a/src/query/sql/src/planner/binder/ddl/virtual_column.rs
+++ b/src/query/sql/src/planner/binder/ddl/virtual_column.rs
@@ -166,12 +166,8 @@ impl Binder {
         let table_info = self.ctx.get_table(&catalog, &database, &table).await?;
 
         let catalog_info = self.ctx.get_catalog(&catalog).await?;
-        let res = catalog_info
-            .list_virtual_columns(ListVirtualColumnsReq {
-                tenant: self.ctx.get_tenant().name().to_string(),
-                table_id: Some(table_info.get_id()),
-            })
-            .await?;
+        let req = ListVirtualColumnsReq::new(self.ctx.get_tenant(), Some(table_info.get_id()));
+        let res = catalog_info.list_virtual_columns(req).await?;
 
         let virtual_columns = if res.is_empty() {
             vec![]

--- a/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
@@ -93,10 +93,7 @@ impl VirtualColumnRewriter {
             }
 
             let table_id = table.get_id();
-            let req = ListVirtualColumnsReq {
-                tenant: self.ctx.get_tenant().name().to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListVirtualColumnsReq::new(&self.ctx.get_tenant(), Some(table_id));
             let catalog = self.ctx.get_catalog(table_entry.catalog()).await?;
 
             if let Ok(virtual_column_metas) = catalog.list_virtual_columns(req).await {

--- a/src/query/storages/system/src/virtual_columns_table.rs
+++ b/src/query/storages/system/src/virtual_columns_table.rs
@@ -57,12 +57,8 @@ impl AsyncSystemTable for VirtualColumnsTable {
     ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
-        let virtual_column_metas = catalog
-            .list_virtual_columns(ListVirtualColumnsReq {
-                tenant: tenant.name().to_string(),
-                table_id: None,
-            })
-            .await?;
+        let req = ListVirtualColumnsReq::new(tenant, None);
+        let virtual_column_metas = catalog.list_virtual_columns(req).await?;
 
         let mut database_names = Vec::with_capacity(virtual_column_metas.len());
         let mut table_names: Vec<String> = Vec::with_capacity(virtual_column_metas.len());


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: use Tenat in VirtualColumnNameIdent

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues