### PR TITLE
chore(query): use i64 min max value as histogram bucket min max limit

### DIFF
--- a/src/common/base/src/runtime/metrics/family_metrics/histogram.rs
+++ b/src/common/base/src/runtime/metrics/family_metrics/histogram.rs
@@ -27,6 +27,7 @@ use crate::runtime::metrics::family::Family;
 use crate::runtime::metrics::family::FamilyLabels;
 use crate::runtime::metrics::family::FamilyMetric;
 use crate::runtime::metrics::registry::DatabendMetric;
+use crate::runtime::metrics::registry::MAX_HISTOGRAM_BOUND;
 use crate::runtime::metrics::sample::HistogramCount;
 use crate::runtime::metrics::sample::MetricSample;
 use crate::runtime::metrics::sample::MetricValue;
@@ -69,7 +70,7 @@ impl<Labels: FamilyLabels> FamilyHistogram<Labels> {
                 count: Default::default(),
                 buckets: buckets
                     .into_iter()
-                    .chain(once(f64::MAX))
+                    .chain(once(MAX_HISTOGRAM_BOUND))
                     .map(|upper_bound| (upper_bound, 0))
                     .collect(),
             })),

--- a/src/common/base/src/runtime/metrics/histogram.rs
+++ b/src/common/base/src/runtime/metrics/histogram.rs
@@ -24,6 +24,7 @@ use prometheus_client::metrics::MetricType;
 use prometheus_client::metrics::TypedMetric;
 
 use crate::runtime::metrics::registry::DatabendMetric;
+use crate::runtime::metrics::registry::MAX_HISTOGRAM_BOUND;
 use crate::runtime::metrics::sample::HistogramCount;
 use crate::runtime::metrics::sample::MetricSample;
 use crate::runtime::metrics::sample::MetricValue;
@@ -72,7 +73,7 @@ impl Histogram {
                 count: Default::default(),
                 buckets: buckets
                     .into_iter()
-                    .chain(once(f64::MAX))
+                    .chain(once(MAX_HISTOGRAM_BOUND))
                     .map(|upper_bound| (upper_bound, 0))
                     .collect(),
             })),

--- a/src/common/base/src/runtime/metrics/mod.rs
+++ b/src/common/base/src/runtime/metrics/mod.rs
@@ -40,6 +40,8 @@ pub use registry::FamilyGauge;
 pub use registry::FamilyHistogram;
 pub use registry::ScopedRegistry;
 pub use registry::GLOBAL_METRICS_REGISTRY;
+pub use registry::MAX_HISTOGRAM_BOUND;
+pub use registry::MIN_HISTOGRAM_BOUND;
 pub use sample::HistogramCount;
 pub use sample::MetricSample;
 pub use sample::MetricValue;

