### PR TITLE
chore(planner): refine explain read size

### DIFF
--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -23,6 +23,7 @@ use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_pipeline_core::processors::PlanProfile;
 use itertools::Itertools;
 
+use databend_common_base::base::convert_byte_size;
 use crate::executor::explain::PlanStatsInfo;
 use crate::executor::physical_plans::AggregateExpand;
 use crate::executor::physical_plans::AggregateFinal;
@@ -1026,9 +1027,14 @@ fn union_all_to_format_tree(
 }
 
 fn part_stats_info_to_format_tree(info: &PartStatistics) -> Vec<FormatTreeNode<String>> {
+    let read_size = if info.read_bytes < 1024 {
+        "< 1 KiB".to_string()
+    } else {
+        convert_byte_size(info.read_bytes as f64)
+    };
     let mut items = vec![
         FormatTreeNode::new(format!("read rows: {}", info.read_rows)),
-        FormatTreeNode::new(format!("read bytes: {}", info.read_bytes)),
+        FormatTreeNode::new(format!("read size: {}", read_size)),
         FormatTreeNode::new(format!("partitions total: {}", info.partitions_total)),
         FormatTreeNode::new(format!("partitions scanned: {}", info.partitions_scanned)),
     ];

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use databend_common_ast::ast::FormatTreeNode;
+use databend_common_base::base::convert_byte_size;
 use databend_common_base::runtime::profile::get_statistics_desc;
 use databend_common_catalog::plan::PartStatistics;
 use databend_common_exception::Result;
@@ -23,7 +24,6 @@ use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_pipeline_core::processors::PlanProfile;
 use itertools::Itertools;
 
-use databend_common_base::base::convert_byte_size;
 use crate::executor::explain::PlanStatsInfo;
 use crate::executor::physical_plans::AggregateExpand;
 use crate::executor::physical_plans::AggregateFinal;
@@ -1027,7 +1027,9 @@ fn union_all_to_format_tree(
 }
 
 fn part_stats_info_to_format_tree(info: &PartStatistics) -> Vec<FormatTreeNode<String>> {
-    let read_size = if info.read_bytes < 1024 {
+    let read_size = if info.read_bytes == 0 {
+        "0".to_string()
+    } else if info.read_bytes < 1024 {
         "< 1 KiB".to_string()
     } else {
         convert_byte_size(info.read_bytes as f64)

--- a/tests/sqllogictests/suites/ee/02_ee_aggregating_index/02_0000_async_agg_index_base.test
+++ b/tests/sqllogictests/suites/ee/02_ee_aggregating_index/02_0000_async_agg_index_base.test
@@ -393,7 +393,7 @@ EvalScalar
             ├── table: default.test_index.t
             ├── output columns: [id (#0), user_id (#1), event_name (#2)]
             ├── read rows: 8
-            ├── read bytes: 179
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -437,7 +437,7 @@ EvalScalar
                 ├── table: default.test_index.t
                 ├── output columns: [id (#0), user_id (#1), event_name (#2)]
                 ├── read rows: 8
-                ├── read bytes: 179
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -483,7 +483,7 @@ EvalScalar
                     ├── table: default.test_index.t
                     ├── output columns: [id (#0), user_id (#1), event_name (#2)]
                     ├── read rows: 8
-                    ├── read bytes: 179
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/ee/04_ee_inverted_index/04_0000_inverted_index_base.test
+++ b/tests/sqllogictests/suites/ee/04_ee_inverted_index/04_0000_inverted_index_base.test
@@ -48,26 +48,26 @@ t CREATE TABLE t ( id INT NULL, content VARCHAR NULL, SYNC INVERTED INDEX idx1 (
 statement ok
 REFRESH INVERTED INDEX idx1 ON t
 
-query I?T
+query 
 SELECT id, score(), content FROM t WHERE match(content, 'test')
 ----
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, 'the')
 ----
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, 'fly')
 ----
 5 2.4594712 Time flies like an arrow; fruit flies like a banana
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, 'word')
 ----
 2 1.5948367 A picture is worth a thousand words
 4 1.6550698 Actions speak louder than words
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '"early bird"')
 ----
 3 4.503372 The early bird catches the worm
@@ -98,7 +98,7 @@ INSERT INTO t VALUES
 (29, '每个人的人生都是一部独特的传奇，我们需要珍惜每一个瞬间，用心去感受生活的美好。'),
 (30, '张华考上了北京大学，李萍进了中等技术学校，我在百货公司当售货员，我们都有光明的前途。')
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score()
 ----
 21 1.1111465 中国的古代诗词充满了深邃的意境和独特的韵味，是中华文化的重要组成部分。
@@ -107,23 +107,23 @@ SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score
 12 1.4482267 北京的故宫是中国古代建筑的瑰宝，吸引了无数游客前来参观。
 15 1.5346593 中国的茶文化源远流长，品茶已经成为一种生活方式。
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '北京') ORDER BY score()
 ----
 30 1.7396812 张华考上了北京大学，李萍进了中等技术学校，我在百货公司当售货员，我们都有光明的前途。
 12 1.9475443 北京的故宫是中国古代建筑的瑰宝，吸引了无数游客前来参观。
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '北京大学') ORDER BY score()
 ----
 30 5.2190437 张华考上了北京大学，李萍进了中等技术学校，我在百货公司当售货员，我们都有光明的前途。
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '文化博大精深') ORDER BY score()
 ----
 28 7.61753 中国的饮食文化博大精深，各地的美食各具特色，让人流连忘返。
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '文化 博大精深') ORDER BY score()
 ----
 21 1.1111465 中国的古代诗词充满了深邃的意境和独特的韵味，是中华文化的重要组成部分。
@@ -131,17 +131,17 @@ SELECT id, score(), content FROM t WHERE match(content, '文化 博大精深') O
 15 2.063777 中国的茶文化源远流长，品茶已经成为一种生活方式。
 28 7.61753 中国的饮食文化博大精深，各地的美食各具特色，让人流连忘返。
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '化博') ORDER BY score()
 ----
 
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '。') ORDER BY score()
 ----
 
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '不存在') ORDER BY score()
 ----
 
@@ -149,7 +149,7 @@ SELECT id, score(), content FROM t WHERE match(content, '不存在') ORDER BY sc
 statement ok
 UPDATE t SET content = '科技创新是推动社会进步的重要动力，我们应该积极支持和推动科技创新。' WHERE id=24
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score()
 ----
 21 1.423108 中国的古代诗词充满了深邃的意境和独特的韵味，是中华文化的重要组成部分。
@@ -157,7 +157,7 @@ SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score
 15 1.5346593 中国的茶文化源远流长，品茶已经成为一种生活方式。
 28 1.5707673 中国的饮食文化博大精深，各地的美食各具特色，让人流连忘返。
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '科技') ORDER BY score()
 ----
 13 2.1947646 随着科技的发展，人们的生活变得越来越便利。
@@ -166,7 +166,7 @@ SELECT id, score(), content FROM t WHERE match(content, '科技') ORDER BY score
 statement ok
 DELETE FROM t WHERE id=21
 
-query I?T
+query T
 SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score()
 ----
 12 1.4482267 北京的故宫是中国古代建筑的瑰宝，吸引了无数游客前来参观。
@@ -194,12 +194,12 @@ INSERT INTO t_small_blocks VALUES
 (9, 'You can not judge a book by its cover'),
 (10, 'An apple a day keeps the doctor away')
 
-query I?T
+query T
 SELECT id, content FROM t WHERE match(content, '"early bird"')
 ----
 3 The early bird catches the worm
 
-query I?T
+query T
 EXPLAIN SELECT id, content FROM t WHERE match(content, '"early bird"')
 ----
 Filter

--- a/tests/sqllogictests/suites/ee/04_ee_inverted_index/04_0000_inverted_index_base.test
+++ b/tests/sqllogictests/suites/ee/04_ee_inverted_index/04_0000_inverted_index_base.test
@@ -48,26 +48,26 @@ t CREATE TABLE t ( id INT NULL, content VARCHAR NULL, SYNC INVERTED INDEX idx1 (
 statement ok
 REFRESH INVERTED INDEX idx1 ON t
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, 'test')
 ----
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, 'the')
 ----
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, 'fly')
 ----
 5 2.4594712 Time flies like an arrow; fruit flies like a banana
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, 'word')
 ----
 2 1.5948367 A picture is worth a thousand words
 4 1.6550698 Actions speak louder than words
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '"early bird"')
 ----
 3 4.503372 The early bird catches the worm
@@ -98,7 +98,7 @@ INSERT INTO t VALUES
 (29, '每个人的人生都是一部独特的传奇，我们需要珍惜每一个瞬间，用心去感受生活的美好。'),
 (30, '张华考上了北京大学，李萍进了中等技术学校，我在百货公司当售货员，我们都有光明的前途。')
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score()
 ----
 21 1.1111465 中国的古代诗词充满了深邃的意境和独特的韵味，是中华文化的重要组成部分。
@@ -107,23 +107,23 @@ SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score
 12 1.4482267 北京的故宫是中国古代建筑的瑰宝，吸引了无数游客前来参观。
 15 1.5346593 中国的茶文化源远流长，品茶已经成为一种生活方式。
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '北京') ORDER BY score()
 ----
 30 1.7396812 张华考上了北京大学，李萍进了中等技术学校，我在百货公司当售货员，我们都有光明的前途。
 12 1.9475443 北京的故宫是中国古代建筑的瑰宝，吸引了无数游客前来参观。
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '北京大学') ORDER BY score()
 ----
 30 5.2190437 张华考上了北京大学，李萍进了中等技术学校，我在百货公司当售货员，我们都有光明的前途。
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '文化博大精深') ORDER BY score()
 ----
 28 7.61753 中国的饮食文化博大精深，各地的美食各具特色，让人流连忘返。
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '文化 博大精深') ORDER BY score()
 ----
 21 1.1111465 中国的古代诗词充满了深邃的意境和独特的韵味，是中华文化的重要组成部分。
@@ -131,17 +131,17 @@ SELECT id, score(), content FROM t WHERE match(content, '文化 博大精深') O
 15 2.063777 中国的茶文化源远流长，品茶已经成为一种生活方式。
 28 7.61753 中国的饮食文化博大精深，各地的美食各具特色，让人流连忘返。
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '化博') ORDER BY score()
 ----
 
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '。') ORDER BY score()
 ----
 
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '不存在') ORDER BY score()
 ----
 
@@ -149,7 +149,7 @@ SELECT id, score(), content FROM t WHERE match(content, '不存在') ORDER BY sc
 statement ok
 UPDATE t SET content = '科技创新是推动社会进步的重要动力，我们应该积极支持和推动科技创新。' WHERE id=24
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score()
 ----
 21 1.423108 中国的古代诗词充满了深邃的意境和独特的韵味，是中华文化的重要组成部分。
@@ -157,7 +157,7 @@ SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score
 15 1.5346593 中国的茶文化源远流长，品茶已经成为一种生活方式。
 28 1.5707673 中国的饮食文化博大精深，各地的美食各具特色，让人流连忘返。
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '科技') ORDER BY score()
 ----
 13 2.1947646 随着科技的发展，人们的生活变得越来越便利。
@@ -166,7 +166,7 @@ SELECT id, score(), content FROM t WHERE match(content, '科技') ORDER BY score
 statement ok
 DELETE FROM t WHERE id=21
 
-query IFT
+query I?T
 SELECT id, score(), content FROM t WHERE match(content, '中国') ORDER BY score()
 ----
 12 1.4482267 北京的故宫是中国古代建筑的瑰宝，吸引了无数游客前来参观。
@@ -194,12 +194,12 @@ INSERT INTO t_small_blocks VALUES
 (9, 'You can not judge a book by its cover'),
 (10, 'An apple a day keeps the doctor away')
 
-query IFT
+query I?T
 SELECT id, content FROM t WHERE match(content, '"early bird"')
 ----
 3 The early bird catches the worm
 
-query IFT
+query I?T
 EXPLAIN SELECT id, content FROM t WHERE match(content, '"early bird"')
 ----
 Filter
@@ -210,7 +210,7 @@ Filter
     ├── table: default.test_index.t
     ├── output columns: [id (#0), content (#1), _search_matched (#2)]
     ├── read rows: 10
-    ├── read bytes: 383
+    ├── read size: < 1 KiB
     ├── partitions total: 3
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 3, inverted pruning: 3 to 1>]
@@ -222,5 +222,3 @@ use default
 
 statement ok
 drop database test_index
-
-

--- a/tests/sqllogictests/suites/mode/cluster/distributed_sort.test
+++ b/tests/sqllogictests/suites/mode/cluster/distributed_sort.test
@@ -24,7 +24,7 @@ Sort
             ├── table: default.default.t_distributed_sort
             ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -58,7 +58,7 @@ Limit
                 ├── table: default.default.t_distributed_sort
                 ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: 2]
