### PR TITLE
chore: add CopyInto to query queue

### DIFF
--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -302,19 +302,34 @@ impl ExecuteState {
         block_sender: SizedChannelSender<DataBlock>,
         format_settings: Arc<parking_lot::RwLock<Option<FormatSettings>>>,
     ) -> Result<()> {
+        info!("{}: http query prepare to plan sql", &ctx.get_id());
+
         // Use interpreter_plan_sql, we can write the query log if an error occurs.
         let (plan, extras) = interpreter_plan_sql(ctx.clone(), &sql)
             .await
             .map_err(|err| err.display_with_sql(&sql))?;
 
-        let entry = QueryEntry::create(&ctx, &plan, &extras)?;
-        let queue_guard = QueriesQueueManager::instance().acquire(entry).await?;
+        let query_queue_manager = QueriesQueueManager::instance();
 
+        info!(
+            "{}: http query preparing to acquire from query queue, length: {}",
+            &ctx.get_id(),
+            query_queue_manager.length()
+        );
+
+        let entry = QueryEntry::create(&ctx, &plan, &extras)?;
+        let queue_guard = query_queue_manager.acquire(entry).await?;
         {
             // set_var may change settings
             let mut guard = format_settings.write();
             *guard = Some(ctx.get_format_settings()?);
         }
+        info!(
+            "{}: http query finished acquiring from queue, length: {}",
+            &ctx.get_id(),
+            query_queue_manager.length()
+        );
+
         let interpreter = InterpreterFactory::get(ctx.clone(), &plan).await?;
         let running_state = ExecuteRunning {
             session,

--- a/src/query/service/tests/it/sessions/queue_mgr.rs
+++ b/src/query/service/tests/it/sessions/queue_mgr.rs
@@ -80,6 +80,7 @@ async fn test_passed_acquire() -> Result<()> {
     }
 
     assert!(instant.elapsed() < Duration::from_secs(test_count as u64));
+    assert_eq!(queue.length(), 0);
 
     Ok(())
 }
@@ -118,6 +119,7 @@ async fn test_serial_acquire() -> Result<()> {
     }
 
     assert!(instant.elapsed() >= Duration::from_secs(test_count as u64));
+    assert_eq!(queue.length(), 0);
 
     Ok(())
 }
@@ -159,6 +161,8 @@ async fn test_concurrent_acquire() -> Result<()> {
     assert!(instant.elapsed() >= Duration::from_secs((test_count / 2) as u64));
     assert!(instant.elapsed() < Duration::from_secs((test_count) as u64));
 
+    assert_eq!(queue.length(), 0);
+
     Ok(())
 }
 
@@ -192,7 +196,7 @@ async fn test_list_acquire() -> Result<()> {
     }
 
     tokio::time::sleep(Duration::from_secs(5)).await;
-    assert_eq!(queue.list().len(), test_count - 1);
+    assert_eq!(queue.length(), test_count - 1);
 
     Ok(())
 }

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -177,9 +177,6 @@ pub enum Plan {
         plan: Box<Plan>,
     },
 
-    CopyIntoTable(Box<CopyIntoTablePlan>),
-    CopyIntoLocation(CopyIntoLocationPlan),
-
     // Call is rewrite into Query
     // Call(Box<CallPlan>),
 
@@ -227,6 +224,10 @@ pub enum Plan {
     Delete(Box<DeletePlan>),
     Update(Box<UpdatePlan>),
     MergeInto(Box<MergeInto>),
+
+    CopyIntoTable(Box<CopyIntoTablePlan>),
+    CopyIntoLocation(CopyIntoLocationPlan),
+
     // Views
     CreateView(Box<CreateViewPlan>),
     AlterView(Box<AlterViewPlan>),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR:
- Add `CopyIntoTable` and `CopyIntoLocation` into query queue.
- Add `length()` to QueryQueueManager to get the queue length.
- Add more info logs to http handler.

- Fixes https://github.com/datafuselabs/databend/pull/15143/files#r1546928376

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
