### PR TITLE
chore(planner): fix decorrelate exists subquery

### DIFF
--- a/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
@@ -302,7 +302,7 @@ impl SubqueryRewriter {
             SubqueryType::Exists | SubqueryType::NotExists => {
                 if is_conjunctive_predicate {
                     if let Some(result) = self.try_decorrelate_simple_subquery(left, subquery)? {
-                        return Ok((result, UnnestResult::SimpleJoin));
+                        return Ok((result, UnnestResult::SimpleJoin { output_index: None }));
                     }
                 }
                 let correlated_columns = subquery.outer_columns.clone();

--- a/src/query/sql/src/planner/optimizer/decorrelate/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/subquery_rewriter.rs
@@ -57,7 +57,7 @@ use crate::MetadataRef;
 #[allow(clippy::enum_variant_names)]
 pub enum UnnestResult {
     // Semi/Anti Join, Cross join for EXISTS
-    SimpleJoin,
+    SimpleJoin { output_index: Option<IndexType> },
     MarkJoin { marker_index: IndexType },
     SingleJoin { output_index: Option<IndexType> },
 }
@@ -242,7 +242,11 @@ impl SubqueryRewriter {
                     from_count_func: false,
                 };
                 let (s_expr, result) = if prop.outer_columns.is_empty() {
-                    self.try_rewrite_uncorrelated_subquery(s_expr, &subquery)?
+                    self.try_rewrite_uncorrelated_subquery(
+                        s_expr,
+                        &subquery,
+                        is_conjunctive_predicate,
+                    )?
                 } else {
                     self.try_decorrelate_subquery(
                         s_expr,
@@ -254,14 +258,25 @@ impl SubqueryRewriter {
 
                 // If we unnest the subquery into a simple join, then we can replace the
                 // original predicate with a `TRUE` literal to eliminate the conjunction.
-                if matches!(result, UnnestResult::SimpleJoin) {
-                    return Ok((
+                if let UnnestResult::SimpleJoin { output_index } = result {
+                    let scalar_expr = if let Some(output_index) = output_index {
+                        ScalarExpr::BoundColumnRef(BoundColumnRef {
+                            span: subquery.span,
+                            column: ColumnBindingBuilder::new(
+                                "exists_scalar".to_string(),
+                                output_index,
+                                Box::new(DataType::Boolean),
+                                Visibility::Visible,
+                            )
+                            .build(),
+                        })
+                    } else {
                         ScalarExpr::ConstantExpr(ConstantExpr {
                             span: subquery.span,
                             value: Scalar::Boolean(true),
-                        }),
-                        s_expr,
-                    ));
+                        })
+                    };
+                    return Ok((scalar_expr, s_expr));
                 }
                 let (index, name) = if let UnnestResult::MarkJoin { marker_index } = result {
                     (marker_index, marker_index.to_string())
@@ -391,6 +406,7 @@ impl SubqueryRewriter {
         &mut self,
         left: &SExpr,
         subquery: &SubqueryExpr,
+        is_conjunctive_predicate: bool,
     ) -> Result<(SExpr, UnnestResult)> {
         match subquery.typ {
             SubqueryType::Scalar => self.rewrite_uncorrelated_scalar_subquery(left, subquery),
@@ -461,19 +477,35 @@ impl SubqueryRewriter {
                         .into(),
                     ],
                 };
-                let filter = Filter {
-                    predicates: vec![compare.into()],
+
+                let agg_s_expr = Arc::new(SExpr::create_unary(
+                    Arc::new(agg.into()),
+                    Arc::new(subquery_expr),
+                ));
+
+                let mut output_index = None;
+                let rewritten_subquery = if is_conjunctive_predicate {
+                    let filter = Filter {
+                        predicates: vec![compare.into()],
+                    };
+                    // Filter: COUNT(*) = 1 or COUNT(*) != 1
+                    // └── Aggregate: COUNT(*)
+                    SExpr::create_unary(Arc::new(filter.into()), agg_s_expr)
+                } else {
+                    let column_index = self.metadata.write().add_derived_column(
+                        "_exists_scalar_subquery".to_string(),
+                        DataType::Number(NumberDataType::UInt64),
+                    );
+                    output_index = Some(column_index);
+                    let eval_scalar = EvalScalar {
+                        items: vec![ScalarItem {
+                            scalar: compare.into(),
+                            index: column_index,
+                        }],
+                    };
+                    SExpr::create_unary(Arc::new(eval_scalar.into()), agg_s_expr)
                 };
 
-                // Filter: COUNT(*) = 1 or COUNT(*) != 1
-                //     Aggregate: COUNT(*)
-                let rewritten_subquery = SExpr::create_unary(
-                    Arc::new(filter.into()),
-                    Arc::new(SExpr::create_unary(
-                        Arc::new(agg.into()),
-                        Arc::new(subquery_expr),
-                    )),
-                );
                 let cross_join = Join {
                     left_conditions: vec![],
                     right_conditions: vec![],
@@ -492,7 +524,7 @@ impl SubqueryRewriter {
                         Arc::new(left.clone()),
                         Arc::new(rewritten_subquery),
                     ),
-                    UnnestResult::SimpleJoin,
+                    UnnestResult::SimpleJoin { output_index },
                 ))
             }
             SubqueryType::Any => {

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -509,3 +509,72 @@ Filter
     ├── partitions scanned: 1
     ├── push downs: [filters: [numbers.number (#0) > 5], limit: NONE]
     └── estimated rows: 10.00
+
+statement ok
+drop table if exists t;
+
+statement ok
+create table t (i int);
+
+statement ok
+insert into t values(1), (2), (3), (null);
+
+query T
+explain select i, exists(select * from t where i > 10) from t;
+----
+EvalScalar
+├── output columns: [t.i (#0), exists (select * from t where i > 10) (#2)]
+├── expressions: [exists_scalar (#4)]
+├── estimated rows: 4.00
+└── HashJoin
+    ├── output columns: [t.i (#0), _count_scalar_subquery (#4)]
+    ├── join type: CROSS
+    ├── build keys: []
+    ├── probe keys: []
+    ├── filters: []
+    ├── estimated rows: 4.00
+    ├── EvalScalar(Build)
+    │   ├── output columns: [_count_scalar_subquery (#4)]
+    │   ├── expressions: [count(*) (#3) = 1]
+    │   ├── estimated rows: 1.00
+    │   └── AggregateFinal
+    │       ├── output columns: [count(*) (#3)]
+    │       ├── group by: []
+    │       ├── aggregate functions: [count()]
+    │       ├── estimated rows: 1.00
+    │       └── AggregatePartial
+    │           ├── group by: []
+    │           ├── aggregate functions: [count()]
+    │           ├── estimated rows: 1.00
+    │           └── Limit
+    │               ├── output columns: []
+    │               ├── limit: 1
+    │               ├── offset: 0
+    │               ├── estimated rows: 0.00
+    │               └── Filter
+    │                   ├── output columns: []
+    │                   ├── filters: [is_true(t.i (#1) > 10)]
+    │                   ├── estimated rows: 0.00
+    │                   └── TableScan
+    │                       ├── table: default.default.t
+    │                       ├── output columns: [i (#1)]
+    │                       ├── read rows: 0
+    │                       ├── read size: 0
+    │                       ├── partitions total: 1
+    │                       ├── partitions scanned: 0
+    │                       ├── pruning stats: [segments: <range pruning: 1 to 0>]
+    │                       ├── push downs: [filters: [is_true(t.i (#1) > 10)], limit: NONE]
+    │                       └── estimated rows: 4.00
+    └── TableScan(Probe)
+        ├── table: default.default.t
+        ├── output columns: [i (#0)]
+        ├── read rows: 4
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 4.00
+
+statement ok
+drop table if exists t;

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -527,14 +527,14 @@ EvalScalar
 ├── expressions: [exists_scalar (#4)]
 ├── estimated rows: 4.00
 └── HashJoin
-    ├── output columns: [t.i (#0), _count_scalar_subquery (#4)]
+    ├── output columns: [t.i (#0), _exists_scalar_subquery (#4)]
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)
-    │   ├── output columns: [_count_scalar_subquery (#4)]
+    │   ├── output columns: [_exists_scalar_subquery (#4)]
     │   ├── expressions: [count(*) (#3) = 1]
     │   ├── estimated rows: 1.00
     │   └── AggregateFinal

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
@@ -492,3 +492,68 @@ HashJoin
         ├── partitions scanned: 1
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 1.00
+
+statement ok
+drop table if exists t;
+
+statement ok
+create table t (i int);
+
+statement ok
+insert into t values(1), (2), (3), (null);
+
+query T
+explain select i, exists(select * from t where i > 10) from t;
+----
+EvalScalar
+├── output columns: [t.i (#0), exists (select * from t where i > 10) (#2)]
+├── expressions: [exists_scalar (#4)]
+├── estimated rows: 4.00
+└── HashJoin
+    ├── output columns: [t.i (#0), _exists_scalar_subquery (#4)]
+    ├── join type: CROSS
+    ├── build keys: []
+    ├── probe keys: []
+    ├── filters: []
+    ├── estimated rows: 4.00
+    ├── EvalScalar(Build)
+    │   ├── output columns: [_exists_scalar_subquery (#4)]
+    │   ├── expressions: [count(*) (#3) = 1]
+    │   ├── estimated rows: 1.00
+    │   └── AggregateFinal
+    │       ├── output columns: [count(*) (#3)]
+    │       ├── group by: []
+    │       ├── aggregate functions: [count()]
+    │       ├── estimated rows: 1.00
+    │       └── AggregatePartial
+    │           ├── group by: []
+    │           ├── aggregate functions: [count()]
+    │           ├── estimated rows: 1.00
+    │           └── Limit
+    │               ├── output columns: []
+    │               ├── limit: 1
+    │               ├── offset: 0
+    │               ├── estimated rows: 0.00
+    │               └── TableScan
+    │                   ├── table: default.default.t
+    │                   ├── output columns: []
+    │                   ├── read rows: 0
+    │                   ├── read size: 0
+    │                   ├── partitions total: 1
+    │                   ├── partitions scanned: 0
+    │                   ├── pruning stats: [segments: <range pruning: 1 to 0>]
+    │                   ├── push downs: [filters: [is_true(t.i (#1) > 10)], limit: 1]
+    │                   └── estimated rows: 0.00
+    └── TableScan(Probe)
+        ├── table: default.default.t
+        ├── output columns: [i (#0)]
+        ├── read rows: 4
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 4.00
+
+statement ok
+drop table if exists t;

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -751,3 +751,23 @@ select (select sum(a) from t1 where t1.a >= t2.a group by t1.a) from t1 as t2;
 
 statement ok
 drop table t1;
+
+statement ok
+drop table if exists t;
+
+statement ok
+create table t (i int);
+
+statement ok
+insert into t values(1), (2), (3), (null);
+
+query T
+select i, exists(select * from t where i > 10) from t;
+----
+1 0
+2 0
+3 0
+NULL 0
+
+statement ok
+drop table if exists t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When decorrelating uncorrelated exists subquery, if `is_conjunctive_predicate` is false, we need to generate `EvalScalar` instead of `Filter`.

```sql
drop table if exists t;
create table t(i int null);
insert into t values(1), (2), (3), (null);
select i, exists(select * from t where i > 10) from t;
```

Currently this SQL will get an incorrect result: empty result set, but the correct result should be:
```sql
┌─────────────────────────────────────────────────────────┐
│        i        │ exists (select * from t where i > 10) │
│ Nullable(Int32) │           Nullable(Boolean)           │
├─────────────────┼───────────────────────────────────────┤
│               1 │ false                                 │
│               2 │ false                                 │
│               3 │ false                                 │
│            NULL │ false                                 │
└─────────────────────────────────────────────────────────┘
```

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15208)
<!-- Reviewable:end -->
