### PR TITLE
fix(query): show grants panic when role/user has immute db/table privilege

### DIFF
--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -195,8 +195,8 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     // List the tables name by meta ids.
     async fn mget_table_names_by_ids(
         &self,
-        table_ids: &[MetaId],
         tenant: &str,
+        table_ids: &[MetaId],
     ) -> databend_common_exception::Result<Vec<Option<String>>>;
 
     // Mget the db name by meta id.
@@ -205,8 +205,8 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     // Mget the dbs name by meta ids.
     async fn mget_database_names_by_ids(
         &self,
-        db_ids: &[MetaId],
         tenant: &Tenant,
+        db_ids: &[MetaId],
     ) -> databend_common_exception::Result<Vec<Option<String>>>;
 
     // Get one table by db and table name.

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -196,6 +196,7 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     async fn mget_table_names_by_ids(
         &self,
         table_ids: &[MetaId],
+        tenant: &str,
     ) -> databend_common_exception::Result<Vec<Option<String>>>;
 
     // Mget the db name by meta id.
@@ -205,6 +206,7 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     async fn mget_database_names_by_ids(
         &self,
         db_ids: &[MetaId],
+        tenant: &Tenant,
     ) -> databend_common_exception::Result<Vec<Option<String>>>;
 
     // Get one table by db and table name.

