### PR TITLE
chore(query): fix boolean type comparison

### DIFF
--- a/src/query/expression/src/types/boolean.rs
+++ b/src/query/expression/src/types/boolean.rs
@@ -173,7 +173,7 @@ impl ValueType for BooleanType {
 
     #[inline(always)]
     fn greater_than_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        (left & !right) || (left & right)
+        left | !right
     }
 
     #[inline(always)]
@@ -183,7 +183,7 @@ impl ValueType for BooleanType {
 
     #[inline(always)]
     fn less_than_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        (!left & right) || (left & right)
+        !left | right
     }
 }
 

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -209,7 +209,7 @@ fn register_boolean_cmp(registry: &mut FunctionRegistry) {
             (false, true, true, false) => FunctionDomain::Domain(ALL_FALSE_DOMAIN),
             _ => FunctionDomain::Full,
         },
-        |lhs, rhs, _| (lhs & !rhs) || (lhs & rhs),
+        |lhs, rhs, _| lhs | !rhs,
     );
     registry.register_2_arg::<BooleanType, BooleanType, BooleanType, _, _>(
         "lt",
@@ -228,7 +228,7 @@ fn register_boolean_cmp(registry: &mut FunctionRegistry) {
             (true, false, false, true) => FunctionDomain::Domain(ALL_FALSE_DOMAIN),
             _ => FunctionDomain::Full,
         },
-        |lhs, rhs, _| (!lhs & rhs) || (lhs & rhs),
+        |lhs, rhs, _| !lhs | rhs,
     );
 }
 

--- a/tests/sqllogictests/suites/query/filter.test
+++ b/tests/sqllogictests/suites/query/filter.test
@@ -32,3 +32,36 @@ select a from t where a = 0 or 3 / a > 2 order by a
 
 statement ok
 drop table if exists t;
+
+# Boolean comparison
+statement ok
+drop table if exists t;
+
+statement ok
+create table t(a boolean, b boolean);
+
+statement ok
+insert into t values(true, true), (true, false), (false, false);
+
+query I
+select count(*) from t where a > b;
+----
+1
+
+query II
+select count(*) from t where a >= b;
+----
+3
+
+query III
+select count(*) from t where a < b;
+----
+0
+
+query I?
+select count(*) from t where a <= b;
+----
+2
+
+statement ok
+drop table if exists t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Currently the comparison result of `false >= false`/`false <= false` is false, but the result should be true.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15171)
<!-- Reviewable:end -->
