### PR TITLE
feat(query): implement ST_MAKEPOLYGON

### DIFF
--- a/src/common/io/src/geometry.rs
+++ b/src/common/io/src/geometry.rs
@@ -104,7 +104,7 @@ pub fn parse_to_subtype(buf: &[u8]) -> Result<GeometryDataType> {
                 Ok(GeometryDataType::EWKB)
             } else {
                 Err(ErrorCode::GeometryError(
-                    "Invalid geometry type format1".to_string(),
+                    "Invalid geometry type format".to_string(),
                 ))
             }
         }
@@ -113,7 +113,7 @@ pub fn parse_to_subtype(buf: &[u8]) -> Result<GeometryDataType> {
                 Ok(GeometryDataType::EWKB)
             } else {
                 Err(ErrorCode::GeometryError(
-                    "Invalid geometry type format1".to_string(),
+                    "Invalid geometry type format".to_string(),
                 ))
             }
         }

--- a/src/query/functions/src/scalars/geometry.rs
+++ b/src/query/functions/src/scalars/geometry.rs
@@ -24,8 +24,11 @@ use databend_common_expression::vectorize_with_builder_2_arg;
 use databend_common_expression::FunctionDomain;
 use databend_common_expression::FunctionRegistry;
 use databend_common_io::parse_to_ewkb;
+use databend_common_io::parse_to_subtype;
+use databend_common_io::GeometryDataType;
 use geo::MultiPoint;
 use geo::Point;
+use geo_types::Polygon;
 use geohash::decode_bbox;
 use geos::geo_types;
 use geos::geo_types::Coord;
@@ -34,8 +37,10 @@ use geos::Geom;
 use geos::Geometry;
 use geozero::geojson::GeoJson;
 use geozero::wkb::Ewkb;
+use geozero::wkt::Wkt;
 use geozero::CoordDimensions;
 use geozero::GeozeroGeometry;
+use geozero::ToGeo;
 use geozero::ToGeos;
 use geozero::ToJson;
 use geozero::ToWkb;
@@ -46,12 +51,12 @@ use geozero::ToWkt;
 pub fn register(registry: &mut FunctionRegistry) {
     // aliases
     registry.register_aliases("st_makegeompoint", &["st_geom_point"]);
+    registry.register_aliases("st_makepolygon", &["st_polygon"]);
     registry.register_aliases("st_makeline", &["st_make_line"]);
     registry.register_aliases("st_geometryfromwkb", &[
         "st_geomfromwkb",
         "st_geometryfromewkb",
         "st_geomfromewkb",
-        "to_geometry",
     ]);
     registry.register_aliases("st_geometryfromwkt", &[
         "st_geomfromwkt",
@@ -59,7 +64,6 @@ pub fn register(registry: &mut FunctionRegistry) {
         "st_geomfromewkt",
         "st_geometryfromtext",
         "st_geomfromtext",
-        "to_geometry",
     ]);
 
     // functions
@@ -76,6 +80,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             if geohash.len() > 12 {
                 ctx.set_error(builder.len(), "");
                 builder.put_str("Currently the precision only implement within 12 digits!");
+                builder.commit_row();
                 return;
             }
 
@@ -87,6 +92,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                         ErrorCode::GeometryError(e.to_string()).to_string(),
                     );
                     builder.put_str("");
+                    builder.commit_row();
                     return;
                 }
             };
@@ -114,6 +120,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             if geohash.len() > 12 {
                 ctx.set_error(builder.len(), "");
                 builder.put_str("Currently the precision only implement within 12 digits!");
+                builder.commit_row();
                 return;
             }
 
@@ -125,6 +132,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                         ErrorCode::GeometryError(e.to_string()).to_string(),
                     );
                     builder.put_str("");
+                    builder.commit_row();
                     return;
                 }
             };
@@ -163,6 +171,76 @@ pub fn register(registry: &mut FunctionRegistry) {
         })
     );
 