--- a/src/common/base/src/runtime/metrics/registry.rs
+++ b/src/common/base/src/runtime/metrics/registry.rs
@@ -255,11 +255,11 @@ pub fn register_counter(name: &str) -> Counter {
 pub fn register_histogram(name: &str, buckets: impl Iterator<Item = f64>) -> Histogram {
     let buckets = buckets.collect::<Vec<_>>();
 
-    for bound in buckets {
-        if bound <= MIN_HISTOGRAM_BOUND {
+    for bound in &buckets {
+        if *bound <= MIN_HISTOGRAM_BOUND {
             panic!("Histogram bucket bound must > {}", MIN_HISTOGRAM_BOUND);
         }
-        if bound >= MAX_HISTOGRAM_BOUND {
+        if *bound >= MAX_HISTOGRAM_BOUND {
             panic!("Histogram bucket bound must < {}", MAX_HISTOGRAM_BOUND);
         }
     }
@@ -289,11 +289,11 @@ pub fn register_histogram_family<T: FamilyLabels>(
 ) -> FamilyHistogram<T> {
     let buckets = buckets.collect::<Vec<_>>();
 
-    for bound in buckets {
-        if bound <= MIN_HISTOGRAM_BOUND {
+    for bound in &buckets {
+        if *bound <= MIN_HISTOGRAM_BOUND {
             panic!("Histogram bucket bound must > {}", MIN_HISTOGRAM_BOUND);
         }
-        if bound >= MAX_HISTOGRAM_BOUND {
+        if *bound >= MAX_HISTOGRAM_BOUND {
             panic!("Histogram bucket bound must < {}", MAX_HISTOGRAM_BOUND);
         }
     }

--- a/src/common/base/src/runtime/metrics/registry.rs
+++ b/src/common/base/src/runtime/metrics/registry.rs
@@ -42,6 +42,9 @@ use crate::runtime::metrics::histogram::BUCKET_SECONDS;
 use crate::runtime::metrics::sample::MetricSample;
 use crate::runtime::ThreadTracker;
 
+pub const MIN_HISTOGRAM_BOUND: f64 = i64::MIN as f64;
+pub const MAX_HISTOGRAM_BOUND: f64 = i64::MAX as f64;
+
 pub static GLOBAL_METRICS_REGISTRY: LazyLock<GlobalRegistry> =
     LazyLock::new(GlobalRegistry::create);
 
@@ -251,6 +254,16 @@ pub fn register_counter(name: &str) -> Counter {
 
 pub fn register_histogram(name: &str, buckets: impl Iterator<Item = f64>) -> Histogram {
     let buckets = buckets.collect::<Vec<_>>();
+
+    for bound in buckets {
+        if bound <= MIN_HISTOGRAM_BOUND {
+            panic!("Histogram bucket bound must > {}", MIN_HISTOGRAM_BOUND);
+        }
+        if bound >= MAX_HISTOGRAM_BOUND {
+            panic!("Histogram bucket bound must < {}", MAX_HISTOGRAM_BOUND);
+        }
+    }
+
     GLOBAL_METRICS_REGISTRY.register(name, "", HistogramCreator(buckets))
 }
 
@@ -275,6 +288,16 @@ pub fn register_histogram_family<T: FamilyLabels>(
     buckets: impl Iterator<Item = f64>,
 ) -> FamilyHistogram<T> {
     let buckets = buckets.collect::<Vec<_>>();
+
+    for bound in buckets {
+        if bound <= MIN_HISTOGRAM_BOUND {
+            panic!("Histogram bucket bound must > {}", MIN_HISTOGRAM_BOUND);
+        }
+        if bound >= MAX_HISTOGRAM_BOUND {
+            panic!("Histogram bucket bound must < {}", MAX_HISTOGRAM_BOUND);
+        }
+    }
+
     GLOBAL_METRICS_REGISTRY.register(name, "", FamilyHistogramCreator(buckets))
 }
 

--- a/src/common/base/tests/it/metrics/registry.rs
+++ b/src/common/base/tests/it/metrics/registry.rs
@@ -27,6 +27,7 @@ use databend_common_base::runtime::metrics::ScopedRegistry;
 use databend_common_base::runtime::metrics::BUCKET_MILLISECONDS;
 use databend_common_base::runtime::metrics::BUCKET_SECONDS;
 use databend_common_base::runtime::metrics::GLOBAL_METRICS_REGISTRY;
+use databend_common_base::runtime::metrics::MAX_HISTOGRAM_BOUND;
 use databend_common_base::runtime::ThreadTracker;
 use databend_common_exception::Result;
 
@@ -154,7 +155,7 @@ fn test_tracking_scoped_histogram_in_seconds_metrics() -> Result<()> {
                 count: 0.0,
             })
             .chain(std::iter::once(HistogramCount {
-                less_than: f64::MAX,
+                less_than: MAX_HISTOGRAM_BOUND,
                 count: v,
             }))
             .collect::<Vec<_>>()
@@ -214,7 +215,7 @@ fn test_tracking_scoped_histogram_in_milliseconds_metrics() -> Result<()> {
                 count: 0.0,
             })
             .chain(std::iter::once(HistogramCount {
-                less_than: f64::MAX,
+                less_than: MAX_HISTOGRAM_BOUND,
                 count: v,
             }))
             .collect::<Vec<_>>()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(query): use i64 min max value as histogram bucket min max limit

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - unimportant

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):
