### PR TITLE
refactor: move TIdent into separate files

### DIFF
--- a/src/meta/api/src/crud/errors.rs
+++ b/src/meta/api/src/crud/errors.rs
@@ -15,9 +15,9 @@
 use std::error::Error;
 
 use databend_common_exception::ErrorCode;
-use databend_common_meta_app::tenant_key::TenantResource;
-use databend_common_meta_app::tenant_key_errors::ExistError;
-use databend_common_meta_app::tenant_key_errors::UnknownError;
+use databend_common_meta_app::tenant_key::errors::ExistError;
+use databend_common_meta_app::tenant_key::errors::UnknownError;
+use databend_common_meta_app::tenant_key::resource::TenantResource;
 use databend_common_meta_types::MetaError;
 
 /// CRUD Error that can be an API level error or a business error.

--- a/src/meta/api/src/crud/mod.rs
+++ b/src/meta/api/src/crud/mod.rs
@@ -20,10 +20,10 @@ use std::sync::Arc;
 
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
-use databend_common_meta_app::tenant_key::TIdent;
-use databend_common_meta_app::tenant_key::TenantResource;
-use databend_common_meta_app::tenant_key_errors::ExistError;
-use databend_common_meta_app::tenant_key_errors::UnknownError;
+use databend_common_meta_app::tenant_key::errors::ExistError;
+use databend_common_meta_app::tenant_key::errors::UnknownError;
+use databend_common_meta_app::tenant_key::ident::TIdent;
+use databend_common_meta_app::tenant_key::resource::TenantResource;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_kvapi::kvapi::ValueWithName;

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -3141,14 +3141,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 else_then: vec![],
             };
 
-            let _ = update_mask_policy(
-                self,
-                &req.action,
-                &mut txn_req,
-                req.tenant.clone(),
-                req.table_id,
-            )
-            .await;
+            let _ = update_mask_policy(self, &req.action, &mut txn_req, &req.tenant, req.table_id)
+                .await;
 
             let (succ, _responses) = send_txn(self, txn_req).await?;
 
