### PR TITLE
fix: forbid end at stream syntax

### DIFF
--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0004_stream_changes.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0004_stream_changes.test
@@ -61,7 +61,16 @@ select a, b, change$action, change$is_update from t changes(information => appen
 3 3 INSERT 0
 
 statement ok
+create stream s1 on table t append_only = false
+
+statement error 1005
+select a, b, change$action, change$is_update from t changes(information => default) at(stream => s) end(stream => s1)
+
+statement ok
 DROP STREAM s
+
+statement ok
+DROP STREAM s1
 
 statement ok
 DROP TABLE t ALL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


disallowing the use of `end => '....'` within the changes clause, since  it does not make sense so much. 


```
mysql> create table t(a int)change_tracking=true;
Query OK, 0 rows affected (0.15 sec)

mysql> insert into t values(2);
Query OK, 1 row affected (0.15 sec)

mysql> insert into t values(1);
Query OK, 1 row affected (0.16 sec)

mysql> create stream s on table t append_only = false;
Query OK, 0 rows affected (0.14 sec)

mysql> select * from t changes(information=>default) at(snapshot=>'c8aa4edd973246749520bc7c57c47e1a') end(stream=>s1);
 
ERROR 1105 (HY000): SyntaxException. Code: 1005, Text = error: 
  --> SQL:1:100
  |
1 | select * from t changes(information=>default) at(snapshot=>'c8aa4edd973246749520bc7c57c47e1a') end(stream=>s1)
  | ------                                                                                             ^^^^^^ unexpected `stream`, expecting `TIMESTAMP` or `SNAPSHOT`
  | |                                                                                                   
  | while parsing `SELECT ...`
```

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15173)
<!-- Reviewable:end -->
