### PR TITLE
chore(query): add session_running_acquired_queries metric

### DIFF
--- a/src/common/metrics/src/metrics/session.rs
+++ b/src/common/metrics/src/metrics/session.rs
@@ -39,6 +39,9 @@ pub static SESSION_QUEUE_ACQUIRE_TIMEOUT_COUNT: LazyLock<Counter> =
 pub static SESSION_QUEUE_ACQUIRE_DURATION_MS: LazyLock<Histogram> =
     LazyLock::new(|| register_histogram_in_milliseconds("session_queue_acquire_duration_ms"));
 
+pub static SESSION_RUNNING_ACQUIRED_QUERIES: LazyLock<Gauge> =
+    LazyLock::new(|| register_gauge("session_running_acquired_queries"));
+
 pub fn incr_session_connect_numbers() {
     SESSION_CONNECT_NUMBERS.inc();
 }
@@ -69,4 +72,12 @@ pub fn incr_session_queue_acquire_timeout_count() {
 
 pub fn record_session_queue_acquire_duration_ms(duration: Duration) {
     SESSION_QUEUE_ACQUIRE_DURATION_MS.observe(duration.as_millis() as f64);
+}
+
+pub fn inc_session_running_acquired_queries() {
+    SESSION_RUNNING_ACQUIRED_QUERIES.inc();
+}
+
+pub fn dec_session_running_acquired_queries() {
+    SESSION_RUNNING_ACQUIRED_QUERIES.dec();
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(query): add session_running_acquired_queries metric. record the number of running queries in the acquired queue

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): add session_running_acquired_queries metric
