### PR TITLE
fix(query):user option DEFAULT_ROLE ignore ascii_case

### DIFF
--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -3732,7 +3732,7 @@ pub fn user_option(i: Input) -> IResult<UserOptionItem> {
     );
     let default_role_option = map(
         rule! {
-            "DEFAULT_ROLE" ~ ^"=" ~ ^#role_name
+            DEFAULT_ROLE ~ ^"=" ~ ^#role_name
         },
         |(_, _, role)| UserOptionItem::DefaultRole(role),
     );

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -763,6 +763,8 @@ pub enum TokenKind {
     NOT,
     #[token("NOTENANTSETTING", ignore(ascii_case))]
     NOTENANTSETTING,
+    #[token("DEFAULT_ROLE", ignore(ascii_case))]
+    DEFAULT_ROLE,
     #[token("NULL", ignore(ascii_case))]
     NULL,
     #[token("NULLABLE", ignore(ascii_case))]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -179,7 +179,7 @@ fn test_statement() {
         r#"CREATE TABLE t(c1 int default 1);"#,
         r#"create table abc as (select * from xyz limit 10)"#,
         r#"ALTER USER u1 IDENTIFIED BY '123456';"#,
-        r#"ALTER USER u1 WITH DEFAULT_ROLE = role1;"#,
+        r#"ALTER USER u1 WITH default_role = role1;"#,
         r#"ALTER USER u1 WITH DEFAULT_ROLE = role1, TENANTSETTING;"#,
         r#"ALTER USER u1 WITH SET NETWORK POLICY = 'policy1';"#,
         r#"ALTER USER u1 WITH UNSET NETWORK POLICY;"#,

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -4518,7 +4518,7 @@ AlterUser(
 
 
 ---------- Input ----------
-ALTER USER u1 WITH DEFAULT_ROLE = role1;
+ALTER USER u1 WITH default_role = role1;
 ---------- Output ---------
 ALTER USER 'u1'@'%' WITH DEFAULT_ROLE = 'role1'
 ---------- AST ------------


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

user option DEFAULT_ROLE ignore ascii_case

- Fixes #15132

## Tests

- [x] Unit Test


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

