### PR TITLE
feat: support expr in values clause of multi table insert

### DIFF
--- a/src/query/ast/src/ast/statements/insert_multi_table.rs
+++ b/src/query/ast/src/ast/statements/insert_multi_table.rs
@@ -27,7 +27,22 @@ pub struct IntoClause {
     pub database: Option<Identifier>,
     pub table: Identifier,
     pub target_columns: Vec<Identifier>,
-    pub source_columns: Vec<Identifier>,
+    pub source_columns: Vec<SourceExpr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
+pub enum SourceExpr {
+    Expr(Expr),
+    Default,
+}
+
+impl Display for SourceExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            SourceExpr::Expr(expr) => expr.fmt(f),
+            SourceExpr::Default => write!(f, "DEFAULT"),
+        }
+    }
 }
 
 impl Display for IntoClause {

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -2345,12 +2345,16 @@ fn when_clause(i: Input) -> IResult<WhenClause> {
 }
 
 fn into_clause(i: Input) -> IResult<IntoClause> {
+    let source_expr = alt((
+        map(rule! { #expr }, |e| SourceExpr::Expr),
+        map(rule! {DEFAULT}, |_| SourceExpr::Default),
+    ));
     map(
         rule! {
             INTO
             ~ #dot_separated_idents_1_to_3
             ~ ( "(" ~ #comma_separated_list1(ident) ~ ")" )?
-            ~ (VALUES ~ "(" ~ #comma_separated_list1(ident) ~ ")" )?
+            ~ (VALUES ~ "(" ~ #comma_separated_list1(source_expr) ~ ")" )?
         },
         |(_, (catalog, database, table), opt_target_columns, opt_source_columns)| IntoClause {
             catalog,

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -1506,6 +1506,7 @@ impl TokenKind {
             | TokenKind::CURRENT_TIMESTAMP
             // | TokenKind::CURRENT_USER
             // | TokenKind::DEFERRABLE
+            | TokenKind::DEFAULT
             | TokenKind::DESC
             | TokenKind::DISTINCT
             // | TokenKind::DO

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -196,7 +196,9 @@ impl PipelineBuilder {
             PhysicalPlan::Duplicate(duplicate) => self.build_duplicate(duplicate),
             PhysicalPlan::Shuffle(shuffle) => self.build_shuffle(shuffle),
             PhysicalPlan::ChunkFilter(chunk_filter) => self.build_chunk_filter(chunk_filter),
-            PhysicalPlan::ChunkProject(chunk_project) => self.build_chunk_project(chunk_project),
+            PhysicalPlan::ChunkEvalScalar(chunk_project) => {
+                self.build_chunk_eval_scalar(chunk_project)
+            }
             PhysicalPlan::ChunkCastSchema(chunk_cast_schema) => {
                 self.build_chunk_cast_schema(chunk_cast_schema)
             }

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -254,7 +254,7 @@ fn to_format_tree(
         PhysicalPlan::Duplicate(_) => Ok(FormatTreeNode::new("Duplicate".to_string())),
         PhysicalPlan::Shuffle(_) => Ok(FormatTreeNode::new("Shuffle".to_string())),
         PhysicalPlan::ChunkFilter(_) => Ok(FormatTreeNode::new("ChunkFilter".to_string())),
-        PhysicalPlan::ChunkProject(_) => Ok(FormatTreeNode::new("ChunkProject".to_string())),
+        PhysicalPlan::ChunkEvalScalar(_) => Ok(FormatTreeNode::new("ChunkProject".to_string())),
         PhysicalPlan::ChunkCastSchema(_) => Ok(FormatTreeNode::new("ChunkCastSchema".to_string())),
         PhysicalPlan::ChunkFillAndReorder(_) => {
             Ok(FormatTreeNode::new("ChunkFillAndReorder".to_string()))

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -28,10 +28,10 @@ use crate::executor::physical_plans::AggregatePartial;
 use crate::executor::physical_plans::ChunkAppendData;
 use crate::executor::physical_plans::ChunkCastSchema;
 use crate::executor::physical_plans::ChunkCommitInsert;
+use crate::executor::physical_plans::ChunkEvalScalar;
 use crate::executor::physical_plans::ChunkFillAndReorder;
 use crate::executor::physical_plans::ChunkFilter;
 use crate::executor::physical_plans::ChunkMerge;
-use crate::executor::physical_plans::ChunkProject;
 use crate::executor::physical_plans::CommitSink;
 use crate::executor::physical_plans::CompactSource;
 use crate::executor::physical_plans::ConstantTableScan;
@@ -137,7 +137,7 @@ pub enum PhysicalPlan {
     Duplicate(Box<Duplicate>),
     Shuffle(Box<Shuffle>),
     ChunkFilter(Box<ChunkFilter>),
-    ChunkProject(Box<ChunkProject>),
+    ChunkEvalScalar(Box<ChunkEvalScalar>),
     ChunkCastSchema(Box<ChunkCastSchema>),
     ChunkFillAndReorder(Box<ChunkFillAndReorder>),
     ChunkAppendData(Box<ChunkAppendData>),
@@ -351,7 +351,7 @@ impl PhysicalPlan {
                 *next_id += 1;
                 plan.input.adjust_plan_id(next_id);
             }
-            PhysicalPlan::ChunkProject(plan) => {
+            PhysicalPlan::ChunkEvalScalar(plan) => {
                 plan.plan_id = *next_id;
                 *next_id += 1;
                 plan.input.adjust_plan_id(next_id);
@@ -428,7 +428,7 @@ impl PhysicalPlan {
             PhysicalPlan::Duplicate(v) => v.plan_id,
             PhysicalPlan::Shuffle(v) => v.plan_id,
             PhysicalPlan::ChunkFilter(v) => v.plan_id,
-            PhysicalPlan::ChunkProject(v) => v.plan_id,
+            PhysicalPlan::ChunkEvalScalar(v) => v.plan_id,
             PhysicalPlan::ChunkCastSchema(v) => v.plan_id,
             PhysicalPlan::ChunkFillAndReorder(v) => v.plan_id,
             PhysicalPlan::ChunkAppendData(v) => v.plan_id,
@@ -480,7 +480,7 @@ impl PhysicalPlan {
             PhysicalPlan::Duplicate(plan) => plan.input.output_schema(),
             PhysicalPlan::Shuffle(plan) => plan.input.output_schema(),
             PhysicalPlan::ChunkFilter(plan) => plan.input.output_schema(),
-            PhysicalPlan::ChunkProject(_) => todo!(),
+            PhysicalPlan::ChunkEvalScalar(_) => todo!(),
             PhysicalPlan::ChunkCastSchema(_) => todo!(),
             PhysicalPlan::ChunkFillAndReorder(_) => todo!(),
             PhysicalPlan::ChunkAppendData(_) => todo!(),
@@ -537,7 +537,7 @@ impl PhysicalPlan {
             PhysicalPlan::Duplicate(_) => "Duplicate".to_string(),
             PhysicalPlan::Shuffle(_) => "Shuffle".to_string(),
             PhysicalPlan::ChunkFilter(_) => "ChunkFilter".to_string(),
-            PhysicalPlan::ChunkProject(_) => "ChunkProject".to_string(),
+            PhysicalPlan::ChunkEvalScalar(_) => "ChunkProject".to_string(),
             PhysicalPlan::ChunkCastSchema(_) => "ChunkCastSchema".to_string(),
             PhysicalPlan::ChunkFillAndReorder(_) => "ChunkFillAndReorder".to_string(),
             PhysicalPlan::ChunkAppendData(_) => "ChunkAppendData".to_string(),
@@ -605,7 +605,7 @@ impl PhysicalPlan {
             PhysicalPlan::Duplicate(plan) => Box::new(std::iter::once(plan.input.as_ref())),
             PhysicalPlan::Shuffle(plan) => Box::new(std::iter::once(plan.input.as_ref())),
             PhysicalPlan::ChunkFilter(plan) => Box::new(std::iter::once(plan.input.as_ref())),
-            PhysicalPlan::ChunkProject(plan) => Box::new(std::iter::once(plan.input.as_ref())),
+            PhysicalPlan::ChunkEvalScalar(plan) => Box::new(std::iter::once(plan.input.as_ref())),
             PhysicalPlan::ChunkCastSchema(plan) => Box::new(std::iter::once(plan.input.as_ref())),
             PhysicalPlan::ChunkFillAndReorder(plan) => {
                 Box::new(std::iter::once(plan.input.as_ref()))
@@ -660,7 +660,7 @@ impl PhysicalPlan {
             | PhysicalPlan::Duplicate(_)
             | PhysicalPlan::Shuffle(_)
             | PhysicalPlan::ChunkFilter(_)
-            | PhysicalPlan::ChunkProject(_)
+            | PhysicalPlan::ChunkEvalScalar(_)
             | PhysicalPlan::ChunkCastSchema(_)
             | PhysicalPlan::ChunkFillAndReorder(_)
             | PhysicalPlan::ChunkAppendData(_)

--- a/src/query/sql/src/executor/physical_plan_display.rs
+++ b/src/query/sql/src/executor/physical_plan_display.rs
@@ -120,7 +120,7 @@ impl<'a> Display for PhysicalPlanIndentFormatDisplay<'a> {
             PhysicalPlan::Duplicate(_) => "Duplicate".fmt(f)?,
             PhysicalPlan::Shuffle(_) => "Shuffle".fmt(f)?,
             PhysicalPlan::ChunkFilter(_) => "ChunkFilter".fmt(f)?,
-            PhysicalPlan::ChunkProject(_) => "ChunkProject".fmt(f)?,
+            PhysicalPlan::ChunkEvalScalar(_) => "ChunkProject".fmt(f)?,
             PhysicalPlan::ChunkCastSchema(_) => "ChunkCastSchema".fmt(f)?,
             PhysicalPlan::ChunkFillAndReorder(_) => "ChunkFillAndReorder".fmt(f)?,
             PhysicalPlan::ChunkAppendData(_) => "ChunkAppendData".fmt(f)?,

--- a/src/query/sql/src/executor/physical_plans/physical_multi_table_insert.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_multi_table_insert.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataSchemaRef;
@@ -70,10 +72,10 @@ pub struct ChunkFilter {
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct ChunkProject {
+pub struct ChunkEvalScalar {
     pub plan_id: u32,
     pub input: Box<PhysicalPlan>,
-    pub projections: Vec<Option<Vec<usize>>>,
+    pub eval_scalars: Vec<Option<(Vec<RemoteExpr>, HashSet<usize>)>>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/src/query/sql/src/planner/binder/insert_multi_table.rs
+++ b/src/query/sql/src/planner/binder/insert_multi_table.rs
@@ -16,14 +16,15 @@ use std::sync::Arc;
 
 use databend_common_ast::ast::InsertMultiTableStmt;
 use databend_common_ast::ast::IntoClause;
+use databend_common_ast::ast::SourceExpr;
 use databend_common_ast::ast::TableReference;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
 use databend_common_expression::DataSchemaRef;
+use databend_common_expression::TableSchema;
 
 use crate::binder::ScalarBinder;
-use crate::normalize_identifier;
 use crate::optimizer::optimize;
 use crate::optimizer::OptimizerContext;
 use crate::plans::Else;
@@ -99,7 +100,11 @@ impl Binder {
                 ));
             }
             let intos = self
-                .bind_into_clauses(&when_clause.into_clauses, source_schema.clone())
+                .bind_into_clauses(
+                    &when_clause.into_clauses,
+                    source_schema.clone(),
+                    &mut source_bind_context,
+                )
                 .await?;
             whens.push(When { condition, intos });
         }
@@ -107,7 +112,11 @@ impl Binder {
         let opt_else = match else_clause {
             Some(else_clause) => {
                 let intos = self
-                    .bind_into_clauses(&else_clause.into_clauses, source_schema.clone())
+                    .bind_into_clauses(
+                        &else_clause.into_clauses,
+                        source_schema.clone(),
+                        &mut source_bind_context,
+                    )
                     .await?;
                 Some(Else { intos })
             }
@@ -121,7 +130,11 @@ impl Binder {
             overwrite: *overwrite,
             is_first: *is_first,
             intos: self
-                .bind_into_clauses(into_clauses, source_schema.clone())
+                .bind_into_clauses(
+                    into_clauses,
+                    source_schema.clone(),
+                    &mut source_bind_context,
+                )
                 .await?,
         };
         Ok(Plan::InsertMultiTable(Box::new(plan)))
@@ -133,6 +146,7 @@ impl Binder {
         &mut self,
         into_clauses: &[IntoClause],
         source_schema: DataSchemaRef,
+        source_bind_context: &mut BindContext,
     ) -> Result<Vec<Into>> {
         let mut intos = vec![];
         for into_clause in into_clauses {
@@ -151,42 +165,88 @@ impl Binder {
                 .get_table(&catalog_name, &database_name, &table_name)
                 .await?;
 
-            let casted_schema = if target_columns.is_empty() {
-                target_table.schema()
+            let n_target_col = if target_columns.is_empty() {
+                target_table.schema().fields().len()
             } else {
-                self.schema_project(&target_table.schema(), target_columns.as_ref())?
+                target_columns.len()
             };
-
-            let projection = if source_columns.is_empty() {
-                None
+            let n_source_col = if source_columns.is_empty() {
+                source_schema.fields().len()
             } else {
-                let mut indices = vec![];
-                for source_column in source_columns {
-                    let index = source_schema.index_of(
-                        &normalize_identifier(source_column, &self.name_resolution_ctx).name,
-                    )?;
-                    indices.push(index);
-                }
-                Some(indices)
+                source_columns.len()
             };
-
-            if casted_schema.fields().len()
-                != projection
-                    .as_ref()
-                    .map(|p| p.len())
-                    .unwrap_or(source_schema.fields().len())
-            {
+            if n_target_col != n_source_col {
                 return Err(ErrorCode::BadArguments(
                     "The number of columns in the target and the source must be the same"
                         .to_string(),
                 ));
             }
 
+            let mut casted_schema = if target_columns.is_empty() {
+                target_table.schema()
+            } else {
+                self.schema_project(&target_table.schema(), target_columns.as_ref())?
+            };
+
+            let default_indices = source_columns
+                .iter()
+                .enumerate()
+                .filter_map(|(i, col)| {
+                    if matches!(col, SourceExpr::Default) {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            if !default_indices.is_empty() {
+                let mut casted_schema_fields = vec![];
+                for (i, field) in casted_schema.fields().iter().enumerate() {
+                    if default_indices.contains(&i) {
+                        continue;
+                    }
+                    casted_schema_fields.push(field.clone());
+                }
+                casted_schema = Arc::new(TableSchema {
+                    fields: casted_schema_fields,
+                    metadata: casted_schema.metadata.clone(),
+                    next_column_id: casted_schema.next_column_id(),
+                });
+            }
+
+            let source_scalar_exprs = if source_columns.is_empty() {
+                None
+            } else {
+                let mut scalar_binder = ScalarBinder::new(
+                    source_bind_context,
+                    self.ctx.clone(),
+                    &self.name_resolution_ctx,
+                    self.metadata.clone(),
+                    &[],
+                    self.m_cte_bound_ctx.clone(),
+                    self.ctes_map.clone(),
+                );
+                let mut source_scalar_exprs = vec![];
+                for source_column in source_columns {
+                    match source_column {
+                        SourceExpr::Expr(expr) => {
+                            let (scalar_expr, _) = scalar_binder.bind(expr).await?;
+                            source_scalar_exprs.push(scalar_expr);
+                        }
+                        SourceExpr::Default => {
+                            continue;
+                        }
+                    }
+                }
+                Some(source_scalar_exprs)
+            };
+
             intos.push(Into {
                 catalog: catalog_name,
                 database: database_name,
                 table: table_name,
-                projection,
+                source_scalar_exprs,
                 casted_schema: Arc::new(casted_schema.into()),
             });
         }

--- a/src/query/sql/src/planner/plans/insert_multi_table.rs
+++ b/src/query/sql/src/planner/plans/insert_multi_table.rs
@@ -38,8 +38,8 @@ pub struct Into {
     pub catalog: String,
     pub database: String,
     pub table: String,
-    // project subquery's output with VALUES ( source_col_name [ , ... ] ) (if exists)
-    pub projection: Option<Vec<usize>>,
+    // eval scalar and project subquery's output with VALUES ( source_col_name [ , ... ] ) (if exists)
+    pub source_scalar_exprs: Option<Vec<ScalarExpr>>,
     //  cast to ( target_col_name [ , ... ] )'s schema (if exists) or target table's schema
     pub casted_schema: DataSchemaRef,
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
1. Improved syntax:
```
intoClause ::=
  INTO <target_table> [ ( <target_col_name> [ , ... ] ) ] [VALUES( { Expr | DEFAULT } [ , ... ] ) ]
```
2. Example:
https://github.com/SkyFan2002/databend/blob/857ed205c41f918cef88061a9654484cfccc407f/tests/sqllogictests/suites/base/09_fuse_engine/09_0100_insert_multi_table.sql#L451-L480
- part of #15141

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