@@ -5347,11 +5341,9 @@ async fn update_mask_policy(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     action: &SetTableColumnMaskPolicyAction,
     txn_req: &mut TxnRequest,
-    tenant: String,
+    tenant: &Tenant,
     table_id: u64,
 ) -> Result<(), KVAppError> {
-    let tenant = Tenant::new_or_err(&tenant, func_name!())?;
-
     /// Fetch and update the table id list with `f`, and fill in the txn preconditions and operations.
     async fn update_table_ids(
         kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1179,12 +1179,10 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
     ) -> Result<Vec<u64>, KVAppError> {
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
-        // Get index id list by `prefix_list` "<prefix>/<tenant>"
-        let prefix_key = kvapi::KeyBuilder::new_prefixed(IndexNameIdent::PREFIX)
-            .push_str(&req.tenant)
-            .done();
+        let ident = IndexNameIdent::new(req.tenant.clone(), "");
+        let prefix = ident.to_string_key();
 
-        let id_list = self.prefix_list_kv(&prefix_key).await?;
+        let id_list = self.prefix_list_kv(&prefix).await?;
         let mut id_name_list = Vec::with_capacity(id_list.len());
         for (key, seq) in id_list.iter() {
             let name_ident = IndexNameIdent::from_str_key(key).map_err(|e| {
@@ -1194,7 +1192,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             id_name_list.push((index_id.0, name_ident.index_name));
         }
 
-        debug!(ident :% =(&prefix_key); "list_indexes");
+        debug!(ident :% =(&prefix); "list_indexes");
 
         if id_name_list.is_empty() {
             return Ok(vec![]);
@@ -1220,12 +1218,10 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
     ) -> Result<Vec<(u64, String, IndexMeta)>, KVAppError> {
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
-        // Get index id list by `prefix_list` "<prefix>/<tenant>"
-        let prefix_key = kvapi::KeyBuilder::new_prefixed(IndexNameIdent::PREFIX)
-            .push_str(&req.tenant)
-            .done();
+        let ident = IndexNameIdent::new(req.tenant.clone(), "");
+        let prefix = ident.to_string_key();
 
-        let id_list = self.prefix_list_kv(&prefix_key).await?;
+        let id_list = self.prefix_list_kv(&prefix).await?;
         let mut id_name_list = Vec::with_capacity(id_list.len());
         for (key, seq) in id_list.iter() {
             let name_ident = IndexNameIdent::from_str_key(key).map_err(|e| {
@@ -1235,7 +1231,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             id_name_list.push((index_id.0, name_ident.index_name));
         }
 
-        debug!(ident :% =(&prefix_key); "list_indexes");
+        debug!(ident :% =(&prefix); "list_indexes");
 
         if id_name_list.is_empty() {
             return Ok(vec![]);

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -6059,10 +6059,7 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- list indexes by table id");
-            let req = ListIndexesByIdReq {
-                tenant: tenant_name.to_string(),
-                table_id,
-            };
+            let req = ListIndexesByIdReq::new(&tenant, table_id);
 
             let res = mt.list_indexes_by_table_id(req).await?;
             assert_eq!(2, res.len());

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -2802,7 +2802,7 @@ impl SchemaApiTestSuite {
             table_id_1 = table_id;
 
             let req = SetTableColumnMaskPolicyReq {
-                tenant: tenant_name.to_string(),
+                tenant: tenant.clone(),
                 seq: MatchSeq::Exact(res.ident.seq),
                 table_id,
                 column: "number".to_string(),
@@ -2844,7 +2844,7 @@ impl SchemaApiTestSuite {
             table_id_2 = table_id;
 
             let req = SetTableColumnMaskPolicyReq {
-                tenant: tenant_name.to_string(),
+                tenant: tenant.clone(),
                 seq: MatchSeq::Exact(res.ident.seq),
                 table_id,
                 column: "number".to_string(),
@@ -2884,7 +2884,7 @@ impl SchemaApiTestSuite {
             let res = mt.get_table(req).await?;
 
             let req = SetTableColumnMaskPolicyReq {
-                tenant: tenant_name.to_string(),
+                tenant: tenant.clone(),
                 seq: MatchSeq::Exact(res.ident.seq),
                 table_id: table_id_1,
                 column: "number".to_string(),
@@ -2932,7 +2932,7 @@ impl SchemaApiTestSuite {
             let res = mt.get_table(req).await?;
 
             let req = SetTableColumnMaskPolicyReq {
-                tenant: tenant_name.to_string(),
+                tenant: tenant.clone(),
                 seq: MatchSeq::Exact(res.ident.seq),
                 table_id: table_id_1,
                 column: "number".to_string(),

--- a/src/meta/api/src/share_api_impl.rs
+++ b/src/meta/api/src/share_api_impl.rs
@@ -1408,12 +1408,12 @@ async fn get_outbound_share_info_by_name(
 
 async fn get_outbound_share_infos_by_tenant(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
-    tenant: &str,
+    tenant: &Tenant,
 ) -> Result<Vec<ShareAccountReply>, KVAppError> {
     let mut outbound_share_accounts: Vec<ShareAccountReply> = vec![];
 
     let tenant_share_name_key = ShareNameIdent {
-        tenant: Tenant::new_or_err(tenant, func_name!())?,
+        tenant: tenant.clone(),
         share_name: "".to_string(),
     };
     let share_name_keys = list_keys(kv_api, &tenant_share_name_key).await?;

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -150,7 +150,7 @@ impl ShareApiTestSuite {
         info!("--- show share when there are no share");
         {
             let req = ShowSharesReq {
-                tenant: tenant.name().to_string(),
+                tenant: tenant.clone(),
             };
 
             let res = mt.show_shares(req).await;
@@ -186,7 +186,7 @@ impl ShareApiTestSuite {
         info!("--- show share again");
         {
             let req = ShowSharesReq {
-                tenant: tenant.name().to_string(),
+                tenant: tenant.clone(),
             };
 
             let res = mt.show_shares(req).await;
@@ -620,7 +620,7 @@ impl ShareApiTestSuite {
         info!("--- show share check account information");
         {
             let req = ShowSharesReq {
-                tenant: tenant_name1.to_string(),
+                tenant: tenant1.clone(),
             };
 
             let res = mt.show_shares(req).await;

--- a/src/meta/app/src/background/job_ident.rs
+++ b/src/meta/app/src/background/job_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// Defines the meta-service key for background job.
 pub type BackgroundJobIdent = TIdent<Resource>;
@@ -25,7 +25,7 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi::Key;
 
     use crate::background::BackgroundJobId;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/background/task_ident.rs
+++ b/src/meta/app/src/background/task_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// Defines the meta-service key for background task.
 pub type BackgroundTaskIdent = TIdent<Resource>;
@@ -24,7 +24,7 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::background::BackgroundTaskInfo;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/data_mask/data_mask_name_ident.rs
+++ b/src/meta/app/src/data_mask/data_mask_name_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 pub type DataMaskNameIdent = TIdent<Resource>;
 
@@ -24,7 +24,7 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi::Key;
 
     use crate::data_mask::DatamaskId;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/data_mask/mask_policy_table_id_list_ident.rs
+++ b/src/meta/app/src/data_mask/mask_policy_table_id_list_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 pub type MaskPolicyTableIdListIdent = TIdent<Resource>;
 
@@ -23,7 +23,7 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::data_mask::MaskpolicyTableIdList;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/lib.rs
+++ b/src/meta/app/src/lib.rs
@@ -31,7 +31,6 @@ pub mod share;
 pub mod storage;
 pub mod tenant;
 pub mod tenant_key;
-pub mod tenant_key_errors;
 
 pub mod id_generator;
 

--- a/src/meta/app/src/principal/connection_ident.rs
+++ b/src/meta/app/src/principal/connection_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// Defines the meta-service key for connection.
 pub type ConnectionIdent = TIdent<Resource>;
@@ -25,9 +25,9 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::principal::UserDefinedConnection;
-    use crate::tenant_key::TenantResource;
-    use crate::tenant_key_errors::ExistError;
-    use crate::tenant_key_errors::UnknownError;
+    use crate::tenant_key::errors::ExistError;
+    use crate::tenant_key::errors::UnknownError;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/principal/network_policy_ident.rs
+++ b/src/meta/app/src/principal/network_policy_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// Defines the meta-service key for network policy.
 pub type NetworkPolicyIdent = TIdent<Resource>;
@@ -25,9 +25,9 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::principal::NetworkPolicy;
-    use crate::tenant_key::TenantResource;
-    use crate::tenant_key_errors::ExistError;
-    use crate::tenant_key_errors::UnknownError;
+    use crate::tenant_key::errors::ExistError;
+    use crate::tenant_key::errors::UnknownError;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/principal/password_policy_ident.rs
+++ b/src/meta/app/src/principal/password_policy_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// Defines the meta-service key for password policy.
 pub type PasswordPolicyIdent = TIdent<Resource>;
@@ -25,9 +25,9 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::principal::PasswordPolicy;
-    use crate::tenant_key::TenantResource;
-    use crate::tenant_key_errors::ExistError;
-    use crate::tenant_key_errors::UnknownError;
+    use crate::tenant_key::errors::ExistError;
+    use crate::tenant_key::errors::UnknownError;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
 

--- a/src/meta/app/src/principal/user_defined_file_format_ident.rs
+++ b/src/meta/app/src/principal/user_defined_file_format_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// Defines the meta-service key for user defined file format.
 pub type UserDefinedFileFormatIdent = TIdent<Resource>;
@@ -25,9 +25,9 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::principal::UserDefinedFileFormat;
-    use crate::tenant_key::TenantResource;
-    use crate::tenant_key_errors::ExistError;
-    use crate::tenant_key_errors::UnknownError;
+    use crate::tenant_key::errors::ExistError;
+    use crate::tenant_key::errors::UnknownError;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/principal/user_setting_ident.rs
+++ b/src/meta/app/src/principal/user_setting_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// Define the meta-service key for a user setting.
 pub type SettingIdent = TIdent<Resource>;
@@ -24,7 +24,7 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::principal::UserSetting;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/principal/user_stage_ident.rs
+++ b/src/meta/app/src/principal/user_stage_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// Define the meta-service key for a stage.
 pub type StageIdent = TIdent<Resource>;
@@ -24,7 +24,7 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::principal::StageInfo;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/schema/catalog_name_ident.rs
+++ b/src/meta/app/src/schema/catalog_name_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 /// The identifier of a catalog,
 /// which is used as a key and does not support other codec method such as serde.
@@ -26,7 +26,7 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi::Key;
 
     use crate::schema::CatalogId;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -243,14 +243,14 @@ impl ListIndexesReq {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListIndexesByIdReq {
-    pub tenant: String,
+    pub tenant: Tenant,
     pub table_id: MetaId,
 }
 
 impl ListIndexesByIdReq {
-    pub fn new(tenant: impl Into<String>, table_id: MetaId) -> Self {
+    pub fn new(tenant: impl ToTenant, table_id: MetaId) -> Self {
         Self {
-            tenant: tenant.into(),
+            tenant: tenant.to_tenant(),
             table_id,
         }
     }

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -726,7 +726,7 @@ pub enum SetTableColumnMaskPolicyAction {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SetTableColumnMaskPolicyReq {
-    pub tenant: String,
+    pub tenant: Tenant,
     pub table_id: u64,
     pub seq: MatchSeq,
     pub column: String,

--- a/src/meta/app/src/share/share.rs
+++ b/src/meta/app/src/share/share.rs
@@ -70,9 +70,9 @@ impl Display for ShareConsumer {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ShowSharesReq {
-    pub tenant: String,
+    pub tenant: Tenant,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/meta/app/src/share/share_end_point_ident.rs
+++ b/src/meta/app/src/share/share_end_point_ident.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tenant_key::TIdent;
+use crate::tenant_key::ident::TIdent;
 
 pub type ShareEndpointIdent = TIdent<Resource>;
 
@@ -24,7 +24,7 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi::Key;
 
     use crate::share::ShareEndpointId;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {

--- a/src/meta/app/src/tenant_key/errors.rs
+++ b/src/meta/app/src/tenant_key/errors.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 use std::fmt::Formatter;
 
-use crate::tenant_key::TenantResource;
+use crate::tenant_key::resource::TenantResource;
 
 /// Error occurred when a record already exists for a key.
 #[derive(Clone, PartialEq, Eq, thiserror::Error)]

--- a/src/meta/app/src/tenant_key/ident.rs
+++ b/src/meta/app/src/tenant_key/ident.rs
@@ -17,23 +17,8 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::hash::Hasher;
 
-use databend_common_meta_kvapi::kvapi;
-
 use crate::tenant::Tenant;
 use crate::tenant::ToTenant;
-
-/// Defines the in-meta-service data for some resource that belongs to a tenant.
-/// Such as `PasswordPolicy`.
-///
-/// It includes a prefix to store the `ValueType`.
-/// This trait is used to define a concrete [`TIdent`] can be used as a `kvapi::Key`.
-pub trait TenantResource {
-    /// The key prefix to store in meta-service.
-    const PREFIX: &'static str;
-
-    /// The type of the value for the key [`TIdent<R: TenantResource>`](TIdent).
-    type ValueType: kvapi::Value;
-}
 
 /// `[T]enant[Ident]` is a common meta-service key structure in form of `<PREFIX>/<TENANT>/<NAME>`.
 pub struct TIdent<R> {
@@ -109,9 +94,9 @@ mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
     use databend_common_meta_kvapi::kvapi::KeyError;
 
-    use super::TIdent;
     use crate::tenant::Tenant;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::ident::TIdent;
+    use crate::tenant_key::resource::TenantResource;
     use crate::KeyWithTenant;
 
     impl<R> kvapi::Key for TIdent<R>
@@ -153,8 +138,8 @@ mod tests {
     use databend_common_meta_types::NonEmptyString;
 
     use crate::tenant::Tenant;
-    use crate::tenant_key::TIdent;
-    use crate::tenant_key::TenantResource;
+    use crate::tenant_key::ident::TIdent;
+    use crate::tenant_key::resource::TenantResource;
 
     #[test]
     fn test_tenant_ident() {

--- a/src/meta/app/src/tenant_key/mod.rs
+++ b/src/meta/app/src/tenant_key/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tenant key is an abstraction of key in form `<PREFIX>/<TENANT>/<NAME>`.
+
+pub mod errors;
+pub mod ident;
+pub mod resource;

--- a/src/meta/app/src/tenant_key/resource.rs
+++ b/src/meta/app/src/tenant_key/resource.rs
@@ -1,0 +1,32 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_kvapi::kvapi;
+
+// For doc
+#[allow(unused_imports)]
+use crate::tenant_key::ident::TIdent;
+
+/// Defines the in-meta-service data for some resource that belongs to a tenant.
+/// Such as `PasswordPolicy`.
+///
+/// It includes a prefix to store the `ValueType`.
+/// This trait is used to define a concrete [`TIdent`] can be used as a `kvapi::Key`.
+pub trait TenantResource {
+    /// The key prefix to store in meta-service.
+    const PREFIX: &'static str;
+
+    /// The type of the value for the key [`TIdent<R: TenantResource>`](TIdent).
+    type ValueType: kvapi::Value;
+}

--- a/src/meta/proto-conv/src/tident_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/tident_from_to_protobuf_impl.rs
@@ -16,8 +16,8 @@
 //! Everytime update anything in this file, update the `VER` and let the tests pass.
 
 use databend_common_meta_app::tenant::Tenant;
-use databend_common_meta_app::tenant_key as tk;
-use databend_common_meta_app::tenant_key::TenantResource;
+use databend_common_meta_app::tenant_key::ident;
+use databend_common_meta_app::tenant_key::resource::TenantResource;
 use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_types::NonEmptyString;
 use databend_common_protos::pb;
@@ -28,7 +28,7 @@ use crate::Incompatible;
 use crate::MIN_READER_VER;
 use crate::VER;
 
-impl<R> FromToProto for tk::TIdent<R>
+impl<R> FromToProto for ident::TIdent<R>
 where R: TenantResource
 {
     type PB = pb::TIdent;

--- a/src/query/service/src/interpreters/hook/refresh_hook.rs
+++ b/src/query/service/src/interpreters/hook/refresh_hook.rs
@@ -205,10 +205,7 @@ async fn generate_refresh_index_plan(
     let catalog = ctx.get_catalog(catalog).await?;
     let mut plans = vec![];
     let indexes = catalog
-        .list_indexes_by_table_id(ListIndexesByIdReq {
-            tenant: ctx.get_tenant().name().to_string(),
-            table_id,
-        })
+        .list_indexes_by_table_id(ListIndexesByIdReq::new(ctx.get_tenant(), table_id))
         .await?;
 
     let sync_indexes = indexes

--- a/src/query/service/src/interpreters/interpreter_share_show.rs
+++ b/src/query/service/src/interpreters/interpreter_share_show.rs
@@ -75,7 +75,7 @@ impl Interpreter for ShowSharesInterpreter {
         }
 
         let req = ShowSharesReq {
-            tenant: tenant.name().to_string(),
+            tenant: tenant.clone(),
         };
         let resp = meta_api.show_shares(req).await?;
 

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -117,7 +117,7 @@ impl ModifyTableColumnInterpreter {
                 None
             };
         let req = SetTableColumnMaskPolicyReq {
-            tenant: self.ctx.get_tenant().name().to_string(),
+            tenant: self.ctx.get_tenant(),
             seq: MatchSeq::Exact(table_version),
             table_id,
             column,
@@ -162,7 +162,7 @@ impl ModifyTableColumnInterpreter {
 
         if let Some(prev_column_mask_name) = prev_column_mask_name {
             let req = SetTableColumnMaskPolicyReq {
-                tenant: self.ctx.get_tenant().name().to_string(),
+                tenant: self.ctx.get_tenant(),
                 seq: MatchSeq::Exact(table_version),
                 table_id,
                 column,

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -82,10 +82,7 @@ impl FuseTable {
 
         let catalog = ctx.get_catalog(&ctx.get_current_catalog()).await?;
         let table_agg_index_ids = catalog
-            .list_index_ids_by_table_id(ListIndexesByIdReq {
-                tenant: ctx.get_tenant().name().to_string(),
-                table_id: self.get_id(),
-            })
+            .list_index_ids_by_table_id(ListIndexesByIdReq::new(ctx.get_tenant(), self.get_id()))
             .await?;
 
         // 2. Read snapshot fields by chunk size.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: move TIdent into separate files


##### refactor: use `Tenant` for `ShowSharesReq`


##### refactor: use `Tenant` for `SetTableColumnMaskPolicyReq`


##### refactor: use `Tenant` for `ListIndexesByIdReq`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues