### PR TITLE
fix: fix map get return double nested nullable

### DIFF
--- a/src/query/functions/src/scalars/map.rs
+++ b/src/query/functions/src/scalars/map.rs
@@ -97,6 +97,32 @@ pub fn register(registry: &mut FunctionRegistry) {
         |_, _, _| Value::Scalar(()),
     );
 
+    // NOTE: order is matter, we first catch <K, Nullable<V>> here.
+    registry.register_combine_nullable_2_arg::<MapType<GenericType<0>, NullableType<GenericType<1>>>, GenericType<0>, GenericType<1>, _, _>(
+        "get",
+        |_, domain, _| {
+            FunctionDomain::Domain(NullableDomain {
+                has_null: true,
+                value: domain.as_ref().and_then(|(_, val_domain)| val_domain.value.clone())
+            })
+        },
+        vectorize_with_builder_2_arg::<MapType<GenericType<0>, NullableType<GenericType<1>>>, GenericType<0>, NullableType<GenericType<1>>>(
+            |map, key, output, _| {
+                for (k, v) in map.iter() {
+                    if k == key {
+                        match v {
+                            Some(v) => output.push(v),
+                            None => output.push_null()
+                        }
+                        return
+                    }
+                }
+                output.push_null()
+            }
+        ),
+    );
+
+    // NOTE: order is matter, we catch <K, V> here after <K, Nullable<V>>
     registry.register_combine_nullable_2_arg::<MapType<GenericType<0>, GenericType<1>>, GenericType<0>, GenericType<1>, _, _>(
         "get",
         |_, domain, _| {

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -2002,11 +2002,13 @@ Functions overloads:
 7 get(Array(T0 NULL) NULL, UInt64 NULL) :: T0 NULL
 8 get(Map(Nothing) NULL, T0 NULL) :: NULL
 9 get(Map(T0, NULL) NULL, T0 NULL) :: NULL
-10 get(Map(T0, T1), T0) :: T1 NULL
-11 get(Map(T0, T1) NULL, T0 NULL) :: T1 NULL
-12 get FACTORY
-13 get FACTORY
+10 get(Map(T0, T1 NULL), T0) :: T1 NULL
+11 get(Map(T0, T1 NULL) NULL, T0 NULL) :: T1 NULL
+12 get(Map(T0, T1), T0) :: T1 NULL
+13 get(Map(T0, T1) NULL, T0 NULL) :: T1 NULL
 14 get FACTORY
+15 get FACTORY
+16 get FACTORY
 0 get_by_keypath FACTORY
 0 get_by_keypath_string FACTORY
 0 get_ignore_case(Variant, String) :: Variant NULL

--- a/src/query/functions/tests/it/scalars/testdata/map.txt
+++ b/src/query/functions/tests/it/scalars/testdata/map.txt
@@ -117,7 +117,7 @@ output         : NULL
 
 ast            : map([1,2],['a','b'])[1]
 raw expr       : get(map(array(1, 2), array('a', 'b')), 1)
-checked expr   : get<T0=UInt8, T1=String><Map(T0, T1), T0>(map<T0=UInt8, T1=String><Array(T0), Array(T1)>(array<T0=UInt8><T0, T0>(1_u8, 2_u8), array<T0=String><T0, T0>("a", "b")), 1_u8)
+checked expr   : get<T0=UInt8, T1=String><Map(T0, T1 NULL), T0>(CAST(map<T0=UInt8, T1=String><Array(T0), Array(T1)>(array<T0=UInt8><T0, T0>(1_u8, 2_u8), array<T0=String><T0, T0>("a", "b")) AS Map(UInt8, String NULL)), 1_u8)
 optimized expr : "a"
 output type    : String NULL
 output domain  : {"a"..="a"}
@@ -126,7 +126,7 @@ output         : 'a'
 
 ast            : map([1,2],['a','b'])[10]
 raw expr       : get(map(array(1, 2), array('a', 'b')), 10)
-checked expr   : get<T0=UInt8, T1=String><Map(T0, T1), T0>(map<T0=UInt8, T1=String><Array(T0), Array(T1)>(array<T0=UInt8><T0, T0>(1_u8, 2_u8), array<T0=String><T0, T0>("a", "b")), 10_u8)
+checked expr   : get<T0=UInt8, T1=String><Map(T0, T1 NULL), T0>(CAST(map<T0=UInt8, T1=String><Array(T0), Array(T1)>(array<T0=UInt8><T0, T0>(1_u8, 2_u8), array<T0=String><T0, T0>("a", "b")) AS Map(UInt8, String NULL)), 10_u8)
 optimized expr : NULL
 output type    : String NULL
 output domain  : {NULL}
@@ -135,7 +135,7 @@ output         : NULL
 
 ast            : map(['a','b'],[1,2])['a']
 raw expr       : get(map(array('a', 'b'), array(1, 2)), 'a')
-checked expr   : get<T0=String, T1=UInt8><Map(T0, T1), T0>(map<T0=String, T1=UInt8><Array(T0), Array(T1)>(array<T0=String><T0, T0>("a", "b"), array<T0=UInt8><T0, T0>(1_u8, 2_u8)), "a")
+checked expr   : get<T0=String, T1=UInt8><Map(T0, T1 NULL), T0>(CAST(map<T0=String, T1=UInt8><Array(T0), Array(T1)>(array<T0=String><T0, T0>("a", "b"), array<T0=UInt8><T0, T0>(1_u8, 2_u8)) AS Map(String, UInt8 NULL)), "a")
 optimized expr : 1_u8
 output type    : UInt8 NULL
 output domain  : {1..=1}
@@ -144,7 +144,7 @@ output         : 1
 
 ast            : map(['a','b'],[1,2])['x']
 raw expr       : get(map(array('a', 'b'), array(1, 2)), 'x')
-checked expr   : get<T0=String, T1=UInt8><Map(T0, T1), T0>(map<T0=String, T1=UInt8><Array(T0), Array(T1)>(array<T0=String><T0, T0>("a", "b"), array<T0=UInt8><T0, T0>(1_u8, 2_u8)), "x")
+checked expr   : get<T0=String, T1=UInt8><Map(T0, T1 NULL), T0>(CAST(map<T0=String, T1=UInt8><Array(T0), Array(T1)>(array<T0=String><T0, T0>("a", "b"), array<T0=UInt8><T0, T0>(1_u8, 2_u8)) AS Map(String, UInt8 NULL)), "x")
 optimized expr : NULL
 output type    : UInt8 NULL
 output domain  : {NULL}
@@ -171,7 +171,7 @@ output         : NULL
 
 ast            : {'k1':'v1','k2':'v2'}['k1']
 raw expr       : get(map(array('k1', 'k2'), array('v1', 'v2')), 'k1')
-checked expr   : get<T0=String, T1=String><Map(T0, T1), T0>(map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0, T0>("k1", "k2"), array<T0=String><T0, T0>("v1", "v2")), "k1")
+checked expr   : get<T0=String, T1=String><Map(T0, T1 NULL), T0>(CAST(map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0, T0>("k1", "k2"), array<T0=String><T0, T0>("v1", "v2")) AS Map(String, String NULL)), "k1")
 optimized expr : "v1"
 output type    : String NULL
 output domain  : {"v1"..="v1"}
