### PR TITLE
chore: old op LogicalGet modify to new op name Scan

### DIFF
--- a/src/query/sql/src/planner/optimizer/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/flatten_plan.rs
@@ -65,7 +65,7 @@ impl SubqueryRewriter {
             if !need_cross_join {
                 return Ok(plan.clone());
             }
-            // Construct a LogicalGet plan by correlated columns.
+            // Construct a Scan plan by correlated columns.
             // Finally generate a cross join, so we finish flattening the subquery.
             let mut metadata = self.metadata.write();
             // Currently, we don't support left plan's from clause contains subquery.

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_scan.rs
@@ -53,7 +53,7 @@ impl RulePushDownFilterScan {
             id: RuleID::PushDownFilterScan,
             // Filter
             //  \
-            //   LogicalGet
+            //   Scan
             matchers: vec![Matcher::MatchOp {
                 op_type: RelOp::Filter,
                 children: vec![Matcher::MatchOp {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_limit_scan.rs
@@ -29,12 +29,12 @@ use crate::plans::Scan;
 
 /// Input:  Limit
 ///           \
-///          LogicalGet
+///          Scan
 ///
 /// Output:
 ///         Limit
 ///           \
-///           LogicalGet(padding limit)
+///           Scan(padding limit)
 pub struct RulePushDownLimitScan {
     id: RuleID,
     matchers: Vec<Matcher>,

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_prewhere.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_prewhere.rs
@@ -88,7 +88,7 @@ impl RulePushDownPrewhere {
                 }
             }
             _ => {
-                // SubqueryExpr and AggregateFunction will not appear in Filter-LogicalGet
+                // SubqueryExpr and AggregateFunction will not appear in Filter-Scan
                 return Err(ErrorCode::Unimplemented(format!(
                     "Prewhere don't support expr {:?}",
                     expr

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_sort_scan.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_sort_scan.rs
@@ -29,12 +29,12 @@ use crate::plans::Sort;
 
 /// Input:  Sort
 ///           \
-///          LogicalGet
+///          Scan
 ///
 /// Output:
 ///         Sort
 ///           \
-///           LogicalGet(padding order_by and limit)
+///           Scan(padding order_by and limit)
 pub struct RulePushDownSortScan {
     id: RuleID,
     matchers: Vec<Matcher>,

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -372,9 +372,7 @@ impl TryFrom<RelOperator> for Scan {
         if let RelOperator::Scan(value) = value {
             Ok(value)
         } else {
-            Err(ErrorCode::Internal(
-                "Cannot downcast RelOperator to LogicalGet",
-            ))
+            Err(ErrorCode::Internal("Cannot downcast RelOperator to Scan"))
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Replace op name LogicalGet to Scan. 

- Fixes #15218

## Tests

- [x] No Test: only modfiy some comment and err msg.

## Type of change

- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15222)
<!-- Reviewable:end -->
