### PR TITLE
chore: refine the query queue is_heavy_action func

### DIFF
--- a/src/query/service/tests/it/sessions/queue_mgr.rs
+++ b/src/query/service/tests/it/sessions/queue_mgr.rs
@@ -20,8 +20,13 @@ use std::time::UNIX_EPOCH;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_sql::Planner;
+use databend_query::interpreters::InterpreterFactory;
+use databend_query::sessions::QueryEntry;
 use databend_query::sessions::QueueData;
 use databend_query::sessions::QueueManager;
+use databend_query::test_kits::TestFixture;
+use log::error;
 
 #[derive(Debug)]
 struct TestData<const PASSED: bool = false>(String);
@@ -197,6 +202,127 @@ async fn test_list_acquire() -> Result<()> {
 
     tokio::time::sleep(Duration::from_secs(5)).await;
     assert_eq!(queue.length(), test_count - 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_heavy_actions() -> Result<()> {
+    struct Query {
+        sql: &'static str,
+        add_to_queue: bool,
+    }
+
+    let queries = [
+        Query {
+            sql: "create table t1(a int)", // DDL
+            add_to_queue: false,
+        },
+        Query {
+            sql: "select 1",
+            add_to_queue: false,
+        },
+        Query {
+            sql: "select version()", // FUNCTION
+            add_to_queue: false,
+        },
+        Query {
+            sql: "select * from numbers(10)", // Table Function
+            add_to_queue: false,
+        },
+        Query {
+            sql: "begin", // BEGIN
+            add_to_queue: false,
+        },
+        Query {
+            sql: "kill query 9", // KILL
+            add_to_queue: false,
+        },
+        Query {
+            sql: "select * from system.queries_queue", // SYSTEM
+            add_to_queue: false,
+        },
+        Query {
+            sql: "explain select * from system.queries_queue", // EXPLAIN SYSTEM
+            add_to_queue: false,
+        },
+        Query {
+            sql: "explain select * from t1", // EXPLAIN SELECT
+            add_to_queue: false,
+        },
+        Query {
+            sql: "insert into t1 values(1)", // INSERT
+            add_to_queue: true,
+        },
+        Query {
+            sql: "copy into t1 from @s1", // COPY INTO
+            add_to_queue: true,
+        },
+        Query {
+            sql: "copy into @s1 from (select * from t1)", // COPY INTO
+            add_to_queue: true,
+        },
+        Query {
+            sql: "update t1 set a = 2", // UPDATE
+            add_to_queue: true,
+        },
+        Query {
+            sql: "delete from t1", // DELETE
+            add_to_queue: true,
+        },
+        Query {
+            sql: "replace into t1 on(a) values(1)", // REPLACE INTO
+            add_to_queue: true,
+        },
+        Query {
+            sql: "merge into t1 using (select * from t2) as t2 on t1.a = t2.a when matched then delete",
+            // MERGE INTO
+            add_to_queue: true,
+        },
+    ];
+
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+
+    // Create table and stage.
+    {
+        let mut planner = Planner::new(ctx.clone());
+
+        {
+            let sql = "create table t1(a int)";
+            let (plan, _extras) = planner.plan_sql(sql).await?;
+            let interpreter = InterpreterFactory::get(ctx.clone(), &plan).await?;
+            let _ = interpreter.execute(ctx.clone()).await?;
+        }
+        {
+            let sql = "create table t2(a int)";
+            let (plan, _extras) = planner.plan_sql(sql).await?;
+            let interpreter = InterpreterFactory::get(ctx.clone(), &plan).await?;
+            let _ = interpreter.execute(ctx.clone()).await?;
+        }
+        {
+            let sql = "create stage s1";
+            let (plan, _extras) = planner.plan_sql(sql).await?;
+            let interpreter = InterpreterFactory::get(ctx.clone(), &plan).await?;
+            let _ = interpreter.execute(ctx.clone()).await?;
+        }
+    }
+
+    // Check.
+    for query in queries.iter() {
+        let mut planner = Planner::new(ctx.clone());
+        let (plan, extras) = planner.plan_sql(query.sql).await?;
+
+        let query_entry = QueryEntry::create(&ctx, &plan, &extras)?;
+        if query.add_to_queue != query_entry.need_acquire_to_queue() {
+            error!(
+                "query: {:?}, query-entry: {:?}",
+                query.sql,
+                query_entry.need_acquire_to_queue()
+            );
+        }
+        assert_eq!(query.add_to_queue, query_entry.need_acquire_to_queue());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* spill out a new function:  `is_heavy_action`
* add unit test for difference plan

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