+    registry.register_passthrough_nullable_1_arg::<GeometryType, GeometryType, _, _>(
+        "st_makepolygon",
+        |_, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_1_arg::<GeometryType, GeometryType>(|binary, builder, ctx| {
+            if let Some(validity) = &ctx.validity {
+                if !validity.get_bit(builder.len()) {
+                    builder.commit_row();
+                    return;
+                }
+            }
+
+            let subtype = match parse_to_subtype(binary) {
+                Ok(subtype) => subtype,
+                Err(e) => {
+                    ctx.set_error(
+                        builder.len(),
+                        ErrorCode::GeometryError(e.to_string()).to_string(),
+                    );
+                    builder.put_str("");
+                    builder.commit_row();
+                    return;
+                }
+            };
+
+            let geometry = match subtype {
+                GeometryDataType::EWKT => Wkt(binary).to_geo(),
+                GeometryDataType::EWKB => Ewkb(binary).to_geo(),
+                GeometryDataType::GEOJSON => GeoJson(std::str::from_utf8(binary).unwrap()).to_geo(),
+            };
+
+            let line_string = match geometry {
+                Ok(geo) => geo.try_into(),
+                Err(e) => {
+                    ctx.set_error(
+                        builder.len(),
+                        ErrorCode::GeometryError(e.to_string()).to_string(),
+                    );
+                    builder.put_str("");
+                    builder.commit_row();
+                    return;
+                }
+            };
+
+            let wkt = line_string
+                .map_err(|e: geo_types::Error| ErrorCode::GeometryError(e.to_string()))
+                .and_then(|line_string: LineString| {
+                    let points = line_string.into_points();
+                    if points.len() < 4 {
+                        Err(ErrorCode::GeometryError(
+                            "Input lines must have at least 4 points!",
+                        ))
+                    } else if points.last() != points.first() {
+                        Err(ErrorCode::GeometryError(
+                            "The first and last elements are not equal.",
+                        ))
+                    } else {
+                        let polygon = Polygon::new(LineString::from(points), vec![]);
+                        geo_types::Geometry::from(polygon)
+                            .to_json()
+                            .map_err(|e| ErrorCode::GeometryError(e.to_string()))
+                    }
+                });
+            match wkt {
+                Ok(data) => builder.put_slice(data.as_bytes()),
+                Err(e) => ctx.set_error(builder.len(), e.to_string()),
+            }
+            builder.commit_row();
+        }),
+    );
+
     registry.register_passthrough_nullable_2_arg::<GeometryType, GeometryType, GeometryType, _, _>(
         "st_makeline",
         |_, _, _| FunctionDomain::Full,
@@ -180,21 +258,24 @@ pub fn register(registry: &mut FunctionRegistry) {
                     match binary_to_geos(params)
                     {
                         Ok(geos) => {
-                                match get_shared_srid(&geos){
-                                    Ok(s) => {
-                                        srid = s;
-                                        geos
-                                    },
-                                    Err(e) => {
-                                        ctx.set_error(builder.len(), ErrorCode::GeometryError(e).to_string());
-                                        builder.put_str("");
-                                        return;
-                                    }
+                            match get_shared_srid(&geos){
+                                Ok(s) => {
+                                    srid = s;
+                                    geos
+                                },
+                                Err(e) => {
+                                    ctx.set_error(builder.len(), ErrorCode::GeometryError(e).to_string());
+                                    builder.put_str("");
+                                    builder.commit_row();
+                                    return;
+                                }
                             }
                         },
                         Err(e) => {
                             ctx.set_error(builder.len(), ErrorCode::GeometryError(e.to_string()).to_string());
-                            return builder.put_str("");
+                            builder.put_str("");
+                            builder.commit_row();
+                            return;
                         }
                     };
 
@@ -207,7 +288,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 Ok(point) => point,
                                 Err(e) => {
                                     ctx.set_error(builder.len(), ErrorCode::GeometryError(e.to_string()).to_string());
-                                    return builder.put_str("");
+                                    builder.put_str("");
+                                    builder.commit_row();
+                                    return;
                                 }
                             };
                             coords.push(point.into());
@@ -217,7 +300,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 Ok(line) => line,
                                 Err(e) => {
                                     ctx.set_error(builder.len(), e.to_string());
-                                    return builder.put_str("");
+                                    builder.put_str("");
+                                    builder.commit_row();
+                                    return;
                                 }
                             };
                             coords.append(&mut line.into_inner());
@@ -227,7 +312,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 Ok(multi_point) => multi_point,
                                 Err(e) => {
                                     ctx.set_error(builder.len(), e.to_string());
-                                    return builder.put_str("");
+                                    builder.put_str("");
+                                    builder.commit_row();
+                                    return;
                                 }
                             };
                             for point in multi_point.into_iter() {
@@ -239,7 +326,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 builder.len(),
                                 ErrorCode::GeometryError("Geometry expression must be a Point, MultiPoint, or LineString.").to_string(),
                             );
