### PR TITLE
refactor: add view system tables

### DIFF
--- a/src/query/service/src/databases/system/system_database.rs
+++ b/src/query/service/src/databases/system/system_database.rs
@@ -63,6 +63,8 @@ use databend_common_storages_system::TempFilesTable;
 use databend_common_storages_system::TracingTable;
 use databend_common_storages_system::UserFunctionsTable;
 use databend_common_storages_system::UsersTable;
+use databend_common_storages_system::ViewsTableWithHistory;
+use databend_common_storages_system::ViewsTableWithoutHistory;
 use databend_common_storages_system::VirtualColumnsTable;
 
 use crate::catalogs::InMemoryMetas;
@@ -137,6 +139,8 @@ impl SystemDatabase {
             UserFunctionsTable::create(sys_db_meta.next_table_id()),
             NotificationsTable::create(sys_db_meta.next_table_id()),
             NotificationHistoryTable::create(sys_db_meta.next_table_id()),
+            ViewsTableWithHistory::create(sys_db_meta.next_table_id()),
+            ViewsTableWithoutHistory::create(sys_db_meta.next_table_id()),
         ];
 
         let disable_tables = Self::disable_system_tables();

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -53,12 +53,14 @@ enum ObjectId {
 // some statements like `SELECT 1`, `SHOW USERS`, `SHOW ROLES`, `SHOW TABLES` will be
 // rewritten to the queries on the system tables, we need to skip the privilege check on
 // these tables.
-const SYSTEM_TABLES_ALLOW_LIST: [&str; 15] = [
+const SYSTEM_TABLES_ALLOW_LIST: [&str; 17] = [
     "catalogs",
     "columns",
     "databases",
     "tables",
+    "views",
     "tables_with_history",
+    "views_with_history",
     "password_policies",
     "streams",
     "virtual_columns",

--- a/src/query/service/src/interpreters/interpreter_view_describe.rs
+++ b/src/query/service/src/interpreters/interpreter_view_describe.rs
@@ -18,19 +18,18 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::infer_table_schema;
 use databend_common_expression::types::StringType;
-use databend_common_expression::ComputedExpr;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
-use databend_common_expression::Scalar;
 use databend_common_sql::plans::DescribeViewPlan;
+use databend_common_storages_fuse::TableContext;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 use databend_common_storages_view::view_table::QUERY;
 use databend_common_storages_view::view_table::VIEW_ENGINE;
 
+use crate::interpreters::util::generate_desc_schema;
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
 use crate::sessions::QueryContext;
-use crate::sessions::TableContext;
 use crate::sql::Planner;
 
 pub struct DescribeViewInterpreter {
@@ -87,39 +86,7 @@ impl Interpreter for DescribeViewInterpreter {
             )));
         }?;
 
-        let mut names: Vec<String> = vec![];
-        let mut types: Vec<String> = vec![];
-        let mut nulls: Vec<String> = vec![];
-        let mut default_exprs: Vec<String> = vec![];
-        let mut extras: Vec<String> = vec![];
-
-        for field in schema.fields().iter() {
-            names.push(field.name().to_string());
-
-            let non_null_type = field.data_type().remove_recursive_nullable();
-            types.push(non_null_type.sql_name());
-            nulls.push(if field.is_nullable() {
-                "YES".to_string()
-            } else {
-                "NO".to_string()
-            });
-            match field.default_expr() {
-                Some(expr) => {
-                    default_exprs.push(expr.clone());
-                }
-
-                None => {
-                    let value = Scalar::default_value(&field.data_type().into());
-                    default_exprs.push(value.to_string());
-                }
-            }
-            let extra = match field.computed_expr() {
-                Some(ComputedExpr::Virtual(expr)) => format!("VIRTUAL COMPUTED COLUMN `{}`", expr),
-                Some(ComputedExpr::Stored(expr)) => format!("STORED COMPUTED COLUMN `{}`", expr),
-                _ => "".to_string(),
-            };
-            extras.push(extra);
-        }
+        let (names, types, nulls, default_exprs, extras) = generate_desc_schema(schema);
 
         PipelineBuildResult::from_blocks(vec![DataBlock::new_from_columns(vec![
             StringType::from_data(names),

--- a/src/query/service/src/interpreters/util.rs
+++ b/src/query/service/src/interpreters/util.rs
@@ -14,6 +14,9 @@
 
 use databend_common_ast::parser::quote::quote_ident;
 use databend_common_ast::parser::Dialect;
+use databend_common_expression::ComputedExpr;
+use databend_common_expression::Scalar;
+use databend_common_expression::TableSchemaRef;
 
 pub fn format_name(name: &str, quoted_ident_case_sensitive: bool, dialect: Dialect) -> String {
     // Db-s -> "Db-s" ; dbs -> dbs
@@ -22,4 +25,50 @@ pub fn format_name(name: &str, quoted_ident_case_sensitive: bool, dialect: Diale
     } else {
         quote_ident(name, dialect.default_ident_quote(), false)
     }
+}
+
+#[allow(clippy::type_complexity)]
+pub fn generate_desc_schema(
+    schema: TableSchemaRef,
+) -> (
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+) {
+    let mut names: Vec<String> = vec![];
+    let mut types: Vec<String> = vec![];
+    let mut nulls: Vec<String> = vec![];
+    let mut default_exprs: Vec<String> = vec![];
+    let mut extras: Vec<String> = vec![];
+
+    for field in schema.fields().iter() {
+        names.push(field.name().to_string());
+
+        let non_null_type = field.data_type().remove_recursive_nullable();
+        types.push(non_null_type.sql_name());
+        nulls.push(if field.is_nullable() {
+            "YES".to_string()
+        } else {
+            "NO".to_string()
+        });
+        match field.default_expr() {
+            Some(expr) => {
+                default_exprs.push(expr.clone());
+            }
+
+            None => {
+                let value = Scalar::default_value(&field.data_type().into());
+                default_exprs.push(value.to_string());
+            }
+        }
+        let extra = match field.computed_expr() {
+            Some(ComputedExpr::Virtual(expr)) => format!("VIRTUAL COMPUTED COLUMN `{}`", expr),
+            Some(ComputedExpr::Stored(expr)) => format!("STORED COMPUTED COLUMN `{}`", expr),
+            _ => "".to_string(),
+        };
+        extras.push(extra);
+    }
+    (names, types, nulls, default_exprs, extras)
 }

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -280,7 +280,7 @@ async fn test_simple_sql() -> Result<()> {
     assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
     assert_eq!(result.next_uri, Some(final_uri.clone()), "{:?}", result);
     assert_eq!(result.data.len(), 10, "{:?}", result);
-    assert_eq!(result.schema.len(), 20, "{:?}", result);
+    assert_eq!(result.schema.len(), 19, "{:?}", result);
 
     // get state
     let uri = make_state_uri(query_id);

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -26,6 +26,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'catalog'                         | 'system'             | 'streams'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'catalog'                         | 'system'             | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'catalog'                         | 'system'             | 'tables_with_history'  | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'catalog'                         | 'system'             | 'views'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'catalog'                         | 'system'             | 'views_with_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'catalog_name'                    | 'information_schema' | 'schemata'             | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'character_maximum_length'        | 'information_schema' | 'columns'              | 'NULL'                | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'character_octet_length'          | 'information_schema' | 'columns'              | 'NULL'                | 'NULL'              | ''       | ''       | 'NO'     | ''       |
@@ -62,6 +64,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'comment'                         | 'system'             | 'tables_with_history'  | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'comment'                         | 'system'             | 'task_history'         | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'comment'                         | 'system'             | 'tasks'                | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
+| 'comment'                         | 'system'             | 'views'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'comment'                         | 'system'             | 'views_with_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'compaction_stats'                | 'system'             | 'background_tasks'     | 'Nullable(Variant)'   | 'VARIANT'           | ''       | ''       | 'YES'    | ''       |
 | 'completed_time'                  | 'system'             | 'task_history'         | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
 | 'condition_text'                  | 'system'             | 'task_history'         | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
@@ -85,6 +89,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'created_on'                      | 'system'             | 'tables_with_history'  | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'created_on'                      | 'system'             | 'tasks'                | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'created_on'                      | 'system'             | 'user_functions'       | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
+| 'created_on'                      | 'system'             | 'views'                | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
+| 'created_on'                      | 'system'             | 'views_with_history'   | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'created_on'                      | 'system'             | 'virtual_columns'      | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'creator'                         | 'system'             | 'background_jobs'      | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'creator'                         | 'system'             | 'background_tasks'     | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
@@ -106,6 +112,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'database'                        | 'system'             | 'streams'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'database'                        | 'system'             | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'database'                        | 'system'             | 'tables_with_history'  | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'database'                        | 'system'             | 'views'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'database'                        | 'system'             | 'views_with_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'database'                        | 'system'             | 'virtual_columns'      | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'database_id'                     | 'system'             | 'background_tasks'     | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'database_id'                     | 'system'             | 'databases'            | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
@@ -134,14 +142,20 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'drop_time'                       | 'information_schema' | 'tables'               | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
 | 'dropped_on'                      | 'system'             | 'tables'               | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
 | 'dropped_on'                      | 'system'             | 'tables_with_history'  | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
+| 'dropped_on'                      | 'system'             | 'views'                | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
+| 'dropped_on'                      | 'system'             | 'views_with_history'   | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
 | 'dummy'                           | 'system'             | 'one'                  | 'UInt8'               | 'TINYINT UNSIGNED'  | ''       | ''       | 'NO'     | ''       |
 | 'enabled'                         | 'system'             | 'notifications'        | 'Boolean'             | 'BOOLEAN'           | ''       | ''       | 'NO'     | ''       |
 | 'end_time'                        | 'system'             | 'clustering_history'   | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'engine'                          | 'information_schema' | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'engine'                          | 'system'             | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'engine'                          | 'system'             | 'tables_with_history'  | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'engine'                          | 'system'             | 'views'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'engine'                          | 'system'             | 'views_with_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'engine_full'                     | 'system'             | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'engine_full'                     | 'system'             | 'tables_with_history'  | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'engine_full'                     | 'system'             | 'views'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'engine_full'                     | 'system'             | 'views_with_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'entry'                           | 'system'             | 'tracing'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'error_integration'               | 'system'             | 'tasks'                | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'error_message'                   | 'system'             | 'notification_history' | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
@@ -251,6 +265,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'name'                            | 'system'             | 'tasks'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'name'                            | 'system'             | 'user_functions'       | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'name'                            | 'system'             | 'users'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'name'                            | 'system'             | 'views'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'name'                            | 'system'             | 'views_with_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'next_schedule_time'              | 'system'             | 'tasks'                | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
 | 'next_task_scheduled_time'        | 'system'             | 'background_jobs'      | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
 | 'node'                            | 'system'             | 'backtrace'            | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
@@ -287,6 +303,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'owner'                           | 'system'             | 'tables_with_history'  | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'owner'                           | 'system'             | 'task_history'         | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'owner'                           | 'system'             | 'tasks'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'owner'                           | 'system'             | 'views'                | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
+| 'owner'                           | 'system'             | 'views_with_history'   | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'packed'                          | 'information_schema' | 'statistics'           | 'NULL'                | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'parent_plan_id'                  | 'system'             | 'processor_profile'    | 'Nullable(UInt32)'    | 'INT UNSIGNED'      | ''       | ''       | 'YES'    | ''       |
 | 'partitions_sha'                  | 'system'             | 'query_cache'          | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
@@ -381,6 +399,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'table_id'                        | 'system'             | 'streams'              | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'table_id'                        | 'system'             | 'tables'               | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'table_id'                        | 'system'             | 'tables_with_history'  | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
+| 'table_id'                        | 'system'             | 'views'                | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
+| 'table_id'                        | 'system'             | 'views_with_history'   | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'table_name'                      | 'information_schema' | 'columns'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'table_name'                      | 'information_schema' | 'key_column_usage'     | 'NULL'                | 'NULL'              | ''       | ''       | 'NO'     | ''       |
 | 'table_name'                      | 'information_schema' | 'statistics'           | 'NULL'                | 'NULL'              | ''       | ''       | 'NO'     | ''       |
@@ -417,6 +437,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'updated_on'                      | 'system'             | 'streams'              | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'updated_on'                      | 'system'             | 'tables'               | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'updated_on'                      | 'system'             | 'tables_with_history'  | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
+| 'updated_on'                      | 'system'             | 'views'                | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
+| 'updated_on'                      | 'system'             | 'views_with_history'   | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'updated_on'                      | 'system'             | 'virtual_columns'      | 'Nullable(Timestamp)' | 'TIMESTAMP'         | ''       | ''       | 'YES'    | ''       |
 | 'user'                            | 'system'             | 'locks'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'user'                            | 'system'             | 'processes'            | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
@@ -430,8 +452,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'version'                         | 'system'             | 'clusters'             | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'version'                         | 'system'             | 'credits'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'view_definition'                 | 'information_schema' | 'views'                | 'NULL'                | 'NULL'              | ''       | ''       | 'NO'     | ''       |
-| 'view_query'                      | 'system'             | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
-| 'view_query'                      | 'system'             | 'tables_with_history'  | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'view_query'                      | 'system'             | 'views'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'view_query'                      | 'system'             | 'views_with_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'virtual_columns'                 | 'system'             | 'virtual_columns'      | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'wait_time'                       | 'system'             | 'queries_queue'        | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'warehouse'                       | 'system'             | 'task_history'         | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |

--- a/src/query/storages/information_schema/src/views_table.rs
+++ b/src/query/storages/information_schema/src/views_table.rs
@@ -37,7 +37,7 @@ impl ViewsTable {
             0 AS is_trigger_updatable,
             0 AS is_trigger_deletable,
             0 AS is_trigger_insertable_into
-        FROM system.tables
+        FROM system.views
         WHERE engine LIKE '%View';";
 
         let mut options = BTreeMap::new();

--- a/src/query/storages/information_schema/src/views_table.rs
+++ b/src/query/storages/information_schema/src/views_table.rs
@@ -27,7 +27,7 @@ pub struct ViewsTable {}
 impl ViewsTable {
     pub fn create(table_id: u64) -> Arc<dyn Table> {
         let query = "SELECT
-            database AS table_catalog,
+            catalog AS table_catalog,
             database AS table_schema,
             name AS table_name,
             NULL AS view_definition,
@@ -37,8 +37,7 @@ impl ViewsTable {
             0 AS is_trigger_updatable,
             0 AS is_trigger_deletable,
             0 AS is_trigger_insertable_into
-        FROM system.views
-        WHERE engine LIKE '%View';";
+        FROM system.views";
 
         let mut options = BTreeMap::new();
         options.insert(QUERY.to_string(), query.to_string());

--- a/src/query/storages/system/src/lib.rs
+++ b/src/query/storages/system/src/lib.rs
@@ -114,6 +114,8 @@ pub use table_functions_table::TableFunctionsTable;
 pub use tables_table::TablesTable;
 pub use tables_table::TablesTableWithHistory;
 pub use tables_table::TablesTableWithoutHistory;
+pub use tables_table::ViewsTableWithHistory;
+pub use tables_table::ViewsTableWithoutHistory;
 pub use task_history_table::parse_task_runs_to_datablock;
 pub use task_history_table::TaskHistoryTable;
 pub use tasks_table::parse_tasks_to_datablock;

--- a/tests/sqllogictests/suites/base/01_system/01_0003_information_schema.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0003_information_schema.test
@@ -1,24 +1,12 @@
 query T
-show tables from information_schema
+show views from information_schema like 'tables'
 ----
-columns
-key_column_usage
-keywords
-schemata
-statistics
-tables
-views
+tables SELECT database AS table_catalog, database AS table_schema, name AS table_name, 'BASE TABLE' AS table_type, engine AS engine, created_on AS create_time, dropped_on AS drop_time, data_size AS data_length, index_size AS index_length, num_rows AS table_rows, NULL AS auto_increment, NULL AS table_collation, NULL AS data_free, comment AS table_comment FROM system.tables;
 
 query T
-SHOW TABLES FROM INFORMATION_SCHEMA
+show views from INFORMATION_SCHEMA like 'tables'
 ----
-columns
-key_column_usage
-keywords
-schemata
-statistics
-tables
-views
+tables SELECT database AS table_catalog, database AS table_schema, name AS table_name, 'BASE TABLE' AS table_type, engine AS engine, created_on AS create_time, dropped_on AS drop_time, data_size AS data_length, index_size AS index_length, num_rows AS table_rows, NULL AS auto_increment, NULL AS table_collation, NULL AS data_free, comment AS table_comment FROM system.tables;
 
 query TTTTT
 DESC INFORMATION_SCHEMA.KEY_COLUMN_USAGE
@@ -68,15 +56,15 @@ select count(1) > 1 from information_Schema.Columns
 1
 
 query T
-SELECT t.table_catalog FROM information_schema.TABLES t WHERE t.TABLE_SCHEMA = 'information_schema'
+SELECT t.table_catalog FROM information_schema.VIEWS t WHERE t.TABLE_SCHEMA = 'information_schema'
 ----
-information_schema
-information_schema
-information_schema
-information_schema
-information_schema
-information_schema
-information_schema
+default
+default
+default
+default
+default
+default
+default
 
 statement ok
 drop table if exists t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add system tables: system.view and system.view_with_history

The view engine no need to display stat info.

And fuse engine does not have view_query.

### Note

After this pr merged, if user wants to show the views in one database, 

Only can according sql `show views [ from|in database ]`.

`show tables` only support show tables.


- Fixes #[Link the issue here]

## Tests

- [x] Unit Test


## Type of change

- [x] Refactoring

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15184)
<!-- Reviewable:end -->
