### PR TITLE
feat(query): show create table support display inverted index

### DIFF
--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -335,6 +335,8 @@ build_exceptions! {
     UnknownIndex(2722),
     DropIndexWithDropTime(2723),
     GetIndexWithDropTime(2724),
+    DuplicatedIndexColumnId(2725),
+    IndexColumnIdNotFound(2726),
 
     // Stream error codes.
     UnknownStream(2730),

--- a/tests/sqllogictests/suites/ee/04_ee_inverted_index/04_0000_async_inverted_index_base.test
+++ b/tests/sqllogictests/suites/ee/04_ee_inverted_index/04_0000_async_inverted_index_base.test
@@ -40,6 +40,11 @@ INSERT INTO t VALUES
 statement ok
 CREATE INVERTED INDEX IF NOT EXISTS idx1 ON t(content) tokenizer = 'chinese'
 
+query TT
+SHOW CREATE TABLE t
+----
+t CREATE TABLE t ( id INT NULL, content VARCHAR NULL, SYNC INVERTED INDEX idx1 (content) tokenizer = 'chinese') ENGINE=FUSE
+
 statement ok
 REFRESH INVERTED INDEX idx1 ON t
 
@@ -173,3 +178,4 @@ use default
 
 statement ok
 drop database test_index
+

--- a/tests/sqllogictests/suites/ee/04_ee_inverted_index/04_0000_async_inverted_index_base.test
+++ b/tests/sqllogictests/suites/ee/04_ee_inverted_index/04_0000_async_inverted_index_base.test
@@ -43,7 +43,7 @@ CREATE INVERTED INDEX IF NOT EXISTS idx1 ON t(content) tokenizer = 'chinese'
 query TT
 SHOW CREATE TABLE t
 ----
-t CREATE TABLE t ( id INT NULL, content VARCHAR NULL, SYNC INVERTED INDEX idx1 (content) tokenizer = 'chinese') ENGINE=FUSE
+t CREATE TABLE t ( id INT NULL, content VARCHAR NULL, SYNC INVERTED INDEX idx1 (content) tokenizer = 'chinese' ) ENGINE=FUSE
 
 statement ok
 REFRESH INVERTED INDEX idx1 ON t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Show create table support display inverted index.
- Add `DuplicatedIndexColumnId` error code to check column id duplicate in different inverted indexes.
- Add `IndexColumnIdNotFound` error code to check invalid column id.

for example:
```sql
mysql> CREATE TABLE t (id int, content string);
Query OK, 0 rows affected (0.49 sec)

mysql> CREATE INVERTED INDEX IF NOT EXISTS idx1 ON t(content) tokenizer = 'chinese';
Query OK, 0 rows affected (0.16 sec)

mysql> SHOW CREATE TABLE t;
+-------+----------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                     |
+-------+----------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE t (
  id INT NULL,
  content VARCHAR NULL,
  SYNC INVERTED INDEX idx1 (content) tokenizer = 'chinese'
) ENGINE=FUSE |
+-------+----------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.37 sec)
Read 0 rows, 0.00 B in 0.155 sec., 0 rows/sec., 0.00 B/sec.
```

part of #14825

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