-                            return builder.put_str("");
+                            builder.put_str("");
+                            builder.commit_row();
+                            return;
                         }
                     }
                 }
@@ -271,7 +360,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                         builder.len(),
                         ErrorCode::GeometryError(e.to_string()).to_string(),
                     );
-                    return builder.put_str("");
+                    builder.put_str("");
+                    builder.commit_row();
+                    return;
                 }
             };
             match Ewkb(&b_ewkb).to_geos() {
@@ -437,6 +528,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                         );
                         ctx.set_error(builder.len(), ErrorCode::GeometryError(error).to_string());
                         builder.put_str("");
+                        builder.commit_row();
                         return;
                     }
                 },

--- a/src/query/functions/tests/it/scalars/geometry.rs
+++ b/src/query/functions/tests/it/scalars/geometry.rs
@@ -30,6 +30,7 @@ fn test_geometry() {
     test_st_geompointfromgeohash(file);
     test_st_makeline(file);
     test_st_makepoint(file);
+    test_st_makepolygon(file);
     test_to_string(file);
     test_st_geometryfromwkb(file);
     test_st_geometryfromwkt(file);
@@ -50,22 +51,22 @@ fn test_st_makeline(file: &mut impl Write) {
     run_ast(
         file,
         "st_makeline(
-                            to_geometry('SRID=4326;POINT(1.0 2.0)'),
-                            to_geometry('SRID=4326;POINT(3.5 4.5)'))",
+                            st_geometryfromwkt('SRID=4326;POINT(1.0 2.0)'),
+                            st_geometryfromwkt('SRID=4326;POINT(3.5 4.5)'))",
         &[],
     );
     run_ast(
         file,
         "st_makeline(
-                            to_geometry('SRID=3857;POINT(1.0 2.0)'),
-                            to_geometry('SRID=3857;LINESTRING(1.0 2.0, 10.1 5.5)'))",
+                            st_geometryfromwkt('SRID=3857;POINT(1.0 2.0)'),
+                            st_geometryfromwkt('SRID=3857;LINESTRING(1.0 2.0, 10.1 5.5)'))",
         &[],
     );
     run_ast(
         file,
         "st_makeline(
-                            to_geometry('LINESTRING(1.0 2.0, 10.1 5.5)'),
-                            to_geometry('MULTIPOINT(3.5 4.5, 6.1 7.9)'))",
+                            st_geometryfromwkt('LINESTRING(1.0 2.0, 10.1 5.5)'),
+                            st_geometryfromwkt('MULTIPOINT(3.5 4.5, 6.1 7.9)'))",
         &[],
     );
 }
@@ -77,6 +78,26 @@ fn test_st_makepoint(file: &mut impl Write) {
         ("a", Float64Type::from_data(vec![1.0, 2.0, 3.0])),
         ("b", Float64Type::from_data(vec![1.0, 2.0, 3.0])),
     ]);
