### PR TITLE
feat(http): get client ip from headers

### DIFF
--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -113,7 +113,7 @@ fn get_credential(req: &Request, kind: HttpHandlerKind) -> Result<Credential> {
 /// not found, fallback to the remote address, which might be local proxy's ip address.
 /// please note that when it comes with network policy, we need make sure the incoming
 /// traffic comes from a trustworthy proxy instance.
-fn get_client_ip(req: &Request) -> Option<String> {
+pub fn get_client_ip(req: &Request) -> Option<String> {
     let headers = ["X-Real-IP", "X-Forwarded-For", "CF-Connecting-IP"];
     for &header in headers.iter() {
         if let Some(value) = req.headers().get(header) {

--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -117,12 +117,11 @@ fn get_client_ip(req: &Request) -> Option<String> {
     let headers = ["X-Real-IP", "X-Forwarded-For", "CF-Connecting-IP"];
     for &header in headers.iter() {
         if let Some(value) = req.headers().get(header) {
-            if let Ok(ip_str) = value.to_str() {
-                let mut ip_str = ip_str.to_string();
+            if let Ok(mut ip_str) = value.to_str() {
                 if header == "X-Forwarded-For" {
-                    ip_str = ip_str.split(',')[0];
+                    ip_str = ip_str.split(',').next().unwrap_or("");
                 }
-                return Some(ip_str);
+                return Some(ip_str.to_string());
             }
         }
     }

--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -95,7 +95,7 @@ fn get_credential(req: &Request, kind: HttpHandlerKind) -> Result<Credential> {
         let msg = &format!("Multiple {} headers detected", AUTHORIZATION);
         return Err(ErrorCode::AuthenticateFailure(msg));
     }
-    let client_ip = get_client_ip(&req);
+    let client_ip = get_client_ip(req);
     if std_auth_headers.is_empty() {
         if matches!(kind, HttpHandlerKind::Clickhouse) {
             auth_clickhouse_name_password(req, client_ip)

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -28,6 +28,7 @@ use databend_common_meta_app::principal::PasswordHashMethod;
 use databend_common_users::CustomClaims;
 use databend_common_users::EnsureUser;
 use databend_query::auth::AuthMgr;
+use databend_query::servers::http::middleware::get_client_ip;
 use databend_query::servers::http::middleware::HTTPSessionEndpoint;
 use databend_query::servers::http::middleware::HTTPSessionMiddleware;
 use databend_query::servers::http::v1::make_final_uri;
@@ -1707,5 +1708,15 @@ async fn test_txn_timeout() -> Result<()> {
             last_query_id
         )
     );
+    Ok(())
+}
+
+#[test]
+fn test_parse_ip() -> Result<()> {
+    let req = poem::Request::builder()
+        .header("X-Forwarded-For", "1.2.3.4")
+        .finish();
+    let ip = get_client_ip(&req);
+    assert_eq!(ip, Some("1.2.3.4".to_string()));
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

currently the IP we got is retrieved from req.remote_addr, which represents the direct connection's IP address.

but when we deployed with having a proxy up front, it only reprents the proxy's IP.

this PR tries to retrieve the ip from headers including X-Real-IP, X-Forwarded-For, CF-Connecting-IP, these headers can help us retrieve the real ip of the client.

please note that the ip address from the headers are easy to be manipulated by middleman. we have to ensure the proxies are trustworthy, or the middleman may use a fake header to trick the network policy.

(however, it's necessary to trust the proxy in a cloud deployment IMHO.)

## Tests

- [x] Unit Test

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15205)
<!-- Reviewable:end -->