@@ -180,7 +180,7 @@ output         : 'v1'
 
 ast            : {'k1':'v1','k2':'v2'}['k3']
 raw expr       : get(map(array('k1', 'k2'), array('v1', 'v2')), 'k3')
-checked expr   : get<T0=String, T1=String><Map(T0, T1), T0>(map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0, T0>("k1", "k2"), array<T0=String><T0, T0>("v1", "v2")), "k3")
+checked expr   : get<T0=String, T1=String><Map(T0, T1 NULL), T0>(CAST(map<T0=String, T1=String><Array(T0), Array(T1)>(array<T0=String><T0, T0>("k1", "k2"), array<T0=String><T0, T0>("v1", "v2")) AS Map(String, String NULL)), "k3")
 optimized expr : NULL
 output type    : String NULL
 output domain  : {NULL}
@@ -189,8 +189,8 @@ output         : NULL
 
 ast            : map([k1,k2],[v1,v2])[1]
 raw expr       : get(map(array(k1::Int16, k2::Int16), array(v1::String, v2::String)), 1)
-checked expr   : get<T0=Int16, T1=String><Map(T0, T1), T0>(map<T0=Int16, T1=String><Array(T0), Array(T1)>(array<T0=Int16><T0, T0>(k1, k2), array<T0=String><T0, T0>(v1, v2)), to_int16<UInt8>(1_u8))
-optimized expr : get<T0=Int16, T1=String><Map(T0, T1), T0>(map<T0=Int16, T1=String><Array(T0), Array(T1)>(array<T0=Int16><T0, T0>(k1, k2), array<T0=String><T0, T0>(v1, v2)), 1_i16)
+checked expr   : get<T0=Int16, T1=String><Map(T0, T1 NULL), T0>(CAST(map<T0=Int16, T1=String><Array(T0), Array(T1)>(array<T0=Int16><T0, T0>(k1, k2), array<T0=String><T0, T0>(v1, v2)) AS Map(Int16, String NULL)), to_int16<UInt8>(1_u8))
+optimized expr : get<T0=Int16, T1=String><Map(T0, T1 NULL), T0>(CAST(map<T0=Int16, T1=String><Array(T0), Array(T1)>(array<T0=Int16><T0, T0>(k1, k2), array<T0=String><T0, T0>(v1, v2)) AS Map(Int16, String NULL)), 1_i16)
 evaluation:
 +--------+---------+---------+---------------+---------------+-------------+
 |        | k1      | k2      | v1            | v2            | Output      |

