### PR TITLE
chore(query): fix nullable array domain

### DIFF
--- a/src/query/storages/common/index/src/range_index.rs
+++ b/src/query/storages/common/index/src/range_index.rs
@@ -166,7 +166,7 @@ pub fn statistics_to_domain(mut stats: Vec<&ColumnStatistics>, data_type: &DataT
                     value: None,
                 });
             }
-            let has_null = if stats.len() == 1 {
+            let has_null = if stats.len() == 1 && !matches!(inner_ty, &DataType::Array(_)) {
                 stats[0].null_count > 0
             } else {
                 // Only leaf columns have statistics,

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_04_range_pruning.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_04_range_pruning.test
@@ -44,8 +44,23 @@ select max(a) from range_test_t where a >= 4000 and a <= 5000;
 ----
 5000
 
+## issue:https://github.com/datafuselabs/databend/issues/15170
+
 statement ok
-drop table range_test_t
+create or replace table test_range_array(doc varchar, embedding ARRAY(FLOAT32 not null));
+
+statement ok
+insert into test_range_array(doc)values('xx');
+
+query I
+select count() from test_range_array where embedding is not null;
+----
+0
+
+query I
+select count() from test_range_array where embedding is null;
+----
+1
 
 statement ok
 DROP DATABASE db_09_0009_04


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 fix nullable array domain
 
The previous domain of `nullable<array>` will generate stats of `null_count` = 0.
This is incorrect.
 

- Fixes #15170

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15224)
<!-- Reviewable:end -->
