### PR TITLE
chore: client should not depend on the final response.

### DIFF
--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -149,7 +149,9 @@ impl TestHttpQueryRequest {
                 .do_request(Method::GET, self.next_uri.as_ref().unwrap())
                 .await?;
             self.next_uri = resp.as_ref().and_then(|r| r.next_uri.clone());
-            resps.push((status, resp.clone().unwrap()));
+            if self.next_uri.is_some() {
+                resps.push((status, resp.clone().unwrap()));
+            }
         }
 
         Ok(TestHttpQueryFetchReply { resps })
@@ -1540,15 +1542,15 @@ async fn test_affect() -> Result<()> {
             .last();
         assert_eq!(result.0, StatusCode::OK, "{} {:?}", json, result.1.error);
         assert!(result.1.error.is_none(), "{} {:?}", json, result.1.error);
-        assert_eq!(result.1.state, ExecuteStateKind::Succeeded);
-        assert_eq!(result.1.affect, affect);
+        assert_eq!(result.1.state, ExecuteStateKind::Succeeded, "{}", json);
+        assert_eq!(result.1.affect, affect, "{}", json);
         let session = result.1.session.map(|s| HttpSessionConf {
             last_server_info: None,
             last_query_ids: vec![],
             ..s
         });
 
-        assert_eq!(session, session_conf);
+        assert_eq!(session, session_conf, "{}", json);
     }
 
     Ok(())

--- a/tests/sqllogictests/src/client/http_client.rs
+++ b/tests/sqllogictests/src/client/http_client.rs
@@ -35,7 +35,7 @@ pub struct HttpClient {
 #[derive(serde::Deserialize)]
 struct QueryResponse {
     session: Option<HttpSessionConf>,
-    data: serde_json::Value,
+    data: Option<serde_json::Value>,
     next_uri: Option<String>,
 
     error: Option<serde_json::Value>,
@@ -78,12 +78,20 @@ impl HttpClient {
 
         let url = "http://127.0.0.1:8000/v1/query".to_string();
         let mut parsed_rows = vec![];
-        let mut response =
-            self.handle_response(self.post_query(sql, &url).await?, &mut parsed_rows)?;
-        while let Some(next_uri) = response.next_uri {
+        let mut response = self.post_query(sql, &url).await?;
+        self.handle_response(&response, &mut parsed_rows)?;
+        while let Some(next_uri) = &response.next_uri {
             let url = format!("http://127.0.0.1:8000{next_uri}");
-            response =
-                self.handle_response(self.poll_query_result(&url).await?, &mut parsed_rows)?;
+            let new_response = self.poll_query_result(&url).await?;
+            if new_response.next_uri.is_some() {
+                self.handle_response(&new_response, &mut parsed_rows)?;
+                response = new_response;
+            } else {
+                break;
+            }
+        }
+        if let Some(error) = response.error {
+            return Err(format_error(error).into());
         }
         // Todo: add types to compare
         let mut types = vec![];
@@ -106,18 +114,16 @@ impl HttpClient {
 
     fn handle_response(
         &mut self,
-        response: QueryResponse,
+        response: &QueryResponse,
         parsed_rows: &mut Vec<Vec<String>>,
-    ) -> Result<QueryResponse> {
+    ) -> Result<()> {
         if response.session.is_some() {
             self.session = response.session.clone();
         }
-        if let Some(error) = response.error {
-            Err(format_error(error).into())
-        } else {
-            parsed_rows.append(&mut parser_rows(&response.data)?);
-            Ok(response)
+        if let Some(data) = &response.data {
+            parsed_rows.append(&mut parser_rows(data)?);
         }
+        Ok(())
     }
 
     // Send request and get response by json format
@@ -133,9 +139,15 @@ impl HttpClient {
             .json(&query)
             .basic_auth("root", Some(""))
             .send()
-            .await?
+            .await
+            .inspect_err(|e| {
+                println!("fail to send to {}: {:?}", url, e);
+            })?
             .json::<QueryResponse>()
-            .await?)
+            .await
+            .inspect_err(|e| {
+                println!("fail to decode json when call {}: {:?}", url, e);
+            })?)
     }
 
     async fn poll_query_result(&self, url: &str) -> Result<QueryResponse> {
@@ -144,8 +156,14 @@ impl HttpClient {
             .get(url)
             .basic_auth("root", Some(""))
             .send()
-            .await?
+            .await
+            .inspect_err(|e| {
+                println!("fail to send to {}: {:?}", url, e);
+            })?
             .json::<QueryResponse>()
-            .await?)
+            .await
+            .inspect_err(|e| {
+                println!("fail to decode json when call {}: {:?}", url, e);
+            })?)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


final is not ACKed by client, so client should not depend on the final response,

 for server:
1. when response with `next_uri` =  `.../final`, all states should already be delivered to the client the latest in this response.
2. `/final` SHOULD response with nothing but `next_uri` = `null`, BUT to tolerant old clients, we still keep some fields.

for clients:

check `next_uri` before referring to other fields of the response.



## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