--- a/tests/sqllogictests/suites/base/03_common/03_0037_insert_into_map.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0037_insert_into_map.test
@@ -79,6 +79,18 @@ select {'id':number} from numbers(5)
 {'id':3}
 {'id':4}
 
+statement ok
+CREATE OR REPLACE TABLE t1(tags Map(String, String)) Engine = Fuse
+
+statement ok
+INSERT INTO t1 VALUES ({'region':'sg', 'az': '1'}),({'region':'sg', 'az': '2'}), ({'region':'hk', 'az': '1'}),({'region':'hk', 'az': '2'})
+
+query I
+SELECT to_int32(tags['az']) AS int_az FROM t1 WHERE tags['region'] = 'sg' ORDER BY int_az;
+----
+1
+2
+
 statement error 1006
 CREATE TABLE IF NOT EXISTS t3(id Int, m Map(Array(Date), String)) Engine = Fuse
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

for this query:
```sql
CREATE OR REPLACE TABLE t1(tags Map(String, String)) Engine = Fuse

statement ok
INSERT INTO t1 VALUES ({'region':'sg', 'az': '1'}),({'region':'sg', 'az': '2'}), ({'region':'hk', 'az': '1'}),({'region':'hk', 'az': '2'})

query I
SELECT to_int32(tags['az']) AS int_az FROM t1 WHERE tags['region'] = 'sg' ORDER BY int_az;
```

The `tags[az]` will call `map#get` with input data type `MapType<GenericType<0>, GenericType<1>>` and return data type `NullableType<GenericType<1>>`, however, if `GenericType<1>` is already a nullable type, this will return `Nullable<Nullable<XXX>>`.

When this return type pass to `to_int32`, the `try_downcast_column().unwrap()` will failed.

This PR add a new `get` function for map get that catch nullable value in map first. 

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15230)
<!-- Reviewable:end -->
