### PR TITLE
fix(query): alter modify col comment need modify when type not modify

### DIFF
--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -137,53 +137,6 @@ impl ModifyTableColumnInterpreter {
         Ok(PipelineBuildResult::create())
     }
 
-    // unset data mask policy to a column is a ee feature.
-    async fn do_unset_data_mask_policy(
-        &self,
-        catalog: Arc<dyn Catalog>,
-        table: &Arc<dyn Table>,
-        column: String,
-    ) -> Result<PipelineBuildResult> {
-        let license_manager = get_license_manager();
-        license_manager
-            .manager
-            .check_enterprise_enabled(self.ctx.get_license_key(), DataMask)?;
-
-        let table_info = table.get_table_info();
-        let table_id = table_info.ident.table_id;
-        let table_version = table_info.ident.seq;
-
-        let prev_column_mask_name =
-            if let Some(column_mask_policy) = &table_info.meta.column_mask_policy {
-                column_mask_policy.get(&column).cloned()
-            } else {
-                None
-            };
-
-        if let Some(prev_column_mask_name) = prev_column_mask_name {
-            let req = SetTableColumnMaskPolicyReq {
-                tenant: self.ctx.get_tenant(),
-                seq: MatchSeq::Exact(table_version),
-                table_id,
-                column,
-                action: SetTableColumnMaskPolicyAction::Unset(prev_column_mask_name),
-            };
-
-            let res = catalog.set_table_column_mask_policy(req).await?;
-
-            if let Some(share_table_info) = res.share_table_info {
-                save_share_table_info(
-                    self.ctx.get_tenant().name(),
-                    self.ctx.get_data_operator()?.operator(),
-                    share_table_info,
-                )
-                .await?;
-            }
-        }
-
-        Ok(PipelineBuildResult::create())
-    }
-
     // Set data column type.
     async fn do_set_data_type(
         &self,
@@ -238,6 +191,7 @@ impl ModifyTableColumnInterpreter {
 
         let mut table_info = table.get_table_info().clone();
         table_info.meta.fill_field_comments();
+        let mut modify_comment = false;
         for (field, comment) in field_and_comments {
             let column = &field.name.to_string();
             let data_type = &field.data_type;
@@ -263,7 +217,10 @@ impl ModifyTableColumnInterpreter {
                         )));
                     }
                     new_schema.fields[i].data_type = data_type.clone();
+                }
+                if table_info.meta.field_comments[i] != *comment {
                     table_info.meta.field_comments[i] = comment.to_string();
+                    modify_comment = true;
                 }
             } else {
                 return Err(ErrorCode::UnknownColumn(format!(
@@ -274,7 +231,7 @@ impl ModifyTableColumnInterpreter {
         }
 
         // check if schema has changed
-        if schema == new_schema {
+        if schema == new_schema && !modify_comment {
             return Ok(PipelineBuildResult::create());
         }
 
@@ -338,7 +295,7 @@ impl ModifyTableColumnInterpreter {
                         && (old_data_type == new_data_type
                             || is_string_to_binary(&old_field.data_type, &new_field.data_type))
                 });
-        if is_alter_column_string_to_binary {
+        if modify_comment || is_alter_column_string_to_binary {
             table_info.meta.schema = new_schema.into();
 
             let table_id = table_info.ident.table_id;
@@ -443,6 +400,53 @@ impl ModifyTableColumnInterpreter {
 
         build_res.main_pipeline.add_lock_guard(lock_guard);
         Ok(build_res)
+    }
+
+    // unset data mask policy to a column is a ee feature.
+    async fn do_unset_data_mask_policy(
+        &self,
+        catalog: Arc<dyn Catalog>,
+        table: &Arc<dyn Table>,
+        column: String,
+    ) -> Result<PipelineBuildResult> {
+        let license_manager = get_license_manager();
+        license_manager
+            .manager
+            .check_enterprise_enabled(self.ctx.get_license_key(), DataMask)?;
+
+        let table_info = table.get_table_info();
+        let table_id = table_info.ident.table_id;
+        let table_version = table_info.ident.seq;
+
+        let prev_column_mask_name =
+            if let Some(column_mask_policy) = &table_info.meta.column_mask_policy {
+                column_mask_policy.get(&column).cloned()
+            } else {
+                None
+            };
+
+        if let Some(prev_column_mask_name) = prev_column_mask_name {
+            let req = SetTableColumnMaskPolicyReq {
+                tenant: self.ctx.get_tenant(),
+                seq: MatchSeq::Exact(table_version),
+                table_id,
+                column,
+                action: SetTableColumnMaskPolicyAction::Unset(prev_column_mask_name),
+            };
+
+            let res = catalog.set_table_column_mask_policy(req).await?;
+
+            if let Some(share_table_info) = res.share_table_info {
+                save_share_table_info(
+                    self.ctx.get_tenant().name(),
+                    self.ctx.get_data_operator()?.operator(),
+                    share_table_info,
+                )
+                .await?;
+            }
+        }
+
+        Ok(PipelineBuildResult::create())
     }
 
     async fn do_convert_stored_computed_column(

--- a/tests/sqllogictests/suites/base/05_ddl/05_0003_ddl_alter_table.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0003_ddl_alter_table.test
@@ -197,5 +197,14 @@ c1 VARCHAR YES NULL (empty)
 c2 VARCHAR YES NULL (empty)
 
 statement ok
+alter table t modify c1 varchar comment 'c1-column', c2 int comment 'test';
+
+query TTTTT
+select database,table,name,data_type,comment from system.columns where table='t' and database='default';
+----
+default t c1 VARCHAR 'c1-column'
+default t c2 INT 'test'
+
+statement ok
 DROP TABLE IF EXISTS t;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```sql
create table t1(id varchar, id2 varchar);
Query OK, 0 rows affected (0.060 sec)

MySQL [(none)]> alter table t1 modify id varchar comment 'ss';
Query OK, 0 rows affected (0.246 sec)

MySQL [(none)]> alter table t1 modify id varchar comment 'ss', id2 varchar comment 's3';
Query OK, 0 rows affected (0.079 sec)
```

After alter:

```sql
show create table t1;
+-------+-----------------------------------------------------------------------+
| Table | Create Table                                                          |
+-------+-----------------------------------------------------------------------+
| t1    | CREATE TABLE t1 (
  id VARCHAR NULL,
  id2 VARCHAR NULL
) ENGINE=FUSE |
+-------+-----------------------------------------------------------------------+

```


Because in 
https://github.com/datafuselabs/databend/blob/3aeb2d0290ac004adda4a8e13306b50e33798d4f/src/query/service/src/interpreters/interpreter_table_modify_column.rs#L245

So if new type is same, the schema will always eq with old schema.

So if column type is not modify, the comment will be ignored.

- Fixes #15216

## Tests

- [x] Logic Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15217)
<!-- Reviewable:end -->