+}
+
+fn test_st_makepolygon(file: &mut impl Write) {
+    run_ast(
+        file,
+        "st_makepolygon(st_geometryfromwkt('LINESTRING(0.0 0.0, 1.0 0.0, 1.0 2.0, 0.0 2.0, 0.0 0.0)'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "st_makepolygon(st_geometryfromwkb(unhex('01020000000500000000000000000000000000000000000000000000000000f03f0000000000000000000000000000f03f00000000000000400000000000000000000000000000004000000000000000000000000000000000')))",
+        &[],
+    );
+    run_ast(file, "st_makepolygon(a)", &[(
+        "a",
+        StringType::from_data(vec![
+            "LINESTRING(0.0 0.0, 1.0 0.0, 1.0 2.0, 0.0 2.0, 0.0 0.0)",
+            "LINESTRING(10.1 5.2, 15.2 7.3, 20.2 8.3, 10.9 7.7, 10.1 5.2)",
+        ]),
+    )]);
 }
 
 fn test_to_string(file: &mut impl Write) {

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -44,6 +44,7 @@ st_geomfromtext -> st_geometryfromwkt
 st_geomfromwkb -> st_geometryfromwkb
 st_geomfromwkt -> st_geometryfromwkt
 st_make_line -> st_makeline
+st_polygon -> st_makepolygon
 str_to_date -> to_date
 str_to_timestamp -> to_timestamp
 str_to_year -> to_year
@@ -52,7 +53,6 @@ substring -> substr
 substring_utf8 -> substr
 subtract -> minus
 to_datetime -> to_timestamp
-to_geometry -> st_geometryfromwkt
 to_text -> to_string
 to_varchar -> to_string
 try_ipv4_num_to_string -> try_inet_ntoa
@@ -3518,6 +3518,8 @@ Functions overloads:
 1 st_makegeompoint(Float64 NULL, Float64 NULL) :: Geometry NULL
 0 st_makeline(Geometry, Geometry) :: Geometry
 1 st_makeline(Geometry NULL, Geometry NULL) :: Geometry NULL
+0 st_makepolygon(Geometry) :: Geometry
+1 st_makepolygon(Geometry NULL) :: Geometry NULL
 0 strcmp(String, String) :: Int8
 1 strcmp(String NULL, String NULL) :: Int8 NULL
 0 string_to_h3(String) :: UInt64

--- a/src/query/functions/tests/it/scalars/testdata/geometry.txt
+++ b/src/query/functions/tests/it/scalars/testdata/geometry.txt
@@ -38,9 +38,9 @@ output         : '{"type": "Point", "coordinates": [1.0004425048828125,2.0001983
 
 
 ast            : st_makeline(
-                            to_geometry('SRID=4326;POINT(1.0 2.0)'),
-                            to_geometry('SRID=4326;POINT(3.5 4.5)'))
-raw expr       : st_makeline(to_geometry('SRID=4326;POINT(1.0 2.0)'), to_geometry('SRID=4326;POINT(3.5 4.5)'))
+                            st_geometryfromwkt('SRID=4326;POINT(1.0 2.0)'),
+                            st_geometryfromwkt('SRID=4326;POINT(3.5 4.5)'))
+raw expr       : st_makeline(st_geometryfromwkt('SRID=4326;POINT(1.0 2.0)'), st_geometryfromwkt('SRID=4326;POINT(3.5 4.5)'))
 checked expr   : st_makeline<Geometry, Geometry>(st_geometryfromwkt<String>("SRID=4326;POINT(1.0 2.0)"), st_geometryfromwkt<String>("SRID=4326;POINT(3.5 4.5)"))
 optimized expr : '"SRID=4326;LINESTRING(1 2,3.5 4.5)"'
 output type    : Geometry
@@ -49,9 +49,9 @@ output         : 'SRID=4326;LINESTRING(1 2,3.5 4.5)'
 
 
 ast            : st_makeline(
-                            to_geometry('SRID=3857;POINT(1.0 2.0)'),
-                            to_geometry('SRID=3857;LINESTRING(1.0 2.0, 10.1 5.5)'))
-raw expr       : st_makeline(to_geometry('SRID=3857;POINT(1.0 2.0)'), to_geometry('SRID=3857;LINESTRING(1.0 2.0, 10.1 5.5)'))
+                            st_geometryfromwkt('SRID=3857;POINT(1.0 2.0)'),
+                            st_geometryfromwkt('SRID=3857;LINESTRING(1.0 2.0, 10.1 5.5)'))
+raw expr       : st_makeline(st_geometryfromwkt('SRID=3857;POINT(1.0 2.0)'), st_geometryfromwkt('SRID=3857;LINESTRING(1.0 2.0, 10.1 5.5)'))
 checked expr   : st_makeline<Geometry, Geometry>(st_geometryfromwkt<String>("SRID=3857;POINT(1.0 2.0)"), st_geometryfromwkt<String>("SRID=3857;LINESTRING(1.0 2.0, 10.1 5.5)"))
 optimized expr : '"SRID=3857;LINESTRING(1 2,1 2,10.1 5.5)"'
 output type    : Geometry
