### PR TITLE
chore: change parquet_fast_read_bytes setting from 0 to 16MB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,7 +2998,6 @@ dependencies = [
  "ethnum 1.5.0 (git+https://github.com/ariesdevil/ethnum-rs?rev=4cb05f1)",
  "futures",
  "geo",
- "geos",
  "geozero",
  "goldenfile",
  "hex",

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -454,8 +454,8 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
                 ("parquet_fast_read_bytes", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
-                    desc: "Parquet file with smaller size will be read as a whole file, instead of column by column.",
+                    value: UserSettingValue::UInt64(16 * 1024 * 1024),
+                    desc: "Parquet file with smaller size will be read as a whole file, instead of column by column. Default value: 16MB",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When copying from the Parquet stage, we default to reading metadata each time, which is not efficient for small Parquet files (less than 16MB) due to the cost of reading metadata. 
See https://github.com/datafuselabs/databend/blob/c2e3ee652985a3a8aca1f4e3b46941889501fcb6/src/query/storages/parquet/src/parquet_rs/parquet_table/partition.rs#L79-L92

This PR sets `parquet_fast_read_bytes` default value to 16MB, meaning if a parquet file is less than 16MB, we won't read the metadata; instead, we'll read the entire file.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):
