### PR TITLE
refactor: use `Tenant` for `ListBackgroundTasksReq`

### DIFF
--- a/src/meta/api/src/background_api_impl.rs
+++ b/src/meta/api/src/background_api_impl.rs
@@ -261,7 +261,9 @@ impl<KV: kvapi::KVApi<Error = MetaError>> BackgroundApi for KV {
         &self,
         req: ListBackgroundTasksReq,
     ) -> Result<Vec<(u64, String, BackgroundTaskInfo)>, KVAppError> {
-        let prefix = format!("{}/{}", BackgroundTaskIdent::PREFIX, req.tenant);
+        let ident = BackgroundTaskIdent::new(&req.tenant, "dummy");
+        let prefix = ident.tenant_prefix();
+
         let reply = self.prefix_list_kv(&prefix).await?;
         let mut res = vec![];
         for (k, v) in reply {

--- a/src/meta/api/src/background_api_impl.rs
+++ b/src/meta/api/src/background_api_impl.rs
@@ -39,6 +39,7 @@ use databend_common_meta_app::background::UpdateBackgroundJobStatusReq;
 use databend_common_meta_app::background::UpdateBackgroundTaskReply;
 use databend_common_meta_app::background::UpdateBackgroundTaskReq;
 use databend_common_meta_app::id_generator::IdGenerator;
+use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
@@ -206,7 +207,9 @@ impl<KV: kvapi::KVApi<Error = MetaError>> BackgroundApi for KV {
         &self,
         req: ListBackgroundJobsReq,
     ) -> Result<Vec<(u64, String, BackgroundJobInfo)>, KVAppError> {
-        let prefix = format!("{}/{}", BackgroundJobIdent::PREFIX, req.tenant);
+        let ident = BackgroundJobIdent::new(&req.tenant, "dummy");
+        let prefix = ident.tenant_prefix();
+
         let reply = self.prefix_list_kv(&prefix).await?;
         let mut res = vec![];
         for (k, v) in reply {

--- a/src/meta/api/src/background_api_test_suite.rs
+++ b/src/meta/api/src/background_api_test_suite.rs
@@ -113,13 +113,11 @@ impl BackgroundApiTestSuite {
         let tenant = Tenant::new_literal(tenant_name);
 
         let task_id = "uuid1";
-        let task_ident = BackgroundTaskIdent::new(tenant, task_id);
+        let task_ident = BackgroundTaskIdent::new(&tenant, task_id);
 
         info!("--- list background tasks when their is no tasks");
         {
-            let req = ListBackgroundTasksReq {
-                tenant: tenant_name.to_string(),
-            };
+            let req = ListBackgroundTasksReq::new(&tenant);
 
             let res = mt.list_background_tasks(req).await;
             assert!(res.is_ok());
@@ -176,9 +174,7 @@ impl BackgroundApiTestSuite {
             );
         }
         {
-            let req = ListBackgroundTasksReq {
-                tenant: tenant_name.to_string(),
-            };
+            let req = ListBackgroundTasksReq::new(&tenant);
 
             let res = mt.list_background_tasks(req).await;
             info!("update log res: {:?}", res);

--- a/src/meta/api/src/background_api_test_suite.rs
+++ b/src/meta/api/src/background_api_test_suite.rs
@@ -207,9 +207,7 @@ impl BackgroundApiTestSuite {
 
         info!("--- list background jobs when their is no tasks");
         {
-            let req = ListBackgroundJobsReq {
-                tenant: tenant_name.to_string(),
-            };
+            let req = ListBackgroundJobsReq::new(&tenant);
 
             let res = mt.list_background_jobs(req).await;
             assert!(res.is_ok());
@@ -332,9 +330,7 @@ impl BackgroundApiTestSuite {
 
         info!("--- list background jobs when their is 1 tasks");
         {
-            let req = ListBackgroundJobsReq {
-                tenant: tenant_name.to_string(),
-            };
+            let req = ListBackgroundJobsReq::new(&tenant);
 
             let res = mt.list_background_jobs(req).await;
             assert!(res.is_ok());

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -44,7 +44,6 @@ use databend_common_meta_app::app_error::StreamVersionMismatched;
 use databend_common_meta_app::app_error::TableAlreadyExists;
 use databend_common_meta_app::app_error::TableLockExpired;
 use databend_common_meta_app::app_error::TableVersionMismatched;
-use databend_common_meta_app::app_error::TenantIsEmpty;
 use databend_common_meta_app::app_error::UndropDbHasNoHistory;
 use databend_common_meta_app::app_error::UndropDbWithNoDropTime;
 use databend_common_meta_app::app_error::UndropTableAlreadyExists;
@@ -196,7 +195,6 @@ use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::MetaId;
 use databend_common_meta_types::MetaNetworkError;
-use databend_common_meta_types::NonEmptyString;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::SeqV;
 use databend_common_meta_types::TxnCondition;
@@ -3960,10 +3958,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
     ) -> Result<Vec<Arc<CatalogInfo>>, KVAppError> {
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
-        let tenant = Tenant::new_nonempty(
-            NonEmptyString::new(req.tenant)
-                .map_err(|_e| AppError::from(TenantIsEmpty::new("SchemaApi::list_catalogs")))?,
-        );
+        let tenant = req.tenant;
         let name_key = CatalogNameIdent::new(tenant, "");
 
         // Pairs of catalog-name and catalog_id with seq

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1134,7 +1134,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         // Get index id list by `prefix_list` "<prefix>/<tenant>"
         let prefix_key = kvapi::KeyBuilder::new_prefixed(IndexNameIdent::PREFIX)
             .push_str(req.tenant.name())
-            .push_raw("")
+            .push_str("")
             .done();
 
         let id_list = self.prefix_list_kv(&prefix_key).await?;

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1133,7 +1133,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
 
         // Get index id list by `prefix_list` "<prefix>/<tenant>"
         let prefix_key = kvapi::KeyBuilder::new_prefixed(IndexNameIdent::PREFIX)
-            .push_str(&req.tenant)
+            .push_str(req.tenant.name())
+            .push_raw("")
             .done();
 
         let id_list = self.prefix_list_kv(&prefix_key).await?;

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -5991,10 +5991,7 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- list index with no create before");
-            let req = ListIndexesReq {
-                tenant: tenant_name.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListIndexesReq::new(&tenant, Some(table_id));
 
             let res = mt.list_indexes(req).await?;
             assert!(res.is_empty())
@@ -6049,18 +6046,12 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- list index");
-            let req = ListIndexesReq {
-                tenant: tenant_name.to_string(),
-                table_id: None,
-            };
+            let req = ListIndexesReq::new(&tenant, None);
 
             let res = mt.list_indexes(req).await?;
             assert_eq!(2, res.len());
 
-            let req = ListIndexesReq {
-                tenant: tenant_name.to_string(),
-                table_id: Some(u64::MAX),
-            };
+            let req = ListIndexesReq::new(&tenant, Some(u64::MAX));
 
             let res = mt.list_indexes(req).await?;
             assert!(res.is_empty())
@@ -6090,10 +6081,7 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- list index after drop one");
-            let req = ListIndexesReq {
-                tenant: tenant_name.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListIndexesReq::new(&tenant, Some(table_id));
 
             let res = mt.list_indexes(req).await?;
             assert_eq!(1, res.len());
@@ -6101,10 +6089,7 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- check list index content");
-            let req = ListIndexesReq {
-                tenant: tenant_name.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListIndexesReq::new(&tenant, Some(table_id));
 
             let res = mt.list_indexes(req).await?;
             assert_eq!(1, res.len());
@@ -6124,10 +6109,7 @@ impl SchemaApiTestSuite {
             let res = mt.drop_index(req).await;
             assert!(res.is_ok());
 
-            let req = ListIndexesReq {
-                tenant: tenant_name.to_string(),
-                table_id: Some(table_id),
-            };
+            let req = ListIndexesReq::new(&tenant, Some(table_id));
 
             let res = mt.list_indexes(req).await?;
             assert!(res.is_empty())

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -1462,7 +1462,9 @@ impl SchemaApiTestSuite {
         assert_eq!(got.name_ident.tenant, "tenant1");
         assert_eq!(got.name_ident.catalog_name, "catalog1");
 
-        let got = mt.list_catalogs(ListCatalogReq::new("tenant1")).await?;
+        let got = mt
+            .list_catalogs(ListCatalogReq::new(tenant.clone()))
+            .await?;
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].name_ident.tenant, "tenant1");
         assert_eq!(got[0].name_ident.catalog_name, "catalog1");
@@ -1474,7 +1476,9 @@ impl SchemaApiTestSuite {
             })
             .await?;
 
-        let got = mt.list_catalogs(ListCatalogReq::new("tenant1")).await?;
+        let got = mt
+            .list_catalogs(ListCatalogReq::new(tenant.clone()))
+            .await?;
         assert_eq!(got.len(), 0);
 
         Ok(())

--- a/src/meta/app/src/background/background_job.rs
+++ b/src/meta/app/src/background/background_job.rs
@@ -24,6 +24,8 @@ use cron::Schedule;
 use crate::background::BackgroundJobIdent;
 use crate::background::BackgroundTaskType;
 use crate::principal::UserIdentity;
+use crate::tenant::Tenant;
+use crate::tenant::ToTenant;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, num_derive::FromPrimitive)]
 pub enum BackgroundJobState {
@@ -338,12 +340,20 @@ pub struct DeleteBackgroundJobReply {}
 // list
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListBackgroundJobsReq {
-    pub tenant: String,
+    pub tenant: Tenant,
+}
+
+impl ListBackgroundJobsReq {
+    pub fn new(tenant: impl ToTenant) -> Self {
+        Self {
+            tenant: tenant.to_tenant(),
+        }
+    }
 }
 
 impl Display for ListBackgroundJobsReq {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "list_background_job({})", self.tenant)
+        write!(f, "list_background_job({})", self.tenant.name())
     }
 }
 

--- a/src/meta/app/src/background/background_task.rs
+++ b/src/meta/app/src/background/background_task.rs
@@ -25,6 +25,8 @@ use crate::background::BackgroundJobIdent;
 use crate::background::BackgroundTaskIdent;
 use crate::background::ManualTriggerParams;
 use crate::schema::TableStatistics;
+use crate::tenant::Tenant;
+use crate::tenant::ToTenant;
 
 #[derive(
     serde::Serialize,
@@ -195,19 +197,19 @@ pub struct GetBackgroundTaskReply {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListBackgroundTasksReq {
-    pub tenant: String,
+    pub tenant: Tenant,
 }
 
 impl Display for ListBackgroundTasksReq {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "list_background_tasks({})", self.tenant)
+        write!(f, "list_background_tasks({})", self.tenant.name())
     }
 }
 
 impl ListBackgroundTasksReq {
-    pub fn new(tenant: impl Into<String>) -> ListBackgroundTasksReq {
+    pub fn new(tenant: impl ToTenant) -> ListBackgroundTasksReq {
         ListBackgroundTasksReq {
-            tenant: tenant.into(),
+            tenant: tenant.to_tenant(),
         }
     }
 }

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -20,6 +20,7 @@ use chrono::Utc;
 
 use crate::schema::CatalogNameIdent;
 use crate::storage::StorageParams;
+use crate::tenant::Tenant;
 use crate::KeyWithTenant;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
@@ -259,16 +260,14 @@ impl GetCatalogReq {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListCatalogReq {
-    pub tenant: String,
+    pub tenant: Tenant,
 }
 
 impl ListCatalogReq {
-    pub fn new(tenant: impl Into<String>) -> ListCatalogReq {
-        ListCatalogReq {
-            tenant: tenant.into(),
-        }
+    pub fn new(tenant: Tenant) -> ListCatalogReq {
+        ListCatalogReq { tenant }
     }
 }
 

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -22,6 +22,7 @@ use databend_common_meta_types::MetaId;
 
 use super::CreateOption;
 use crate::tenant::Tenant;
+use crate::tenant::ToTenant;
 use crate::KeyWithTenant;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -225,16 +226,16 @@ pub struct UpdateIndexReq {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct UpdateIndexReply {}
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListIndexesReq {
-    pub tenant: String,
+    pub tenant: Tenant,
     pub table_id: Option<MetaId>,
 }
 
 impl ListIndexesReq {
-    pub fn new(tenant: impl Into<String>, table_id: Option<MetaId>) -> ListIndexesReq {
+    pub fn new(tenant: impl ToTenant, table_id: Option<MetaId>) -> ListIndexesReq {
         ListIndexesReq {
-            tenant: tenant.into(),
+            tenant: tenant.to_tenant(),
             table_id,
         }
     }

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -241,7 +241,7 @@ impl ListIndexesReq {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListIndexesByIdReq {
     pub tenant: String,
     pub table_id: MetaId,

--- a/src/meta/app/src/tenant/tenant.rs
+++ b/src/meta/app/src/tenant/tenant.rs
@@ -39,6 +39,9 @@ impl Tenant {
         Ok(t)
     }
 
+    /// Create a `Tenant` without checking if it is empty, if debug mode is disabled.
+    ///
+    /// This method should only be used for testing
     pub fn new_literal(tenant: &str) -> Self {
         debug_assert!(!tenant.is_empty());
         Self {
@@ -66,6 +69,7 @@ impl Tenant {
     }
 }
 
+/// A trait convert other types to [`Tenant`].
 pub trait ToTenant {
     fn to_tenant(self) -> Tenant;
 }

--- a/src/query/catalog/src/catalog/manager.rs
+++ b/src/query/catalog/src/catalog/manager.rs
@@ -241,7 +241,7 @@ impl CatalogManager {
     #[async_backtrace::framed]
     pub async fn list_catalogs(
         &self,
-        tenant: &str,
+        tenant: &Tenant,
         txn_mgr: TxnManagerRef,
     ) -> Result<Vec<Arc<dyn Catalog>>> {
         let mut catalogs = vec![self.get_default_catalog(txn_mgr.clone())?];
@@ -252,7 +252,10 @@ impl CatalogManager {
         }
 
         // fecth catalogs from metasrv.
-        let infos = self.meta.list_catalogs(ListCatalogReq::new(tenant)).await?;
+        let infos = self
+            .meta
+            .list_catalogs(ListCatalogReq::new(tenant.clone()))
+            .await?;
 
         for info in infos {
             catalogs.push(self.build_catalog(&info, txn_mgr.clone())?);

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/catalog.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/catalog.rs
@@ -62,7 +62,7 @@ impl CatalogInfoProvider {
             )]
         } else {
             catalog_mgr
-                .list_catalogs(tenant.name(), ctx.txn_mgr())
+                .list_catalogs(&tenant, ctx.txn_mgr())
                 .await?
                 .iter()
                 .map(|r| (r.name(), r.clone()))

--- a/src/query/sql/src/planner/binder/ddl/index.rs
+++ b/src/query/sql/src/planner/binder/ddl/index.rs
@@ -116,7 +116,7 @@ impl Binder {
                 {
                     let indexes = self
                         .resolve_table_indexes(
-                            self.ctx.get_tenant().name(),
+                            &self.ctx.get_tenant(),
                             catalog.as_str(),
                             table.get_id(),
                         )

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -70,6 +70,7 @@ use databend_common_meta_app::principal::StageFileFormatType;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::schema::IndexMeta;
 use databend_common_meta_app::schema::ListIndexesReq;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MetaId;
 use databend_common_storage::DataOperator;
 use databend_common_storage::StageFileInfo;
@@ -1430,13 +1431,13 @@ impl Binder {
     #[async_backtrace::framed]
     pub(crate) async fn resolve_table_indexes(
         &self,
-        tenant: &str,
+        tenant: &Tenant,
         catalog_name: &str,
         table_id: MetaId,
     ) -> Result<Vec<(u64, String, IndexMeta)>> {
         let catalog = self
             .catalogs
-            .get_catalog(tenant, catalog_name, self.ctx.txn_mgr())
+            .get_catalog(tenant.name(), catalog_name, self.ctx.txn_mgr())
             .await?;
         let index_metas = catalog
             .list_indexes(ListIndexesReq::new(tenant, Some(table_id)))

--- a/src/query/storages/system/src/background_jobs_table.rs
+++ b/src/query/storages/system/src/background_jobs_table.rs
@@ -59,9 +59,7 @@ impl AsyncSystemTable for BackgroundJobTable {
         let tenant = ctx.get_tenant();
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let jobs = meta_api
-            .list_background_jobs(ListBackgroundJobsReq {
-                tenant: tenant.name().to_string(),
-            })
+            .list_background_jobs(ListBackgroundJobsReq::new(&tenant))
             .await?;
         let mut names = Vec::with_capacity(jobs.len());
         let mut job_types = Vec::with_capacity(jobs.len());

--- a/src/query/storages/system/src/background_tasks_table.rs
+++ b/src/query/storages/system/src/background_tasks_table.rs
@@ -59,9 +59,7 @@ impl AsyncSystemTable for BackgroundTaskTable {
         let tenant = ctx.get_tenant();
         let meta_api = UserApiProvider::instance().get_meta_store_client();
         let tasks = meta_api
-            .list_background_tasks(ListBackgroundTasksReq {
-                tenant: tenant.name().to_string(),
-            })
+            .list_background_tasks(ListBackgroundTasksReq::new(&tenant))
             .await?;
         let mut names = Vec::with_capacity(tasks.len());
         let mut types = Vec::with_capacity(tasks.len());

--- a/src/query/storages/system/src/catalogs_table.rs
+++ b/src/query/storages/system/src/catalogs_table.rs
@@ -53,7 +53,7 @@ impl AsyncSystemTable for CatalogsTable {
         let mgr = CatalogManager::instance();
 
         let catalog_names = mgr
-            .list_catalogs(ctx.get_tenant().name(), ctx.txn_mgr())
+            .list_catalogs(&ctx.get_tenant(), ctx.txn_mgr())
             .await?
             .into_iter()
             .map(|v| v.name())

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -59,7 +59,7 @@ impl AsyncSystemTable for DatabasesTable {
 
         let catalogs = CatalogManager::instance();
         let catalogs: Vec<(String, Arc<dyn Catalog>)> = catalogs
-            .list_catalogs(tenant.name(), ctx.txn_mgr())
+            .list_catalogs(&tenant, ctx.txn_mgr())
             .await?
             .iter()
             .map(|e| (e.name(), e.clone()))

--- a/src/query/storages/system/src/indexes_table.rs
+++ b/src/query/storages/system/src/indexes_table.rs
@@ -54,10 +54,7 @@ impl AsyncSystemTable for IndexesTable {
         let tenant = ctx.get_tenant();
         let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
         let indexes = catalog
-            .list_indexes(ListIndexesReq {
-                tenant: tenant.name().to_string(),
-                table_id: None,
-            })
+            .list_indexes(ListIndexesReq::new(&tenant, None))
             .await?;
 
         let mut names = Vec::with_capacity(indexes.len());

--- a/src/query/storages/system/src/locks_table.rs
+++ b/src/query/storages/system/src/locks_table.rs
@@ -60,9 +60,7 @@ impl AsyncSystemTable for LocksTable {
     ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let catalog_mgr = CatalogManager::instance();
-        let ctls = catalog_mgr
-            .list_catalogs(tenant.name(), ctx.txn_mgr())
-            .await?;
+        let ctls = catalog_mgr.list_catalogs(&tenant, ctx.txn_mgr()).await?;
 
         let mut lock_table_id = Vec::new();
         let mut lock_revision = Vec::new();

--- a/src/query/storages/system/src/streams_table.rs
+++ b/src/query/storages/system/src/streams_table.rs
@@ -68,7 +68,7 @@ impl AsyncSystemTable for StreamsTable {
 
         let catalog_mgr = CatalogManager::instance();
         let ctls: Vec<(String, Arc<dyn Catalog>)> = catalog_mgr
-            .list_catalogs(tenant.name(), ctx.txn_mgr())
+            .list_catalogs(&tenant, ctx.txn_mgr())
             .await?
             .iter()
             .map(|e| (e.name(), e.clone()))

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -106,9 +106,7 @@ where TablesTable<T>: HistoryAware
     ) -> Result<DataBlock> {
         let tenant = ctx.get_tenant();
         let catalog_mgr = CatalogManager::instance();
-        let catalogs = catalog_mgr
-            .list_catalogs(tenant.name(), ctx.txn_mgr())
-            .await?;
+        let catalogs = catalog_mgr.list_catalogs(&tenant, ctx.txn_mgr()).await?;
         let visibility_checker = ctx.get_visibility_checker().await?;
 
         Ok(self


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: use `Tenant` for `ListBackgroundTasksReq`


##### refactor: use `Tenant` for `ListBackgroundJobsReq`


##### refactor: use `Tenant` for `ListIndexesReq`


##### refactor: use `Tenant` for `ListCatalogReq`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues