### PR TITLE
feat(rbac): drop role will transfer role owns object to account_admin

### DIFF
--- a/.github/actions/fuse_compat/action.yml
+++ b/.github/actions/fuse_compat/action.yml
@@ -23,6 +23,8 @@ runs:
           bash ./tests/fuse-compat/test-fuse-compat.sh 1.1.46 base
           bash ./tests/fuse-compat/test-fuse-compat.sh 1.2.241 revoke
           bash ./tests/fuse-compat/test-fuse-compat.sh 1.2.306 rbac
+          bash ./tests/fuse-compat/test-fuse-compat.sh 1.2.307 rbac
+          bash ./tests/fuse-compat/test-fuse-compat.sh 1.2.318 rbac
           bash ./tests/fuse-compat/test-fuse-forward-compat.sh 1.2.307 rbac
           bash ./tests/fuse-compat/test-fuse-forward-compat.sh 1.2.318 rbac
     - name: Upload failure

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -44,7 +44,7 @@ pub trait RoleApi: Sync + Send {
     /// If a role is dropped, but the owner object is exists,
     ///
     /// The owner role need to update to account_admin.
-    async fn transfer_ownership_to_admin(&self, object: &OwnershipObject) -> Result<()>;
+    async fn transfer_ownership_to_admin(&self, object: &Vec<OwnershipObject>) -> Result<()>;
 
     /// Grant ownership would transfer ownership of a object from one role to another role
     ///

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -44,7 +44,7 @@ pub trait RoleApi: Sync + Send {
     /// If a role is dropped, but the owner object is exists,
     ///
     /// The owner role need to update to account_admin.
-    async fn transfer_ownership_to_admin(&self, object: &[OwnershipObject]) -> Result<()>;
+    async fn transfer_ownership_to_admin(&self, object: &[(u64, OwnershipObject)]) -> Result<()>;
 
     /// Grant ownership would transfer ownership of a object from one role to another role
     ///

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -44,7 +44,7 @@ pub trait RoleApi: Sync + Send {
     /// If a role is dropped, but the owner object is exists,
     ///
     /// The owner role need to update to account_admin.
-    async fn transfer_ownership_to_admin(&self, object: &[(u64, OwnershipObject)]) -> Result<()>;
+    async fn transfer_ownership_to_admin(&self, role: &str) -> Result<()>;
 
     /// Grant ownership would transfer ownership of a object from one role to another role
     ///

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -39,6 +39,13 @@ pub trait RoleApi: Sync + Send {
     async fn update_role_with<F>(&self, role: &String, seq: MatchSeq, f: F) -> Result<Option<u64>>
     where F: FnOnce(&mut RoleInfo) + Send;
 
+    /// Only drop role will call transfer.
+    ///
+    /// If a role is dropped, but the owner object is exists,
+    ///
+    /// The owner role need to update to account_admin.
+    async fn transfer_ownership_to_admin(&self, object: &OwnershipObject) -> Result<()>;
+
     /// Grant ownership would transfer ownership of a object from one role to another role
     ///
     ///

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -44,7 +44,7 @@ pub trait RoleApi: Sync + Send {
     /// If a role is dropped, but the owner object is exists,
     ///
     /// The owner role need to update to account_admin.
-    async fn transfer_ownership_to_admin(&self, object: &Vec<OwnershipObject>) -> Result<()>;
+    async fn transfer_ownership_to_admin(&self, object: &[OwnershipObject]) -> Result<()>;
 
     /// Grant ownership would transfer ownership of a object from one role to another role
     ///

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -266,6 +266,7 @@ impl RoleApi for RoleMgr {
     ) -> databend_common_exception::Result<()> {
         let mut trials = txn_backoff(None, func_name!());
         loop {
+            trials.next().unwrap()?.await;
             let mut if_then = vec![];
             let mut condition = vec![];
             let seq_owns = self.get_ownerships().await.map_err(|e| {
@@ -280,7 +281,7 @@ impl RoleApi for RoleMgr {
                     let owner_value = serialize_struct(
                         &OwnershipInfo {
                             object,
-                            role: "account_admin".to_string(),
+                            role: BUILTIN_ROLE_ACCOUNT_ADMIN.to_string(),
                         },
                         ErrorCode::IllegalUserInfoFormat,
                         || "",
@@ -292,7 +293,6 @@ impl RoleApi for RoleMgr {
             }
 
             if need_transfer {
-                trials.next().unwrap()?.await;
                 let txn_req = TxnRequest {
                     condition: condition.clone(),
                     if_then: if_then.clone(),

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -34,13 +34,11 @@ use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::ConditionResult::Eq;
-use databend_common_meta_types::InvalidReply;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::SeqV;
-use databend_common_meta_types::SeqValue;
 use databend_common_meta_types::TxnRequest;
 use enumflags2::make_bitflags;
 use minitrace::func_name;
@@ -258,7 +256,7 @@ impl RoleApi for RoleMgr {
     #[minitrace::trace]
     async fn transfer_ownership_to_admin(
         &self,
-        objects: &Vec<OwnershipObject>,
+        objects: &[OwnershipObject],
     ) -> databend_common_exception::Result<()> {
         // Ensure accurate matching of a key
         let mut if_then = vec![];

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -268,25 +268,11 @@ impl UserApiProvider {
     }
 
     // Drop a role by name
-    // If the dropped role owns objects, transfer objects owner to account_admin role.
     #[async_backtrace::framed]
     pub async fn drop_role(&self, tenant: &Tenant, role: String, if_exists: bool) -> Result<()> {
         let client = self.role_api(tenant);
-        // get_ownerships use prefix_list_kv that will generate once meta call
-        let seq_owns = client
-            .get_ownerships()
-            .await
-            .map_err(|e| e.add_message_back("(while get ownerships)."))?;
-        let mut objects = vec![];
-        for own in seq_owns {
-            if own.data.role == role {
-                objects.push((own.seq, own.data.object));
-            }
-        }
-        if !objects.is_empty() {
-            // According to Txn reduce meta call. If role own n objects, will generate once meta call.
-            client.transfer_ownership_to_admin(&objects).await?;
-        }
+        // If the dropped role owns objects, transfer objects owner to account_admin role.
+        client.transfer_ownership_to_admin(&role).await?;
 
         let drop_role = client.drop_role(role, MatchSeq::GE(1));
         match drop_role.await {

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -274,11 +274,15 @@ impl UserApiProvider {
         let client = self.role_api(tenant);
         // get_ownerships use prefix_list_kv that will generate once meta call
         let ownerships = self.get_ownerships(tenant).await?;
+        let mut objects = vec![];
         for (k, v) in ownerships {
             if v == role {
-                // If role own n objects, will generate n meta call.
-                client.transfer_ownership_to_admin(&k).await?;
+                objects.push(k);
             }
+        }
+        if !objects.is_empty() {
+            // According to Txn reduce meta call. If role own n objects, will generate once meta call.
+            client.transfer_ownership_to_admin(&objects).await?;
         }
 
         let drop_role = client.drop_role(role, MatchSeq::GE(1));

--- a/tests/fuse-compat/compat-logictest/rbac/fuse_compat_read
+++ b/tests/fuse-compat/compat-logictest/rbac/fuse_compat_read
@@ -9,3 +9,12 @@ show grants for role 'role1';
 
 statement ok
 show grants for role 'role2';
+
+statement ok
+drop role role1;
+
+statement ok
+drop role role2;
+
+statement ok
+show roles;

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
@@ -42,7 +42,7 @@ t1
 a	drop_role
 t	drop_role
 a	account_admin
-t	drop_role
+t	account_admin
 a	drop_role1
 t	drop_role1
 OWNERSHIP a  ROLE drop_role1 GRANT OWNERSHIP ON 'default'.'a'.* TO ROLE `drop_role1`

--- a/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.result
+++ b/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.result
@@ -3,8 +3,11 @@
 3
 === test drop role ===
 table1	d20_0014_owner
+table2	d20_0014_owner
 d20_0014	d20_0014_owner
 table1	account_admin
+table2	account_admin
 d20_0014	account_admin
 table1	account_admin
+table2	account_admin
 d20_0014	account_admin

--- a/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.result
+++ b/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.result
@@ -1,3 +1,10 @@
 1
 2
 3
+=== test drop role ===
+table1	d20_0014_owner
+d20_0014	d20_0014_owner
+table1	account_admin
+d20_0014	account_admin
+table1	account_admin
+d20_0014	account_admin

--- a/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.sh
@@ -25,14 +25,24 @@ echo "create database d20_0014" | $BENDSQL_CLIENT_CONNECT
 echo "GRANT OWNERSHIP ON d20_0014.* TO ROLE 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
 
 echo "GRANT ROLE 'd20_0014_owner' TO '${TEST_USER_NAME}'" | $BENDSQL_CLIENT_CONNECT
-echo "ALTER USER '${TEST_USER_NAME}' WITH DEFAULT_ROLE='20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
+echo "ALTER USER '${TEST_USER_NAME}' WITH DEFAULT_ROLE='d20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
 
 ## owner should have all privileges on the table
 echo "create table d20_0014.table1(i int);" | $TEST_USER_CONNECT
 echo "insert into d20_0014.table1 values(1),(2),(3);" | $TEST_USER_CONNECT
 echo "select * from d20_0014.table1;" | $TEST_USER_CONNECT
 
+echo "=== test drop role ==="
+echo "select name, owner from system.tables where name='table1' and database='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "drop role 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.tables where name='table1' and database='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "create role 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.tables where name='table1' and database='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+
 ## cleanup
+echo "drop role 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
 echo "drop database d20_0014;" | $BENDSQL_CLIENT_CONNECT
 echo "drop user '${TEST_USER_NAME}'" | $BENDSQL_CLIENT_CONNECT
-echo "drop role 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.sh
@@ -29,17 +29,18 @@ echo "ALTER USER '${TEST_USER_NAME}' WITH DEFAULT_ROLE='d20_0014_owner'" | $BEND
 
 ## owner should have all privileges on the table
 echo "create table d20_0014.table1(i int);" | $TEST_USER_CONNECT
+echo "create table d20_0014.table2(i int);" | $TEST_USER_CONNECT
 echo "insert into d20_0014.table1 values(1),(2),(3);" | $TEST_USER_CONNECT
 echo "select * from d20_0014.table1;" | $TEST_USER_CONNECT
 
 echo "=== test drop role ==="
-echo "select name, owner from system.tables where name='table1' and database='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | $BENDSQL_CLIENT_CONNECT
 echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
 echo "drop role 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.tables where name='table1' and database='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | $BENDSQL_CLIENT_CONNECT
 echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
 echo "create role 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.tables where name='table1' and database='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | $BENDSQL_CLIENT_CONNECT
 echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
 
 ## cleanup


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

drop role will transfer role owns object to account_admin

E.g.

```sql
create role role1;
create user u1 identified by '123' with default_role='role1';
grant role role1 to u1;

```

use u1 create some database then, drop the role1. In ownership-kv, the object keys value is a dropped role role1.

If admin user wants to create a new role also named role1, the new role `role1` will directly has objects ownership. That maybe dangerous. 

So in this pr, add a check: dorp role will check the dropped role owns some object. If true, transfer the owner to account_admin.


### Note

Add forward/backward compat test.

drop role can execute in old version(1.0.307) and new version.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15154)
<!-- Reviewable:end -->