--- a/src/query/catalog/src/catalog/session_catalog.rs
+++ b/src/query/catalog/src/catalog/session_catalog.rs
@@ -251,8 +251,9 @@ impl Catalog for SessionCatalog {
     async fn mget_table_names_by_ids(
         &self,
         table_ids: &[MetaId],
+        tenant: &str,
     ) -> databend_common_exception::Result<Vec<Option<String>>> {
-        self.inner.mget_table_names_by_ids(table_ids).await
+        self.inner.mget_table_names_by_ids(table_ids, tenant).await
     }
 
     // Mget the db name by meta id.
@@ -264,8 +265,9 @@ impl Catalog for SessionCatalog {
     async fn mget_database_names_by_ids(
         &self,
         db_ids: &[MetaId],
+        tenant: &Tenant,
     ) -> databend_common_exception::Result<Vec<Option<String>>> {
-        self.inner.mget_database_names_by_ids(db_ids).await
+        self.inner.mget_database_names_by_ids(db_ids, tenant).await
     }
 
     // Get one table by db and table name.

--- a/src/query/catalog/src/catalog/session_catalog.rs
+++ b/src/query/catalog/src/catalog/session_catalog.rs
@@ -250,10 +250,10 @@ impl Catalog for SessionCatalog {
     // Mget the dbs name by meta ids.
     async fn mget_table_names_by_ids(
         &self,
-        table_ids: &[MetaId],
         tenant: &str,
+        table_ids: &[MetaId],
     ) -> databend_common_exception::Result<Vec<Option<String>>> {
-        self.inner.mget_table_names_by_ids(table_ids, tenant).await
+        self.inner.mget_table_names_by_ids(tenant, table_ids).await
     }
 
     // Mget the db name by meta id.
@@ -264,10 +264,10 @@ impl Catalog for SessionCatalog {
     // Mget the dbs name by meta ids.
     async fn mget_database_names_by_ids(
         &self,
-        db_ids: &[MetaId],
         tenant: &Tenant,
+        db_ids: &[MetaId],
     ) -> databend_common_exception::Result<Vec<Option<String>>> {
-        self.inner.mget_database_names_by_ids(db_ids, tenant).await
+        self.inner.mget_database_names_by_ids(tenant, db_ids).await
     }
 
     // Get one table by db and table name.

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -281,8 +281,8 @@ impl Catalog for DatabaseCatalog {
     #[async_backtrace::framed]
     async fn mget_table_names_by_ids(
         &self,
-        table_ids: &[MetaId],
         tenant: &str,
+        table_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
         // Fetching system database names
         let sys_dbs = self
@@ -312,13 +312,13 @@ impl Catalog for DatabaseCatalog {
         // Fetching table names for mutable table IDs
         let mut tables = self
             .immutable_catalog
-            .mget_table_names_by_ids(table_ids, tenant)
+            .mget_table_names_by_ids(tenant, table_ids)
             .await?;
 
         // Fetching table names for remaining system table IDs
         let other = self
             .mutable_catalog
-            .mget_table_names_by_ids(&mut_table_ids, tenant)
+            .mget_table_names_by_ids(tenant, &mut_table_ids)
             .await?;
 
         // Appending the results from the mutable catalog to tables
@@ -341,8 +341,8 @@ impl Catalog for DatabaseCatalog {
     #[async_backtrace::framed]
     async fn mget_database_names_by_ids(
         &self,
-        db_ids: &[MetaId],
         tenant: &Tenant,
+        db_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
         let sys_db_ids: Vec<_> = self
             .immutable_catalog
@@ -360,12 +360,12 @@ impl Catalog for DatabaseCatalog {
 
         let mut dbs = self
             .immutable_catalog
-            .mget_database_names_by_ids(db_ids, tenant)
+            .mget_database_names_by_ids(tenant, db_ids)
             .await?;
 
         let other = self
             .mutable_catalog
-            .mget_database_names_by_ids(&mut_db_ids, tenant)
+            .mget_database_names_by_ids(tenant, &mut_db_ids)
             .await?;
 
         dbs.extend(other);

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -279,16 +279,51 @@ impl Catalog for DatabaseCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn mget_table_names_by_ids(&self, table_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
+    async fn mget_table_names_by_ids(
+        &self,
+        table_ids: &[MetaId],
+        tenant: &str,
+    ) -> Result<Vec<Option<String>>> {
+        // Fetching system database names
+        let sys_dbs = self
+            .immutable_catalog
+            .list_databases(&Tenant::new_literal(tenant))
+            .await?;
+
+        // Collecting system table names from all system databases
+        let mut sys_table_ids = Vec::new();
+        for sys_db in sys_dbs {
+            let sys_tables = self
+                .immutable_catalog
+                .list_tables(tenant, sys_db.name())
+                .await?;
+            for sys_table in sys_tables {
+                sys_table_ids.push(sys_table.get_id());
+            }
+        }
+
+        // Filtering table IDs that are not in the system table IDs
+        let mut_table_ids: Vec<MetaId> = table_ids
+            .iter()
+            .copied()
+            .filter(|table_id| !sys_table_ids.contains(table_id))
+            .collect();
+
+        // Fetching table names for mutable table IDs
         let mut tables = self
             .immutable_catalog
-            .mget_table_names_by_ids(table_ids)
+            .mget_table_names_by_ids(table_ids, tenant)
             .await?;
-        let mut other = self
+
+        // Fetching table names for remaining system table IDs
+        let other = self
             .mutable_catalog
-            .mget_table_names_by_ids(table_ids)
+            .mget_table_names_by_ids(&mut_table_ids, tenant)
             .await?;
-        tables.append(&mut other);
+
+        // Appending the results from the mutable catalog to tables
+        tables.extend(other);
+
         Ok(tables)
     }
 
@@ -304,16 +339,37 @@ impl Catalog for DatabaseCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn mget_database_names_by_ids(&self, db_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
+    async fn mget_database_names_by_ids(
+        &self,
+        db_ids: &[MetaId],
+        tenant: &Tenant,
+    ) -> Result<Vec<Option<String>>> {
+        let sys_db_ids: Vec<_> = self
+            .immutable_catalog
+            .list_databases(tenant)
+            .await?
+            .iter()
+            .map(|sys_db| sys_db.get_db_info().ident.db_id)
+            .collect();
+
+        let mut_db_ids: Vec<MetaId> = db_ids
+            .iter()
+            .filter(|db_id| !sys_db_ids.contains(db_id))
+            .copied()
+            .collect();
+
         let mut dbs = self
             .immutable_catalog
-            .mget_database_names_by_ids(db_ids)
+            .mget_database_names_by_ids(db_ids, tenant)
             .await?;
-        let mut other = self
+
+        let other = self
             .mutable_catalog
-            .mget_database_names_by_ids(db_ids)
+            .mget_database_names_by_ids(&mut_db_ids, tenant)
             .await?;
-        dbs.append(&mut other);
+
+        dbs.extend(other);
+
         Ok(dbs)
     }
 

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -204,6 +204,7 @@ impl Catalog for ImmutableCatalog {
     async fn mget_table_names_by_ids(
         &self,
         table_ids: &[MetaId],
+        _tenant: &str,
     ) -> databend_common_exception::Result<Vec<Option<String>>> {
         let mut table_name = Vec::with_capacity(table_ids.len());
         for id in table_ids {
@@ -227,7 +228,11 @@ impl Catalog for ImmutableCatalog {
         }
     }
 
-    async fn mget_database_names_by_ids(&self, db_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
+    async fn mget_database_names_by_ids(
+        &self,
+        db_ids: &[MetaId],
+        _tenant: &Tenant,
+    ) -> Result<Vec<Option<String>>> {
         let mut res = Vec::new();
         for id in db_ids {
             if self.sys_db.get_db_info().ident.db_id == *id {

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -203,8 +203,8 @@ impl Catalog for ImmutableCatalog {
 
     async fn mget_table_names_by_ids(
         &self,
-        table_ids: &[MetaId],
         _tenant: &str,
+        table_ids: &[MetaId],
     ) -> databend_common_exception::Result<Vec<Option<String>>> {
         let mut table_name = Vec::with_capacity(table_ids.len());
         for id in table_ids {
@@ -230,8 +230,8 @@ impl Catalog for ImmutableCatalog {
 
     async fn mget_database_names_by_ids(
         &self,
-        db_ids: &[MetaId],
         _tenant: &Tenant,
+        db_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
         let mut res = Vec::new();
         for id in db_ids {

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -376,8 +376,8 @@ impl Catalog for MutableCatalog {
 
     async fn mget_table_names_by_ids(
         &self,
-        table_ids: &[MetaId],
         _tenant: &str,
+        table_ids: &[MetaId],
     ) -> databend_common_exception::Result<Vec<Option<String>>> {
         let res = self.ctx.meta.mget_table_names_by_ids(table_ids).await?;
         Ok(res)
@@ -391,8 +391,8 @@ impl Catalog for MutableCatalog {
 
     async fn mget_database_names_by_ids(
         &self,
-        db_ids: &[MetaId],
         _tenant: &Tenant,
+        db_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
         let res = self.ctx.meta.mget_database_names_by_ids(db_ids).await?;
         Ok(res)

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -377,6 +377,7 @@ impl Catalog for MutableCatalog {
     async fn mget_table_names_by_ids(
         &self,
         table_ids: &[MetaId],
+        _tenant: &str,
     ) -> databend_common_exception::Result<Vec<Option<String>>> {
         let res = self.ctx.meta.mget_table_names_by_ids(table_ids).await?;
         Ok(res)
@@ -388,7 +389,11 @@ impl Catalog for MutableCatalog {
         Ok(res)
     }
 
-    async fn mget_database_names_by_ids(&self, db_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
+    async fn mget_database_names_by_ids(
+        &self,
+        db_ids: &[MetaId],
+        _tenant: &Tenant,
+    ) -> Result<Vec<Option<String>>> {
         let res = self.ctx.meta.mget_database_names_by_ids(db_ids).await?;
         Ok(res)
     }

--- a/src/query/service/src/interpreters/interpreter_show_grants.rs
+++ b/src/query/service/src/interpreters/interpreter_show_grants.rs
@@ -191,7 +191,7 @@ impl Interpreter for ShowGrantsInterpreter {
                 .iter()
                 .map(|res| res.1.clone())
                 .collect::<Vec<String>>();
-            let dbs_name = catalog.mget_database_names_by_ids(&db_ids, &tenant).await?;
+            let dbs_name = catalog.mget_database_names_by_ids(&tenant, &db_ids).await?;
 
             for (i, db_name) in dbs_name.iter().enumerate() {
                 if let Some(db_name) = db_name {
@@ -214,9 +214,9 @@ impl Interpreter for ShowGrantsInterpreter {
                 .iter()
                 .map(|res| res.2.clone())
                 .collect::<Vec<String>>();
-            let dbs_name = catalog.mget_database_names_by_ids(&db_ids, &tenant).await?;
+            let dbs_name = catalog.mget_database_names_by_ids(&tenant, &db_ids).await?;
             let tables_name = catalog
-                .mget_table_names_by_ids(&table_ids, tenant.name())
+                .mget_table_names_by_ids(tenant.name(), &table_ids)
                 .await?;
 
             for (i, table_name) in tables_name.iter().enumerate() {

--- a/src/query/service/src/interpreters/interpreter_show_grants.rs
+++ b/src/query/service/src/interpreters/interpreter_show_grants.rs
@@ -191,7 +191,7 @@ impl Interpreter for ShowGrantsInterpreter {
                 .iter()
                 .map(|res| res.1.clone())
                 .collect::<Vec<String>>();
-            let dbs_name = catalog.mget_database_names_by_ids(&db_ids).await?;
+            let dbs_name = catalog.mget_database_names_by_ids(&db_ids, &tenant).await?;
 
             for (i, db_name) in dbs_name.iter().enumerate() {
                 if let Some(db_name) = db_name {
@@ -214,8 +214,10 @@ impl Interpreter for ShowGrantsInterpreter {
                 .iter()
                 .map(|res| res.2.clone())
                 .collect::<Vec<String>>();
-            let dbs_name = catalog.mget_database_names_by_ids(&db_ids).await?;
-            let tables_name = catalog.mget_table_names_by_ids(&table_ids).await?;
+            let dbs_name = catalog.mget_database_names_by_ids(&db_ids, &tenant).await?;
+            let tables_name = catalog
+                .mget_table_names_by_ids(&table_ids, tenant.name())
+                .await?;
 
             for (i, table_name) in tables_name.iter().enumerate() {
                 if let Some(table_name) = table_name {

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -189,10 +189,10 @@ impl Catalog for FakedCatalog {
 
     async fn mget_table_names_by_ids(
         &self,
-        table_ids: &[MetaId],
         tenant: &str,
+        table_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
-        self.cat.mget_table_names_by_ids(table_ids, tenant).await
+        self.cat.mget_table_names_by_ids(tenant, table_ids).await
     }
 
     async fn get_db_name_by_id(&self, db_id: MetaId) -> Result<String> {
@@ -201,10 +201,10 @@ impl Catalog for FakedCatalog {
 
     async fn mget_database_names_by_ids(
         &self,
-        db_ids: &[MetaId],
         tenant: &Tenant,
+        db_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
-        self.cat.mget_database_names_by_ids(db_ids, tenant).await
+        self.cat.mget_database_names_by_ids(tenant, db_ids).await
     }
 
     async fn get_table(

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -187,16 +187,24 @@ impl Catalog for FakedCatalog {
         self.cat.get_table_name_by_id(table_id).await
     }
 
-    async fn mget_table_names_by_ids(&self, table_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
-        self.cat.mget_table_names_by_ids(table_ids).await
+    async fn mget_table_names_by_ids(
+        &self,
+        table_ids: &[MetaId],
+        tenant: &str,
+    ) -> Result<Vec<Option<String>>> {
+        self.cat.mget_table_names_by_ids(table_ids, tenant).await
     }
 
     async fn get_db_name_by_id(&self, db_id: MetaId) -> Result<String> {
         self.cat.get_db_name_by_id(db_id).await
     }
 
-    async fn mget_database_names_by_ids(&self, db_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
-        self.cat.mget_database_names_by_ids(db_ids).await
+    async fn mget_database_names_by_ids(
+        &self,
+        db_ids: &[MetaId],
+        tenant: &Tenant,
+    ) -> Result<Vec<Option<String>>> {
+        self.cat.mget_database_names_by_ids(db_ids, tenant).await
     }
 
     async fn get_table(

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -823,10 +823,10 @@ impl Catalog for FakedCatalog {
     #[async_backtrace::framed]
     async fn mget_table_names_by_ids(
         &self,
-        table_id: &[MetaId],
         tenant: &str,
+        table_id: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
-        self.cat.mget_table_names_by_ids(table_id, tenant).await
+        self.cat.mget_table_names_by_ids(tenant, table_id).await
     }
 
     async fn get_db_name_by_id(&self, db_id: MetaId) -> Result<String> {
@@ -836,10 +836,10 @@ impl Catalog for FakedCatalog {
     #[async_backtrace::framed]
     async fn mget_database_names_by_ids(
         &self,
-        db_ids: &[MetaId],
         tenant: &Tenant,
+        db_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
-        self.cat.mget_database_names_by_ids(db_ids, tenant).await
+        self.cat.mget_database_names_by_ids(tenant, db_ids).await
     }
 
     async fn get_table(

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -821,8 +821,12 @@ impl Catalog for FakedCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn mget_table_names_by_ids(&self, table_id: &[MetaId]) -> Result<Vec<Option<String>>> {
-        self.cat.mget_table_names_by_ids(table_id).await
+    async fn mget_table_names_by_ids(
+        &self,
+        table_id: &[MetaId],
+        tenant: &str,
+    ) -> Result<Vec<Option<String>>> {
+        self.cat.mget_table_names_by_ids(table_id, tenant).await
     }
 
     async fn get_db_name_by_id(&self, db_id: MetaId) -> Result<String> {
@@ -830,8 +834,12 @@ impl Catalog for FakedCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn mget_database_names_by_ids(&self, db_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
-        self.cat.mget_database_names_by_ids(db_ids).await
+    async fn mget_database_names_by_ids(
+        &self,
+        db_ids: &[MetaId],
+        tenant: &Tenant,
+    ) -> Result<Vec<Option<String>>> {
+        self.cat.mget_database_names_by_ids(db_ids, tenant).await
     }
 
     async fn get_table(

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -359,7 +359,11 @@ impl Catalog for HiveCatalog {
         ))
     }
 
-    async fn mget_table_names_by_ids(&self, _table_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
+    async fn mget_table_names_by_ids(
+        &self,
+        _table_ids: &[MetaId],
+        _tenant: &str,
+    ) -> Result<Vec<Option<String>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get tables name by ids in HIVE catalog",
         ))
@@ -371,7 +375,11 @@ impl Catalog for HiveCatalog {
         ))
     }
 
-    async fn mget_database_names_by_ids(&self, _db_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
+    async fn mget_database_names_by_ids(
+        &self,
+        _db_ids: &[MetaId],
+        _tenant: &Tenant,
+    ) -> Result<Vec<Option<String>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get dbs name by ids in HIVE catalog",
         ))

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -361,8 +361,8 @@ impl Catalog for HiveCatalog {
 
     async fn mget_table_names_by_ids(
         &self,
-        _table_ids: &[MetaId],
         _tenant: &str,
+        _table_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get tables name by ids in HIVE catalog",
@@ -377,8 +377,8 @@ impl Catalog for HiveCatalog {
 
     async fn mget_database_names_by_ids(
         &self,
-        _db_ids: &[MetaId],
         _tenant: &Tenant,
+        _db_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get dbs name by ids in HIVE catalog",

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -267,8 +267,8 @@ impl Catalog for IcebergCatalog {
 
     async fn mget_table_names_by_ids(
         &self,
-        _table_ids: &[MetaId],
         _tenant: &str,
+        _table_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get tables name by ids in HIVE catalog",
@@ -284,8 +284,8 @@ impl Catalog for IcebergCatalog {
 
     async fn mget_database_names_by_ids(
         &self,
-        _db_ids: &[MetaId],
         _tenant: &Tenant,
+        _db_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get dbs name by ids in ICEBERG catalog",

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -265,7 +265,11 @@ impl Catalog for IcebergCatalog {
         ))
     }
 
-    async fn mget_table_names_by_ids(&self, _table_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
+    async fn mget_table_names_by_ids(
+        &self,
+        _table_ids: &[MetaId],
+        _tenant: &str,
+    ) -> Result<Vec<Option<String>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get tables name by ids in HIVE catalog",
         ))
@@ -278,7 +282,11 @@ impl Catalog for IcebergCatalog {
         ))
     }
 
-    async fn mget_database_names_by_ids(&self, _db_ids: &[MetaId]) -> Result<Vec<Option<String>>> {
+    async fn mget_database_names_by_ids(
+        &self,
+        _db_ids: &[MetaId],
+        _tenant: &Tenant,
+    ) -> Result<Vec<Option<String>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get dbs name by ids in ICEBERG catalog",
         ))

--- a/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.result
+++ b/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.result
@@ -1,25 +1,71 @@
+=== review init role3 grants ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
 OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
+SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
+UPDATE,DELETE default.c_r2.t2  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r2'.'t2' TO ROLE `role3`
+=== drop table c_r2.t2 ===
+=== drop c_r2.t2 once ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
+INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
+SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
+SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
+=== create same name table c_r2.t2 ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
+INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
+SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
+SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
+SELECT default.c_r2.t2  ROLE role3 GRANT SELECT ON 'default'.'c_r2'.'t2' TO ROLE `role3`
+=== drop c_r2.t2 twice ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
+INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
+SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
+SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
+=== test database drop ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
+INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
+SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
 SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 UPDATE,DELETE default.c_r2.t2  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r2'.'t2' TO ROLE `role3`
 === drop database c_r , c_r2 ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 === undrop database c_r2 ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 UPDATE,DELETE default.c_r2.t2  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r2'.'t2' TO ROLE `role3`
 === undrop database c_r, contain table c_r.t's ownership ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
 SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 UPDATE,DELETE default.c_r2.t2  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r2'.'t2' TO ROLE `role3`
 === drop database c_r, c_r2, re-create c_r, c_r2 ===
+UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
+SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 === show grants test ===
 SELECT,INSERT	*.*	NULL	ROLE	role1	GRANT SELECT,INSERT ON *.* TO ROLE `role1`

--- a/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.sh
@@ -10,6 +10,9 @@ echo "drop database if exists c_r1;" | $BENDSQL_CLIENT_CONNECT
 echo "drop database if exists c_r2;" | $BENDSQL_CLIENT_CONNECT
 
 echo "create role role3;" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on system.one to role role3" | $BENDSQL_CLIENT_CONNECT
+echo "grant update on information_schema.* to role role3" | $BENDSQL_CLIENT_CONNECT
+
 echo "create database c_r1" | $BENDSQL_CLIENT_CONNECT
 echo "create table c_r1.t1(id int)" | $BENDSQL_CLIENT_CONNECT
 echo "create database c_r2" | $BENDSQL_CLIENT_CONNECT
@@ -25,6 +28,25 @@ echo "grant update, delete on c_r1.t1 to role role3;" | $BENDSQL_CLIENT_CONNECT
 echo "grant select, insert on c_r2.* to role role3;" | $BENDSQL_CLIENT_CONNECT
 echo "grant update, delete on c_r2.t2 to role role3;" | $BENDSQL_CLIENT_CONNECT
 
+echo "=== review init role3 grants ==="
+echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+
+echo "=== drop table c_r2.t2 ==="
+echo "drop table c_r2.t2;" | $BENDSQL_CLIENT_CONNECT
+echo "=== drop c_r2.t2 once ==="
+echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+
+echo "=== create same name table c_r2.t2 ==="
+echo "create table c_r2.t2(id int);" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on c_r2.t2 to role role3;" | $BENDSQL_CLIENT_CONNECT
+echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "drop table c_r2.t2;" | $BENDSQL_CLIENT_CONNECT
+echo "=== drop c_r2.t2 twice ==="
+echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "create table c_r2.t2(id int);" | $BENDSQL_CLIENT_CONNECT
+echo "grant update, delete on c_r2.t2 to role role3;" | $BENDSQL_CLIENT_CONNECT
+
+echo "=== test database drop ==="
 echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
 echo "drop database c_r;" | $BENDSQL_CLIENT_CONNECT
 echo "drop database c_r2;" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

show grants panic when role/user has immute db/table privilege

The mutetable catalog mget need discard the immuteable db/table id.

If not, will generate vec out of index.

Easy way to reproduce

```sql
create role role3;
grant select on system.one to role role3;
show grants for role role3;
```

So in this pr, we split the db/table id in DatabaseCatalog

- Fixes #15187

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
