### PR TITLE
chore(query): turn on new agg hashtable

### DIFF
--- a/src/query/expression/src/aggregate/aggregate_hashtable.rs
+++ b/src/query/expression/src/aggregate/aggregate_hashtable.rs
@@ -220,9 +220,11 @@ impl AggregateHashTable {
             }
         }
 
-        if self.config.partial_agg && self.capacity >= self.config.max_partial_capacity {
+        if self.config.partial_agg {
             // check size
-            if self.count + BATCH_ADD_SIZE > self.resize_threshold() {
+            if self.count + BATCH_ADD_SIZE > self.resize_threshold()
+                && self.capacity >= self.config.max_partial_capacity
+            {
                 self.clear_ht();
                 self.reset_count();
             }

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -643,7 +643,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
                 ("enable_experimental_aggregate_hashtable", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
+                    value: UserSettingValue::UInt64(1),
                     desc: "Enables experimental aggregate hashtable",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -167,8 +167,8 @@ Exchange
     │       ├── aggregate functions: [sum(number)]
     │       ├── estimated rows: 1.00
     │       └── Exchange
-    │           ├── output columns: [sum(number) (#2), #_group_by_key]
-    │           ├── exchange type: Hash(_group_by_key)
+    │           ├── output columns: [sum(number) (#2), numbers.number (#0)]
+    │           ├── exchange type: Hash(0)
     │           └── AggregatePartial
     │               ├── group by: [number]
     │               ├── aggregate functions: [sum(number)]

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -198,7 +198,7 @@ explain fragments select * from (select sum(number) as number from numbers(1) gr
 Fragment 0:
   DataExchange: Shuffle
     ExchangeSink
-    ├── output columns: [sum(number) (#2), #_group_by_key]
+    ├── output columns: [sum(number) (#2), numbers.number (#0)]
     ├── destination fragment: [1]
     └── AggregatePartial
         ├── group by: [number]
@@ -226,7 +226,7 @@ Fragment 1:
         ├── aggregate functions: [sum(number)]
         ├── estimated rows: 1.00
         └── ExchangeSource
-            ├── output columns: [sum(number) (#2), #_group_by_key]
+            ├── output columns: [sum(number) (#2), numbers.number (#0)]
             └── source fragment: [0]
 (empty)
 (empty)

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -410,8 +410,8 @@ Exchange
     │       ├── aggregate functions: []
     │       ├── estimated rows: 2.00
     │       └── Exchange
-    │           ├── output columns: [#_group_by_key]
-    │           ├── exchange type: Hash(_group_by_key)
+    │           ├── output columns: [col0 (#2)]
+    │           ├── exchange type: Hash(0)
     │           └── AggregatePartial
     │               ├── group by: [col0]
     │               ├── aggregate functions: []

--- a/tests/sqllogictests/suites/mode/cluster/group_shuffle.test
+++ b/tests/sqllogictests/suites/mode/cluster/group_shuffle.test
@@ -45,8 +45,8 @@ Exchange
     ├── aggregate functions: []
     ├── estimated rows: 100000.00
     └── Exchange
-        ├── output columns: [#_group_by_key]
-        ├── exchange type: Hash(_group_by_key)
+        ├── output columns: [numbers_mt.number (#0)]
+        ├── exchange type: Hash(0)
         └── AggregatePartial
             ├── group by: [number]
             ├── aggregate functions: []


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In the previous PR, we implemented a new aggregation hash table. Now, it supports both singleton and cluster environments, and we have also added support for spill. This PR includes performance tests and try to enable the new aggregation hash table.

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):