@@ -94,7 +94,7 @@ RowFetch
                     ├── table: default.default.t_distributed_sort
                     ├── output columns: [a (#0), _row_id (#7)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: 2]
@@ -116,7 +116,7 @@ Limit
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1000
-        ├── read bytes: 8000
+        ├── read size: 7.81 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -142,7 +142,7 @@ Limit
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 110
-            ├── read bytes: 880
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: 110]
@@ -168,7 +168,7 @@ Limit
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 110
-            ├── read bytes: 880
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: 110]

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -18,7 +18,7 @@ Exchange
     │       ├── table: default.system.numbers
     │       ├── output columns: [number (#0)]
     │       ├── read rows: 1
-    │       ├── read bytes: 8
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── push downs: [filters: [], limit: NONE]
@@ -27,7 +27,7 @@ Exchange
         ├── table: default.system.numbers
         ├── output columns: [number (#1)]
         ├── read rows: 2
-        ├── read bytes: 16
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -63,7 +63,7 @@ Exchange
     │       │       ├── table: default.system.numbers
     │       │       ├── output columns: [number (#0)]
     │       │       ├── read rows: 1
-    │       │       ├── read bytes: 8
+    │       │       ├── read size: < 1 KiB
     │       │       ├── partitions total: 1
     │       │       ├── partitions scanned: 1
     │       │       ├── push downs: [filters: [], limit: NONE]
@@ -72,7 +72,7 @@ Exchange
     │           ├── table: default.system.numbers
     │           ├── output columns: [number (#1)]
     │           ├── read rows: 2
-    │           ├── read bytes: 16
+    │           ├── read size: < 1 KiB
     │           ├── partitions total: 1
     │           ├── partitions scanned: 1
     │           ├── push downs: [filters: [], limit: NONE]
@@ -81,7 +81,7 @@ Exchange
         ├── table: default.system.numbers
         ├── output columns: [number (#2)]
         ├── read rows: 3
-        ├── read bytes: 24
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -121,7 +121,7 @@ Exchange
     │       │           ├── table: default.system.numbers
     │       │           ├── output columns: [number (#0)]
     │       │           ├── read rows: 1
-    │       │           ├── read bytes: 8
+    │       │           ├── read size: < 1 KiB
     │       │           ├── partitions total: 1
     │       │           ├── partitions scanned: 1
     │       │           ├── push downs: [filters: [], limit: NONE]
@@ -130,7 +130,7 @@ Exchange
     │           ├── table: default.system.numbers
     │           ├── output columns: [number (#2)]
     │           ├── read rows: 2
-    │           ├── read bytes: 16
+    │           ├── read size: < 1 KiB
     │           ├── partitions total: 1
     │           ├── partitions scanned: 1
     │           ├── push downs: [filters: [], limit: NONE]
@@ -139,7 +139,7 @@ Exchange
         ├── table: default.system.numbers
         ├── output columns: [number (#3)]
         ├── read rows: 3
-        ├── read bytes: 24
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -177,7 +177,7 @@ Exchange
     │                   ├── table: default.system.numbers
     │                   ├── output columns: [number (#0)]
     │                   ├── read rows: 1
-    │                   ├── read bytes: 8
+    │                   ├── read size: < 1 KiB
     │                   ├── partitions total: 1
     │                   ├── partitions scanned: 1
     │                   ├── push downs: [filters: [], limit: NONE]
@@ -186,7 +186,7 @@ Exchange
         ├── table: default.system.numbers
         ├── output columns: [number (#3)]
         ├── read rows: 2
-        ├── read bytes: 16
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -208,7 +208,7 @@ Fragment 0:
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 1
-            ├── read bytes: 8
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
@@ -249,7 +249,7 @@ Fragment 2:
             ├── table: default.system.numbers
             ├── output columns: [number (#3)]
             ├── read rows: 2
-            ├── read bytes: 16
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
@@ -303,7 +303,7 @@ AggregateFinal
             │   │       ├── table: default.system.numbers
             │   │       ├── output columns: [number (#0)]
             │   │       ├── read rows: 10
-            │   │       ├── read bytes: 80
+            │   │       ├── read size: < 1 KiB
             │   │       ├── partitions total: 1
             │   │       ├── partitions scanned: 1
             │   │       ├── push downs: [filters: [], limit: NONE]
@@ -312,7 +312,7 @@ AggregateFinal
             │       ├── table: default.system.numbers
             │       ├── output columns: [number (#1)]
             │       ├── read rows: 1000
-            │       ├── read bytes: 8000
+            │       ├── read size: 7.81 KiB
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
             │       ├── push downs: [filters: [], limit: NONE]
@@ -331,7 +331,7 @@ AggregateFinal
                 │       ├── table: default.system.numbers
                 │       ├── output columns: [number (#3)]
                 │       ├── read rows: 10
-                │       ├── read bytes: 80
+                │       ├── read size: < 1 KiB
                 │       ├── partitions total: 1
                 │       ├── partitions scanned: 1
                 │       ├── push downs: [filters: [], limit: NONE]
@@ -340,7 +340,7 @@ AggregateFinal
                     ├── table: default.system.numbers
                     ├── output columns: [number (#2)]
                     ├── read rows: 10
-                    ├── read bytes: 80
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]
@@ -392,7 +392,7 @@ AggregateFinal
         │           │       ├── table: default.system.numbers
         │           │       ├── output columns: [number (#0)]
         │           │       ├── read rows: 10
-        │           │       ├── read bytes: 80
+        │           │       ├── read size: < 1 KiB
         │           │       ├── partitions total: 1
         │           │       ├── partitions scanned: 1
         │           │       ├── push downs: [filters: [], limit: NONE]
@@ -401,7 +401,7 @@ AggregateFinal
         │               ├── table: default.system.numbers
         │               ├── output columns: [number (#1)]
         │               ├── read rows: 1000
-        │               ├── read bytes: 8000
+        │               ├── read size: 7.81 KiB
         │               ├── partitions total: 1
         │               ├── partitions scanned: 1
         │               ├── push downs: [filters: [], limit: NONE]
@@ -432,7 +432,7 @@ AggregateFinal
                         │       ├── table: default.system.numbers
                         │       ├── output columns: [number (#3)]
                         │       ├── read rows: 10
-                        │       ├── read bytes: 80
+                        │       ├── read size: < 1 KiB
                         │       ├── partitions total: 1
                         │       ├── partitions scanned: 1
                         │       ├── push downs: [filters: [], limit: NONE]
@@ -441,7 +441,7 @@ AggregateFinal
                             ├── table: default.system.numbers
                             ├── output columns: [number (#2)]
                             ├── read rows: 10
-                            ├── read bytes: 80
+                            ├── read size: < 1 KiB
                             ├── partitions total: 1
                             ├── partitions scanned: 1
                             ├── push downs: [filters: [], limit: NONE]
@@ -488,7 +488,7 @@ AggregateFinal
             │   │       ├── table: default.system.numbers
             │   │       ├── output columns: [number (#0)]
             │   │       ├── read rows: 10
-            │   │       ├── read bytes: 80
+            │   │       ├── read size: < 1 KiB
             │   │       ├── partitions total: 1
             │   │       ├── partitions scanned: 1
             │   │       ├── push downs: [filters: [], limit: NONE]
@@ -497,7 +497,7 @@ AggregateFinal
             │       ├── table: default.system.numbers
             │       ├── output columns: [number (#1)]
             │       ├── read rows: 1000
-            │       ├── read bytes: 8000
+            │       ├── read size: 7.81 KiB
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
             │       ├── push downs: [filters: [], limit: NONE]
@@ -506,7 +506,7 @@ AggregateFinal
                 ├── table: default.system.numbers
                 ├── output columns: [number (#2)]
                 ├── read rows: 10
-                ├── read bytes: 80
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── push downs: [filters: [], limit: NONE]
@@ -537,7 +537,7 @@ Exchange
     │       ├── table: default.system.numbers
     │       ├── output columns: [number (#2)]
     │       ├── read rows: 10
-    │       ├── read bytes: 80
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── push downs: [filters: [], limit: NONE]
@@ -556,7 +556,7 @@ Exchange
         │       ├── table: default.system.numbers
         │       ├── output columns: [number (#0)]
         │       ├── read rows: 10
-        │       ├── read bytes: 80
+        │       ├── read size: < 1 KiB
         │       ├── partitions total: 1
         │       ├── partitions scanned: 1
         │       ├── push downs: [filters: [], limit: NONE]
@@ -565,7 +565,7 @@ Exchange
             ├── table: default.system.numbers
             ├── output columns: [number (#1)]
             ├── read rows: 1000
-            ├── read bytes: 8000
+            ├── read size: 7.81 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
@@ -594,7 +594,7 @@ Exchange
     │       ├── table: default.system.numbers
     │       ├── output columns: [number (#1)]
     │       ├── read rows: 20
-    │       ├── read bytes: 160
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── push downs: [filters: [], limit: NONE]
@@ -606,7 +606,7 @@ Exchange
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 10
-            ├── read bytes: 80
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -426,7 +426,7 @@ Exchange
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 3.00
 

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -25,9 +25,9 @@ Exchange
         ├── output columns: [a (#0)]
         ├── read rows: 100
         ├── read size: < 1 KiB
-        ├── partitions total: 3
-        ├── partitions scanned: 3
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
         ├── push downs: [filters: [t1.a (#0) > 0], limit: NONE]
         └── estimated rows: 100.00
 

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -25,9 +25,9 @@ Exchange
         ├── output columns: [a (#0)]
         ├── read rows: 100
         ├── read size: < 1 KiB
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
         ├── push downs: [filters: [t1.a (#0) > 0], limit: NONE]
         └── estimated rows: 100.00
 
@@ -60,9 +60,9 @@ Exchange
         │           ├── output columns: [a (#2), b (#3)]
         │           ├── read rows: 100
         │           ├── read size: < 1 KiB
-        │           ├── partitions total: 1
-        │           ├── partitions scanned: 1
-        │           ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        │           ├── partitions total: 3
+        │           ├── partitions scanned: 3
+        │           ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
         │           ├── push downs: [filters: [t2.a (#2) > 3 OR t2.a (#2) > 1], limit: NONE]
         │           └── estimated rows: 100.00
         └── Filter(Probe)
@@ -74,9 +74,9 @@ Exchange
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 100
                 ├── read size: < 1 KiB
-                ├── partitions total: 1
-                ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+                ├── partitions total: 3
+                ├── partitions scanned: 3
+                ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
                 ├── push downs: [filters: [t1.a (#0) > 3 OR t1.a (#0) > 1], limit: NONE]
                 └── estimated rows: 100.00
 
@@ -101,9 +101,9 @@ Exchange
     │       ├── output columns: [a (#2), b (#3)]
     │       ├── read rows: 100
     │       ├── read size: < 1 KiB
-    │       ├── partitions total: 1
-    │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    │       ├── partitions total: 3
+    │       ├── partitions scanned: 3
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
     │       ├── push downs: [filters: [], limit: NONE]
     │       └── estimated rows: 100.00
     └── TableScan(Probe)
@@ -111,9 +111,9 @@ Exchange
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 100
         ├── read size: < 1 KiB
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -194,9 +194,9 @@ Limit
                         ├── output columns: [a (#0)]
                         ├── read rows: 100
                         ├── read size: < 1 KiB
-                        ├── partitions total: 1
-                        ├── partitions scanned: 1
-                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+                        ├── partitions total: 3
+                        ├── partitions scanned: 3
+                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
                         ├── push downs: [filters: [], limit: NONE]
                         └── estimated rows: 100.00
 
@@ -238,9 +238,9 @@ Limit
                     │       ├── output columns: [a (#2)]
                     │       ├── read rows: 100
                     │       ├── read size: < 1 KiB
-                    │       ├── partitions total: 1
-                    │       ├── partitions scanned: 1
-                    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+                    │       ├── partitions total: 3
+                    │       ├── partitions scanned: 3
+                    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
                     │       ├── push downs: [filters: [], limit: NONE]
                     │       └── estimated rows: 100.00
                     └── TableScan(Probe)
@@ -248,9 +248,9 @@ Limit
                         ├── output columns: [a (#0), b (#1)]
                         ├── read rows: 100
                         ├── read size: < 1 KiB
-                        ├── partitions total: 1
-                        ├── partitions scanned: 1
-                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+                        ├── partitions total: 3
+                        ├── partitions scanned: 3
+                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
                         ├── push downs: [filters: [], limit: NONE]
                         └── estimated rows: 100.00
 
@@ -278,9 +278,9 @@ Exchange
     │       ├── output columns: [a (#2), b (#3)]
     │       ├── read rows: 100
     │       ├── read size: < 1 KiB
-    │       ├── partitions total: 1
-    │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    │       ├── partitions total: 3
+    │       ├── partitions scanned: 3
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
     │       ├── push downs: [filters: [], limit: NONE]
     │       └── estimated rows: 100.00
     └── TableScan(Probe)
@@ -288,9 +288,9 @@ Exchange
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 100
         ├── read size: < 1 KiB
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -321,8 +321,8 @@ Limit
                 ├── output columns: [number (#0)]
                 ├── read rows: 10
                 ├── read size: < 1 KiB
-                ├── partitions total: 1
-                ├── partitions scanned: 1
+                ├── partitions total: 3
+                ├── partitions scanned: 3
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 10.00
 
@@ -356,8 +356,8 @@ AggregateFinal
             │       ├── output columns: [number (#1)]
             │       ├── read rows: 5
             │       ├── read size: < 1 KiB
-            │       ├── partitions total: 1
-            │       ├── partitions scanned: 1
+            │       ├── partitions total: 3
+            │       ├── partitions scanned: 3
             │       ├── push downs: [filters: [], limit: NONE]
             │       └── estimated rows: 5.00
             └── Exchange(Probe)
@@ -368,8 +368,8 @@ AggregateFinal
                     ├── output columns: [number (#0)]
                     ├── read rows: 10
                     ├── read size: < 1 KiB
-                    ├── partitions total: 1
-                    ├── partitions scanned: 1
+                    ├── partitions total: 3
+                    ├── partitions scanned: 3
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 10.00
 
@@ -424,9 +424,9 @@ Exchange
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 3
         ├── read size: < 1 KiB
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 3.00
 

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -321,8 +321,8 @@ Limit
                 ├── output columns: [number (#0)]
                 ├── read rows: 10
                 ├── read size: < 1 KiB
-                ├── partitions total: 3
-                ├── partitions scanned: 3
+                ├── partitions total: 1
+                ├── partitions scanned: 1
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 10.00
 
@@ -356,8 +356,8 @@ AggregateFinal
             │       ├── output columns: [number (#1)]
             │       ├── read rows: 5
             │       ├── read size: < 1 KiB
-            │       ├── partitions total: 3
-            │       ├── partitions scanned: 3
+            │       ├── partitions total: 1
+            │       ├── partitions scanned: 1
             │       ├── push downs: [filters: [], limit: NONE]
             │       └── estimated rows: 5.00
             └── Exchange(Probe)
@@ -368,8 +368,8 @@ AggregateFinal
                     ├── output columns: [number (#0)]
                     ├── read rows: 10
                     ├── read size: < 1 KiB
-                    ├── partitions total: 3
-                    ├── partitions scanned: 3
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 10.00
 
@@ -424,8 +424,8 @@ Exchange
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 3
         ├── read size: < 1 KiB
-        ├── partitions total: 3
-        ├── partitions scanned: 3
+        ├── partitions total: 1
+        ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 3.00

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -25,9 +25,9 @@ Exchange
         ├── output columns: [a (#0)]
         ├── read rows: 100
         ├── read size: < 1 KiB
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
         ├── push downs: [filters: [t1.a (#0) > 0], limit: NONE]
         └── estimated rows: 100.00
 

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -24,10 +24,10 @@ Exchange
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 100
-        ├── read bytes: 251
-        ├── partitions total: 3
-        ├── partitions scanned: 3
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
         ├── push downs: [filters: [t1.a (#0) > 0], limit: NONE]
         └── estimated rows: 100.00
 
@@ -59,10 +59,10 @@ Exchange
         │           ├── table: default.default.t2
         │           ├── output columns: [a (#2), b (#3)]
         │           ├── read rows: 100
-        │           ├── read bytes: 504
-        │           ├── partitions total: 3
-        │           ├── partitions scanned: 3
-        │           ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+        │           ├── read size: < 1 KiB
+        │           ├── partitions total: 1
+        │           ├── partitions scanned: 1
+        │           ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
         │           ├── push downs: [filters: [t2.a (#2) > 3 OR t2.a (#2) > 1], limit: NONE]
         │           └── estimated rows: 100.00
         └── Filter(Probe)
@@ -73,10 +73,10 @@ Exchange
                 ├── table: default.default.t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 100
-                ├── read bytes: 504
-                ├── partitions total: 3
-                ├── partitions scanned: 3
-                ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+                ├── read size: < 1 KiB
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
                 ├── push downs: [filters: [t1.a (#0) > 3 OR t1.a (#0) > 1], limit: NONE]
                 └── estimated rows: 100.00
 
@@ -100,20 +100,20 @@ Exchange
     │       ├── table: default.default.t2
     │       ├── output columns: [a (#2), b (#3)]
     │       ├── read rows: 100
-    │       ├── read bytes: 504
-    │       ├── partitions total: 3
-    │       ├── partitions scanned: 3
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+    │       ├── read size: < 1 KiB
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
     │       ├── push downs: [filters: [], limit: NONE]
     │       └── estimated rows: 100.00
     └── TableScan(Probe)
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 100
-        ├── read bytes: 504
-        ├── partitions total: 3
-        ├── partitions scanned: 3
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -193,10 +193,10 @@ Limit
                         ├── table: default.default.t1
                         ├── output columns: [a (#0)]
                         ├── read rows: 100
-                        ├── read bytes: 251
-                        ├── partitions total: 3
-                        ├── partitions scanned: 3
-                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
                         ├── push downs: [filters: [], limit: NONE]
                         └── estimated rows: 100.00
 
@@ -237,20 +237,20 @@ Limit
                     │       ├── table: default.default.t2
                     │       ├── output columns: [a (#2)]
                     │       ├── read rows: 100
-                    │       ├── read bytes: 251
-                    │       ├── partitions total: 3
-                    │       ├── partitions scanned: 3
-                    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+                    │       ├── read size: < 1 KiB
+                    │       ├── partitions total: 1
+                    │       ├── partitions scanned: 1
+                    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
                     │       ├── push downs: [filters: [], limit: NONE]
                     │       └── estimated rows: 100.00
                     └── TableScan(Probe)
                         ├── table: default.default.t1
                         ├── output columns: [a (#0), b (#1)]
                         ├── read rows: 100
-                        ├── read bytes: 504
-                        ├── partitions total: 3
-                        ├── partitions scanned: 3
-                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
                         ├── push downs: [filters: [], limit: NONE]
                         └── estimated rows: 100.00
 
@@ -277,20 +277,20 @@ Exchange
     │       ├── table: default.default.t2
     │       ├── output columns: [a (#2), b (#3)]
     │       ├── read rows: 100
-    │       ├── read bytes: 504
-    │       ├── partitions total: 3
-    │       ├── partitions scanned: 3
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+    │       ├── read size: < 1 KiB
+    │       ├── partitions total: 1
+    │       ├── partitions scanned: 1
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
     │       ├── push downs: [filters: [], limit: NONE]
     │       └── estimated rows: 100.00
     └── TableScan(Probe)
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 100
-        ├── read bytes: 504
-        ├── partitions total: 3
-        ├── partitions scanned: 3
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 100.00
 
@@ -320,7 +320,7 @@ Limit
                 ├── table: default.system.numbers
                 ├── output columns: [number (#0)]
                 ├── read rows: 10
-                ├── read bytes: 80
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── push downs: [filters: [], limit: NONE]
@@ -355,7 +355,7 @@ AggregateFinal
             │       ├── table: default.system.numbers
             │       ├── output columns: [number (#1)]
             │       ├── read rows: 5
-            │       ├── read bytes: 40
+            │       ├── read size: < 1 KiB
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
             │       ├── push downs: [filters: [], limit: NONE]
@@ -367,7 +367,7 @@ AggregateFinal
                     ├── table: default.system.numbers
                     ├── output columns: [number (#0)]
                     ├── read rows: 10
-                    ├── read bytes: 80
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]
@@ -423,7 +423,7 @@ Exchange
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 3
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/cluster/group_shuffle.test
+++ b/tests/sqllogictests/suites/mode/cluster/group_shuffle.test
@@ -23,7 +23,7 @@ Exchange
                 ├── table: default.system.numbers_mt
                 ├── output columns: [number (#0)]
                 ├── read rows: 100000
-                ├── read bytes: 800000
+                ├── read size: 781.25 KiB
                 ├── partitions total: 2
                 ├── partitions scanned: 2
                 ├── push downs: [filters: [], limit: NONE]
@@ -55,7 +55,7 @@ Exchange
                 ├── table: default.system.numbers_mt
                 ├── output columns: [number (#0)]
                 ├── read rows: 100000
-                ├── read bytes: 800000
+                ├── read size: 781.25 KiB
                 ├── partitions total: 2
                 ├── partitions scanned: 2
                 ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/cluster/lazy_read.test
+++ b/tests/sqllogictests/suites/mode/cluster/lazy_read.test
@@ -31,7 +31,7 @@ RowFetch
                     ├── table: default.default.t_lazy
                     ├── output columns: [a (#0), _row_id (#7)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: 2]
@@ -65,7 +65,7 @@ RowFetch
                     ├── table: default.default.t_lazy
                     ├── output columns: [a (#0), _row_id (#7)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [t_lazy.a (#0) > 1], limit: NONE]
@@ -97,7 +97,7 @@ Limit
                 ├── table: default.default.t_lazy
                 ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: 2]
@@ -127,7 +127,7 @@ Limit
                 ├── table: default.default.t_lazy
                 ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [t_lazy.a (#0) > 1], limit: NONE]
@@ -153,7 +153,7 @@ Limit
             ├── table: default.default.t_lazy
             ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: 2]

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -131,7 +131,7 @@ drop table if exists t2;
 statement ok
 create table t1(a int);
 
-statement error mysql client error: Server error: `ERROR HY000 \(1105\): StageAlreadyExists\. Code: 2502, Text = Stage 'ss' already exists\.\.'
+statement ok
 create stage ss FILE_FORMAT = (TYPE = CSV);
 
 statement ok

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -77,7 +77,7 @@ HashJoin
 │       ├── table: default.default.t1
 │       ├── output columns: [a (#1), _row_id (#2)]
 │       ├── read rows: 15
-│       ├── read bytes: 156
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 3
 │       ├── partitions scanned: 3
 │       ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 3>]
@@ -90,7 +90,7 @@ HashJoin
         ├── table: default.default.t2
         ├── output columns: [a (#0)]
         ├── read rows: 1
-        ├── read bytes: 36
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -131,7 +131,7 @@ drop table if exists t2;
 statement ok
 create table t1(a int);
 
-statement ok
+statement error mysql client error: Server error: `ERROR HY000 \(1105\): StageAlreadyExists\. Code: 2502, Text = Stage 'ss' already exists\.\.'
 create stage ss FILE_FORMAT = (TYPE = CSV);
 
 statement ok
@@ -176,7 +176,7 @@ Exchange
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#1), _row_id (#2)]
     │       ├── read rows: 2
-    │       ├── read bytes: 40
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -188,26 +188,38 @@ Exchange
         └── TableScan
             ├── table: default.system.stage
             ├── output columns: [_$1 (#0)]
-            ├── read rows: 6
-            ├── read bytes: 12
-            ├── partitions total: 1
-            ├── partitions scanned: 1
+            ├── read rows: 18
+            ├── read size: < 1 KiB
+            ├── partitions total: 3
+            ├── partitions scanned: 3
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 0.00
 
 query TT
 merge into t1 using (select $1 as a from @ss) as t2 on t1.a = t2.a when matched then update * when not matched then insert *;
 ----
-6 0
+18 0
 
 query T
 select * from t1 order by a;
 ----
 1
+1
+1
+2
+2
 2
 3
+3
+3
+4
+4
 4
 5
+5
+5
+6
+6
 6
 9
 10

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -132,6 +132,9 @@ statement ok
 create table t1(a int);
 
 statement ok
+drop stage if exists ss;
+
+statement ok
 create stage ss FILE_FORMAT = (TYPE = CSV);
 
 statement ok
@@ -188,38 +191,26 @@ Exchange
         └── TableScan
             ├── table: default.system.stage
             ├── output columns: [_$1 (#0)]
-            ├── read rows: 18
+            ├── read rows: 6
             ├── read size: < 1 KiB
-            ├── partitions total: 3
-            ├── partitions scanned: 3
+            ├── partitions total: 1
+            ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 0.00
 
 query TT
 merge into t1 using (select $1 as a from @ss) as t2 on t1.a = t2.a when matched then update * when not matched then insert *;
 ----
-18 0
+6 0
 
 query T
 select * from t1 order by a;
 ----
 1
-1
-1
-2
-2
 2
 3
-3
-3
-4
-4
 4
 5
-5
-5
-6
-6
 6
 9
 10

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
@@ -53,7 +53,7 @@ AggregateFinal
             ├── table: default.test_index_db.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [t1.b (#1) > 3], limit: NONE]
@@ -81,7 +81,7 @@ AggregateFinal
             ├── table: default.test_index_db.t1
             ├── output columns: [b (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [t1.b (#1) > 3], limit: NONE]
@@ -113,7 +113,7 @@ EvalScalar
                 ├── table: default.test_index_db.t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [t1.b (#1) > 3], limit: NONE]
@@ -145,7 +145,7 @@ EvalScalar
                 ├── table: default.test_index_db.t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [t1.b (#1) > 5], limit: NONE]
@@ -180,7 +180,7 @@ HashJoin
 │               ├── table: default.test_index_db.t1
 │               ├── output columns: [a (#3), b (#4)]
 │               ├── read rows: 0
-│               ├── read size: < 1 KiB
+│               ├── read size: 0
 │               ├── partitions total: 0
 │               ├── partitions scanned: 0
 │               ├── push downs: [filters: [t1.b (#4) > 3], limit: NONE]
@@ -200,7 +200,7 @@ HashJoin
             ├── table: default.test_index_db.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -230,7 +230,7 @@ AggregateFinal
             ├── table: default.test_index_db.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [t1.b (#1) > 3], limit: NONE]
@@ -269,7 +269,7 @@ EvalScalar
                 ├── table: default.test_index_db.t1
                 ├── output columns: [a (#0)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: NONE]
@@ -303,7 +303,7 @@ EvalScalar
             ├── table: default.test_index_db.t1
             ├── output columns: [a (#0)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -340,7 +340,7 @@ EvalScalar
             ├── table: default.test_index_db.onebrc
             ├── output columns: [station_name (#0), measurement (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -378,7 +378,7 @@ EvalScalar
                 ├── table: default.test_index_db.onebrc
                 ├── output columns: [station_name (#0), measurement (#1)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: NONE]
@@ -416,7 +416,7 @@ Sort
                 ├── table: default.test_index_db.onebrc
                 ├── output columns: [station_name (#0), measurement (#1)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: NONE]
@@ -454,7 +454,7 @@ Sort
                 ├── table: default.test_index_db.onebrc
                 ├── output columns: [station_name (#0), measurement (#1)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: NONE]
@@ -497,7 +497,7 @@ Sort
                     ├── table: default.test_index_db.onebrc
                     ├── output columns: [station_name (#0), measurement (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [and_filters(and_filters(onebrc.measurement (#1) > 0, onebrc.station_name (#0) = 'Beijing'), onebrc.measurement (#1) = 1 OR onebrc.measurement (#1) = 2)], limit: NONE]
@@ -540,7 +540,7 @@ Sort
                     ├── table: default.test_index_db.onebrc
                     ├── output columns: [station_name (#0), measurement (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [is_true(onebrc.station_name (#0) = 'Beijing')], limit: NONE]
@@ -583,7 +583,7 @@ Sort
                     ├── table: default.test_index_db.onebrc
                     ├── output columns: [station_name (#0), measurement (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [and_filters(onebrc.measurement (#1) > 2, onebrc.measurement (#1) < 5)], limit: NONE]
@@ -626,7 +626,7 @@ Sort
                     ├── table: default.test_index_db.onebrc
                     ├── output columns: [station_name (#0), measurement (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [is_true(onebrc.station_name (#0) = 'Paris' OR onebrc.station_name (#0) = 'Beijing')], limit: NONE]
@@ -656,7 +656,7 @@ AggregateFinal
         ├── table: default.test_index_db.onebrc
         ├── output columns: [measurement (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -690,7 +690,7 @@ AggregateFinal
         ├── table: default.test_index_db.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -761,7 +761,7 @@ Sort
         ├── table: default.test_index_db.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
@@ -53,7 +53,7 @@ AggregateFinal
             ├── table: default.test_index_db.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [t1.b (#1) > 3], limit: NONE]
@@ -81,7 +81,7 @@ AggregateFinal
             ├── table: default.test_index_db.t1
             ├── output columns: [b (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [t1.b (#1) > 3], limit: NONE]
@@ -113,7 +113,7 @@ EvalScalar
                 ├── table: default.test_index_db.t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [t1.b (#1) > 3], limit: NONE]
@@ -145,7 +145,7 @@ EvalScalar
                 ├── table: default.test_index_db.t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [t1.b (#1) > 5], limit: NONE]
@@ -180,7 +180,7 @@ HashJoin
 │               ├── table: default.test_index_db.t1
 │               ├── output columns: [a (#3), b (#4)]
 │               ├── read rows: 0
-│               ├── read bytes: 0
+│               ├── read size: < 1 KiB
 │               ├── partitions total: 0
 │               ├── partitions scanned: 0
 │               ├── push downs: [filters: [t1.b (#4) > 3], limit: NONE]
@@ -200,7 +200,7 @@ HashJoin
             ├── table: default.test_index_db.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -230,7 +230,7 @@ AggregateFinal
             ├── table: default.test_index_db.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [t1.b (#1) > 3], limit: NONE]
@@ -269,7 +269,7 @@ EvalScalar
                 ├── table: default.test_index_db.t1
                 ├── output columns: [a (#0)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: NONE]
@@ -303,7 +303,7 @@ EvalScalar
             ├── table: default.test_index_db.t1
             ├── output columns: [a (#0)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -340,7 +340,7 @@ EvalScalar
             ├── table: default.test_index_db.onebrc
             ├── output columns: [station_name (#0), measurement (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -378,7 +378,7 @@ EvalScalar
                 ├── table: default.test_index_db.onebrc
                 ├── output columns: [station_name (#0), measurement (#1)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: NONE]
@@ -416,7 +416,7 @@ Sort
                 ├── table: default.test_index_db.onebrc
                 ├── output columns: [station_name (#0), measurement (#1)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: NONE]
@@ -454,7 +454,7 @@ Sort
                 ├── table: default.test_index_db.onebrc
                 ├── output columns: [station_name (#0), measurement (#1)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [], limit: NONE]
@@ -497,7 +497,7 @@ Sort
                     ├── table: default.test_index_db.onebrc
                     ├── output columns: [station_name (#0), measurement (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [and_filters(and_filters(onebrc.measurement (#1) > 0, onebrc.station_name (#0) = 'Beijing'), onebrc.measurement (#1) = 1 OR onebrc.measurement (#1) = 2)], limit: NONE]
@@ -540,7 +540,7 @@ Sort
                     ├── table: default.test_index_db.onebrc
                     ├── output columns: [station_name (#0), measurement (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [is_true(onebrc.station_name (#0) = 'Beijing')], limit: NONE]
@@ -583,7 +583,7 @@ Sort
                     ├── table: default.test_index_db.onebrc
                     ├── output columns: [station_name (#0), measurement (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [and_filters(onebrc.measurement (#1) > 2, onebrc.measurement (#1) < 5)], limit: NONE]
@@ -626,7 +626,7 @@ Sort
                     ├── table: default.test_index_db.onebrc
                     ├── output columns: [station_name (#0), measurement (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [is_true(onebrc.station_name (#0) = 'Paris' OR onebrc.station_name (#0) = 'Beijing')], limit: NONE]
@@ -656,7 +656,7 @@ AggregateFinal
         ├── table: default.test_index_db.onebrc
         ├── output columns: [measurement (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -690,7 +690,7 @@ AggregateFinal
         ├── table: default.test_index_db.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -734,7 +734,7 @@ EvalScalar
                 ├── table: default.test_index_db.t1
                 ├── output columns: [a (#0)]
                 ├── read rows: 4
-                ├── read bytes: 42
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -761,7 +761,7 @@ Sort
         ├── table: default.test_index_db.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_virtual_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_virtual_column.test
@@ -41,7 +41,7 @@ EvalScalar
     ├── table: default.test_virtual_db.t1
     ├── output columns: [a (#0), v (#1)]
     ├── read rows: 1
-    ├── read bytes: 137
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -59,7 +59,7 @@ EvalScalar
     ├── table: default.test_virtual_db.t1
     ├── output columns: [a (#0), v (#1)]
     ├── read rows: 1
-    ├── read bytes: 137
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -79,7 +79,7 @@ TableScan
 ├── table: default.test_virtual_db.t1
 ├── output columns: [a (#0), v['a'][0] (#2), v['b'] (#3)]
 ├── read rows: 1
-├── read bytes: 137
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -93,7 +93,7 @@ TableScan
 ├── table: default.test_virtual_db.t1
 ├── output columns: [a (#0), v['b'] (#2)]
 ├── read rows: 1
-├── read bytes: 137
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -124,7 +124,7 @@ EvalScalar
     ├── table: default.test_virtual_db.t2
     ├── output columns: [a (#0), v (#1)]
     ├── read rows: 1
-    ├── read bytes: 128
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -146,7 +146,7 @@ EvalScalar
         ├── table: default.test_virtual_db.t2
         ├── output columns: [a (#0), v (#1)]
         ├── read rows: 1
-        ├── read bytes: 128
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -166,7 +166,7 @@ TableScan
 ├── table: default.test_virtual_db.t2
 ├── output columns: [a (#0), v['a'][0] (#2), v['b'] (#3)]
 ├── read rows: 1
-├── read bytes: 128
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -180,7 +180,7 @@ TableScan
 ├── table: default.test_virtual_db.t2
 ├── output columns: [a (#0), v['a'][0] (#2)]
 ├── read rows: 1
-├── read bytes: 128
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -198,7 +198,7 @@ Filter
     ├── table: default.test_virtual_db.t2
     ├── output columns: [a (#0), v['b'] (#2), v['a'][0] (#3)]
     ├── read rows: 1
-    ├── read bytes: 128
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/09_0039_target_build_merge_into_standalone.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/09_0039_target_build_merge_into_standalone.test
@@ -75,7 +75,7 @@ HashJoin
 │   ├── table: default.default.target_build_optimization
 │   ├── output columns: [a (#3), b (#4), c (#5), _row_id (#6)]
 │   ├── read rows: 8
-│   ├── read bytes: 512
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 4
 │   ├── pruning stats: [segments: <range pruning: 4 to 4>, blocks: <range pruning: 4 to 4>]
@@ -85,7 +85,7 @@ HashJoin
     ├── table: default.default.source_optimization
     ├── output columns: [a (#0), b (#1), c (#2)]
     ├── read rows: 12
-    ├── read bytes: 770
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 6
     ├── pruning stats: [segments: <range pruning: 6 to 6>, blocks: <range pruning: 6 to 6>]
@@ -150,7 +150,7 @@ HashJoin
 │   ├── table: default.default.target_build_optimization
 │   ├── output columns: [a (#3), b (#4), c (#5), _row_id (#6)]
 │   ├── read rows: 8
-│   ├── read bytes: 512
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 4
 │   ├── pruning stats: [segments: <range pruning: 4 to 4>, blocks: <range pruning: 4 to 4>]
@@ -160,7 +160,7 @@ HashJoin
     ├── table: default.default.source_optimization
     ├── output columns: [a (#0), b (#1), c (#2)]
     ├── read rows: 10
-    ├── read bytes: 752
+    ├── read size: < 1 KiB
     ├── partitions total: 6
     ├── partitions scanned: 6
     ├── pruning stats: [segments: <range pruning: 6 to 6>, blocks: <range pruning: 6 to 6>]
@@ -242,7 +242,7 @@ HashJoin
 │   ├── table: default.default.target_build_optimization
 │   ├── output columns: [a (#3), b (#4), c (#5), _row_id (#6)]
 │   ├── read rows: 8
-│   ├── read bytes: 512
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 4
 │   ├── partitions scanned: 4
 │   ├── pruning stats: [segments: <range pruning: 4 to 4>, blocks: <range pruning: 4 to 4>]
@@ -252,7 +252,7 @@ HashJoin
     ├── table: default.default.source_optimization
     ├── output columns: [a (#0), b (#1), c (#2)]
     ├── read rows: 10
-    ├── read bytes: 752
+    ├── read size: < 1 KiB
     ├── partitions total: 6
     ├── partitions scanned: 6
     ├── pruning stats: [segments: <range pruning: 6 to 6>, blocks: <range pruning: 6 to 6>]
@@ -338,7 +338,7 @@ HashJoin
 │   ├── table: default.default.target_build_optimization
 │   ├── output columns: [a (#3), b (#4), c (#5), _row_id (#6)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -347,7 +347,7 @@ HashJoin
     ├── table: default.default.source_optimization
     ├── output columns: [a (#0), b (#1), c (#2)]
     ├── read rows: 10
-    ├── read bytes: 752
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 6
     ├── pruning stats: [segments: <range pruning: 6 to 6>, blocks: <range pruning: 6 to 6>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/09_0039_target_build_merge_into_standalone.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/09_0039_target_build_merge_into_standalone.test
@@ -338,7 +338,7 @@ HashJoin
 │   ├── table: default.default.target_build_optimization
 │   ├── output columns: [a (#3), b (#4), c (#5), _row_id (#6)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
@@ -14,7 +14,7 @@ AggregateFinal
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 10
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -37,7 +37,7 @@ AggregateFinal
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 10
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -55,7 +55,7 @@ EvalScalar
     ├── table: default.system.numbers
     ├── output columns: []
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -83,7 +83,7 @@ EvalScalar
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 10
-            ├── read bytes: 80
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
@@ -110,7 +110,7 @@ EvalScalar
             ├── table: default.system.columns
             ├── output columns: [name (#0), type (#3)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -140,7 +140,7 @@ AggregateFinal
             ├── table: default.default.explain_agg_t1
             ├── output columns: [a (#0)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [false], limit: NONE]
@@ -166,7 +166,7 @@ AggregateFinal
             ├── table: default.default.explain_agg_t1
             ├── output columns: [a (#0)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [explain_agg_t1.a (#0) > 3], limit: NONE]
@@ -192,7 +192,7 @@ AggregateFinal
             ├── table: default.default.explain_agg_t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -226,7 +226,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -260,7 +260,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -295,7 +295,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -329,7 +329,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -363,7 +363,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -397,7 +397,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -440,7 +440,7 @@ AggregateFinal
         │   ├── table: default.default.t1
         │   ├── output columns: [a (#0)]
         │   ├── read rows: 10
-        │   ├── read bytes: 60
+        │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
         │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -450,7 +450,7 @@ AggregateFinal
             ├── table: default.default.t2
             ├── output columns: [a (#1)]
             ├── read rows: 100
-            ├── read bytes: 166
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -489,7 +489,7 @@ EvalScalar
             ├── table: default.default.t
             ├── output columns: [referer (#0), isrefresh (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
@@ -110,7 +110,7 @@ EvalScalar
             ├── table: default.system.columns
             ├── output columns: [name (#0), type (#3)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -140,7 +140,7 @@ AggregateFinal
             ├── table: default.default.explain_agg_t1
             ├── output columns: [a (#0)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [false], limit: NONE]
@@ -166,7 +166,7 @@ AggregateFinal
             ├── table: default.default.explain_agg_t1
             ├── output columns: [a (#0)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [explain_agg_t1.a (#0) > 3], limit: NONE]
@@ -192,7 +192,7 @@ AggregateFinal
             ├── table: default.default.explain_agg_t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -226,7 +226,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -260,7 +260,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -295,7 +295,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -329,7 +329,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -363,7 +363,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -397,7 +397,7 @@ EvalScalar
                     ├── table: default.default.explain_agg_t1
                     ├── output columns: [a (#0), b (#1)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [], limit: NONE]
@@ -489,7 +489,7 @@ EvalScalar
             ├── table: default.default.t
             ├── output columns: [referer (#0), isrefresh (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -29,7 +29,7 @@ EvalScalar
         ├── table: default.default.bloom_test_t
         ├── output columns: [c1 (#0)]
         ├── read rows: 3
-        ├── read bytes: 44
+        ├── read size: < 1 KiB
         ├── partitions total: 2
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 2 to 1>]
@@ -115,7 +115,7 @@ EvalScalar
         ├── table: default.default.bloom_test_t
         ├── output columns: [c2 (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 3
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 3 to 2>, blocks: <range pruning: 2 to 0>]
@@ -137,7 +137,7 @@ EvalScalar
         ├── table: default.default.bloom_test_t
         ├── output columns: [c2 (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 3
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 1, bloom pruning: 1 to 0>]
@@ -159,7 +159,7 @@ EvalScalar
         ├── table: default.default.bloom_test_t
         ├── output columns: [c3 (#2)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 3
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 1, bloom pruning: 1 to 0>]
@@ -201,7 +201,7 @@ EvalScalar
         ├── table: default.default.bloom_test_alter_t1
         ├── output columns: [c1 (#0)]
         ├── read rows: 6
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
         ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]
@@ -235,7 +235,7 @@ EvalScalar
         ├── table: default.default.bloom_test_alter_t2
         ├── output columns: [c1 (#0)]
         ├── read rows: 6
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
         ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]
@@ -266,7 +266,7 @@ EvalScalar
         ├── table: default.default.bloom_test_alter_t2
         ├── output columns: [c1 (#0)]
         ├── read rows: 6
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 3
         ├── partitions scanned: 2
         ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 3, bloom pruning: 3 to 2>]
@@ -292,7 +292,7 @@ EvalScalar
         ├── table: default.default.bloom_test_alter_t2
         ├── output columns: [c1 (#0)]
         ├── read rows: 9
-        ├── read bytes: 132
+        ├── read size: < 1 KiB
         ├── partitions total: 3
         ├── partitions scanned: 3
         ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 3>]
@@ -326,7 +326,7 @@ EvalScalar
         ├── table: default.default.bloom_test_nullable_t
         ├── output columns: [c1 (#0), c2 (#1)]
         ├── read rows: 3
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 2
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 2 to 1>]
@@ -348,7 +348,7 @@ EvalScalar
         ├── table: default.default.bloom_test_nullable_t
         ├── output columns: [c2 (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 2
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -115,7 +115,7 @@ EvalScalar
         ├── table: default.default.bloom_test_t
         ├── output columns: [c2 (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 3
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 3 to 2>, blocks: <range pruning: 2 to 0>]
@@ -137,7 +137,7 @@ EvalScalar
         ├── table: default.default.bloom_test_t
         ├── output columns: [c2 (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 3
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 1, bloom pruning: 1 to 0>]
@@ -159,7 +159,7 @@ EvalScalar
         ├── table: default.default.bloom_test_t
         ├── output columns: [c3 (#2)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 3
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 1, bloom pruning: 1 to 0>]
@@ -348,7 +348,7 @@ EvalScalar
         ├── table: default.default.bloom_test_nullable_t
         ├── output columns: [c2 (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 2
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -24,7 +24,7 @@ HashJoin
 │   ├── table: default.eliminate_outer_join.t
 │   ├── output columns: [a (#1)]
 │   ├── read rows: 10
-│   ├── read bytes: 72
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -34,7 +34,7 @@ HashJoin
     ├── table: default.eliminate_outer_join.t
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 72
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -55,7 +55,7 @@ HashJoin
 │   ├── table: default.eliminate_outer_join.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 10
-│   ├── read bytes: 72
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -65,7 +65,7 @@ HashJoin
     ├── table: default.eliminate_outer_join.t
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 72
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -86,7 +86,7 @@ HashJoin
 │   ├── table: default.eliminate_outer_join.t
 │   ├── output columns: [a (#1)]
 │   ├── read rows: 10
-│   ├── read bytes: 72
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -96,7 +96,7 @@ HashJoin
     ├── table: default.eliminate_outer_join.t
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 72
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -121,7 +121,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -135,7 +135,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -160,7 +160,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -174,7 +174,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -199,7 +199,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -213,7 +213,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -238,7 +238,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#0)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -252,7 +252,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#1)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -277,7 +277,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -291,7 +291,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -316,7 +316,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
@@ -330,7 +330,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
@@ -355,7 +355,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -369,7 +369,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -394,7 +394,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -408,7 +408,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -433,7 +433,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -447,7 +447,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -472,7 +472,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -486,7 +486,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -511,7 +511,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.t
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 72
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -525,7 +525,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -551,7 +551,7 @@ Filter
     │   ├── table: default.eliminate_outer_join.t
     │   ├── output columns: [a (#1)]
     │   ├── read rows: 10
-    │   ├── read bytes: 72
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -561,7 +561,7 @@ Filter
         ├── table: default.eliminate_outer_join.t
         ├── output columns: [a (#0)]
         ├── read rows: 10
-        ├── read bytes: 72
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -590,7 +590,7 @@ Filter
     │       ├── table: default.eliminate_outer_join.t
     │       ├── output columns: [a (#1)]
     │       ├── read rows: 10
-    │       ├── read bytes: 72
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -604,7 +604,7 @@ Filter
             ├── table: default.eliminate_outer_join.t
             ├── output columns: [a (#0)]
             ├── read rows: 10
-            ├── read bytes: 72
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -625,7 +625,7 @@ HashJoin
 │   ├── table: default.eliminate_outer_join.t
 │   ├── output columns: [a (#1)]
 │   ├── read rows: 10
-│   ├── read bytes: 72
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -635,7 +635,7 @@ HashJoin
     ├── table: default.eliminate_outer_join.t
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 72
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -663,7 +663,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.time_table
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(time_table.a (#1) > '2001-01-01 00:00:00.000000')], limit: NONE]
@@ -676,7 +676,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.time_table
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(time_table.a (#0) > '2001-01-01 00:00:00.000000')], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -663,7 +663,7 @@ HashJoin
 │       ├── table: default.eliminate_outer_join.time_table
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(time_table.a (#1) > '2001-01-01 00:00:00.000000')], limit: NONE]
@@ -676,7 +676,7 @@ HashJoin
         ├── table: default.eliminate_outer_join.time_table
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(time_table.a (#0) > '2001-01-01 00:00:00.000000')], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_sort.test
@@ -9,7 +9,7 @@ Sort
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -26,7 +26,7 @@ Sort
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -47,7 +47,7 @@ Sort
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 10
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -68,7 +68,7 @@ Sort
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 10
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -93,7 +93,7 @@ Sort
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 10
-            ├── read bytes: 80
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -21,7 +21,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -50,7 +50,7 @@ Filter
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 0
-    │       ├── read size: < 1 KiB
+    │       ├── read size: 0
     │       ├── partitions total: 1
     │       ├── partitions scanned: 0
     │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -1033,7 +1033,7 @@ Filter
     ├── table: default.default.t4
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t4.a (#0) = 1, TRY_CAST(get(try_parse_json(t4.b (#1)), 'bb') AS String NULL) = 'xx')], limit: NONE]
@@ -1060,7 +1060,7 @@ EvalScalar
         ├── table: default.default.t4
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(TRY_CAST(get(try_parse_json(t4.b (#1)), 'bb') AS String NULL) = 'xx')], limit: NONE]
@@ -1081,7 +1081,7 @@ EvalScalar
         ├── table: default.default.t4
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t4.a (#0) > 100)], limit: NONE]
@@ -1396,7 +1396,7 @@ Sort
     │       ├── table: default.default.t2
     │       ├── output columns: [k (#2), l (#3)]
     │       ├── read rows: 0
-    │       ├── read size: < 1 KiB
+    │       ├── read size: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [false], limit: NONE]
@@ -1559,7 +1559,7 @@ EvalScalar
     │       ├── table: default.default.t2
     │       ├── output columns: [b (#1)]
     │       ├── read rows: 0
-    │       ├── read size: < 1 KiB
+    │       ├── read size: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [false], limit: NONE]
@@ -1572,7 +1572,7 @@ EvalScalar
             ├── table: default.default.t1
             ├── output columns: [a (#0)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [false], limit: NONE]
@@ -1631,7 +1631,7 @@ Filter
     │                       ├── table: default.default.t1
     │                       ├── output columns: [a (#3), c (#5)]
     │                       ├── read rows: 0
-    │                       ├── read size: < 1 KiB
+    │                       ├── read size: 0
     │                       ├── partitions total: 0
     │                       ├── partitions scanned: 0
     │                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
@@ -1640,7 +1640,7 @@ Filter
         ├── table: default.default.t2
         ├── output columns: [a (#0), b (#1), c (#2)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -1685,7 +1685,7 @@ Filter
     │                       ├── table: default.default.t1
     │                       ├── output columns: [a (#3), c (#5)]
     │                       ├── read rows: 0
-    │                       ├── read size: < 1 KiB
+    │                       ├── read size: 0
     │                       ├── partitions total: 0
     │                       ├── partitions scanned: 0
     │                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
@@ -1694,7 +1694,7 @@ Filter
         ├── table: default.default.t2
         ├── output columns: [a (#0), b (#1), c (#2)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -1708,7 +1708,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1), c (#2)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [], limit: NONE]
@@ -1720,3 +1720,107 @@ drop table t1;
 
 statement ok
 drop table t2;
+
+query T
+explain select * from numbers(0);
+----
+TableScan
+├── table: default.system.numbers
+├── output columns: [number (#0)]
+├── read rows: 0
+├── read size: 0
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 0.00
+
+query T
+explain select * from numbers(10);
+----
+TableScan
+├── table: default.system.numbers
+├── output columns: [number (#0)]
+├── read rows: 10
+├── read size: < 1 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 10.00
+
+query T
+explain select * from numbers(10000);
+----
+TableScan
+├── table: default.system.numbers
+├── output columns: [number (#0)]
+├── read rows: 10000
+├── read size: 78.12 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 10000.00
+
+query T
+explain select * from numbers(10000000);
+----
+TableScan
+├── table: default.system.numbers
+├── output columns: [number (#0)]
+├── read rows: 10000000
+├── read size: 76.29 MiB
+├── partitions total: 153
+├── partitions scanned: 153
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 10000000.00
+
+query T
+explain select * from numbers(10000000000);
+----
+TableScan
+├── table: default.system.numbers
+├── output columns: [number (#0)]
+├── read rows: 10000000000
+├── read size: 74.51 GiB
+├── partitions total: 152588
+├── partitions scanned: 152588
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 10000000000.00
+
+query T
+explain select * from numbers(10000000000000);
+----
+TableScan
+├── table: default.system.numbers
+├── output columns: [number (#0)]
+├── read rows: 10000000000000
+├── read size: 72.76 TiB
+├── partitions total: 152587891
+├── partitions scanned: 152587891
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 10000000000000.00
+
+query T
+explain select * from numbers(10000000000000000);
+----
+TableScan
+├── table: default.system.numbers
+├── output columns: [number (#0)]
+├── read rows: 10000000000000000
+├── read size: 71.05 PiB
+├── partitions total: 152587890626
+├── partitions scanned: 152587890626
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 10000000000000000.00
+
+query T
+explain select * from numbers(10000000000000000000);
+----
+TableScan
+├── table: default.system.numbers
+├── output columns: [number (#0)]
+├── read rows: 10000000000000000000
+├── read size: 5.39 EiB
+├── partitions total: 152587890625001
+├── partitions scanned: 152587890625001
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 10000000000000000000.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -21,7 +21,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -50,7 +50,7 @@ Filter
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 0
-    │       ├── read bytes: 0
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 0
     │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -64,7 +64,7 @@ Filter
             ├── table: default.default.t2
             ├── output columns: [a (#2), b (#3)]
             ├── read rows: 5
-            ├── read bytes: 98
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -85,7 +85,7 @@ HashJoin
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 68
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -95,7 +95,7 @@ HashJoin
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]
     ├── read rows: 5
-    ├── read bytes: 98
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -597,7 +597,7 @@ UnionAll
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -607,7 +607,7 @@ UnionAll
     ├── table: default.default.t2
     ├── output columns: [a (#2)]
     ├── read rows: 5
-    ├── read bytes: 49
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -636,7 +636,7 @@ Filter
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 1
-    │       ├── read bytes: 68
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -650,7 +650,7 @@ Filter
             ├── table: default.default.t2
             ├── output columns: [a (#2), b (#3)]
             ├── read rows: 5
-            ├── read bytes: 98
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -679,7 +679,7 @@ Filter
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 1
-    │       ├── read bytes: 68
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
@@ -689,7 +689,7 @@ Filter
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
         ├── read rows: 5
-        ├── read bytes: 98
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -723,7 +723,7 @@ HashJoin
 │   │   ├── table: default.default.t1
 │   │   ├── output columns: [a (#0), b (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 68
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -733,7 +733,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 5
-│       ├── read bytes: 98
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -743,7 +743,7 @@ HashJoin
     ├── table: default.default.t3
     ├── output columns: [a (#4), b (#5)]
     ├── read rows: 10
-    ├── read bytes: 120
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -779,7 +779,7 @@ HashJoin
 │       │       ├── table: default.default.t1
 │       │       ├── output columns: [a (#0), b (#1)]
 │       │       ├── read rows: 1
-│       │       ├── read bytes: 68
+│       │       ├── read size: < 1 KiB
 │       │       ├── partitions total: 1
 │       │       ├── partitions scanned: 1
 │       │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -793,7 +793,7 @@ HashJoin
 │               ├── table: default.default.t2
 │               ├── output columns: [a (#2), b (#3)]
 │               ├── read rows: 5
-│               ├── read bytes: 98
+│               ├── read size: < 1 KiB
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
 │               ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -807,7 +807,7 @@ HashJoin
         ├── table: default.default.t3
         ├── output columns: [a (#4), b (#5)]
         ├── read rows: 10
-        ├── read bytes: 120
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -845,7 +845,7 @@ Limit
             │       ├── table: default.default.t1
             │       ├── output columns: [a (#0), b (#1)]
             │       ├── read rows: 1
-            │       ├── read bytes: 68
+            │       ├── read size: < 1 KiB
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
             │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -859,7 +859,7 @@ Limit
                     ├── table: default.default.t2
                     ├── output columns: [a (#2), b (#3)]
                     ├── read rows: 5
-                    ├── read bytes: 98
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -884,7 +884,7 @@ HashJoin
 │       ├── table: default.default.t1
 │       ├── output columns: [a (#0), b (#1)]
 │       ├── read rows: 1
-│       ├── read bytes: 68
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -894,7 +894,7 @@ HashJoin
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]
     ├── read rows: 5
-    ├── read bytes: 98
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -926,7 +926,7 @@ AggregateFinal
                 ├── table: default.default.t1
                 ├── output columns: [a (#0)]
                 ├── read rows: 1
-                ├── read bytes: 34
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -958,7 +958,7 @@ AggregateFinal
                 ├── table: default.default.t1
                 ├── output columns: [a (#0)]
                 ├── read rows: 1
-                ├── read bytes: 34
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -1033,7 +1033,7 @@ Filter
     ├── table: default.default.t4
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t4.a (#0) = 1, TRY_CAST(get(try_parse_json(t4.b (#1)), 'bb') AS String NULL) = 'xx')], limit: NONE]
@@ -1060,7 +1060,7 @@ EvalScalar
         ├── table: default.default.t4
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(TRY_CAST(get(try_parse_json(t4.b (#1)), 'bb') AS String NULL) = 'xx')], limit: NONE]
@@ -1081,7 +1081,7 @@ EvalScalar
         ├── table: default.default.t4
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t4.a (#0) > 100)], limit: NONE]
@@ -1132,7 +1132,7 @@ Limit
     │       ├── table: default.default.a
     │       ├── output columns: [id (#0), c1 (#1)]
     │       ├── read rows: 1
-    │       ├── read bytes: 72
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -1146,7 +1146,7 @@ Limit
             ├── table: default.default.b
             ├── output columns: [id (#2), c1 (#3)]
             ├── read rows: 2
-            ├── read bytes: 144
+            ├── read size: < 1 KiB
             ├── partitions total: 2
             ├── partitions scanned: 2
             ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]
@@ -1189,7 +1189,7 @@ Sort
     │           ├── table: default.system.numbers
     │           ├── output columns: [number (#2)]
     │           ├── read rows: 10
-    │           ├── read bytes: 80
+    │           ├── read size: < 1 KiB
     │           ├── partitions total: 1
     │           ├── partitions scanned: 1
     │           ├── push downs: [filters: [numbers.number (#2) > 5], limit: NONE]
@@ -1206,7 +1206,7 @@ Sort
                 ├── table: default.system.numbers
                 ├── output columns: [number (#0)]
                 ├── read rows: 10
-                ├── read bytes: 80
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── push downs: [filters: [numbers.number (#0) > 5], limit: NONE]
@@ -1254,7 +1254,7 @@ Filter
     │       ├── table: default.default.b
     │       ├── output columns: [id (#2)]
     │       ├── read rows: 2
-    │       ├── read bytes: 40
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -1264,7 +1264,7 @@ Filter
         ├── table: default.default.a
         ├── output columns: [id (#0), c1 (#1)]
         ├── read rows: 3
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -1297,7 +1297,7 @@ HashJoin
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
 │   ├── read rows: 3
-│   ├── read bytes: 88
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -1334,7 +1334,7 @@ Filter
     │   ├── table: default.default.t1
     │   ├── output columns: [a (#0), b (#1)]
     │   ├── read rows: 3
-    │   ├── read bytes: 88
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -1396,7 +1396,7 @@ Sort
     │       ├── table: default.default.t2
     │       ├── output columns: [k (#2), l (#3)]
     │       ├── read rows: 0
-    │       ├── read bytes: 0
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [false], limit: NONE]
@@ -1405,7 +1405,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [i (#0), j (#1)]
         ├── read rows: 3
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -1559,7 +1559,7 @@ EvalScalar
     │       ├── table: default.default.t2
     │       ├── output columns: [b (#1)]
     │       ├── read rows: 0
-    │       ├── read bytes: 0
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [false], limit: NONE]
@@ -1572,7 +1572,7 @@ EvalScalar
             ├── table: default.default.t1
             ├── output columns: [a (#0)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [false], limit: NONE]
@@ -1631,7 +1631,7 @@ Filter
     │                       ├── table: default.default.t1
     │                       ├── output columns: [a (#3), c (#5)]
     │                       ├── read rows: 0
-    │                       ├── read bytes: 0
+    │                       ├── read size: < 1 KiB
     │                       ├── partitions total: 0
     │                       ├── partitions scanned: 0
     │                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
@@ -1640,7 +1640,7 @@ Filter
         ├── table: default.default.t2
         ├── output columns: [a (#0), b (#1), c (#2)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -1685,7 +1685,7 @@ Filter
     │                       ├── table: default.default.t1
     │                       ├── output columns: [a (#3), c (#5)]
     │                       ├── read rows: 0
-    │                       ├── read bytes: 0
+    │                       ├── read size: < 1 KiB
     │                       ├── partitions total: 0
     │                       ├── partitions scanned: 0
     │                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
@@ -1694,7 +1694,7 @@ Filter
         ├── table: default.default.t2
         ├── output columns: [a (#0), b (#1), c (#2)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -1708,7 +1708,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1), c (#2)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1812,15 +1812,3 @@ TableScan
 ├── push downs: [filters: [], limit: NONE]
 └── estimated rows: 10000000000000000.00
 
-query T
-explain select * from numbers(10000000000000000000);
-----
-TableScan
-├── table: default.system.numbers
-├── output columns: [number (#0)]
-├── read rows: 10000000000000000000
-├── read size: 5.39 EiB
-├── partitions total: 152587890625001
-├── partitions scanned: 152587890625001
-├── push downs: [filters: [], limit: NONE]
-└── estimated rows: 10000000000000000000.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_ddl.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_ddl.test
@@ -11,7 +11,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#1)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [numbers.number (#1) > 5], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_grouping_sets.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_grouping_sets.test
@@ -26,7 +26,7 @@ EvalScalar
                     ├── table: default.system.numbers
                     ├── output columns: [number (#0)]
                     ├── read rows: 1
-                    ├── read bytes: 8
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]
@@ -60,7 +60,7 @@ EvalScalar
                     ├── table: default.system.numbers
                     ├── output columns: [number (#0)]
                     ├── read rows: 1
-                    ├── read bytes: 8
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_like.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_like.test
@@ -29,7 +29,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [s (#0)]
         ├── read rows: 4
-        ├── read bytes: 66
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -56,7 +56,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [s (#0)]
         ├── read rows: 4
-        ├── read bytes: 66
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/filter.test
@@ -21,7 +21,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) = 1, t1.b (#1) > 2 OR t1.b (#1) < 100)], limit: NONE]
@@ -38,7 +38,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.b (#1) > 2 OR t1.b (#1) < 100)], limit: NONE]
@@ -85,7 +85,7 @@ HashJoin
 │           ├── table: default.default.t
 │           ├── output columns: [a (#0)]
 │           ├── read rows: 0
-│           ├── read size: < 1 KiB
+│           ├── read size: 0
 │           ├── partitions total: 0
 │           ├── partitions scanned: 0
 │           ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/filter.test
@@ -21,7 +21,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) = 1, t1.b (#1) > 2 OR t1.b (#1) < 100)], limit: NONE]
@@ -38,7 +38,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.b (#1) > 2 OR t1.b (#1) < 100)], limit: NONE]
@@ -85,7 +85,7 @@ HashJoin
 │           ├── table: default.default.t
 │           ├── output columns: [a (#0)]
 │           ├── read rows: 0
-│           ├── read bytes: 0
+│           ├── read size: < 1 KiB
 │           ├── partitions total: 0
 │           ├── partitions scanned: 0
 │           ├── push downs: [filters: [false], limit: NONE]
@@ -94,7 +94,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#2)]
     ├── read rows: 5
-    ├── read bytes: 52
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_count.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_count.test
@@ -45,7 +45,7 @@ AggregateFinal
             ├── table: default.default.t
             ├── output columns: [number (#0)]
             ├── read rows: 1000
-            ├── read bytes: 1436
+            ├── read size: 1.40 KiB
             ├── partitions total: 2
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1>]
@@ -68,7 +68,7 @@ AggregateFinal
         ├── table: default.default.t
         ├── output columns: [number (#0)]
         ├── read rows: 1001
-        ├── read bytes: 1470
+        ├── read size: 1.44 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
         ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
@@ -28,7 +28,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -46,7 +46,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -64,7 +64,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -82,7 +82,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -100,7 +100,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -118,7 +118,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -136,7 +136,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -154,7 +154,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -172,7 +172,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -190,7 +190,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -208,7 +208,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -226,7 +226,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -245,7 +245,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -263,7 +263,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 2], limit: NONE]
@@ -281,7 +281,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) <> 1], limit: NONE]
@@ -299,7 +299,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <> 2)], limit: NONE]
@@ -317,7 +317,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) < 1], limit: NONE]
@@ -335,7 +335,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) < 2)], limit: NONE]
@@ -353,7 +353,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <= 1)], limit: NONE]
@@ -371,7 +371,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <= 2)], limit: NONE]
@@ -389,7 +389,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) > 1], limit: NONE]
@@ -407,7 +407,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) > 0)], limit: NONE]
@@ -425,7 +425,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) >= 1)], limit: NONE]
@@ -443,7 +443,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) >= 0)], limit: NONE]
@@ -461,7 +461,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -479,7 +479,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 2], limit: NONE]
@@ -497,7 +497,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) < 5], limit: NONE]
@@ -515,7 +515,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) < 5, t1.a (#0) <> 2)], limit: NONE]
@@ -533,7 +533,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) < 5], limit: NONE]
@@ -551,7 +551,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -569,7 +569,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) < 5, t1.a (#0) > 2)], limit: NONE]
@@ -587,7 +587,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <= 100, t1.a (#0) > 10)], limit: NONE]
@@ -612,7 +612,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [t2.a (#2) > 10], limit: NONE]
@@ -625,7 +625,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [t1.a (#0) > 10], limit: NONE]
@@ -657,7 +657,7 @@ HashJoin
 │   │       ├── table: default.default.t3
 │   │       ├── output columns: [a (#4), b (#5)]
 │   │       ├── read rows: 0
-│   │       ├── read bytes: 0
+│   │       ├── read size: < 1 KiB
 │   │       ├── partitions total: 0
 │   │       ├── partitions scanned: 0
 │   │       ├── push downs: [filters: [and_filters(t3.a (#4) > 5, t3.a (#4) < 10)], limit: NONE]
@@ -670,7 +670,7 @@ HashJoin
 │           ├── table: default.default.t2
 │           ├── output columns: [a (#2), b (#3)]
 │           ├── read rows: 0
-│           ├── read bytes: 0
+│           ├── read size: < 1 KiB
 │           ├── partitions total: 0
 │           ├── partitions scanned: 0
 │           ├── push downs: [filters: [and_filters(t2.a (#2) > 5, t2.a (#2) < 10)], limit: NONE]
@@ -683,7 +683,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [and_filters(t1.a (#0) > 5, t1.a (#0) < 10)], limit: NONE]
@@ -707,7 +707,7 @@ MergeJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [t2.a (#2) > 10], limit: NONE]
@@ -720,7 +720,7 @@ MergeJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [t1.a (#0) > 5], limit: NONE]
@@ -740,7 +740,7 @@ MergeJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -753,7 +753,7 @@ MergeJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [t1.a (#0) > 10], limit: NONE]
@@ -778,7 +778,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [false], limit: NONE]
@@ -791,7 +791,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [false], limit: NONE]
@@ -816,7 +816,7 @@ HashJoin
 │       ├── table: default.default.t3
 │       ├── output columns: [a (#4), b (#5)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [false], limit: NONE]
@@ -836,7 +836,7 @@ HashJoin
     │       ├── table: default.default.t2
     │       ├── output columns: [a (#2), b (#3)]
     │       ├── read rows: 0
-    │       ├── read bytes: 0
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [false], limit: NONE]
@@ -849,7 +849,7 @@ HashJoin
             ├── table: default.default.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [false], limit: NONE]
@@ -877,7 +877,7 @@ HashJoin
 │   │   ├── table: default.default.t3
 │   │   ├── output columns: [a (#4), b (#5)]
 │   │   ├── read rows: 0
-│   │   ├── read bytes: 0
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 0
 │   │   ├── partitions scanned: 0
 │   │   ├── push downs: [filters: [], limit: NONE]
@@ -886,7 +886,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [], limit: NONE]
@@ -895,7 +895,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
@@ -28,7 +28,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -46,7 +46,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -64,7 +64,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -82,7 +82,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -100,7 +100,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -118,7 +118,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -136,7 +136,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -154,7 +154,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -172,7 +172,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -190,7 +190,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -208,7 +208,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -226,7 +226,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -245,7 +245,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -263,7 +263,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 2], limit: NONE]
@@ -281,7 +281,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) <> 1], limit: NONE]
@@ -299,7 +299,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <> 2)], limit: NONE]
@@ -317,7 +317,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) < 1], limit: NONE]
@@ -335,7 +335,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) < 2)], limit: NONE]
@@ -353,7 +353,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <= 1)], limit: NONE]
@@ -371,7 +371,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <= 2)], limit: NONE]
@@ -389,7 +389,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) > 1], limit: NONE]
@@ -407,7 +407,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) > 0)], limit: NONE]
@@ -425,7 +425,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) >= 1)], limit: NONE]
@@ -443,7 +443,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) >= 0)], limit: NONE]
@@ -461,7 +461,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -479,7 +479,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) = 2], limit: NONE]
@@ -497,7 +497,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) < 5], limit: NONE]
@@ -515,7 +515,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) < 5, t1.a (#0) <> 2)], limit: NONE]
@@ -533,7 +533,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) < 5], limit: NONE]
@@ -551,7 +551,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -569,7 +569,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) < 5, t1.a (#0) > 2)], limit: NONE]
@@ -587,7 +587,7 @@ Filter
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) <= 100, t1.a (#0) > 10)], limit: NONE]
@@ -612,7 +612,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [t2.a (#2) > 10], limit: NONE]
@@ -625,7 +625,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [t1.a (#0) > 10], limit: NONE]
@@ -657,7 +657,7 @@ HashJoin
 │   │       ├── table: default.default.t3
 │   │       ├── output columns: [a (#4), b (#5)]
 │   │       ├── read rows: 0
-│   │       ├── read size: < 1 KiB
+│   │       ├── read size: 0
 │   │       ├── partitions total: 0
 │   │       ├── partitions scanned: 0
 │   │       ├── push downs: [filters: [and_filters(t3.a (#4) > 5, t3.a (#4) < 10)], limit: NONE]
@@ -670,7 +670,7 @@ HashJoin
 │           ├── table: default.default.t2
 │           ├── output columns: [a (#2), b (#3)]
 │           ├── read rows: 0
-│           ├── read size: < 1 KiB
+│           ├── read size: 0
 │           ├── partitions total: 0
 │           ├── partitions scanned: 0
 │           ├── push downs: [filters: [and_filters(t2.a (#2) > 5, t2.a (#2) < 10)], limit: NONE]
@@ -683,7 +683,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [and_filters(t1.a (#0) > 5, t1.a (#0) < 10)], limit: NONE]
@@ -707,7 +707,7 @@ MergeJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [t2.a (#2) > 10], limit: NONE]
@@ -720,7 +720,7 @@ MergeJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [t1.a (#0) > 5], limit: NONE]
@@ -740,7 +740,7 @@ MergeJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -753,7 +753,7 @@ MergeJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [t1.a (#0) > 10], limit: NONE]
@@ -778,7 +778,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [false], limit: NONE]
@@ -791,7 +791,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [false], limit: NONE]
@@ -816,7 +816,7 @@ HashJoin
 │       ├── table: default.default.t3
 │       ├── output columns: [a (#4), b (#5)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [false], limit: NONE]
@@ -836,7 +836,7 @@ HashJoin
     │       ├── table: default.default.t2
     │       ├── output columns: [a (#2), b (#3)]
     │       ├── read rows: 0
-    │       ├── read size: < 1 KiB
+    │       ├── read size: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [false], limit: NONE]
@@ -849,7 +849,7 @@ HashJoin
             ├── table: default.default.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [false], limit: NONE]
@@ -877,7 +877,7 @@ HashJoin
 │   │   ├── table: default.default.t3
 │   │   ├── output columns: [a (#4), b (#5)]
 │   │   ├── read rows: 0
-│   │   ├── read size: < 1 KiB
+│   │   ├── read size: 0
 │   │   ├── partitions total: 0
 │   │   ├── partitions scanned: 0
 │   │   ├── push downs: [filters: [], limit: NONE]
@@ -886,7 +886,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [], limit: NONE]
@@ -895,7 +895,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -30,7 +30,7 @@ HashJoin
 │   ├── table: default.default.t
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -40,7 +40,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [number (#1)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -61,7 +61,7 @@ HashJoin
 │   ├── table: default.default.t
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -75,7 +75,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [number (#1)]
         ├── read rows: 10
-        ├── read bytes: 60
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -100,7 +100,7 @@ HashJoin
 │       ├── table: default.default.t
 │       ├── output columns: [number (#0)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -114,7 +114,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [number (#1)]
         ├── read rows: 10
-        ├── read bytes: 60
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -139,7 +139,7 @@ Filter
     │   ├── table: default.default.t
     │   ├── output columns: [number (#0)]
     │   ├── read rows: 1
-    │   ├── read bytes: 34
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -149,7 +149,7 @@ Filter
         ├── table: default.default.t1
         ├── output columns: [number (#1)]
         ├── read rows: 10
-        ├── read bytes: 60
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -182,7 +182,7 @@ HashJoin
 │   │       ├── table: default.default.t
 │   │       ├── output columns: [number (#0)]
 │   │       ├── read rows: 0
-│   │       ├── read bytes: 0
+│   │       ├── read size: < 1 KiB
 │   │       ├── partitions total: 1
 │   │       ├── partitions scanned: 0
 │   │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -192,7 +192,7 @@ HashJoin
 │       ├── table: default.default.t1
 │       ├── output columns: [number (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -202,7 +202,7 @@ HashJoin
     ├── table: default.default.t2
     ├── output columns: [number (#2)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -247,7 +247,7 @@ HashJoin
 │       ├── table: default.default.onecolumn
 │       ├── output columns: [x (#0)]
 │       ├── read rows: 4
-│       ├── read bytes: 44
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -261,7 +261,7 @@ HashJoin
         ├── table: default.default.twocolumn
         ├── output columns: [x (#1), y (#2)]
         ├── read rows: 4
-        ├── read bytes: 92
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -286,7 +286,7 @@ HashJoin
 │       ├── table: default.default.onecolumn
 │       ├── output columns: [x (#0)]
 │       ├── read rows: 4
-│       ├── read bytes: 44
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -300,7 +300,7 @@ HashJoin
         ├── table: default.default.twocolumn
         ├── output columns: [x (#1), y (#2)]
         ├── read rows: 4
-        ├── read bytes: 92
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -325,7 +325,7 @@ HashJoin
 │       ├── table: default.default.onecolumn
 │       ├── output columns: [x (#0)]
 │       ├── read rows: 4
-│       ├── read bytes: 44
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -339,7 +339,7 @@ HashJoin
         ├── table: default.default.twocolumn
         ├── output columns: [x (#1), y (#2)]
         ├── read rows: 4
-        ├── read bytes: 92
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -366,7 +366,7 @@ Filter
     │   ├── table: default.default.twocolumn
     │   ├── output columns: [x (#1), y (#2)]
     │   ├── read rows: 4
-    │   ├── read bytes: 92
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -376,7 +376,7 @@ Filter
         ├── table: default.default.onecolumn
         ├── output columns: [x (#0)]
         ├── read rows: 4
-        ├── read bytes: 44
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -401,7 +401,7 @@ HashJoin
 │       ├── table: default.default.onecolumn
 │       ├── output columns: [x (#0)]
 │       ├── read rows: 4
-│       ├── read bytes: 44
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -415,7 +415,7 @@ HashJoin
         ├── table: default.default.twocolumn
         ├── output columns: [x (#1), y (#2)]
         ├── read rows: 4
-        ├── read bytes: 92
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -455,7 +455,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 10)], limit: NONE]
@@ -468,7 +468,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 10)], limit: NONE]
@@ -488,7 +488,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -501,7 +501,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) + t1.b (#1) > 10)], limit: NONE]
@@ -525,7 +525,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 10)], limit: NONE]
@@ -538,7 +538,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 10)], limit: NONE]
@@ -562,7 +562,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) + t2.b (#3) > 10)], limit: NONE]
@@ -575,7 +575,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) + t1.b (#1) > 10)], limit: NONE]
@@ -599,7 +599,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.b (#3) + t2.a (#2) > 10)], limit: NONE]
@@ -612,7 +612,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.b (#1) + t1.a (#0) > 10)], limit: NONE]
@@ -633,7 +633,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -642,7 +642,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -750,7 +750,7 @@ HashJoin
 │       ├── table: default.default.twocolumn
 │       ├── output columns: [x (#1), y (#2)]
 │       ├── read rows: 8
-│       ├── read bytes: 184
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 2
 │       ├── partitions scanned: 2
 │       ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 2 to 2>]
@@ -760,7 +760,7 @@ HashJoin
     ├── table: default.default.onecolumn
     ├── output columns: [x (#0)]
     ├── read rows: 7
-    ├── read bytes: 84
+    ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 2
     ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]
@@ -792,7 +792,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 20
-│   ├── read bytes: 160
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -801,7 +801,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -841,7 +841,7 @@ EvalScalar
     │       ├── table: default.default.t2
     │       ├── output columns: [wms_id (#4)]
     │       ├── read rows: 0
-    │       ├── read bytes: 0
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [is_true(substr(t2.wms_id (#4), 1) = 'R006')], limit: NONE]
@@ -854,7 +854,7 @@ EvalScalar
             ├── table: default.default.t1
             ├── output columns: [ext (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [is_true(substr(replace(t1.ext (#1), '33', '44'), 1) = 'R006')], limit: NONE]
@@ -882,7 +882,7 @@ EvalScalar
     │       ├── table: default.default.t2
     │       ├── output columns: [wms_id (#4)]
     │       ├── read rows: 0
-    │       ├── read bytes: 0
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [is_true(t2.wms_id (#4) = 'R006')], limit: NONE]
@@ -895,7 +895,7 @@ EvalScalar
             ├── table: default.default.t1
             ├── output columns: [ext (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [is_true(replace(t1.ext (#1), '33', '44') = 'R006')], limit: NONE]
@@ -919,7 +919,7 @@ EvalScalar
     │   ├── table: default.default.t2
     │   ├── output columns: [wms_id (#4)]
     │   ├── read rows: 0
-    │   ├── read bytes: 0
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
     │   ├── push downs: [filters: [], limit: NONE]
@@ -932,7 +932,7 @@ EvalScalar
             ├── table: default.default.t1
             ├── output columns: [ext (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [is_true(replace(substr(t1.ext (#1), 1), '33', '44') = 'R006')], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -100,7 +100,7 @@ HashJoin
 │       ├── table: default.default.t
 │       ├── output columns: [number (#0)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -182,7 +182,7 @@ HashJoin
 │   │       ├── table: default.default.t
 │   │       ├── output columns: [number (#0)]
 │   │       ├── read rows: 0
-│   │       ├── read size: < 1 KiB
+│   │       ├── read size: 0
 │   │       ├── partitions total: 1
 │   │       ├── partitions scanned: 0
 │   │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -455,7 +455,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 10)], limit: NONE]
@@ -468,7 +468,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 10)], limit: NONE]
@@ -488,7 +488,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -501,7 +501,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) + t1.b (#1) > 10)], limit: NONE]
@@ -525,7 +525,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 10)], limit: NONE]
@@ -538,7 +538,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 10)], limit: NONE]
@@ -562,7 +562,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) + t2.b (#3) > 10)], limit: NONE]
@@ -575,7 +575,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) + t1.b (#1) > 10)], limit: NONE]
@@ -599,7 +599,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.b (#3) + t2.a (#2) > 10)], limit: NONE]
@@ -612,7 +612,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.b (#1) + t1.a (#0) > 10)], limit: NONE]
@@ -633,7 +633,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -642,7 +642,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -841,7 +841,7 @@ EvalScalar
     │       ├── table: default.default.t2
     │       ├── output columns: [wms_id (#4)]
     │       ├── read rows: 0
-    │       ├── read size: < 1 KiB
+    │       ├── read size: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [is_true(substr(t2.wms_id (#4), 1) = 'R006')], limit: NONE]
@@ -854,7 +854,7 @@ EvalScalar
             ├── table: default.default.t1
             ├── output columns: [ext (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [is_true(substr(replace(t1.ext (#1), '33', '44'), 1) = 'R006')], limit: NONE]
@@ -882,7 +882,7 @@ EvalScalar
     │       ├── table: default.default.t2
     │       ├── output columns: [wms_id (#4)]
     │       ├── read rows: 0
-    │       ├── read size: < 1 KiB
+    │       ├── read size: 0
     │       ├── partitions total: 0
     │       ├── partitions scanned: 0
     │       ├── push downs: [filters: [is_true(t2.wms_id (#4) = 'R006')], limit: NONE]
@@ -895,7 +895,7 @@ EvalScalar
             ├── table: default.default.t1
             ├── output columns: [ext (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [is_true(replace(t1.ext (#1), '33', '44') = 'R006')], limit: NONE]
@@ -919,7 +919,7 @@ EvalScalar
     │   ├── table: default.default.t2
     │   ├── output columns: [wms_id (#4)]
     │   ├── read rows: 0
-    │   ├── read size: < 1 KiB
+    │   ├── read size: 0
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
     │   ├── push downs: [filters: [], limit: NONE]
@@ -932,7 +932,7 @@ EvalScalar
             ├── table: default.default.t1
             ├── output columns: [ext (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [is_true(replace(substr(t1.ext (#1), 1), '33', '44') = 'R006')], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -46,7 +46,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -56,7 +56,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -66,7 +66,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#2)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -94,7 +94,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -104,7 +104,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -114,7 +114,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#2)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -142,7 +142,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -152,7 +152,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -162,7 +162,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -190,7 +190,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -200,7 +200,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -210,7 +210,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -238,7 +238,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -248,7 +248,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -258,7 +258,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -286,7 +286,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -296,7 +296,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -306,7 +306,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -327,7 +327,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -337,7 +337,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -358,7 +358,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -368,7 +368,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -389,7 +389,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -399,7 +399,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -420,7 +420,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -430,7 +430,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -451,7 +451,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -461,7 +461,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -482,7 +482,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 34
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -492,7 +492,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -37,7 +37,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -47,7 +47,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -57,7 +57,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#2)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -85,7 +85,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -95,7 +95,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -105,7 +105,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#2)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -133,7 +133,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -143,7 +143,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -153,7 +153,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -181,7 +181,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -191,7 +191,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -201,7 +201,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -229,7 +229,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -239,7 +239,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -249,7 +249,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -277,7 +277,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -287,7 +287,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -297,7 +297,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
@@ -12,7 +12,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1000
-│   ├── read bytes: 8000
+│   ├── read size: 7.81 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -21,7 +21,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10000
-    ├── read bytes: 80000
+    ├── read size: 78.12 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -41,7 +41,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 1000
-│   ├── read bytes: 8000
+│   ├── read size: 7.81 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -50,7 +50,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#1)]
     ├── read rows: 10000
-    ├── read bytes: 80000
+    ├── read size: 78.12 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -110,7 +110,7 @@ EvalScalar
     │       │       ├── table: default.default.t1
     │       │       ├── output columns: [a (#2)]
     │       │       ├── read rows: 3
-    │       │       ├── read bytes: 44
+    │       │       ├── read size: < 1 KiB
     │       │       ├── partitions total: 1
     │       │       ├── partitions scanned: 1
     │       │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -137,7 +137,7 @@ EvalScalar
     │                       ├── table: default.default.t2
     │                       ├── output columns: [c (#8)]
     │                       ├── read rows: 4
-    │                       ├── read bytes: 48
+    │                       ├── read size: < 1 KiB
     │                       ├── partitions total: 1
     │                       ├── partitions scanned: 1
     │                       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -147,7 +147,7 @@ EvalScalar
         ├── table: default.default.t2
         ├── output columns: [c (#0)]
         ├── read rows: 4
-        ├── read bytes: 48
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -37,7 +37,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -47,7 +47,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -57,7 +57,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#2)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -85,7 +85,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -95,7 +95,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -105,7 +105,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#2)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -133,7 +133,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -143,7 +143,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -153,7 +153,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -181,7 +181,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -191,7 +191,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 166
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -201,7 +201,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 60
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -229,7 +229,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -239,7 +239,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -249,7 +249,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -277,7 +277,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 34
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -287,7 +287,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 10
-│       ├── read bytes: 60
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -297,7 +297,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 166
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/lateral.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lateral.test
@@ -12,7 +12,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 10
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -21,7 +21,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -41,7 +41,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 10
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -61,7 +61,7 @@ HashJoin
         │   ├── table: default.system.numbers
         │   ├── output columns: [number (#1)]
         │   ├── read rows: 10
-        │   ├── read bytes: 80
+        │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
         │   ├── push downs: [filters: [], limit: NONE]
@@ -79,7 +79,7 @@ HashJoin
                     ├── table: default.system.numbers
                     ├── output columns: [number (#3)]
                     ├── read rows: 10
-                    ├── read bytes: 80
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]
@@ -99,7 +99,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 10
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -119,7 +119,7 @@ HashJoin
         │   ├── table: default.system.numbers
         │   ├── output columns: [number (#1)]
         │   ├── read rows: 10
-        │   ├── read bytes: 80
+        │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
         │   ├── push downs: [filters: [], limit: NONE]
@@ -137,7 +137,7 @@ HashJoin
                     ├── table: default.system.numbers
                     ├── output columns: [number (#3)]
                     ├── read rows: 10
-                    ├── read bytes: 80
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/lazy_read.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lazy_read.test
@@ -24,7 +24,7 @@ RowFetch
             ├── table: default.default.t_lazy
             ├── output columns: [a (#0), _row_id (#7)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: 2]
@@ -50,7 +50,7 @@ RowFetch
             ├── table: default.default.t_lazy
             ├── output columns: [a (#0), _row_id (#7)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [is_true(t_lazy.a (#0) > 1)], limit: NONE]
@@ -68,7 +68,7 @@ Limit
     ├── table: default.default.t_lazy
     ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: 2]
@@ -103,7 +103,7 @@ RowFetch
                 ├── table: default.default.t_11831
                 ├── output columns: [uid (#0), time (#3), _row_id (#4)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [and_filters(and_filters(t_11831.time (#3) >= 1686672000000, t_11831.time (#3) <= 1686758399000), t_11831.uid (#0) = 11)], limit: NONE]
@@ -131,7 +131,7 @@ Limit
         ├── table: default.default.t_lazy
         ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: 2]
@@ -153,7 +153,7 @@ Limit
         ├── table: default.default.t_lazy
         ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t_lazy.a (#0) > 1)], limit: NONE]
@@ -171,7 +171,7 @@ Limit
     ├── table: default.default.t_lazy
     ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: 2]
@@ -203,7 +203,7 @@ Limit
             ├── table: default.default.t_lazy
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -256,7 +256,7 @@ Limit
                                     ├── table: default.default.t_lazy
                                     ├── output columns: [a (#0), _row_id (#9)]
                                     ├── read rows: 0
-                                    ├── read size: < 1 KiB
+                                    ├── read size: 0
                                     ├── partitions total: 0
                                     ├── partitions scanned: 0
                                     ├── push downs: [filters: [], limit: 3]

--- a/tests/sqllogictests/suites/mode/standalone/explain/lazy_read.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lazy_read.test
@@ -24,7 +24,7 @@ RowFetch
             ├── table: default.default.t_lazy
             ├── output columns: [a (#0), _row_id (#7)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: 2]
@@ -50,7 +50,7 @@ RowFetch
             ├── table: default.default.t_lazy
             ├── output columns: [a (#0), _row_id (#7)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [is_true(t_lazy.a (#0) > 1)], limit: NONE]
@@ -68,7 +68,7 @@ Limit
     ├── table: default.default.t_lazy
     ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: 2]
@@ -103,7 +103,7 @@ RowFetch
                 ├── table: default.default.t_11831
                 ├── output columns: [uid (#0), time (#3), _row_id (#4)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [and_filters(and_filters(t_11831.time (#3) >= 1686672000000, t_11831.time (#3) <= 1686758399000), t_11831.uid (#0) = 11)], limit: NONE]
@@ -131,7 +131,7 @@ Limit
         ├── table: default.default.t_lazy
         ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: 2]
@@ -153,7 +153,7 @@ Limit
         ├── table: default.default.t_lazy
         ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t_lazy.a (#0) > 1)], limit: NONE]
@@ -171,7 +171,7 @@ Limit
     ├── table: default.default.t_lazy
     ├── output columns: [a (#0), b (#1), c (#2), d (#3), e (#6)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: 2]
@@ -203,7 +203,7 @@ Limit
             ├── table: default.default.t_lazy
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -256,7 +256,7 @@ Limit
                                     ├── table: default.default.t_lazy
                                     ├── output columns: [a (#0), _row_id (#9)]
                                     ├── read rows: 0
-                                    ├── read bytes: 0
+                                    ├── read size: < 1 KiB
                                     ├── partitions total: 0
                                     ├── partitions scanned: 0
                                     ├── push downs: [filters: [], limit: 3]

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -15,7 +15,7 @@ Limit
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 8
-        ├── read bytes: 64
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: 8]
@@ -36,7 +36,7 @@ Sort
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 10
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -67,7 +67,7 @@ Limit
                 ├── table: default.system.numbers
                 ├── output columns: [number (#0)]
                 ├── read rows: 10
-                ├── read bytes: 80
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── push downs: [filters: [], limit: 8]
@@ -125,7 +125,7 @@ Limit
                     │           │   ├── table: default.system.numbers
                     │           │   ├── output columns: []
                     │           │   ├── read rows: 1
-                    │           │   ├── read bytes: 8
+                    │           │   ├── read size: < 1 KiB
                     │           │   ├── partitions total: 1
                     │           │   ├── partitions scanned: 1
                     │           │   ├── push downs: [filters: [], limit: NONE]
@@ -134,7 +134,7 @@ Limit
                     │               ├── table: default.system.numbers
                     │               ├── output columns: [number (#2)]
                     │               ├── read rows: 1
-                    │               ├── read bytes: 8
+                    │               ├── read size: < 1 KiB
                     │               ├── partitions total: 1
                     │               ├── partitions scanned: 1
                     │               ├── push downs: [filters: [], limit: NONE]
@@ -150,7 +150,7 @@ Limit
                         │   ├── table: default.system.numbers
                         │   ├── output columns: []
                         │   ├── read rows: 1
-                        │   ├── read bytes: 8
+                        │   ├── read size: < 1 KiB
                         │   ├── partitions total: 1
                         │   ├── partitions scanned: 1
                         │   ├── push downs: [filters: [], limit: NONE]
@@ -159,7 +159,7 @@ Limit
                             ├── table: default.system.numbers
                             ├── output columns: [number (#0)]
                             ├── read rows: 1
-                            ├── read bytes: 8
+                            ├── read size: < 1 KiB
                             ├── partitions total: 1
                             ├── partitions scanned: 1
                             ├── push downs: [filters: [], limit: NONE]
@@ -197,7 +197,7 @@ Limit
         │           ├── table: default.system.numbers
         │           ├── output columns: [number (#0)]
         │           ├── read rows: 1
-        │           ├── read bytes: 8
+        │           ├── read size: < 1 KiB
         │           ├── partitions total: 1
         │           ├── partitions scanned: 1
         │           ├── push downs: [filters: [], limit: NONE]
@@ -215,7 +215,7 @@ Limit
                     ├── table: default.system.numbers
                     ├── output columns: [number (#3)]
                     ├── read rows: 2
-                    ├── read bytes: 16
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/materialized_cte.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/materialized_cte.test
@@ -8,7 +8,7 @@ MaterializedCTE
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 10
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -36,7 +36,7 @@ MaterializedCTE
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 10
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
@@ -143,7 +143,7 @@ HashJoin
 │   ├── table: default.default.column_only_optimization_target
 │   ├── output columns: [a (#2), b (#3), _row_id (#4)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -152,7 +152,7 @@ HashJoin
     ├── table: default.default.column_only_optimization_source
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -180,7 +180,7 @@ HashJoin
 │   ├── table: default.default.column_only_optimization_target
 │   ├── output columns: [a (#2), b (#3), _row_id (#4)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -189,7 +189,7 @@ HashJoin
     ├── table: default.default.column_only_optimization_source
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -220,7 +220,7 @@ HashJoin
 │   ├── table: default.default.column_only_optimization_target
 │   ├── output columns: [a (#2), b (#3), _row_id (#4)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -229,7 +229,7 @@ HashJoin
     ├── table: default.default.column_only_optimization_source
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -257,7 +257,7 @@ HashJoin
 │   ├── table: default.default.column_only_optimization_target
 │   ├── output columns: [a (#2), b (#3), _row_id (#4)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -266,7 +266,7 @@ HashJoin
     ├── table: default.default.column_only_optimization_source
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
@@ -2,6 +2,12 @@ statement ok
 set enable_experimental_merge_into = 1;
 
 statement ok
+DROP TABLE IF EXISTS employees2;
+
+statement ok
+DROP TABLE IF EXISTS salaries2;
+
+statement ok
 CREATE TABLE employees2 (employee_id INT, employee_name VARCHAR(255),department VARCHAR(255));
 
 statement ok
@@ -40,7 +46,7 @@ HashJoin
 │   ├── table: default.default.salaries2
 │   ├── output columns: [employee_id (#3), salary (#4), _row_id (#5)]
 │   ├── read rows: 4
-│   ├── read bytes: 107
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -50,7 +56,7 @@ HashJoin
     ├── table: default.default.employees2
     ├── output columns: [employee_id (#0), employee_name (#1), department (#2)]
     ├── read rows: 4
-    ├── read bytes: 177
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -82,7 +88,7 @@ HashJoin
 │   ├── table: default.default.salaries2
 │   ├── output columns: [employee_id (#3), salary (#4), _row_id (#5)]
 │   ├── read rows: 6
-│   ├── read bytes: 195
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 2
 │   ├── partitions scanned: 2
 │   ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]
@@ -92,7 +98,7 @@ HashJoin
     ├── table: default.default.employees2
     ├── output columns: [employee_id (#0), employee_name (#1), department (#2)]
     ├── read rows: 4
-    ├── read bytes: 177
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -137,7 +143,7 @@ HashJoin
 │   ├── table: default.default.column_only_optimization_target
 │   ├── output columns: [a (#2), b (#3), _row_id (#4)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -146,7 +152,7 @@ HashJoin
     ├── table: default.default.column_only_optimization_source
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -174,7 +180,7 @@ HashJoin
 │   ├── table: default.default.column_only_optimization_target
 │   ├── output columns: [a (#2), b (#3), _row_id (#4)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -183,7 +189,7 @@ HashJoin
     ├── table: default.default.column_only_optimization_source
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -214,7 +220,7 @@ HashJoin
 │   ├── table: default.default.column_only_optimization_target
 │   ├── output columns: [a (#2), b (#3), _row_id (#4)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -223,7 +229,7 @@ HashJoin
     ├── table: default.default.column_only_optimization_source
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -251,7 +257,7 @@ HashJoin
 │   ├── table: default.default.column_only_optimization_target
 │   ├── output columns: [a (#2), b (#3), _row_id (#4)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -260,7 +266,7 @@ HashJoin
     ├── table: default.default.column_only_optimization_source
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
@@ -20,7 +20,7 @@ TableScan
 ├── table: default.default.t_nullable_prune
 ├── output columns: [a (#0)]
 ├── read rows: 6
-├── read bytes: 76
+├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
 ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]
@@ -38,7 +38,7 @@ Filter
     ├── table: default.default.t_nullable_prune
     ├── output columns: [a (#0)]
     ├── read rows: 3
-    ├── read bytes: 44
+    ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1>]
@@ -56,7 +56,7 @@ Filter
     ├── table: default.default.t_nullable_prune
     ├── output columns: [a (#0)]
     ├── read rows: 3
-    ├── read bytes: 32
+    ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/outer_to_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/outer_to_inner.test
@@ -29,7 +29,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 'a')], limit: NONE]
@@ -38,7 +38,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -76,7 +76,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > '2022-01-01')], limit: NONE]
@@ -85,7 +85,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -122,7 +122,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 1.10)], limit: NONE]
@@ -131,7 +131,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -168,7 +168,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 1.1)], limit: NONE]
@@ -177,7 +177,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/outer_to_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/outer_to_inner.test
@@ -29,7 +29,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 'a')], limit: NONE]
@@ -38,7 +38,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -76,7 +76,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > '2022-01-01')], limit: NONE]
@@ -85,7 +85,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -122,7 +122,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 1.10)], limit: NONE]
@@ -131,7 +131,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -168,7 +168,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [is_true(t2.a (#2) > 1.1)], limit: NONE]
@@ -177,7 +177,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/prewhere_optimization.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prewhere_optimization.test
@@ -15,7 +15,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = 1)], limit: NONE]
@@ -32,7 +32,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = t_where_optimizer.b (#1))], limit: NONE]
@@ -49,7 +49,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = 1 OR t_where_optimizer.b (#1) > 2)], limit: NONE]
@@ -66,7 +66,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t_where_optimizer.a (#0) = 1, t_where_optimizer.b (#1) > 2)], limit: NONE]
@@ -83,7 +83,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.b (#1) = 1)], limit: NONE]
@@ -100,7 +100,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.b (#1) = 1)], limit: NONE]
@@ -123,7 +123,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [id (#0), s (#1), s:a (#2)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t_where_optimizer.s:a (#2) > 0], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/prewhere_optimization.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prewhere_optimization.test
@@ -15,7 +15,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = 1)], limit: NONE]
@@ -32,7 +32,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = t_where_optimizer.b (#1))], limit: NONE]
@@ -49,7 +49,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = 1 OR t_where_optimizer.b (#1) > 2)], limit: NONE]
@@ -66,7 +66,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t_where_optimizer.a (#0) = 1, t_where_optimizer.b (#1) > 2)], limit: NONE]
@@ -83,7 +83,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.b (#1) = 1)], limit: NONE]
@@ -100,7 +100,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t_where_optimizer.b (#1) = 1)], limit: NONE]
@@ -123,7 +123,7 @@ Filter
     ├── table: default.default.t_where_optimizer
     ├── output columns: [id (#0), s (#1), s:a (#2)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t_where_optimizer.s:a (#2) > 0], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
@@ -104,7 +104,7 @@ EvalScalar
         ├── table: default.project_set.t
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -125,7 +125,7 @@ EvalScalar
         ├── table: default.project_set.t
         ├── output columns: [b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
@@ -30,7 +30,7 @@ AggregateFinal
             ├── table: default.default.fold_count
             ├── output columns: [id (#0)]
             ├── read rows: 1
-            ├── read bytes: 54
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -60,7 +60,7 @@ ProjectSet
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -77,7 +77,7 @@ ProjectSet
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -104,7 +104,7 @@ EvalScalar
         ├── table: default.project_set.t
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -125,7 +125,7 @@ EvalScalar
         ├── table: default.project_set.t
         ├── output columns: [b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -5,7 +5,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -27,7 +27,7 @@ AggregateFinal
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -62,7 +62,7 @@ Limit
                     ├── table: default.system.numbers
                     ├── output columns: [number (#0)]
                     ├── read rows: 1
-                    ├── read bytes: 8
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [numbers.number (#0) > 1], limit: NONE]
@@ -90,7 +90,7 @@ HashJoin
 │           ├── table: default.system.numbers
 │           ├── output columns: [number (#0)]
 │           ├── read rows: 1
-│           ├── read bytes: 8
+│           ├── read size: < 1 KiB
 │           ├── partitions total: 1
 │           ├── partitions scanned: 1
 │           ├── push downs: [filters: [numbers.number (#0) + 1 = 1], limit: NONE]
@@ -103,7 +103,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#5)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -166,7 +166,7 @@ HashJoin
 │                           │           ├── table: default.system.numbers
 │                           │           ├── output columns: [number (#3)]
 │                           │           ├── read rows: 1
-│                           │           ├── read bytes: 8
+│                           │           ├── read size: < 1 KiB
 │                           │           ├── partitions total: 1
 │                           │           ├── partitions scanned: 1
 │                           │           ├── push downs: [filters: [numbers.number (#3) + 1 = 1], limit: NONE]
@@ -179,7 +179,7 @@ HashJoin
 │                                   ├── table: default.system.numbers
 │                                   ├── output columns: [number (#8)]
 │                                   ├── read rows: 1
-│                                   ├── read bytes: 8
+│                                   ├── read size: < 1 KiB
 │                                   ├── partitions total: 1
 │                                   ├── partitions scanned: 1
 │                                   ├── push downs: [filters: [], limit: NONE]
@@ -192,7 +192,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 2
-        ├── read bytes: 16
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -209,7 +209,7 @@ Sort
     ├── table: default.system.functions
     ├── output columns: [name (#0), example (#4)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -247,7 +247,7 @@ HashJoin
 │                   ├── table: default.system.numbers
 │                   ├── output columns: []
 │                   ├── read rows: 1
-│                   ├── read bytes: 8
+│                   ├── read size: < 1 KiB
 │                   ├── partitions total: 1
 │                   ├── partitions scanned: 1
 │                   ├── push downs: [filters: [], limit: 1]
@@ -256,7 +256,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -292,7 +292,7 @@ AggregateFinal
             ├── table: default.default.t
             ├── output columns: [b (#1)]
             ├── read rows: 2
-            ├── read bytes: 40
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -209,7 +209,7 @@ Sort
     ├── table: default.system.functions
     ├── output columns: [name (#0), example (#4)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
@@ -104,7 +104,7 @@ AggregateFinal
         │               │                   ├── table: default.default.t2
         │               │                   ├── output columns: [sid (#1), val (#2)]
         │               │                   ├── read rows: 0
-        │               │                   ├── read bytes: 0
+        │               │                   ├── read size: < 1 KiB
         │               │                   ├── partitions total: 0
         │               │                   ├── partitions scanned: 0
         │               │                   ├── push downs: [filters: [is_true(t2.sid (#1) = 1)], limit: NONE]
@@ -117,7 +117,7 @@ AggregateFinal
         │                       ├── table: default.default.t1
         │                       ├── output columns: [id (#0)]
         │                       ├── read rows: 0
-        │                       ├── read bytes: 0
+        │                       ├── read size: < 1 KiB
         │                       ├── partitions total: 0
         │                       ├── partitions scanned: 0
         │                       ├── push downs: [filters: [is_true(t1.id (#0) = 1)], limit: NONE]
@@ -147,7 +147,7 @@ AggregateFinal
                                 ├── table: default.default.t1
                                 ├── output columns: [id (#9)]
                                 ├── read rows: 0
-                                ├── read bytes: 0
+                                ├── read size: < 1 KiB
                                 ├── partitions total: 0
                                 ├── partitions scanned: 0
                                 ├── push downs: [filters: [is_true(t1.id (#9) = 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
@@ -104,7 +104,7 @@ AggregateFinal
         │               │                   ├── table: default.default.t2
         │               │                   ├── output columns: [sid (#1), val (#2)]
         │               │                   ├── read rows: 0
-        │               │                   ├── read size: < 1 KiB
+        │               │                   ├── read size: 0
         │               │                   ├── partitions total: 0
         │               │                   ├── partitions scanned: 0
         │               │                   ├── push downs: [filters: [is_true(t2.sid (#1) = 1)], limit: NONE]
@@ -117,7 +117,7 @@ AggregateFinal
         │                       ├── table: default.default.t1
         │                       ├── output columns: [id (#0)]
         │                       ├── read rows: 0
-        │                       ├── read size: < 1 KiB
+        │                       ├── read size: 0
         │                       ├── partitions total: 0
         │                       ├── partitions scanned: 0
         │                       ├── push downs: [filters: [is_true(t1.id (#0) = 1)], limit: NONE]
@@ -147,7 +147,7 @@ AggregateFinal
                                 ├── table: default.default.t1
                                 ├── output columns: [id (#9)]
                                 ├── read rows: 0
-                                ├── read size: < 1 KiB
+                                ├── read size: 0
                                 ├── partitions total: 0
                                 ├── partitions scanned: 0
                                 ├── push downs: [filters: [is_true(t1.id (#9) = 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -36,7 +36,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 3
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -50,7 +50,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -76,7 +76,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 3
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -90,7 +90,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -112,7 +112,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -126,7 +126,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -152,7 +152,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 3
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -162,7 +162,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 88
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -188,7 +188,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 3
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -202,7 +202,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -228,7 +228,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 3
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -242,7 +242,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -264,7 +264,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -274,7 +274,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 88
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -36,7 +36,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -50,7 +50,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -36,7 +36,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -50,7 +50,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -80,7 +80,7 @@ Filter
     │       ├── table: default.default.t2
     │       ├── output columns: [a (#2), b (#3)]
     │       ├── read rows: 3
-    │       ├── read bytes: 80
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -94,7 +94,7 @@ Filter
             ├── table: default.default.t1
             ├── output columns: [a (#0), b (#1)]
             ├── read rows: 4
-            ├── read bytes: 88
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -36,7 +36,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 3
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -50,7 +50,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -72,7 +72,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -82,7 +82,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 88
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -104,7 +104,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 80
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -118,7 +118,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -144,7 +144,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 3
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -158,7 +158,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 88
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -184,7 +184,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 3
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -194,7 +194,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 88
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -36,7 +36,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -50,7 +50,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -76,7 +76,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -90,7 +90,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -36,7 +36,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -50,7 +50,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -76,7 +76,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -90,7 +90,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_project_set.test
@@ -31,7 +31,7 @@ EvalScalar
                 ├── table: default.default.products
                 ├── output columns: [name (#0), details (#1)]
                 ├── read rows: 3
-                ├── read bytes: 329
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
@@ -62,7 +62,7 @@ EvalScalar
             ├── table: default.default.products
             ├── output columns: [name (#0), details (#1)]
             ├── read rows: 3
-            ├── read bytes: 329
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_scan.test
@@ -19,7 +19,7 @@ Filter
     ├── table: default.default.t
     ├── output columns: [x (#0)]
     ├── read rows: 2
-    ├── read bytes: 40
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
@@ -19,7 +19,7 @@ EvalScalar
         ├── table: default.default.range_t
         ├── output columns: [c (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ EvalScalar
         ├── table: default.default.range_t
         ├── output columns: [i (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -60,7 +60,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -78,7 +78,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
@@ -19,7 +19,7 @@ EvalScalar
         ├── table: default.default.range_t
         ├── output columns: [c (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ EvalScalar
         ├── table: default.default.range_t
         ├── output columns: [i (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -60,7 +60,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -78,7 +78,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/select.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select.test
@@ -5,7 +5,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -22,7 +22,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [numbers.number (#0) = 1], limit: NONE]
@@ -43,7 +43,7 @@ EvalScalar
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [and_filters(numbers.number (#0) = 1, numbers.number (#0) + 1 = 1)], limit: NONE]
@@ -64,7 +64,7 @@ EvalScalar
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [numbers.number (#0) = 1], limit: NONE]
@@ -81,7 +81,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [to_float64(numbers.number (#0)) = 1], limit: NONE]
@@ -94,7 +94,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -111,7 +111,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -128,7 +128,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -145,7 +145,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -158,7 +158,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -171,7 +171,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -188,7 +188,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/select.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select.test
@@ -111,7 +111,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -128,7 +128,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -145,7 +145,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -188,7 +188,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -147,7 +147,7 @@ Limit
     │       ├── table: default.default.t
     │       ├── output columns: [a (#0)]
     │       ├── read rows: 1
-    │       ├── read bytes: 36
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -157,7 +157,7 @@ Limit
         ├── table: default.default.t1
         ├── output columns: [a (#1)]
         ├── read rows: 2
-        ├── read bytes: 40
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -188,7 +188,7 @@ Limit
     │       ├── table: default.default.t
     │       ├── output columns: [a (#1)]
     │       ├── read rows: 1
-    │       ├── read bytes: 36
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -198,7 +198,7 @@ Limit
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 2
-        ├── read bytes: 40
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/sort.test
@@ -16,7 +16,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
@@ -37,7 +37,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
@@ -58,7 +58,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/sort.test
@@ -16,7 +16,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
@@ -37,7 +37,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
@@ -58,7 +58,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -32,7 +32,7 @@ Filter
     │           │   ├── table: default.system.numbers
     │           │   ├── output columns: []
     │           │   ├── read rows: 1
-    │           │   ├── read bytes: 8
+    │           │   ├── read size: < 1 KiB
     │           │   ├── partitions total: 1
     │           │   ├── partitions scanned: 1
     │           │   ├── push downs: [filters: [], limit: NONE]
@@ -41,7 +41,7 @@ Filter
     │               ├── table: default.system.numbers
     │               ├── output columns: [number (#2)]
     │               ├── read rows: 1
-    │               ├── read bytes: 8
+    │               ├── read size: < 1 KiB
     │               ├── partitions total: 1
     │               ├── partitions scanned: 1
     │               ├── push downs: [filters: [], limit: NONE]
@@ -57,7 +57,7 @@ Filter
         │   ├── table: default.system.numbers
         │   ├── output columns: []
         │   ├── read rows: 1
-        │   ├── read bytes: 8
+        │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
         │   ├── push downs: [filters: [], limit: NONE]
@@ -66,7 +66,7 @@ Filter
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 1
-            ├── read bytes: 8
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
@@ -90,7 +90,7 @@ Filter
     │   ├── table: default.system.numbers
     │   ├── output columns: [number (#1)]
     │   ├── read rows: 1
-    │   ├── read bytes: 8
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── push downs: [filters: [], limit: NONE]
@@ -99,7 +99,7 @@ Filter
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -141,7 +141,7 @@ HashJoin
 │                       ├── table: default.system.numbers
 │                       ├── output columns: [number (#1)]
 │                       ├── read rows: 1
-│                       ├── read bytes: 8
+│                       ├── read size: < 1 KiB
 │                       ├── partitions total: 1
 │                       ├── partitions scanned: 1
 │                       ├── push downs: [filters: [numbers.number (#1) = 0], limit: NONE]
@@ -150,7 +150,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -193,7 +193,7 @@ HashJoin
 │                       ├── table: default.system.numbers
 │                       ├── output columns: [number (#1)]
 │                       ├── read rows: 1
-│                       ├── read bytes: 8
+│                       ├── read size: < 1 KiB
 │                       ├── partitions total: 1
 │                       ├── partitions scanned: 1
 │                       ├── push downs: [filters: [numbers.number (#1) = 0], limit: NONE]
@@ -202,7 +202,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 2
-    ├── read bytes: 16
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -222,7 +222,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -231,7 +231,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -251,7 +251,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -260,7 +260,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -280,7 +280,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -289,7 +289,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -313,7 +313,7 @@ HashJoin
 │       ├── table: default.system.numbers
 │       ├── output columns: [number (#1)]
 │       ├── read rows: 1
-│       ├── read bytes: 8
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── push downs: [filters: [and_filters(and_filters(numbers.number (#1) = 0, numbers.number (#1) < 10), numbers.number (#1) = 0)], limit: NONE]
@@ -326,7 +326,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [numbers.number (#0) < 10], limit: NONE]
@@ -346,7 +346,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -355,7 +355,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -375,7 +375,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -384,7 +384,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -417,7 +417,7 @@ HashJoin
 │               ├── table: default.system.numbers
 │               ├── output columns: [number (#2)]
 │               ├── read rows: 1
-│               ├── read bytes: 8
+│               ├── read size: < 1 KiB
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
 │               ├── push downs: [filters: [], limit: NONE]
@@ -433,7 +433,7 @@ HashJoin
     │   ├── table: default.system.numbers
     │   ├── output columns: [number (#1)]
     │   ├── read rows: 1
-    │   ├── read bytes: 8
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── push downs: [filters: [], limit: NONE]
@@ -442,7 +442,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -462,7 +462,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#2)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -478,7 +478,7 @@ HashJoin
     │   ├── table: default.system.numbers
     │   ├── output columns: [number (#1)]
     │   ├── read rows: 1
-    │   ├── read bytes: 8
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── push downs: [filters: [], limit: NONE]
@@ -487,7 +487,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -504,7 +504,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [numbers.number (#0) > 5], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -36,7 +36,7 @@ UnionAll
 │       ├── table: default.default.t1
 │       ├── output columns: [a (#0), b (#1)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -50,7 +50,7 @@ UnionAll
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -36,7 +36,7 @@ UnionAll
 │       ├── table: default.default.t1
 │       ├── output columns: [a (#0), b (#1)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 0
 │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -50,7 +50,7 @@ UnionAll
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 0
         ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -71,7 +71,7 @@ UnionAll
 │       ├── table: default.default.t1
 │       ├── output columns: [a (#0), b (#1)]
 │       ├── read rows: 2
-│       ├── read bytes: 80
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -85,7 +85,7 @@ UnionAll
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
         ├── read rows: 2
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -112,7 +112,7 @@ Limit
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 2
-    │       ├── read bytes: 80
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -127,7 +127,7 @@ Limit
             ├── table: default.default.t2
             ├── output columns: [a (#2), b (#3)]
             ├── read rows: 2
-            ├── read bytes: 80
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -154,7 +154,7 @@ Limit
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 2
-    │       ├── read bytes: 80
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -169,7 +169,7 @@ Limit
             ├── table: default.default.t2
             ├── output columns: [a (#2), b (#3)]
             ├── read rows: 2
-            ├── read bytes: 80
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -196,7 +196,7 @@ Limit
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 2
-    │       ├── read bytes: 80
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -211,7 +211,7 @@ Limit
             ├── table: default.default.t2
             ├── output columns: [a (#2), b (#3)]
             ├── read rows: 2
-            ├── read bytes: 80
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -27,7 +27,7 @@ Sort
         ├── table: default.test_explain_window.empsalary
         ├── output columns: [depname (#0), empno (#1), salary (#2)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -111,7 +111,7 @@ Filter
         │       ├── table: default.test_explain_window.test
         │       ├── output columns: [k (#0), v (#1)]
         │       ├── read rows: 0
-        │       ├── read bytes: 0
+        │       ├── read size: < 1 KiB
         │       ├── partitions total: 0
         │       ├── partitions scanned: 0
         │       ├── push downs: [filters: [is_true(test.k (#0) = 12)], limit: NONE]
@@ -124,7 +124,7 @@ Filter
                 ├── table: default.test_explain_window.test
                 ├── output columns: [k (#2), v (#3)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [is_true(test.k (#2) = 12)], limit: NONE]
@@ -151,7 +151,7 @@ Filter
         │   ├── table: default.test_explain_window.test
         │   ├── output columns: [k (#0), v (#1)]
         │   ├── read rows: 0
-        │   ├── read bytes: 0
+        │   ├── read size: < 1 KiB
         │   ├── partitions total: 0
         │   ├── partitions scanned: 0
         │   ├── push downs: [filters: [], limit: NONE]
@@ -160,7 +160,7 @@ Filter
             ├── table: default.test_explain_window.test
             ├── output columns: [k (#2), v (#3)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -187,7 +187,7 @@ Filter
         │   ├── table: default.test_explain_window.test
         │   ├── output columns: [k (#0), v (#1)]
         │   ├── read rows: 0
-        │   ├── read bytes: 0
+        │   ├── read size: < 1 KiB
         │   ├── partitions total: 0
         │   ├── partitions scanned: 0
         │   ├── push downs: [filters: [], limit: NONE]
@@ -196,7 +196,7 @@ Filter
             ├── table: default.test_explain_window.test
             ├── output columns: [k (#2), v (#3)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -216,20 +216,20 @@ Filter
 ├── filters: [is_true(max(a) OVER ( PARTITION BY a ) (#1) > 3)]
 ├── estimated rows: 0.00
 └── Window
-  ├── output columns: [t.a (#0), max(a) OVER ( PARTITION BY a ) (#1)]
-  ├── aggregate function: [max(a)]
-  ├── partition by: [a]
-  ├── order by: []
-  ├── frame: [Range: Preceding(None) ~ Following(None)]
-  └── TableScan
-    ├── table: default.test_explain_window.t
-    ├── output columns: [a (#0)]
-    ├── read rows: 0
-    ├── read bytes: 0
-    ├── partitions total: 0
-    ├── partitions scanned: 0
-    ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 0.00
+    ├── output columns: [t.a (#0), max(a) OVER ( PARTITION BY a ) (#1)]
+    ├── aggregate function: [max(a)]
+    ├── partition by: [a]
+    ├── order by: []
+    ├── frame: [Range: Preceding(None) ~ Following(None)]
+    └── TableScan
+        ├── table: default.test_explain_window.t
+        ├── output columns: [a (#0)]
+        ├── read rows: 0
+        ├── read size: < 1 KiB
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 0.00
 
 ## example from: https://community.snowflake.com/s/article/Pushdown-or-Not-Pushdown
 statement ok
@@ -258,14 +258,14 @@ Window
     ├── filters: [is_true(tbpush.b (#0) > 3)]
     ├── estimated rows: 0.00
     └── TableScan
-      ├── table: default.test_explain_window.tbpush
-      ├── output columns: [b (#0)]
-      ├── read rows: 0
-      ├── read bytes: 0
-      ├── partitions total: 0
-      ├── partitions scanned: 0
-      ├── push downs: [filters: [is_true(tbpush.b (#0) > 3)], limit: NONE]
-      └── estimated rows: 0.00
+        ├── table: default.test_explain_window.tbpush
+        ├── output columns: [b (#0)]
+        ├── read rows: 0
+        ├── read size: < 1 KiB
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [is_true(tbpush.b (#0) > 3)], limit: NONE]
+        └── estimated rows: 0.00
 
 query T
 explain select * from vwpush where b > 3;
@@ -284,7 +284,7 @@ Filter
         ├── table: default.test_explain_window.tbpush
         ├── output columns: [b (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -307,7 +307,7 @@ Filter
         ├── table: default.test_explain_window.tbpush
         ├── output columns: [b (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -477,7 +477,7 @@ RowFetch
                     ├── table: default.test_explain_window.t
                     ├── output columns: [a (#0), b (#1), _row_id (#7)]
                     ├── read rows: 0
-                    ├── read bytes: 0
+                    ├── read size: < 1 KiB
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [is_true(t.a (#0) > 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -27,7 +27,7 @@ Sort
         ├── table: default.test_explain_window.empsalary
         ├── output columns: [depname (#0), empno (#1), salary (#2)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -111,7 +111,7 @@ Filter
         │       ├── table: default.test_explain_window.test
         │       ├── output columns: [k (#0), v (#1)]
         │       ├── read rows: 0
-        │       ├── read size: < 1 KiB
+        │       ├── read size: 0
         │       ├── partitions total: 0
         │       ├── partitions scanned: 0
         │       ├── push downs: [filters: [is_true(test.k (#0) = 12)], limit: NONE]
@@ -124,7 +124,7 @@ Filter
                 ├── table: default.test_explain_window.test
                 ├── output columns: [k (#2), v (#3)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [is_true(test.k (#2) = 12)], limit: NONE]
@@ -151,7 +151,7 @@ Filter
         │   ├── table: default.test_explain_window.test
         │   ├── output columns: [k (#0), v (#1)]
         │   ├── read rows: 0
-        │   ├── read size: < 1 KiB
+        │   ├── read size: 0
         │   ├── partitions total: 0
         │   ├── partitions scanned: 0
         │   ├── push downs: [filters: [], limit: NONE]
@@ -160,7 +160,7 @@ Filter
             ├── table: default.test_explain_window.test
             ├── output columns: [k (#2), v (#3)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -187,7 +187,7 @@ Filter
         │   ├── table: default.test_explain_window.test
         │   ├── output columns: [k (#0), v (#1)]
         │   ├── read rows: 0
-        │   ├── read size: < 1 KiB
+        │   ├── read size: 0
         │   ├── partitions total: 0
         │   ├── partitions scanned: 0
         │   ├── push downs: [filters: [], limit: NONE]
@@ -196,7 +196,7 @@ Filter
             ├── table: default.test_explain_window.test
             ├── output columns: [k (#2), v (#3)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -225,7 +225,7 @@ Filter
         ├── table: default.test_explain_window.t
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -261,7 +261,7 @@ Window
         ├── table: default.test_explain_window.tbpush
         ├── output columns: [b (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(tbpush.b (#0) > 3)], limit: NONE]
@@ -284,7 +284,7 @@ Filter
         ├── table: default.test_explain_window.tbpush
         ├── output columns: [b (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -307,7 +307,7 @@ Filter
         ├── table: default.test_explain_window.tbpush
         ├── output columns: [b (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [], limit: NONE]
@@ -477,7 +477,7 @@ RowFetch
                     ├── table: default.test_explain_window.t
                     ├── output columns: [a (#0), b (#1), _row_id (#7)]
                     ├── read rows: 0
-                    ├── read size: < 1 KiB
+                    ├── read size: 0
                     ├── partitions total: 0
                     ├── partitions scanned: 0
                     ├── push downs: [filters: [is_true(t.a (#0) > 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/aggregate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/aggregate.test
@@ -110,7 +110,7 @@ EvalScalar
             ├── table: default.system.columns
             ├── output columns: [name (#0), type (#3)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -136,7 +136,7 @@ AggregateFinal
         ├── table: default.default.explain_agg_t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [false], limit: NONE]
@@ -158,7 +158,7 @@ AggregateFinal
         ├── table: default.default.explain_agg_t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [explain_agg_t1.a (#0) > 3], limit: NONE]
@@ -180,7 +180,7 @@ AggregateFinal
         ├── table: default.default.explain_agg_t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -210,7 +210,7 @@ EvalScalar
                 ├── table: default.default.explain_agg_t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -240,7 +240,7 @@ EvalScalar
                 ├── table: default.default.explain_agg_t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 0
-                ├── read size: < 1 KiB
+                ├── read size: 0
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -333,7 +333,7 @@ EvalScalar
             ├── table: default.default.t
             ├── output columns: [referer (#0), isrefresh (#1)]
             ├── read rows: 0
-            ├── read size: < 1 KiB
+            ├── read size: 0
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/aggregate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/aggregate.test
@@ -14,7 +14,7 @@ AggregateFinal
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 10
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -37,7 +37,7 @@ AggregateFinal
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 10
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -55,7 +55,7 @@ EvalScalar
     ├── table: default.system.numbers
     ├── output columns: []
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -83,7 +83,7 @@ EvalScalar
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 10
-            ├── read bytes: 80
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
@@ -110,7 +110,7 @@ EvalScalar
             ├── table: default.system.columns
             ├── output columns: [name (#0), type (#3)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]
@@ -136,7 +136,7 @@ AggregateFinal
         ├── table: default.default.explain_agg_t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [false], limit: NONE]
@@ -158,7 +158,7 @@ AggregateFinal
         ├── table: default.default.explain_agg_t1
         ├── output columns: [a (#0)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [explain_agg_t1.a (#0) > 3], limit: NONE]
@@ -180,7 +180,7 @@ AggregateFinal
         ├── table: default.default.explain_agg_t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -210,7 +210,7 @@ EvalScalar
                 ├── table: default.default.explain_agg_t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -240,7 +240,7 @@ EvalScalar
                 ├── table: default.default.explain_agg_t1
                 ├── output columns: [a (#0), b (#1)]
                 ├── read rows: 0
-                ├── read bytes: 0
+                ├── read size: < 1 KiB
                 ├── partitions total: 0
                 ├── partitions scanned: 0
                 ├── push downs: [filters: [explain_agg_t1.a (#0) > 1], limit: NONE]
@@ -283,7 +283,7 @@ AggregateFinal
         │   ├── table: default.default.t1
         │   ├── output columns: [a (#0)]
         │   ├── read rows: 10
-        │   ├── read bytes: 54
+        │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
         │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -293,7 +293,7 @@ AggregateFinal
             ├── table: default.default.t2
             ├── output columns: [a (#1)]
             ├── read rows: 100
-            ├── read bytes: 414
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -333,7 +333,7 @@ EvalScalar
             ├── table: default.default.t
             ├── output columns: [referer (#0), isrefresh (#1)]
             ├── read rows: 0
-            ├── read bytes: 0
+            ├── read size: < 1 KiB
             ├── partitions total: 0
             ├── partitions scanned: 0
             ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/bloom_filter.test
@@ -21,7 +21,7 @@ TableScan
 ├── table: default.default.bloom_test_t
 ├── output columns: [c1 (#0), c2 (#1)]
 ├── read rows: 3
-├── read bytes: 56
+├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 2 to 1>]
@@ -96,7 +96,7 @@ TableScan
 ├── table: default.default.bloom_test_t
 ├── output columns: [c1 (#0), c2 (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 3
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <range pruning: 3 to 2>, blocks: <range pruning: 2 to 0>]
@@ -110,7 +110,7 @@ TableScan
 ├── table: default.default.bloom_test_t
 ├── output columns: [c1 (#0), c2 (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 3
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 1, bloom pruning: 1 to 0>]
@@ -136,7 +136,7 @@ TableScan
 ├── table: default.default.bloom_test_nullable_t
 ├── output columns: [c1 (#0), c2 (#1)]
 ├── read rows: 3
-├── read bytes: 56
+├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2, bloom pruning: 2 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/bloom_filter.test
@@ -96,7 +96,7 @@ TableScan
 ├── table: default.default.bloom_test_t
 ├── output columns: [c1 (#0), c2 (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 3
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <range pruning: 3 to 2>, blocks: <range pruning: 2 to 0>]
@@ -110,7 +110,7 @@ TableScan
 ├── table: default.default.bloom_test_t
 ├── output columns: [c1 (#0), c2 (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 3
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <range pruning: 3 to 3>, blocks: <range pruning: 3 to 1, bloom pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
@@ -17,7 +17,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 1
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ Filter
     │   ├── table: default.default.t1
     │   ├── output columns: [a (#0), b (#1)]
     │   ├── read rows: 0
-    │   ├── read size: < 1 KiB
+    │   ├── read size: 0
     │   ├── partitions total: 1
     │   ├── partitions scanned: 0
     │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -981,7 +981,7 @@ TableScan
 ├── table: default.default.t4
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t4.a (#0) = 1, TRY_CAST(get(try_parse_json(t4.b (#1)), 'bb') AS String NULL) = 'xx')], limit: NONE]
@@ -1004,7 +1004,7 @@ EvalScalar
     ├── table: default.default.t4
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(TRY_CAST(get(try_parse_json(t4.b (#1)), 'bb') AS String NULL) = 'xx')], limit: NONE]
@@ -1021,7 +1021,7 @@ EvalScalar
     ├── table: default.default.t4
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t4.a (#0) > 100)], limit: NONE]
@@ -1063,7 +1063,7 @@ Sort
     │   ├── table: default.default.t2
     │   ├── output columns: [k (#2), l (#3)]
     │   ├── read rows: 0
-    │   ├── read size: < 1 KiB
+    │   ├── read size: 0
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
     │   ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
@@ -17,7 +17,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ Filter
     │   ├── table: default.default.t1
     │   ├── output columns: [a (#0), b (#1)]
     │   ├── read rows: 0
-    │   ├── read bytes: 0
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 0
     │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -52,7 +52,7 @@ Filter
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
         ├── read rows: 5
-        ├── read bytes: 68
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -73,7 +73,7 @@ HashJoin
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 36
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -83,7 +83,7 @@ HashJoin
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]
     ├── read rows: 5
-    ├── read bytes: 68
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -585,7 +585,7 @@ UnionAll
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -595,7 +595,7 @@ UnionAll
     ├── table: default.default.t2
     ├── output columns: [a (#2)]
     ├── read rows: 5
-    ├── read bytes: 34
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -620,7 +620,7 @@ Filter
     │   ├── table: default.default.t1
     │   ├── output columns: [a (#0), b (#1)]
     │   ├── read rows: 1
-    │   ├── read bytes: 36
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -630,7 +630,7 @@ Filter
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
         ├── read rows: 5
-        ├── read bytes: 68
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -655,7 +655,7 @@ Filter
     │   ├── table: default.default.t1
     │   ├── output columns: [a (#0), b (#1)]
     │   ├── read rows: 1
-    │   ├── read bytes: 36
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
@@ -665,7 +665,7 @@ Filter
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
         ├── read rows: 5
-        ├── read bytes: 68
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -699,7 +699,7 @@ HashJoin
 │   │   ├── table: default.default.t1
 │   │   ├── output columns: [a (#0), b (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 36
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -709,7 +709,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 5
-│       ├── read bytes: 68
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -719,7 +719,7 @@ HashJoin
     ├── table: default.default.t3
     ├── output columns: [a (#4), b (#5)]
     ├── read rows: 10
-    ├── read bytes: 108
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -751,7 +751,7 @@ HashJoin
 │       │   ├── table: default.default.t1
 │       │   ├── output columns: [a (#0), b (#1)]
 │       │   ├── read rows: 1
-│       │   ├── read bytes: 36
+│       │   ├── read size: < 1 KiB
 │       │   ├── partitions total: 1
 │       │   ├── partitions scanned: 1
 │       │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -761,7 +761,7 @@ HashJoin
 │           ├── table: default.default.t2
 │           ├── output columns: [a (#2), b (#3)]
 │           ├── read rows: 5
-│           ├── read bytes: 68
+│           ├── read size: < 1 KiB
 │           ├── partitions total: 1
 │           ├── partitions scanned: 1
 │           ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -771,7 +771,7 @@ HashJoin
     ├── table: default.default.t3
     ├── output columns: [a (#4), b (#5)]
     ├── read rows: 10
-    ├── read bytes: 108
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -805,7 +805,7 @@ Limit
             │   ├── table: default.default.t1
             │   ├── output columns: [a (#0), b (#1)]
             │   ├── read rows: 1
-            │   ├── read bytes: 36
+            │   ├── read size: < 1 KiB
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
             │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -815,7 +815,7 @@ Limit
                 ├── table: default.default.t2
                 ├── output columns: [a (#2), b (#3)]
                 ├── read rows: 5
-                ├── read bytes: 68
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -836,7 +836,7 @@ HashJoin
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 36
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -846,7 +846,7 @@ HashJoin
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]
     ├── read rows: 5
-    ├── read bytes: 68
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -878,7 +878,7 @@ AggregateFinal
                 ├── table: default.default.t1
                 ├── output columns: [a (#0)]
                 ├── read rows: 1
-                ├── read bytes: 18
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -910,7 +910,7 @@ AggregateFinal
                 ├── table: default.default.t1
                 ├── output columns: [a (#0)]
                 ├── read rows: 1
-                ├── read bytes: 18
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -981,7 +981,7 @@ TableScan
 ├── table: default.default.t4
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t4.a (#0) = 1, TRY_CAST(get(try_parse_json(t4.b (#1)), 'bb') AS String NULL) = 'xx')], limit: NONE]
@@ -1004,7 +1004,7 @@ EvalScalar
     ├── table: default.default.t4
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(TRY_CAST(get(try_parse_json(t4.b (#1)), 'bb') AS String NULL) = 'xx')], limit: NONE]
@@ -1021,7 +1021,7 @@ EvalScalar
     ├── table: default.default.t4
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t4.a (#0) > 100)], limit: NONE]
@@ -1063,7 +1063,7 @@ Sort
     │   ├── table: default.default.t2
     │   ├── output columns: [k (#2), l (#3)]
     │   ├── read rows: 0
-    │   ├── read bytes: 0
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
     │   ├── push downs: [filters: [false], limit: NONE]
@@ -1072,7 +1072,7 @@ Sort
         ├── table: default.default.t1
         ├── output columns: [i (#0), j (#1)]
         ├── read rows: 3
-        ├── read bytes: 56
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain_grouping_sets.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain_grouping_sets.test
@@ -26,7 +26,7 @@ EvalScalar
                     ├── table: default.system.numbers
                     ├── output columns: [number (#0)]
                     ├── read rows: 1
-                    ├── read bytes: 8
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]
@@ -60,7 +60,7 @@ EvalScalar
                     ├── table: default.system.numbers
                     ├── output columns: [number (#0)]
                     ├── read rows: 1
-                    ├── read bytes: 8
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/filter.test
@@ -17,7 +17,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) = 1, t1.b (#1) > 2 OR t1.b (#1) < 100)], limit: NONE]
@@ -30,7 +30,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t1.b (#1) > 2 OR t1.b (#1) < 100)], limit: NONE]
@@ -73,7 +73,7 @@ HashJoin
 │       ├── table: default.default.t
 │       ├── output columns: [a (#0)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [false], limit: NONE]
@@ -82,7 +82,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#2)]
     ├── read rows: 5
-    ├── read bytes: 37
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/filter.test
@@ -17,7 +17,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) = 1, t1.b (#1) > 2 OR t1.b (#1) < 100)], limit: NONE]
@@ -30,7 +30,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t1.b (#1) > 2 OR t1.b (#1) < 100)], limit: NONE]
@@ -73,7 +73,7 @@ HashJoin
 │       ├── table: default.default.t
 │       ├── output columns: [a (#0)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/fold_count.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/fold_count.test
@@ -41,7 +41,7 @@ AggregateFinal
         ├── table: default.default.t
         ├── output columns: []
         ├── read rows: 1000
-        ├── read bytes: 4011
+        ├── read size: 3.92 KiB
         ├── partitions total: 2
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
@@ -24,7 +24,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -38,7 +38,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -52,7 +52,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -66,7 +66,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -80,7 +80,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -94,7 +94,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -108,7 +108,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -122,7 +122,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -136,7 +136,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -150,7 +150,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -164,7 +164,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -178,7 +178,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -193,7 +193,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -207,7 +207,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 2], limit: NONE]
@@ -221,7 +221,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) <> 1], limit: NONE]
@@ -235,7 +235,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <> 2)], limit: NONE]
@@ -249,7 +249,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) < 1], limit: NONE]
@@ -263,7 +263,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) < 2)], limit: NONE]
@@ -277,7 +277,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <= 1)], limit: NONE]
@@ -291,7 +291,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <= 2)], limit: NONE]
@@ -305,7 +305,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) > 1], limit: NONE]
@@ -319,7 +319,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) > 0)], limit: NONE]
@@ -333,7 +333,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) >= 1)], limit: NONE]
@@ -347,7 +347,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) >= 0)], limit: NONE]
@@ -361,7 +361,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -375,7 +375,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 2], limit: NONE]
@@ -389,7 +389,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) < 5], limit: NONE]
@@ -403,7 +403,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) < 5, t1.a (#0) <> 2)], limit: NONE]
@@ -417,7 +417,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) < 5], limit: NONE]
@@ -431,7 +431,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -445,7 +445,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) < 5, t1.a (#0) > 2)], limit: NONE]
@@ -459,7 +459,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <= 100, t1.a (#0) > 10)], limit: NONE]
@@ -480,7 +480,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [t2.a (#2) > 10], limit: NONE]
@@ -489,7 +489,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) > 10], limit: NONE]
@@ -517,7 +517,7 @@ HashJoin
 │   │   ├── table: default.default.t3
 │   │   ├── output columns: [a (#4), b (#5)]
 │   │   ├── read rows: 0
-│   │   ├── read size: < 1 KiB
+│   │   ├── read size: 0
 │   │   ├── partitions total: 0
 │   │   ├── partitions scanned: 0
 │   │   ├── push downs: [filters: [and_filters(t3.a (#4) > 5, t3.a (#4) < 10)], limit: NONE]
@@ -526,7 +526,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [and_filters(t2.a (#2) > 5, t2.a (#2) < 10)], limit: NONE]
@@ -535,7 +535,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) > 5, t1.a (#0) < 10)], limit: NONE]
@@ -555,7 +555,7 @@ MergeJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [t2.a (#2) > 10], limit: NONE]
@@ -564,7 +564,7 @@ MergeJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) > 5], limit: NONE]
@@ -584,7 +584,7 @@ MergeJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -593,7 +593,7 @@ MergeJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) > 10], limit: NONE]
@@ -614,7 +614,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [false], limit: NONE]
@@ -623,7 +623,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -644,7 +644,7 @@ HashJoin
 │   ├── table: default.default.t3
 │   ├── output columns: [a (#4), b (#5)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [false], limit: NONE]
@@ -660,7 +660,7 @@ HashJoin
     │   ├── table: default.default.t2
     │   ├── output columns: [a (#2), b (#3)]
     │   ├── read rows: 0
-    │   ├── read size: < 1 KiB
+    │   ├── read size: 0
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
     │   ├── push downs: [filters: [false], limit: NONE]
@@ -669,7 +669,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read size: < 1 KiB
+        ├── read size: 0
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [false], limit: NONE]
@@ -697,7 +697,7 @@ HashJoin
 │   │   ├── table: default.default.t3
 │   │   ├── output columns: [a (#4), b (#5)]
 │   │   ├── read rows: 0
-│   │   ├── read size: < 1 KiB
+│   │   ├── read size: 0
 │   │   ├── partitions total: 0
 │   │   ├── partitions scanned: 0
 │   │   ├── push downs: [filters: [], limit: NONE]
@@ -706,7 +706,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read size: < 1 KiB
+│       ├── read size: 0
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [], limit: NONE]
@@ -715,7 +715,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
@@ -24,7 +24,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -38,7 +38,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -52,7 +52,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -66,7 +66,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -80,7 +80,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -94,7 +94,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -108,7 +108,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -122,7 +122,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -136,7 +136,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -150,7 +150,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -164,7 +164,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -178,7 +178,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 1], limit: NONE]
@@ -193,7 +193,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -207,7 +207,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 2], limit: NONE]
@@ -221,7 +221,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) <> 1], limit: NONE]
@@ -235,7 +235,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <> 2)], limit: NONE]
@@ -249,7 +249,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) < 1], limit: NONE]
@@ -263,7 +263,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) < 2)], limit: NONE]
@@ -277,7 +277,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <= 1)], limit: NONE]
@@ -291,7 +291,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) <= 2)], limit: NONE]
@@ -305,7 +305,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) > 1], limit: NONE]
@@ -319,7 +319,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) > 0)], limit: NONE]
@@ -333,7 +333,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) >= 1)], limit: NONE]
@@ -347,7 +347,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <> 1, t1.a (#0) >= 0)], limit: NONE]
@@ -361,7 +361,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -375,7 +375,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) = 2], limit: NONE]
@@ -389,7 +389,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) < 5], limit: NONE]
@@ -403,7 +403,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) < 5, t1.a (#0) <> 2)], limit: NONE]
@@ -417,7 +417,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t1.a (#0) < 5], limit: NONE]
@@ -431,7 +431,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [false], limit: NONE]
@@ -445,7 +445,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) < 5, t1.a (#0) > 2)], limit: NONE]
@@ -459,7 +459,7 @@ TableScan
 ├── table: default.default.t1
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t1.a (#0) <= 100, t1.a (#0) > 10)], limit: NONE]
@@ -480,7 +480,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [t2.a (#2) > 10], limit: NONE]
@@ -489,7 +489,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) > 10], limit: NONE]
@@ -517,7 +517,7 @@ HashJoin
 │   │   ├── table: default.default.t3
 │   │   ├── output columns: [a (#4), b (#5)]
 │   │   ├── read rows: 0
-│   │   ├── read bytes: 0
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 0
 │   │   ├── partitions scanned: 0
 │   │   ├── push downs: [filters: [and_filters(t3.a (#4) > 5, t3.a (#4) < 10)], limit: NONE]
@@ -526,7 +526,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [and_filters(t2.a (#2) > 5, t2.a (#2) < 10)], limit: NONE]
@@ -535,7 +535,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [and_filters(t1.a (#0) > 5, t1.a (#0) < 10)], limit: NONE]
@@ -555,7 +555,7 @@ MergeJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [t2.a (#2) > 10], limit: NONE]
@@ -564,7 +564,7 @@ MergeJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) > 5], limit: NONE]
@@ -584,7 +584,7 @@ MergeJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -593,7 +593,7 @@ MergeJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [t1.a (#0) > 10], limit: NONE]
@@ -614,7 +614,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [false], limit: NONE]
@@ -623,7 +623,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -644,7 +644,7 @@ HashJoin
 │   ├── table: default.default.t3
 │   ├── output columns: [a (#4), b (#5)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [false], limit: NONE]
@@ -660,7 +660,7 @@ HashJoin
     │   ├── table: default.default.t2
     │   ├── output columns: [a (#2), b (#3)]
     │   ├── read rows: 0
-    │   ├── read bytes: 0
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 0
     │   ├── partitions scanned: 0
     │   ├── push downs: [filters: [false], limit: NONE]
@@ -669,7 +669,7 @@ HashJoin
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 0
-        ├── read bytes: 0
+        ├── read size: < 1 KiB
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [false], limit: NONE]
@@ -697,7 +697,7 @@ HashJoin
 │   │   ├── table: default.default.t3
 │   │   ├── output columns: [a (#4), b (#5)]
 │   │   ├── read rows: 0
-│   │   ├── read bytes: 0
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 0
 │   │   ├── partitions scanned: 0
 │   │   ├── push downs: [filters: [], limit: NONE]
@@ -706,7 +706,7 @@ HashJoin
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
 │       ├── read rows: 0
-│       ├── read bytes: 0
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 0
 │       ├── partitions scanned: 0
 │       ├── push downs: [filters: [], limit: NONE]
@@ -715,7 +715,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
@@ -30,7 +30,7 @@ HashJoin
 │   ├── table: default.default.t
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -40,7 +40,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [number (#1)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -61,7 +61,7 @@ HashJoin
 │   ├── table: default.default.t
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -71,7 +71,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [number (#1)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -92,7 +92,7 @@ HashJoin
 │   ├── table: default.default.t
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -102,7 +102,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: []
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -127,7 +127,7 @@ Filter
     │   ├── table: default.default.t
     │   ├── output columns: [number (#0)]
     │   ├── read rows: 1
-    │   ├── read bytes: 18
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -137,7 +137,7 @@ Filter
         ├── table: default.default.t1
         ├── output columns: [number (#1)]
         ├── read rows: 10
-        ├── read bytes: 54
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -166,7 +166,7 @@ HashJoin
 │   │   ├── table: default.default.t
 │   │   ├── output columns: [number (#0)]
 │   │   ├── read rows: 0
-│   │   ├── read bytes: 0
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 0
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -176,7 +176,7 @@ HashJoin
 │       ├── table: default.default.t1
 │       ├── output columns: [number (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -186,7 +186,7 @@ HashJoin
     ├── table: default.default.t2
     ├── output columns: [number (#2)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -227,7 +227,7 @@ HashJoin
 │   ├── table: default.default.onecolumn
 │   ├── output columns: [x (#0)]
 │   ├── read rows: 4
-│   ├── read bytes: 29
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -237,7 +237,7 @@ HashJoin
     ├── table: default.default.twocolumn
     ├── output columns: [x (#1), y (#2)]
     ├── read rows: 4
-    ├── read bytes: 62
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -258,7 +258,7 @@ HashJoin
 │   ├── table: default.default.onecolumn
 │   ├── output columns: [x (#0)]
 │   ├── read rows: 4
-│   ├── read bytes: 29
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -268,7 +268,7 @@ HashJoin
     ├── table: default.default.twocolumn
     ├── output columns: [x (#1), y (#2)]
     ├── read rows: 4
-    ├── read bytes: 62
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -289,7 +289,7 @@ HashJoin
 │   ├── table: default.default.onecolumn
 │   ├── output columns: [x (#0)]
 │   ├── read rows: 4
-│   ├── read bytes: 29
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -299,7 +299,7 @@ HashJoin
     ├── table: default.default.twocolumn
     ├── output columns: [x (#1), y (#2)]
     ├── read rows: 4
-    ├── read bytes: 62
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -326,7 +326,7 @@ Filter
     │   ├── table: default.default.twocolumn
     │   ├── output columns: [x (#1), y (#2)]
     │   ├── read rows: 4
-    │   ├── read bytes: 62
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -336,7 +336,7 @@ Filter
         ├── table: default.default.onecolumn
         ├── output columns: [x (#0)]
         ├── read rows: 4
-        ├── read bytes: 29
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -357,7 +357,7 @@ HashJoin
 │   ├── table: default.default.onecolumn
 │   ├── output columns: [x (#0)]
 │   ├── read rows: 4
-│   ├── read bytes: 29
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -367,7 +367,7 @@ HashJoin
     ├── table: default.default.twocolumn
     ├── output columns: [x (#1), y (#2)]
     ├── read rows: 4
-    ├── read bytes: 62
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -403,7 +403,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 10)], limit: NONE]
@@ -412,7 +412,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 10)], limit: NONE]
@@ -432,7 +432,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -441,7 +441,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) + t1.b (#1) > 10)], limit: NONE]
@@ -461,7 +461,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 10)], limit: NONE]
@@ -470,7 +470,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 10)], limit: NONE]
@@ -490,7 +490,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [is_true(t2.a (#2) + t2.b (#3) > 10)], limit: NONE]
@@ -499,7 +499,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) + t1.b (#1) > 10)], limit: NONE]
@@ -519,7 +519,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [is_true(t2.b (#3) + t2.a (#2) > 10)], limit: NONE]
@@ -528,7 +528,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.b (#1) + t1.a (#0) > 10)], limit: NONE]
@@ -548,7 +548,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -557,7 +557,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
@@ -92,7 +92,7 @@ HashJoin
 │   ├── table: default.default.t
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -166,7 +166,7 @@ HashJoin
 │   │   ├── table: default.default.t
 │   │   ├── output columns: [number (#0)]
 │   │   ├── read rows: 0
-│   │   ├── read size: < 1 KiB
+│   │   ├── read size: 0
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 0
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -403,7 +403,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 10)], limit: NONE]
@@ -412,7 +412,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 10)], limit: NONE]
@@ -432,7 +432,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -441,7 +441,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) + t1.b (#1) > 10)], limit: NONE]
@@ -461,7 +461,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 10)], limit: NONE]
@@ -470,7 +470,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 10)], limit: NONE]
@@ -490,7 +490,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [is_true(t2.a (#2) + t2.b (#3) > 10)], limit: NONE]
@@ -499,7 +499,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) + t1.b (#1) > 10)], limit: NONE]
@@ -519,7 +519,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [is_true(t2.b (#3) + t2.a (#2) > 10)], limit: NONE]
@@ -528,7 +528,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.b (#1) + t1.a (#0) > 10)], limit: NONE]
@@ -548,7 +548,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 0
 │   ├── partitions scanned: 0
 │   ├── push downs: [filters: [], limit: NONE]
@@ -557,7 +557,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
@@ -46,7 +46,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -56,7 +56,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -66,7 +66,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#2)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -94,7 +94,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -104,7 +104,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -114,7 +114,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#2)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -142,7 +142,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -152,7 +152,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -162,7 +162,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -190,7 +190,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -200,7 +200,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -210,7 +210,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -238,7 +238,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -248,7 +248,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -258,7 +258,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -286,7 +286,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -296,7 +296,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -306,7 +306,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -327,7 +327,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -337,7 +337,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -358,7 +358,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -368,7 +368,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -389,7 +389,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -399,7 +399,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -420,7 +420,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -430,7 +430,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -451,7 +451,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -461,7 +461,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -482,7 +482,7 @@ HashJoin
 │   ├── table: default.join_reorder.t
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 1
-│   ├── read bytes: 18
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -492,7 +492,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/cycles.test
@@ -37,7 +37,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -47,7 +47,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -57,7 +57,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#2)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -85,7 +85,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -95,7 +95,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -105,7 +105,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#2)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -133,7 +133,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -143,7 +143,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -153,7 +153,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -181,7 +181,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -191,7 +191,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -201,7 +201,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -229,7 +229,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -239,7 +239,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -249,7 +249,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -277,7 +277,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -287,7 +287,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -297,7 +297,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/mark.test
@@ -12,7 +12,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1000
-│   ├── read bytes: 8000
+│   ├── read size: 7.81 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -21,7 +21,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10000
-    ├── read bytes: 80000
+    ├── read size: 78.12 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -41,7 +41,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#0)]
 │   ├── read rows: 1000
-│   ├── read bytes: 8000
+│   ├── read size: 7.81 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -50,7 +50,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#1)]
     ├── read rows: 10000
-    ├── read bytes: 80000
+    ├── read size: 78.12 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/star.test
@@ -37,7 +37,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -47,7 +47,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -57,7 +57,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#2)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -85,7 +85,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#0)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -95,7 +95,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -105,7 +105,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#2)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -133,7 +133,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -143,7 +143,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -153,7 +153,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -181,7 +181,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -191,7 +191,7 @@ HashJoin
 │       ├── table: default.join_reorder.t2
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 100
-│       ├── read bytes: 414
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -201,7 +201,7 @@ HashJoin
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#0)]
     ├── read rows: 10
-    ├── read bytes: 54
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -229,7 +229,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#2)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -239,7 +239,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#1)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -249,7 +249,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -277,7 +277,7 @@ HashJoin
 │   │   ├── table: default.join_reorder.t
 │   │   ├── output columns: [a (#1)]
 │   │   ├── read rows: 1
-│   │   ├── read bytes: 18
+│   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -287,7 +287,7 @@ HashJoin
 │       ├── table: default.join_reorder.t1
 │       ├── output columns: [a (#2)]
 │       ├── read rows: 10
-│       ├── read bytes: 54
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -297,7 +297,7 @@ HashJoin
     ├── table: default.join_reorder.t2
     ├── output columns: [a (#0)]
     ├── read rows: 100
-    ├── read bytes: 414
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
@@ -15,7 +15,7 @@ Limit
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 8
-        ├── read bytes: 64
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: 8]
@@ -36,7 +36,7 @@ Sort
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 10
-        ├── read bytes: 80
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -67,7 +67,7 @@ Limit
                 ├── table: default.system.numbers
                 ├── output columns: [number (#0)]
                 ├── read rows: 10
-                ├── read bytes: 80
+                ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
                 ├── push downs: [filters: [], limit: 8]
@@ -125,7 +125,7 @@ Limit
                     │           │   ├── table: default.system.numbers
                     │           │   ├── output columns: []
                     │           │   ├── read rows: 1
-                    │           │   ├── read bytes: 8
+                    │           │   ├── read size: < 1 KiB
                     │           │   ├── partitions total: 1
                     │           │   ├── partitions scanned: 1
                     │           │   ├── push downs: [filters: [], limit: NONE]
@@ -134,7 +134,7 @@ Limit
                     │               ├── table: default.system.numbers
                     │               ├── output columns: [number (#2)]
                     │               ├── read rows: 1
-                    │               ├── read bytes: 8
+                    │               ├── read size: < 1 KiB
                     │               ├── partitions total: 1
                     │               ├── partitions scanned: 1
                     │               ├── push downs: [filters: [], limit: NONE]
@@ -150,7 +150,7 @@ Limit
                         │   ├── table: default.system.numbers
                         │   ├── output columns: []
                         │   ├── read rows: 1
-                        │   ├── read bytes: 8
+                        │   ├── read size: < 1 KiB
                         │   ├── partitions total: 1
                         │   ├── partitions scanned: 1
                         │   ├── push downs: [filters: [], limit: NONE]
@@ -159,7 +159,7 @@ Limit
                             ├── table: default.system.numbers
                             ├── output columns: [number (#0)]
                             ├── read rows: 1
-                            ├── read bytes: 8
+                            ├── read size: < 1 KiB
                             ├── partitions total: 1
                             ├── partitions scanned: 1
                             ├── push downs: [filters: [], limit: NONE]
@@ -197,7 +197,7 @@ Limit
         │           ├── table: default.system.numbers
         │           ├── output columns: [number (#0)]
         │           ├── read rows: 1
-        │           ├── read bytes: 8
+        │           ├── read size: < 1 KiB
         │           ├── partitions total: 1
         │           ├── partitions scanned: 1
         │           ├── push downs: [filters: [], limit: NONE]
@@ -215,7 +215,7 @@ Limit
                     ├── table: default.system.numbers
                     ├── output columns: [number (#3)]
                     ├── read rows: 2
-                    ├── read bytes: 16
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/nullable_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/nullable_prune.test
@@ -20,7 +20,7 @@ TableScan
 ├── table: default.default.t_nullable_prune
 ├── output columns: [a (#0)]
 ├── read rows: 6
-├── read bytes: 47
+├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
 ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]
@@ -34,7 +34,7 @@ TableScan
 ├── table: default.default.t_nullable_prune
 ├── output columns: [a (#0)]
 ├── read rows: 3
-├── read bytes: 28
+├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1>]
@@ -48,7 +48,7 @@ TableScan
 ├── table: default.default.t_nullable_prune
 ├── output columns: [a (#0)]
 ├── read rows: 3
-├── read bytes: 19
+├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <range pruning: 2 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/prewhere_optimization.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/prewhere_optimization.test
@@ -11,7 +11,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = 1)], limit: NONE]
@@ -24,7 +24,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = t_where_optimizer.b (#1))], limit: NONE]
@@ -37,7 +37,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = 1 OR t_where_optimizer.b (#1) > 2)], limit: NONE]
@@ -50,7 +50,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t_where_optimizer.a (#0) = 1, t_where_optimizer.b (#1) > 2)], limit: NONE]
@@ -63,7 +63,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.b (#1) = 1)], limit: NONE]
@@ -76,7 +76,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.b (#1) = 1)], limit: NONE]
@@ -95,7 +95,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [id (#0), s (#1)]
 ├── read rows: 0
-├── read size: < 1 KiB
+├── read size: 0
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t_where_optimizer.s:a (#2) > 0], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/prewhere_optimization.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/prewhere_optimization.test
@@ -11,7 +11,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = 1)], limit: NONE]
@@ -24,7 +24,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = t_where_optimizer.b (#1))], limit: NONE]
@@ -37,7 +37,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.a (#0) = 1 OR t_where_optimizer.b (#1) > 2)], limit: NONE]
@@ -50,7 +50,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [and_filters(t_where_optimizer.a (#0) = 1, t_where_optimizer.b (#1) > 2)], limit: NONE]
@@ -63,7 +63,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0), b (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.b (#1) = 1)], limit: NONE]
@@ -76,7 +76,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [a (#0)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [is_true(t_where_optimizer.b (#1) = 1)], limit: NONE]
@@ -95,7 +95,7 @@ TableScan
 ├── table: default.default.t_where_optimizer
 ├── output columns: [id (#0), s (#1)]
 ├── read rows: 0
-├── read bytes: 0
+├── read size: < 1 KiB
 ├── partitions total: 0
 ├── partitions scanned: 0
 ├── push downs: [filters: [t_where_optimizer.s:a (#2) > 0], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/project_set.test
@@ -30,7 +30,7 @@ AggregateFinal
             ├── table: default.default.fold_count
             ├── output columns: [id (#0)]
             ├── read rows: 1
-            ├── read bytes: 43
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -60,7 +60,7 @@ ProjectSet
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -77,7 +77,7 @@ ProjectSet
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
@@ -5,7 +5,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -27,7 +27,7 @@ AggregateFinal
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -62,7 +62,7 @@ Limit
                     ├── table: default.system.numbers
                     ├── output columns: [number (#0)]
                     ├── read rows: 1
-                    ├── read bytes: 8
+                    ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── push downs: [filters: [numbers.number (#0) > 1], limit: NONE]
@@ -90,7 +90,7 @@ HashJoin
 │           ├── table: default.system.numbers
 │           ├── output columns: [number (#0)]
 │           ├── read rows: 1
-│           ├── read bytes: 8
+│           ├── read size: < 1 KiB
 │           ├── partitions total: 1
 │           ├── partitions scanned: 1
 │           ├── push downs: [filters: [numbers.number (#0) + 1 = 1], limit: NONE]
@@ -103,7 +103,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#5)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -166,7 +166,7 @@ HashJoin
 │                           │           ├── table: default.system.numbers
 │                           │           ├── output columns: [number (#3)]
 │                           │           ├── read rows: 1
-│                           │           ├── read bytes: 8
+│                           │           ├── read size: < 1 KiB
 │                           │           ├── partitions total: 1
 │                           │           ├── partitions scanned: 1
 │                           │           ├── push downs: [filters: [numbers.number (#3) + 1 = 1], limit: NONE]
@@ -179,7 +179,7 @@ HashJoin
 │                                   ├── table: default.system.numbers
 │                                   ├── output columns: [number (#8)]
 │                                   ├── read rows: 1
-│                                   ├── read bytes: 8
+│                                   ├── read size: < 1 KiB
 │                                   ├── partitions total: 1
 │                                   ├── partitions scanned: 1
 │                                   ├── push downs: [filters: [], limit: NONE]
@@ -192,7 +192,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 2
-        ├── read bytes: 16
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -209,7 +209,7 @@ Sort
     ├── table: default.system.functions
     ├── output columns: [name (#0), example (#4)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]
@@ -247,7 +247,7 @@ HashJoin
 │                   ├── table: default.system.numbers
 │                   ├── output columns: []
 │                   ├── read rows: 1
-│                   ├── read bytes: 8
+│                   ├── read size: < 1 KiB
 │                   ├── partitions total: 1
 │                   ├── partitions scanned: 1
 │                   ├── push downs: [filters: [], limit: 1]
@@ -256,7 +256,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 10
-    ├── read bytes: 80
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -288,7 +288,7 @@ AggregateFinal
         ├── table: default.default.t
         ├── output columns: []
         ├── read rows: 2
-        ├── read bytes: 24
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
@@ -209,7 +209,7 @@ Sort
     ├── table: default.system.functions
     ├── output columns: [name (#0), example (#4)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
@@ -100,7 +100,7 @@ AggregateFinal
         │               │               ├── table: default.default.t2
         │               │               ├── output columns: [sid (#1), val (#2)]
         │               │               ├── read rows: 0
-        │               │               ├── read bytes: 0
+        │               │               ├── read size: < 1 KiB
         │               │               ├── partitions total: 0
         │               │               ├── partitions scanned: 0
         │               │               ├── push downs: [filters: [is_true(t2.sid (#1) = 1)], limit: NONE]
@@ -109,7 +109,7 @@ AggregateFinal
         │                   ├── table: default.default.t1
         │                   ├── output columns: [id (#0)]
         │                   ├── read rows: 0
-        │                   ├── read bytes: 0
+        │                   ├── read size: < 1 KiB
         │                   ├── partitions total: 0
         │                   ├── partitions scanned: 0
         │                   ├── push downs: [filters: [is_true(t1.id (#0) = 1)], limit: NONE]
@@ -135,7 +135,7 @@ AggregateFinal
                             ├── table: default.default.t1
                             ├── output columns: [id (#9)]
                             ├── read rows: 0
-                            ├── read bytes: 0
+                            ├── read size: < 1 KiB
                             ├── partitions total: 0
                             ├── partitions scanned: 0
                             ├── push downs: [filters: [is_true(t1.id (#9) = 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
@@ -100,7 +100,7 @@ AggregateFinal
         │               │               ├── table: default.default.t2
         │               │               ├── output columns: [sid (#1), val (#2)]
         │               │               ├── read rows: 0
-        │               │               ├── read size: < 1 KiB
+        │               │               ├── read size: 0
         │               │               ├── partitions total: 0
         │               │               ├── partitions scanned: 0
         │               │               ├── push downs: [filters: [is_true(t2.sid (#1) = 1)], limit: NONE]
@@ -109,7 +109,7 @@ AggregateFinal
         │                   ├── table: default.default.t1
         │                   ├── output columns: [id (#0)]
         │                   ├── read rows: 0
-        │                   ├── read size: < 1 KiB
+        │                   ├── read size: 0
         │                   ├── partitions total: 0
         │                   ├── partitions scanned: 0
         │                   ├── push downs: [filters: [is_true(t1.id (#0) = 1)], limit: NONE]
@@ -135,7 +135,7 @@ AggregateFinal
                             ├── table: default.default.t1
                             ├── output columns: [id (#9)]
                             ├── read rows: 0
-                            ├── read size: < 1 KiB
+                            ├── read size: 0
                             ├── partitions total: 0
                             ├── partitions scanned: 0
                             ├── push downs: [filters: [is_true(t1.id (#9) = 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -32,7 +32,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -42,7 +42,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -64,7 +64,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -74,7 +74,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -96,7 +96,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -106,7 +106,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -128,7 +128,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -138,7 +138,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -160,7 +160,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -170,7 +170,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -192,7 +192,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -202,7 +202,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -224,7 +224,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -234,7 +234,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -32,7 +32,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -68,7 +68,7 @@ Filter
     │   ├── table: default.default.t2
     │   ├── output columns: [a (#2), b (#3)]
     │   ├── read rows: 3
-    │   ├── read bytes: 56
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -78,7 +78,7 @@ Filter
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]
         ├── read rows: 4
-        ├── read bytes: 66
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -32,7 +32,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -32,7 +32,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -42,7 +42,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -64,7 +64,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -74,7 +74,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -96,7 +96,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -106,7 +106,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -128,7 +128,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -138,7 +138,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -160,7 +160,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
 │   ├── read rows: 3
-│   ├── read bytes: 56
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -170,7 +170,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
     ├── read rows: 4
-    ├── read bytes: 66
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -32,7 +32,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -64,7 +64,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -74,7 +74,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -32,7 +32,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -64,7 +64,7 @@ HashJoin
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -74,7 +74,7 @@ HashJoin
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_project_set.test
@@ -27,7 +27,7 @@ EvalScalar
             ├── table: default.default.products
             ├── output columns: [name (#0), details (#1)]
             ├── read rows: 3
-            ├── read bytes: 370
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
@@ -54,7 +54,7 @@ EvalScalar
         ├── table: default.default.products
         ├── output columns: [name (#0), details (#1)]
         ├── read rows: 3
-        ├── read bytes: 370
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_scan.test
@@ -19,7 +19,7 @@ Filter
     ├── table: default.default.t
     ├── output columns: [x (#0)]
     ├── read rows: 2
-    ├── read bytes: 24
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/range_pruner.test
@@ -15,7 +15,7 @@ EvalScalar
     ├── table: default.default.range_t
     ├── output columns: []
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -33,7 +33,7 @@ EvalScalar
     ├── table: default.default.range_t
     ├── output columns: []
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -51,7 +51,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -69,7 +69,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/range_pruner.test
@@ -15,7 +15,7 @@ EvalScalar
     ├── table: default.default.range_t
     ├── output columns: []
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -33,7 +33,7 @@ EvalScalar
     ├── table: default.default.range_t
     ├── output columns: []
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -51,7 +51,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -69,7 +69,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/select.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/select.test
@@ -5,7 +5,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -22,7 +22,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [numbers.number (#0) = 1], limit: NONE]
@@ -43,7 +43,7 @@ EvalScalar
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [and_filters(numbers.number (#0) = 1, numbers.number (#0) + 1 = 1)], limit: NONE]
@@ -64,7 +64,7 @@ EvalScalar
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [numbers.number (#0) = 1], limit: NONE]
@@ -81,7 +81,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [to_float64(numbers.number (#0)) = 1], limit: NONE]
@@ -94,7 +94,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -111,7 +111,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -128,7 +128,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -145,7 +145,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -158,7 +158,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -171,7 +171,7 @@ TableScan
 ├── table: default.system.numbers
 ├── output columns: [number (#0)]
 ├── read rows: 1
-├── read bytes: 8
+├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
 ├── push downs: [filters: [], limit: NONE]
@@ -188,7 +188,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -214,7 +214,7 @@ EvalScalar
     ├── table: default.default.t_json
     ├── output columns: [a (#0), v (#1)]
     ├── read rows: 1
-    ├── read bytes: 108
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -232,7 +232,7 @@ EvalScalar
     ├── table: default.default.t_json
     ├── output columns: [a (#0), v (#1)]
     ├── read rows: 1
-    ├── read bytes: 108
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/select.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/select.test
@@ -111,7 +111,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -128,7 +128,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -145,7 +145,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]
@@ -188,7 +188,7 @@ Filter
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [false], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/select_limit_offset.test
@@ -147,7 +147,7 @@ Limit
     │       ├── table: default.default.t
     │       ├── output columns: [a (#0)]
     │       ├── read rows: 1
-    │       ├── read bytes: 20
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -157,7 +157,7 @@ Limit
         ├── table: default.default.t1
         ├── output columns: [a (#1)]
         ├── read rows: 2
-        ├── read bytes: 24
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -188,7 +188,7 @@ Limit
     │       ├── table: default.default.t
     │       ├── output columns: [a (#1)]
     │       ├── read rows: 1
-    │       ├── read bytes: 20
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -198,7 +198,7 @@ Limit
         ├── table: default.default.t1
         ├── output columns: [a (#0)]
         ├── read rows: 2
-        ├── read bytes: 24
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/sort.test
@@ -12,7 +12,7 @@ Sort
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
@@ -29,7 +29,7 @@ Sort
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
@@ -46,7 +46,7 @@ Sort
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/sort.test
@@ -12,7 +12,7 @@ Sort
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
@@ -29,7 +29,7 @@ Sort
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
@@ -46,7 +46,7 @@ Sort
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 0
     ├── partitions scanned: 0
     ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
@@ -32,7 +32,7 @@ Filter
     │           │   ├── table: default.system.numbers
     │           │   ├── output columns: []
     │           │   ├── read rows: 1
-    │           │   ├── read bytes: 8
+    │           │   ├── read size: < 1 KiB
     │           │   ├── partitions total: 1
     │           │   ├── partitions scanned: 1
     │           │   ├── push downs: [filters: [], limit: NONE]
@@ -41,7 +41,7 @@ Filter
     │               ├── table: default.system.numbers
     │               ├── output columns: [number (#2)]
     │               ├── read rows: 1
-    │               ├── read bytes: 8
+    │               ├── read size: < 1 KiB
     │               ├── partitions total: 1
     │               ├── partitions scanned: 1
     │               ├── push downs: [filters: [], limit: NONE]
@@ -57,7 +57,7 @@ Filter
         │   ├── table: default.system.numbers
         │   ├── output columns: []
         │   ├── read rows: 1
-        │   ├── read bytes: 8
+        │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
         │   ├── push downs: [filters: [], limit: NONE]
@@ -66,7 +66,7 @@ Filter
             ├── table: default.system.numbers
             ├── output columns: [number (#0)]
             ├── read rows: 1
-            ├── read bytes: 8
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── push downs: [filters: [], limit: NONE]
@@ -90,7 +90,7 @@ Filter
     │   ├── table: default.system.numbers
     │   ├── output columns: [number (#1)]
     │   ├── read rows: 1
-    │   ├── read bytes: 8
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── push downs: [filters: [], limit: NONE]
@@ -99,7 +99,7 @@ Filter
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -141,7 +141,7 @@ HashJoin
 │                       ├── table: default.system.numbers
 │                       ├── output columns: [number (#1)]
 │                       ├── read rows: 1
-│                       ├── read bytes: 8
+│                       ├── read size: < 1 KiB
 │                       ├── partitions total: 1
 │                       ├── partitions scanned: 1
 │                       ├── push downs: [filters: [numbers.number (#1) = 0], limit: NONE]
@@ -150,7 +150,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -193,7 +193,7 @@ HashJoin
 │                       ├── table: default.system.numbers
 │                       ├── output columns: [number (#1)]
 │                       ├── read rows: 1
-│                       ├── read bytes: 8
+│                       ├── read size: < 1 KiB
 │                       ├── partitions total: 1
 │                       ├── partitions scanned: 1
 │                       ├── push downs: [filters: [numbers.number (#1) = 0], limit: NONE]
@@ -202,7 +202,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 2
-    ├── read bytes: 16
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -222,7 +222,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -231,7 +231,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -251,7 +251,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -260,7 +260,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -280,7 +280,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -289,7 +289,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -313,7 +313,7 @@ HashJoin
 │       ├── table: default.system.numbers
 │       ├── output columns: [number (#1)]
 │       ├── read rows: 1
-│       ├── read bytes: 8
+│       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── push downs: [filters: [and_filters(and_filters(numbers.number (#1) = 0, numbers.number (#1) < 10), numbers.number (#1) = 0)], limit: NONE]
@@ -326,7 +326,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [numbers.number (#0) < 10], limit: NONE]
@@ -346,7 +346,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -355,7 +355,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -375,7 +375,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#1)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -384,7 +384,7 @@ HashJoin
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]
     ├── read rows: 1
-    ├── read bytes: 8
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── push downs: [filters: [], limit: NONE]
@@ -417,7 +417,7 @@ HashJoin
 │               ├── table: default.system.numbers
 │               ├── output columns: [number (#2)]
 │               ├── read rows: 1
-│               ├── read bytes: 8
+│               ├── read size: < 1 KiB
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
 │               ├── push downs: [filters: [], limit: NONE]
@@ -433,7 +433,7 @@ HashJoin
     │   ├── table: default.system.numbers
     │   ├── output columns: [number (#1)]
     │   ├── read rows: 1
-    │   ├── read bytes: 8
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── push downs: [filters: [], limit: NONE]
@@ -442,7 +442,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
@@ -462,7 +462,7 @@ HashJoin
 │   ├── table: default.system.numbers
 │   ├── output columns: [number (#2)]
 │   ├── read rows: 1
-│   ├── read bytes: 8
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── push downs: [filters: [], limit: NONE]
@@ -478,7 +478,7 @@ HashJoin
     │   ├── table: default.system.numbers
     │   ├── output columns: [number (#1)]
     │   ├── read rows: 1
-    │   ├── read bytes: 8
+    │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── push downs: [filters: [], limit: NONE]
@@ -487,7 +487,7 @@ HashJoin
         ├── table: default.system.numbers
         ├── output columns: [number (#0)]
         ├── read rows: 1
-        ├── read bytes: 8
+        ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/union.test
@@ -32,7 +32,7 @@ UnionAll
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
 │   ├── read rows: 0
-│   ├── read bytes: 0
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ UnionAll
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]
     ├── read rows: 0
-    ├── read bytes: 0
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -59,7 +59,7 @@ UnionAll
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
 │   ├── read rows: 2
-│   ├── read bytes: 48
+│   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -69,7 +69,7 @@ UnionAll
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]
     ├── read rows: 2
-    ├── read bytes: 48
+    ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -96,7 +96,7 @@ Limit
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 2
-    │       ├── read bytes: 48
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -111,7 +111,7 @@ Limit
             ├── table: default.default.t2
             ├── output columns: [a (#2), b (#3)]
             ├── read rows: 2
-            ├── read bytes: 48
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -138,7 +138,7 @@ Limit
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 2
-    │       ├── read bytes: 48
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -153,7 +153,7 @@ Limit
             ├── table: default.default.t2
             ├── output columns: [a (#2), b (#3)]
             ├── read rows: 2
-            ├── read bytes: 48
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -180,7 +180,7 @@ Limit
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
     │       ├── read rows: 2
-    │       ├── read bytes: 48
+    │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
@@ -195,7 +195,7 @@ Limit
             ├── table: default.default.t2
             ├── output columns: [a (#2), b (#3)]
             ├── read rows: 2
-            ├── read bytes: 48
+            ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/union.test
@@ -32,7 +32,7 @@ UnionAll
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
 │   ├── read rows: 0
-│   ├── read size: < 1 KiB
+│   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
@@ -42,7 +42,7 @@ UnionAll
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]
     ├── read rows: 0
-    ├── read size: < 1 KiB
+    ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Refine the read size in explain to make it clearer.

```sql
query T
explain select * from numbers(0);
----
TableScan
├── table: default.system.numbers
├── output columns: [number (#0)]
├── read rows: 0
├── read size: 0
├── partitions total: 1
├── partitions scanned: 1
├── push downs: [filters: [], limit: NONE]
└── estimated rows: 0.00

query T
explain select * from numbers(10);
----
TableScan
├── table: default.system.numbers
├── output columns: [number (#0)]
├── read rows: 10
├── read size: < 1 KiB
├── partitions total: 1
├── partitions scanned: 1
├── push downs: [filters: [], limit: NONE]
└── estimated rows: 10.00

query T
explain select * from numbers(10000);
----
TableScan
├── table: default.system.numbers
├── output columns: [number (#0)]
├── read rows: 10000
├── read size: 78.12 KiB
├── partitions total: 1
├── partitions scanned: 1
├── push downs: [filters: [], limit: NONE]
└── estimated rows: 10000.00

query T
explain select * from numbers(10000000);
----
TableScan
├── table: default.system.numbers
├── output columns: [number (#0)]
├── read rows: 10000000
├── read size: 76.29 MiB
├── partitions total: 153
├── partitions scanned: 153
├── push downs: [filters: [], limit: NONE]
└── estimated rows: 10000000.00

query T
explain select * from numbers(10000000000);
----
TableScan
├── table: default.system.numbers
├── output columns: [number (#0)]
├── read rows: 10000000000
├── read size: 74.51 GiB
├── partitions total: 152588
├── partitions scanned: 152588
├── push downs: [filters: [], limit: NONE]
└── estimated rows: 10000000000.00

query T
explain select * from numbers(10000000000000);
----
TableScan
├── table: default.system.numbers
├── output columns: [number (#0)]
├── read rows: 10000000000000
├── read size: 72.76 TiB
├── partitions total: 152587891
├── partitions scanned: 152587891
├── push downs: [filters: [], limit: NONE]
└── estimated rows: 10000000000000.00

query T
explain select * from numbers(10000000000000000);
----
TableScan
├── table: default.system.numbers
├── output columns: [number (#0)]
├── read rows: 10000000000000000
├── read size: 71.05 PiB
├── partitions total: 152587890626
├── partitions scanned: 152587890626
├── push downs: [filters: [], limit: NONE]
└── estimated rows: 10000000000000000.00
```

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe): 
