### PR TITLE
feat: Support to add random seed on random engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4077,6 +4077,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-pipeline-core",
  "databend-common-pipeline-sources",
+ "databend-storages-common-table-meta",
  "serde",
  "typetag",
 ]

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -1158,24 +1158,29 @@ impl Column {
         }
     }
 
-    pub fn random(ty: &DataType, len: usize) -> Self {
+    pub fn random(ty: &DataType, len: usize, seed: Option<u64>) -> Self {
         use rand::distributions::Alphanumeric;
         use rand::rngs::SmallRng;
         use rand::Rng;
         use rand::SeedableRng;
+        let mut rng = match seed {
+            None => SmallRng::from_entropy(),
+            Some(seed) => SmallRng::seed_from_u64(seed),
+        };
         match ty {
             DataType::Null => Column::Null { len },
             DataType::EmptyArray => Column::EmptyArray { len },
             DataType::EmptyMap => Column::EmptyMap { len },
-            DataType::Boolean => BooleanType::from_data(
-                (0..len)
-                    .map(|_| SmallRng::from_entropy().gen_bool(0.5))
-                    .collect_vec(),
-            ),
+            DataType::Boolean => {
+                BooleanType::from_data((0..len).map(|_| rng.gen_bool(0.5)).collect_vec())
+            }
             DataType::Binary => BinaryType::from_data(
                 (0..len)
                     .map(|_| {
-                        let rng = SmallRng::from_entropy();
+                        let rng = match seed {
+                            None => SmallRng::from_entropy(),
+                            Some(seed) => SmallRng::seed_from_u64(seed),
+                        };
                         rng.sample_iter(&Alphanumeric)
                             // randomly generate 5 characters.
                             .take(5)
@@ -1187,7 +1192,10 @@ impl Column {
             DataType::String => StringType::from_data(
                 (0..len)
                     .map(|_| {
-                        let rng = SmallRng::from_entropy();
+                        let rng = match seed {
+                            None => SmallRng::from_entropy(),
+                            Some(seed) => SmallRng::seed_from_u64(seed),
+                        };
                         rng.sample_iter(&Alphanumeric)
                             // randomly generate 5 characters.
                             .take(5)
@@ -1200,9 +1208,7 @@ impl Column {
                 with_number_mapped_type!(|NUM_TYPE| match num_ty {
                     NumberDataType::NUM_TYPE => {
                         NumberType::<NUM_TYPE>::from_data(
-                            (0..len)
-                                .map(|_| SmallRng::from_entropy().gen::<NUM_TYPE>())
-                                .collect_vec(),
+                            (0..len).map(|_| rng.gen::<NUM_TYPE>()).collect_vec(),
                         )
                     }
                 })
@@ -1210,45 +1216,41 @@ impl Column {
             DataType::Decimal(t) => match t {
                 DecimalDataType::Decimal128(size) => {
                     let values = (0..len)
-                        .map(|_| i128::from(SmallRng::from_entropy().gen::<i16>()))
+                        .map(|_| i128::from(rng.gen::<i16>()))
                         .collect::<Vec<i128>>();
                     Column::Decimal(DecimalColumn::Decimal128(values.into(), *size))
                 }
                 DecimalDataType::Decimal256(size) => {
                     let values = (0..len)
-                        .map(|_| i256::from(SmallRng::from_entropy().gen::<i16>()))
+                        .map(|_| i256::from(rng.gen::<i16>()))
                         .collect::<Vec<i256>>();
                     Column::Decimal(DecimalColumn::Decimal256(values.into(), *size))
                 }
             },
             DataType::Timestamp => TimestampType::from_data(
                 (0..len)
-                    .map(|_| SmallRng::from_entropy().gen_range(TIMESTAMP_MIN..=TIMESTAMP_MAX))
+                    .map(|_| rng.gen_range(TIMESTAMP_MIN..=TIMESTAMP_MAX))
                     .collect::<Vec<i64>>(),
             ),
             DataType::Date => DateType::from_data(
                 (0..len)
-                    .map(|_| SmallRng::from_entropy().gen_range(DATE_MIN..=DATE_MAX))
+                    .map(|_| rng.gen_range(DATE_MIN..=DATE_MAX))
                     .collect::<Vec<i32>>(),
             ),
             DataType::Nullable(ty) => Column::Nullable(Box::new(NullableColumn {
-                column: Column::random(ty, len),
-                validity: Bitmap::from(
-                    (0..len)
-                        .map(|_| SmallRng::from_entropy().gen_bool(0.5))
-                        .collect::<Vec<bool>>(),
-                ),
+                column: Column::random(ty, len, seed),
+                validity: Bitmap::from((0..len).map(|_| rng.gen_bool(0.5)).collect::<Vec<bool>>()),
             })),
             DataType::Array(inner_ty) => {
                 let mut inner_len = 0;
                 let mut offsets: Vec<u64> = Vec::with_capacity(len + 1);
                 offsets.push(0);
                 for _ in 0..len {
-                    inner_len += SmallRng::from_entropy().gen_range(0..=3);
+                    inner_len += rng.gen_range(0..=3);
                     offsets.push(inner_len);
                 }
                 Column::Array(Box::new(ArrayColumn {
-                    values: Column::random(inner_ty, inner_len as usize),
+                    values: Column::random(inner_ty, inner_len as usize, seed),
                     offsets: offsets.into(),
                 }))
             }
@@ -1257,18 +1259,18 @@ impl Column {
                 let mut offsets: Vec<u64> = Vec::with_capacity(len + 1);
                 offsets.push(0);
                 for _ in 0..len {
-                    inner_len += SmallRng::from_entropy().gen_range(0..=3);
+                    inner_len += rng.gen_range(0..=3);
                     offsets.push(inner_len);
                 }
                 Column::Map(Box::new(ArrayColumn {
-                    values: Column::random(inner_ty, inner_len as usize),
+                    values: Column::random(inner_ty, inner_len as usize, seed),
                     offsets: offsets.into(),
                 }))
             }
             DataType::Bitmap => BitmapType::from_data(
                 (0..len)
                     .map(|_| {
-                        let data: [u64; 4] = SmallRng::from_entropy().gen();
+                        let data: [u64; 4] = rng.gen();
                         let rb = RoaringTreemap::from_iter(data.iter());
                         let mut buf = vec![];
                         rb.serialize_into(&mut buf)
@@ -1280,7 +1282,7 @@ impl Column {
             DataType::Tuple(fields) => {
                 let fields = fields
                     .iter()
-                    .map(|ty| Column::random(ty, len))
+                    .map(|ty| Column::random(ty, len, seed))
                     .collect::<Vec<_>>();
                 Column::Tuple(fields)
             }
@@ -1295,161 +1297,8 @@ impl Column {
             DataType::Geometry => {
                 let mut data = Vec::with_capacity(len);
                 (0..len).for_each(|_| {
-                    let x = SmallRng::from_entropy().gen::<f64>();
-                    let y = SmallRng::from_entropy().gen::<f64>();
-                    let val = Point::new(x, y);
-                    data.push(
-                        Geometry::from(val)
-                            .to_ewkb(CoordDimensions::xy(), None)
-                            .unwrap(),
-                    );
-                });
-                GeometryType::from_data(data)
-            }
-            DataType::Generic(_) => unreachable!(),
-        }
-    }
-
-    pub fn random_with_seed(ty: &DataType, len: usize, seed: u64) -> Self {
-        use rand::distributions::Alphanumeric;
-        use rand::rngs::SmallRng;
-        use rand::Rng;
-        use rand::SeedableRng;
-        // wo need to generate random value with seed
-        match ty {
-            DataType::Null => Column::Null { len },
-            DataType::EmptyArray => Column::EmptyArray { len },
-            DataType::EmptyMap => Column::EmptyMap { len },
-            DataType::Boolean => BooleanType::from_data(
-                (0..len)
-                    .map(|_| SmallRng::seed_from_u64(seed).gen_bool(0.5))
-                    .collect_vec(),
-            ),
-            DataType::Binary => BinaryType::from_data(
-                (0..len)
-                    .map(|_| {
-                        let rng = SmallRng::seed_from_u64(seed);
-                        rng.sample_iter(&Alphanumeric)
-                            // randomly generate 5 characters.
-                            .take(5)
-                            .map(u8::from)
-                            .collect::<Vec<_>>()
-                    })
-                    .collect_vec(),
-            ),
-            DataType::String => StringType::from_data(
-                (0..len)
-                    .map(|_| {
-                        let rng = SmallRng::seed_from_u64(seed);
-                        rng.sample_iter(&Alphanumeric)
-                            // randomly generate 5 characters.
-                            .take(5)
-                            .map(char::from)
-                            .collect::<String>()
-                    })
-                    .collect_vec(),
-            ),
-            DataType::Number(num_ty) => {
-                with_number_mapped_type!(|NUM_TYPE| match num_ty {
-                    NumberDataType::NUM_TYPE => {
-                        NumberType::<NUM_TYPE>::from_data(
-                            (0..len)
-                                .map(|_| SmallRng::seed_from_u64(seed).gen::<NUM_TYPE>())
-                                .collect_vec(),
-                        )
-                    }
-                })
-            }
-            DataType::Decimal(t) => match t {
-                DecimalDataType::Decimal128(size) => {
-                    let values = (0..len)
-                        .map(|_| i128::from(SmallRng::seed_from_u64(seed).gen::<i16>()))
-                        .collect::<Vec<i128>>();
-                    Column::Decimal(DecimalColumn::Decimal128(values.into(), *size))
-                }
-                DecimalDataType::Decimal256(size) => {
-                    let values = (0..len)
-                        .map(|_| i256::from(SmallRng::seed_from_u64(seed).gen::<i16>()))
-                        .collect::<Vec<i256>>();
-                    Column::Decimal(DecimalColumn::Decimal256(values.into(), *size))
-                }
-            },
-            DataType::Timestamp => TimestampType::from_data(
-                (0..len)
-                    .map(|_| SmallRng::seed_from_u64(seed).gen_range(TIMESTAMP_MIN..=TIMESTAMP_MAX))
-                    .collect::<Vec<i64>>(),
-            ),
-            DataType::Date => DateType::from_data(
-                (0..len)
-                    .map(|_| SmallRng::seed_from_u64(seed).gen_range(DATE_MIN..=DATE_MAX))
-                    .collect::<Vec<i32>>(),
-            ),
-            DataType::Nullable(ty) => Column::Nullable(Box::new(NullableColumn {
-                column: Column::random(ty, len),
-                validity: Bitmap::from(
-                    (0..len)
-                        .map(|_| SmallRng::seed_from_u64(seed).gen_bool(0.5))
-                        .collect::<Vec<bool>>(),
-                ),
-            })),
-            DataType::Array(inner_ty) => {
-                let mut inner_len = 0;
-                let mut offsets: Vec<u64> = Vec::with_capacity(len + 1);
-                offsets.push(0);
-                for _ in 0..len {
-                    inner_len += SmallRng::seed_from_u64(seed).gen_range(0..=3);
-                    offsets.push(inner_len);
-                }
-                Column::Array(Box::new(ArrayColumn {
-                    values: Column::random_with_seed(inner_ty, inner_len as usize, seed),
-                    offsets: offsets.into(),
-                }))
-            }
-            DataType::Map(inner_ty) => {
-                let mut inner_len = 0;
-                let mut offsets: Vec<u64> = Vec::with_capacity(len + 1);
-                offsets.push(0);
-                for _ in 0..len {
-                    inner_len += SmallRng::seed_from_u64(seed).gen_range(0..=3);
-                    offsets.push(inner_len);
-                }
-                Column::Map(Box::new(ArrayColumn {
-                    values: Column::random_with_seed(inner_ty, inner_len as usize, seed),
-                    offsets: offsets.into(),
-                }))
-            }
-            DataType::Bitmap => BitmapType::from_data(
-                (0..len)
-                    .map(|_| {
-                        let data: [u64; 4] = SmallRng::seed_from_u64(seed).gen();
-                        let rb = RoaringTreemap::from_iter(data.iter());
-                        let mut buf = vec![];
-                        rb.serialize_into(&mut buf)
-                            .expect("failed serialize roaring treemap");
-                        buf
-                    })
-                    .collect_vec(),
-            ),
-            DataType::Tuple(fields) => {
-                let fields = fields
-                    .iter()
-                    .map(|ty| Column::random_with_seed(ty, len, seed))
-                    .collect::<Vec<_>>();
-                Column::Tuple(fields)
-            }
-            DataType::Variant => {
-                let mut data = Vec::with_capacity(len);
-                for _ in 0..len {
-                    let val = jsonb::rand_value();
-                    data.push(val.to_vec());
-                }
-                VariantType::from_data(data)
-            }
-            DataType::Geometry => {
-                let mut data = Vec::with_capacity(len);
-                (0..len).for_each(|_| {
-                    let x = SmallRng::seed_from_u64(seed).gen::<f64>();
-                    let y = SmallRng::seed_from_u64(seed).gen::<f64>();
+                    let x = rng.gen::<f64>();
+                    let y = rng.gen::<f64>();
                     let val = Point::new(x, y);
                     data.push(
                         Geometry::from(val)

--- a/src/query/expression/tests/it/kernel.rs
+++ b/src/query/expression/tests/it/kernel.rs
@@ -248,7 +248,7 @@ pub fn test_take_and_filter_and_concat() -> databend_common_exception::Result<()
         let slice_end = rng.gen_range(slice_start..len);
         let slice_len = slice_end - slice_start;
 
-        let mut filter = Column::random(&DataType::Boolean, len)
+        let mut filter = Column::random(&DataType::Boolean, len, None)
             .into_boolean()
             .unwrap();
         filter.slice(slice_start, slice_len);
@@ -405,7 +405,7 @@ pub fn test_filters() -> databend_common_exception::Result<()> {
             let end = (start + rng.gen_range(1..num_rows)).min(c.num_rows() - a.num_rows());
 
             // random filter
-            let mut f = Column::random(&DataType::Boolean, num_rows * blocks)
+            let mut f = Column::random(&DataType::Boolean, num_rows * blocks, None)
                 .into_boolean()
                 .unwrap();
             f.slice(start, end - start);

--- a/src/query/expression/tests/it/main.rs
+++ b/src/query/expression/tests/it/main.rs
@@ -40,7 +40,7 @@ fn rand_block_for_all_types(num_rows: usize) -> DataBlock {
     let types = get_all_test_data_types();
     let mut columns = Vec::with_capacity(types.len());
     for data_type in types.iter() {
-        columns.push(Column::random(data_type, num_rows));
+        columns.push(Column::random(data_type, num_rows, None));
     }
 
     let block = DataBlock::new_from_columns(columns);
@@ -53,7 +53,7 @@ fn rand_block_for_simple_types(num_rows: usize) -> DataBlock {
     let types = get_simple_types();
     let mut columns = Vec::with_capacity(types.len());
     for data_type in types.iter() {
-        columns.push(Column::random(data_type, num_rows));
+        columns.push(Column::random(data_type, num_rows, None));
     }
 
     let block = DataBlock::new_from_columns(columns);

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -59,6 +59,7 @@ use databend_storages_common_table_meta::table::OPT_KEY_CONNECTION_NAME;
 use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use databend_storages_common_table_meta::table::OPT_KEY_ENGINE;
 use databend_storages_common_table_meta::table::OPT_KEY_LOCATION;
+use databend_storages_common_table_meta::table::OPT_KEY_RANDOM_SEED;
 use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use databend_storages_common_table_meta::table::OPT_KEY_STORAGE_FORMAT;
 use databend_storages_common_table_meta::table::OPT_KEY_STORAGE_PREFIX;
@@ -353,6 +354,8 @@ impl CreateTableInterpreter {
         // check bloom_index_columns.
         is_valid_bloom_index_columns(&table_meta.options, schema)?;
         is_valid_change_tracking(&table_meta.options)?;
+        // check random seed
+        is_valid_random_seed(&table_meta.options)?;
 
         for table_option in table_meta.options.iter() {
             let key = table_option.0.to_lowercase();
@@ -471,6 +474,8 @@ pub static CREATE_TABLE_OPTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new
     r.insert(OPT_KEY_LOCATION);
     r.insert(OPT_KEY_CONNECTION_NAME);
 
+    r.insert(OPT_KEY_RANDOM_SEED);
+
     r.insert("transient");
     r
 });
@@ -530,6 +535,13 @@ pub fn is_valid_bloom_index_columns(
 pub fn is_valid_change_tracking(options: &BTreeMap<String, String>) -> Result<()> {
     if let Some(value) = options.get(OPT_KEY_CHANGE_TRACKING) {
         value.to_lowercase().parse::<bool>()?;
+    }
+    Ok(())
+}
+
+pub fn is_valid_random_seed(options: &BTreeMap<String, String>) -> Result<()> {
+    if let Some(value) = options.get(OPT_KEY_RANDOM_SEED) {
+        value.parse::<u64>()?;
     }
     Ok(())
 }

--- a/src/query/service/tests/it/pipelines/filter/filter_executor.rs
+++ b/src/query/service/tests/it/pipelines/filter/filter_executor.rs
@@ -44,7 +44,7 @@ pub fn test_filter_executor() -> databend_common_exception::Result<()> {
 
             // 1. Generate a random `DataBlock`.
             let columns = (0..num_columns)
-                .map(|_| Column::random(data_type, num_rows))
+                .map(|_| Column::random(data_type, num_rows, None))
                 .collect_vec();
             let block = DataBlock::new_from_columns(columns);
             block.check_valid()?;

--- a/src/query/service/tests/it/pipelines/filter/random_filter_expr.rs
+++ b/src/query/service/tests/it/pipelines/filter/random_filter_expr.rs
@@ -216,7 +216,10 @@ fn replace_const_to_const_and_column_ref(
                 }
             } else {
                 // Replace the child to `Constant`
-                let scalar = Column::random(data_type, 1).index(0).unwrap().to_owned();
+                let scalar = Column::random(data_type, 1, None)
+                    .index(0)
+                    .unwrap()
+                    .to_owned();
                 Expr::Constant {
                     span: None,
                     scalar,

--- a/src/query/storages/common/table_meta/src/table/table_keys.rs
+++ b/src/query/storages/common/table_meta/src/table/table_keys.rs
@@ -46,6 +46,8 @@ pub const OPT_KEY_ENGINE_META: &str = "engine_meta";
 ///
 /// If both OPT_KEY_SNAPSHOT_LOC and OPT_KEY_SNAPSHOT_LOCATION exist, the latter will be used
 pub const OPT_KEY_LEGACY_SNAPSHOT_LOC: &str = "snapshot_loc";
+// the following are used in for random engine
+pub const OPT_KEY_RANDOM_SEED: &str = "seed";
 
 /// Table option keys that reserved for internal usage only
 /// - Users are not allowed to specified this option keys in DDL

--- a/src/query/storages/random/Cargo.toml
+++ b/src/query/storages/random/Cargo.toml
@@ -18,6 +18,7 @@ databend-common-expression = { path = "../../expression" }
 databend-common-meta-app = { path = "../../../meta/app" }
 databend-common-pipeline-core = { path = "../../pipeline/core" }
 databend-common-pipeline-sources = { path = "../../pipeline/sources" }
+databend-storages-common-table-meta = { path = "../common/table_meta" }
 
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }

--- a/src/query/storages/random/src/random_table.rs
+++ b/src/query/storages/random/src/random_table.rs
@@ -131,7 +131,7 @@ impl Table for RandomTable {
             .iter()
             .map(|f| {
                 let data_type: DataType = f.data_type().into();
-                let column = Column::random(&data_type, 1, self.seed.clone());
+                let column = Column::random(&data_type, 1, self.seed);
                 BlockEntry::new(data_type.clone(), Value::Column(column))
             })
             .collect::<Vec<_>>();
@@ -188,7 +188,7 @@ impl Table for RandomTable {
                     output,
                     output_schema.clone(),
                     parts.rows,
-                    self.seed.clone(),
+                    self.seed,
                 )?,
             );
         }
@@ -197,7 +197,7 @@ impl Table for RandomTable {
             let output = OutputPort::create();
             builder.add_source(
                 output.clone(),
-                RandomSource::create(ctx.clone(), output, output_schema, 0, self.seed.clone())?,
+                RandomSource::create(ctx.clone(), output, output_schema, 0, self.seed)?,
             );
         }
 

--- a/src/query/storages/random/src/random_table.rs
+++ b/src/query/storages/random/src/random_table.rs
@@ -131,10 +131,7 @@ impl Table for RandomTable {
             .iter()
             .map(|f| {
                 let data_type: DataType = f.data_type().into();
-                let column = match self.seed {
-                    None => Column::random(&data_type, 1),
-                    Some(seed) => Column::random_with_seed(&data_type, 1, seed),
-                };
+                let column = Column::random(&data_type, 1, self.seed.clone());
                 BlockEntry::new(data_type.clone(), Value::Column(column))
             })
             .collect::<Vec<_>>();
@@ -243,12 +240,7 @@ impl SyncSource for RandomSource {
             .iter()
             .map(|f| {
                 let data_type = f.data_type().into();
-                let value = match self.seed {
-                    None => Value::Column(Column::random(&data_type, self.rows)),
-                    Some(seed) => {
-                        Value::Column(Column::random_with_seed(&data_type, self.rows, seed))
-                    }
-                };
+                let value = Value::Column(Column::random(&data_type, self.rows, self.seed));
                 BlockEntry::new(data_type, value)
             })
             .collect();

--- a/src/tests/sqlsmith/src/sql_gen/dml.rs
+++ b/src/tests/sqlsmith/src/sql_gen/dml.rs
@@ -578,7 +578,7 @@ impl<'a, R: Rng + 'a> SqlGenerator<'a, R> {
     fn gen_columns(&mut self, data_types: &[DataType], row_count: usize) -> Vec<Column> {
         data_types
             .iter()
-            .map(|ty| Column::random(ty, row_count))
+            .map(|ty| Column::random(ty, row_count, None))
             .collect()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Syntax:
```
create table t(a int, time timestamp) Engine=Random(1000);
select * from t; -- -- this will generate 1000 random values.
```

- Fixes #11863

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15167)
<!-- Reviewable:end -->