@@ -60,9 +60,9 @@ output         : 'SRID=3857;LINESTRING(1 2,1 2,10.1 5.5)'
 
 
 ast            : st_makeline(
-                            to_geometry('LINESTRING(1.0 2.0, 10.1 5.5)'),
-                            to_geometry('MULTIPOINT(3.5 4.5, 6.1 7.9)'))
-raw expr       : st_makeline(to_geometry('LINESTRING(1.0 2.0, 10.1 5.5)'), to_geometry('MULTIPOINT(3.5 4.5, 6.1 7.9)'))
+                            st_geometryfromwkt('LINESTRING(1.0 2.0, 10.1 5.5)'),
+                            st_geometryfromwkt('MULTIPOINT(3.5 4.5, 6.1 7.9)'))
+raw expr       : st_makeline(st_geometryfromwkt('LINESTRING(1.0 2.0, 10.1 5.5)'), st_geometryfromwkt('MULTIPOINT(3.5 4.5, 6.1 7.9)'))
 checked expr   : st_makeline<Geometry, Geometry>(st_geometryfromwkt<String>("LINESTRING(1.0 2.0, 10.1 5.5)"), st_geometryfromwkt<String>("MULTIPOINT(3.5 4.5, 6.1 7.9)"))
 optimized expr : '"LINESTRING(1 2,10.1 5.5,3.5 4.5,6.1 7.9)"'
 output type    : Geometry
@@ -109,6 +109,36 @@ evaluation (internal):
 | b      | Float64([1, 2, 3])                                                                                                                                                                |
 | Output | BinaryColumn { data: 0x0101000000000000000000f03f000000000000f03f010100000000000000000000400000000000000040010100000000000000000008400000000000000840, offsets: [0, 21, 42, 63] } |
 +--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : st_makepolygon(st_geometryfromwkt('LINESTRING(0.0 0.0, 1.0 0.0, 1.0 2.0, 0.0 2.0, 0.0 0.0)'))
+raw expr       : st_makepolygon(st_geometryfromwkt('LINESTRING(0.0 0.0, 1.0 0.0, 1.0 2.0, 0.0 2.0, 0.0 0.0)'))
+checked expr   : st_makepolygon<Geometry>(st_geometryfromwkt<String>("LINESTRING(0.0 0.0, 1.0 0.0, 1.0 2.0, 0.0 2.0, 0.0 0.0)"))
+optimized expr : '"{\"type\": \"Polygon\", \"coordinates\": [[[0,0],[1,0],[1,2],[0,2],[0,0]]]}"'
+output type    : Geometry
+output domain  : Undefined
+output         : '{"type": "Polygon", "coordinates": [[[0,0],[1,0],[1,2],[0,2],[0,0]]]}'
+
+
+ast            : st_makepolygon(st_geometryfromwkb(unhex('01020000000500000000000000000000000000000000000000000000000000f03f0000000000000000000000000000f03f00000000000000400000000000000000000000000000004000000000000000000000000000000000')))
+raw expr       : st_makepolygon(st_geometryfromwkb(unhex('01020000000500000000000000000000000000000000000000000000000000f03f0000000000000000000000000000f03f00000000000000400000000000000000000000000000004000000000000000000000000000000000')))
+checked expr   : st_makepolygon<Geometry>(st_geometryfromwkb<Binary>(from_hex<String>("01020000000500000000000000000000000000000000000000000000000000f03f0000000000000000000000000000f03f00000000000000400000000000000000000000000000004000000000000000000000000000000000")))
+optimized expr : '"{\"type\": \"Polygon\", \"coordinates\": [[[0,0],[1,0],[1,2],[0,2],[0,0]]]}"'
+output type    : Geometry
+output domain  : Undefined
+output         : '{"type": "Polygon", "coordinates": [[[0,0],[1,0],[1,2],[0,2],[0,0]]]}'
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | st_makepolygon(a)
+  | ^^^^^^^^^^^^^^^^^ no overload satisfies `st_makepolygon(String)`
+
+has tried possible overloads:
+  st_makepolygon(Geometry) :: Geometry            : unable to unify `String` with `Geometry`
+  st_makepolygon(Geometry NULL) :: Geometry NULL  : unable to unify `String` with `Geometry`
+
 
 
 ast            : to_string(st_makegeompoint(7.0, -8.0))

