### PR TITLE
chore: vacuum drop table for external location table

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
@@ -32,14 +32,15 @@ pub async fn do_vacuum_drop_table(
     operator: &Operator,
     dry_run_limit: Option<usize>,
 ) -> Result<Option<Vec<VacuumDropFileInfo>>> {
-    // storage_params is_some means it is an external table, ignore
-    if table_info.meta.storage_params.is_some() {
-        info!("ignore external table {}", table_info.name);
-        return Ok(None);
-    }
-
     let dir = format!("{}/", FuseTable::parse_storage_prefix(table_info)?);
-    info!("vacuum drop table {:?} dir {:?}", table_info.name, dir);
+
+    info!(
+        "vacuum drop table {:?} dir {:?}, is_external_table:{:?}",
+        table_info.name,
+        dir,
+        table_info.meta.storage_params.is_some()
+    );
+
     let start = Instant::now();
 
     let ret = match dry_run_limit {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

To enhance security, users would like to utilize their own external bucket location (stage) for the FUSE table. However, the [`VACUUM DROP TABLE`](https://docs.databend.com/sql/sql-commands/ddl/table/vacuum-drop-table) command does not affect this feature. 

This pull request aims to make the external location FUSE table function similarly to a standard location FUSE table.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Exist Tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15220)
<!-- Reviewable:end -->