--- a/tests/sqllogictests/suites/query/functions/02_0060_function_geometry.test
+++ b/tests/sqllogictests/suites/query/functions/02_0060_function_geometry.test
@@ -50,15 +50,30 @@ statement ok
 DROP TABLE IF EXISTS t1
 
 statement ok
+CREATE TABLE t1 (a geometry)
+
+statement ok
+INSERT INTO t1 VALUES(ST_GEOMETRYFROMWKT('LINESTRING(0.0 0.0, 1.0 0.0, 1.0 2.0, 0.0 2.0, 0.0 0.0)')),(ST_GEOMETRYFROMWKT('LINESTRING(0.0 0.2, 1.4 5, 1.9 2, 0 2, 0.0 0.2)'))
+
+query T
+SELECT to_string(st_makepolygon(a)) FROM t1
+----
+{"type": "Polygon", "coordinates": [[[0,0],[1,0],[1,2],[0,2],[0,0]]]}
+{"type": "Polygon", "coordinates": [[[0,0.2],[1.4,5],[1.9,2],[0,2],[0,0.2]]]}
+
+statement ok
+DROP TABLE IF EXISTS t1
+
+statement ok
 CREATE TABLE t1 (g1 geometry, g2 geometry)
 
 statement ok
-SELECT to_string(st_makeline(TO_GEOMETRY('POINT(33.0 44.2)', 32633), TO_GEOMETRY('POINT(224.5 41.5)', 32633))) FROM t1
+SELECT to_string(st_makeline(ST_GEOMFROMWKT('POINT(33.0 44.2)', 32633), ST_GEOMFROMWKT('POINT(224.5 41.5)', 32633))) FROM t1
 
 statement ok
-INSERT INTO t1 VALUES(TO_GEOMETRY('POINT(1.0 2.0)', 32633), TO_GEOMETRY('POINT(3.5 4.5)', 32633)),
-(TO_GEOMETRY('POINT(1.0 2.0)', 4326), TO_GEOMETRY('LINESTRING(1.0 2.0, 10.1 5.5)', 4326)),
-(TO_GEOMETRY('LINESTRING(1.0 2.0, 10.1 5.5)'), TO_GEOMETRY('MULTIPOINT(3.5 4.5, 6.1 7.9)'))
+INSERT INTO t1 VALUES(ST_GEOMFROMWKT('POINT(1.0 2.0)', 32633), ST_GEOMFROMWKT('POINT(3.5 4.5)', 32633)),
+(ST_GEOMFROMWKT('POINT(1.0 2.0)', 4326), ST_GEOMFROMWKT('LINESTRING(1.0 2.0, 10.1 5.5)', 4326)),
+(ST_GEOMFROMWKT('LINESTRING(1.0 2.0, 10.1 5.5)'), ST_GEOMFROMWKT('MULTIPOINT(3.5 4.5, 6.1 7.9)'))
 
 query T
 SELECT to_string(st_makeline(g1, g2)) FROM t1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
feat:  Implement  ST_MAKEPOLYGON(). see alse [doc](https://docs.snowflake.com/en/sql-reference/functions/st_makepolygon).
other: remove to_geometry alias,becasue register_aliases() only depend on alias_name as key which will cause the  registered function to be overwritten.
  ```
      pub fn register_aliases(&mut self, fn_name: &str, aliases: &[&str]) {
          for alias in aliases {
              self.aliases.insert(alias.to_string(), fn_name.to_string());
          }
      }
      registry.register_aliases("st_geometryfromwkb", &[
          "to_geometry",
      ]);
      registry.register_aliases("st_geometryfromwkt", &[
          "to_geometry",
      ]);
  ``` 

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):