### PR TITLE
refactor: avoid using PREFIX directly. use method to build list-prefix

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1137,10 +1137,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
         // Get index id list by `prefix_list` "<prefix>/<tenant>"
-        let prefix_key = kvapi::KeyBuilder::new_prefixed(IndexNameIdent::PREFIX)
-            .push_str(req.tenant.tenant_name())
-            .push_str("")
-            .done();
+        let ident = IndexNameIdent::new(&req.tenant, "dummy");
+        let prefix_key = ident.tenant_prefix();
 
         let id_list = self.prefix_list_kv(&prefix_key).await?;
         let mut id_name_list = Vec::with_capacity(id_list.len());
@@ -1475,9 +1473,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         }
 
         // Get virtual columns list by `prefix_list` "<prefix>/<tenant>"
-        let prefix_key = kvapi::KeyBuilder::new_prefixed(VirtualColumnNameIdent::PREFIX)
-            .push_str(req.tenant.tenant_name())
-            .done();
+        let ident = VirtualColumnNameIdent::new(&req.tenant, 0u64);
+        let prefix_key = ident.tenant_prefix();
 
         let list = self.prefix_list_kv(&prefix_key).await?;
         let mut virtual_column_list = Vec::with_capacity(list.len());
@@ -1779,9 +1776,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
     async fn list_all_tables(&self) -> Result<Vec<(TableId, u64, TableMeta)>, KVAppError> {
         debug!("SchemaApi: {}", func_name!());
 
-        let reply = self
-            .prefix_list_kv(&[TableId::PREFIX, ""].join("/"))
-            .await?;
+        let prefix = TableId::root_prefix();
+        let reply = self.prefix_list_kv(&prefix).await?;
 
         let mut res = vec![];
 
@@ -5158,10 +5154,8 @@ async fn gc_dropped_table_index(
     if_then: &mut Vec<TxnOp>,
 ) -> Result<(), KVAppError> {
     // Get index id list by `prefix_list` "<prefix>/<tenant>/"
-    let prefix_key = kvapi::KeyBuilder::new_prefixed(IndexNameIdent::PREFIX)
-        .push_str(tenant.tenant_name())
-        .push_raw("")
-        .done();
+    let ident = IndexNameIdent::new(tenant, "dummy");
+    let prefix_key = ident.tenant_prefix();
 
     let id_list = kv_api.prefix_list_kv(&prefix_key).await?;
     let mut id_name_list = Vec::with_capacity(id_list.len());

--- a/src/meta/app/src/background/background_job.rs
+++ b/src/meta/app/src/background/background_job.rs
@@ -359,6 +359,9 @@ impl Display for ListBackgroundJobsReq {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyBuilder;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+    use databend_common_meta_kvapi::kvapi::KeyParser;
 
     use crate::background::background_job::BackgroundJobId;
     use crate::background::BackgroundJobInfo;
@@ -372,18 +375,12 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.id)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let id = p.next_u64()?;
-            p.done()?;
-
+        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
+            let id = parser.next_u64()?;
             Ok(BackgroundJobId { id })
         }
     }

--- a/src/meta/app/src/data_mask/mod.rs
+++ b/src/meta/app/src/data_mask/mod.rs
@@ -103,6 +103,9 @@ pub struct MaskpolicyTableIdList {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyBuilder;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+    use databend_common_meta_kvapi::kvapi::KeyParser;
 
     use super::DatamaskId;
     use crate::data_mask::DatamaskMeta;
@@ -117,19 +120,13 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.id)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let id = p.next_u64()?;
-            p.done()?;
-
-            Ok(DatamaskId { id })
+        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
+            let id = parser.next_u64()?;
+            Ok(Self { id })
         }
     }
 

--- a/src/meta/app/src/id_generator.rs
+++ b/src/meta/app/src/id_generator.rs
@@ -108,17 +108,12 @@ impl kvapi::Key for IdGenerator {
         None
     }
 
-    fn to_string_key(&self) -> String {
-        kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-            .push_raw(&self.resource)
-            .done()
+    fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+        b.push_raw(&self.resource)
     }
 
-    fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-        let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
+    fn decode_key(p: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
         let resource = p.next_raw()?;
-        p.done()?;
 
         Ok(IdGenerator {
             resource: resource.to_string(),

--- a/src/meta/app/src/key_with_tenant.rs
+++ b/src/meta/app/src/key_with_tenant.rs
@@ -32,6 +32,7 @@ pub trait KeyWithTenant: kvapi::Key {
     ///
     /// It is in form of `<__PREFIX>/<tenant>/`.
     /// The trailing `/` is important for exclude tenants with prefix same as this tenant.
+    // TODO: test tenant_prefix with tenant config
     fn tenant_prefix(&self) -> String {
         kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
             .push_str(self.tenant().tenant_name())

--- a/src/meta/app/src/principal/user_identity.rs
+++ b/src/meta/app/src/principal/user_identity.rs
@@ -86,7 +86,9 @@ impl TenantUserIdent {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyBuilder;
     use databend_common_meta_kvapi::kvapi::KeyError;
+    use databend_common_meta_kvapi::kvapi::KeyParser;
 
     use crate::principal::user_identity::TenantUserIdent;
     use crate::principal::UserIdentity;
@@ -102,21 +104,18 @@ mod kvapi_key_impl {
             Some(self.tenant.to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_str(self.tenant_name())
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_str(self.tenant_name())
                 .push_str(&self.user.to_string())
-                .done()
         }
 
-        fn from_str_key(s: &str) -> Result<Self, KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-            let tenant = p.next_nonempty()?;
-            let user_str = p.next_str()?;
-            p.done()?;
+        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
+            let tenant = parser.next_nonempty()?;
+            let user_str = parser.next_str()?;
 
             let user = UserIdentity::parse(&user_str)?;
-            Ok(TenantUserIdent {
+
+            Ok(Self {
                 tenant: Tenant::new_nonempty(tenant),
                 user,
             })

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -274,6 +274,9 @@ impl ListCatalogReq {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyBuilder;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+    use databend_common_meta_kvapi::kvapi::KeyParser;
 
     use super::CatalogId;
     use super::CatalogIdToName;
@@ -290,19 +293,14 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.catalog_id)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.catalog_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
+            let catalog_id = parser.next_u64()?;
 
-            let catalog_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(CatalogId { catalog_id })
+            Ok(Self { catalog_id })
         }
     }
 
@@ -316,19 +314,14 @@ mod kvapi_key_impl {
             Some(CatalogId::new(self.catalog_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.catalog_id)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.catalog_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
+            let catalog_id = parser.next_u64()?;
 
-            let catalog_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(CatalogIdToName { catalog_id })
+            Ok(Self { catalog_id })
         }
     }
 

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -374,19 +374,13 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.db_id)
-                .done()
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.db_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let db_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(DatabaseId { db_id })
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let db_id = parser.next_u64()?;
+            Ok(Self { db_id })
         }
     }
 
@@ -400,19 +394,13 @@ mod kvapi_key_impl {
             Some(DatabaseId::new(self.db_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.db_id)
-                .done()
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.db_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let db_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(DatabaseIdToName { db_id })
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let db_id = parser.next_u64()?;
+            Ok(Self { db_id })
         }
     }
 
@@ -426,23 +414,18 @@ mod kvapi_key_impl {
             Some(self.tenant.to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_str(self.tenant.tenant_name())
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_str(self.tenant.tenant_name())
                 .push_str(&self.db_name)
-                .done()
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let tenant = p.next_nonempty()?;
-            let db_name = p.next_str()?;
-            p.done()?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let tenant = parser.next_nonempty()?;
+            let db_name = parser.next_str()?;
 
             let tenant = Tenant::new_nonempty(tenant);
 
-            Ok(DbIdListKey { tenant, db_name })
+            Ok(Self { tenant, db_name })
         }
     }
 

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -250,19 +250,14 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.index_id)
-                .done()
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.index_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let index_id = parser.next_u64()?;
 
-            let index_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(IndexId { index_id })
+            Ok(Self { index_id })
         }
     }
 
@@ -276,19 +271,14 @@ mod kvapi_key_impl {
             Some(IndexId::new(self.index_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.index_id)
-                .done()
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.index_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let index_id = parser.next_u64()?;
 
-            let index_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(IndexIdToName { index_id })
+            Ok(Self { index_id })
         }
     }
 

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -969,6 +969,9 @@ pub struct EmptyProto {}
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
     use databend_common_meta_kvapi::kvapi::Key;
+    use databend_common_meta_kvapi::kvapi::KeyBuilder;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+    use databend_common_meta_kvapi::kvapi::KeyParser;
 
     use crate::primitive::Id;
     use crate::schema::DBIdTableName;
@@ -994,21 +997,14 @@ mod kvapi_key_impl {
             Some(DatabaseId::new(self.db_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.db_id)
-                .push_str(&self.table_name)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.db_id).push_str(&self.table_name)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
+        fn decode_key(p: &mut KeyParser) -> Result<Self, KeyError> {
             let db_id = p.next_u64()?;
             let table_name = p.next_str()?;
-            p.done()?;
-
-            Ok(DBIdTableName { db_id, table_name })
+            Ok(Self { db_id, table_name })
         }
     }
 
@@ -1022,19 +1018,13 @@ mod kvapi_key_impl {
             Some(TableId::new(self.table_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.table_id)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.table_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
+        fn decode_key(p: &mut KeyParser) -> Result<Self, KeyError> {
             let table_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(TableIdToName { table_id })
+            Ok(Self { table_id })
         }
     }
 
@@ -1048,19 +1038,13 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.table_id)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.table_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
+        fn decode_key(p: &mut KeyParser) -> Result<Self, KeyError> {
             let table_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(TableId { table_id })
+            Ok(Self { table_id })
         }
     }
 
@@ -1074,21 +1058,14 @@ mod kvapi_key_impl {
             Some(DatabaseId::new(self.db_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.db_id)
-                .push_str(&self.table_name)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.db_id).push_str(&self.table_name)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let db_id = p.next_u64()?;
-            let table_name = p.next_str()?;
-            p.done()?;
-
-            Ok(TableIdListKey { db_id, table_name })
+        fn decode_key(b: &mut KeyParser) -> Result<Self, kvapi::KeyError> {
+            let db_id = b.next_u64()?;
+            let table_name = b.next_str()?;
+            Ok(Self { db_id, table_name })
         }
     }
 
@@ -1130,14 +1107,11 @@ mod kvapi_key_impl {
             Some(TableId::new(self.table_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
             // TODO: file is not escaped!!!
             //       There already are non escaped data stored on disk.
             //       We can not change it anymore.
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.table_id)
-                .push_raw(&self.file)
-                .done()
+            b.push_u64(self.table_id).push_raw(&self.file)
         }
 
         fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
@@ -1160,19 +1134,13 @@ mod kvapi_key_impl {
             Some(TableId::new(self.table_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.table_id)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.table_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let table_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(LeastVisibleTimeKey { table_id })
+        fn decode_key(b: &mut KeyParser) -> Result<Self, kvapi::KeyError> {
+            let table_id = b.next_u64()?;
+            Ok(Self { table_id })
         }
     }
 

--- a/src/meta/app/src/schema/virtual_column.rs
+++ b/src/meta/app/src/schema/virtual_column.rs
@@ -130,10 +130,13 @@ impl ListVirtualColumnsReq {
 
 mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyError;
+    use databend_common_meta_kvapi::kvapi::KeyParser;
 
     use crate::schema::VirtualColumnMeta;
     use crate::schema::VirtualColumnNameIdent;
     use crate::tenant::Tenant;
+    use crate::KeyWithTenant;
 
     /// <prefix>/<tenant>/<table_id>
     impl kvapi::Key for VirtualColumnNameIdent {
@@ -146,23 +149,25 @@ mod kvapi_key_impl {
             Some(self.tenant.to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_str(self.tenant.tenant_name())
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_str(self.tenant.tenant_name())
                 .push_u64(self.table_id)
-                .done()
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
+        fn decode_key(p: &mut KeyParser) -> Result<Self, KeyError> {
             let tenant = p.next_nonempty()?;
             let table_id = p.next_u64()?;
             p.done()?;
 
             let tenant = Tenant::new_nonempty(tenant);
 
-            Ok(VirtualColumnNameIdent { tenant, table_id })
+            Ok(Self { tenant, table_id })
+        }
+    }
+
+    impl KeyWithTenant for VirtualColumnNameIdent {
+        fn tenant(&self) -> &Tenant {
+            &self.tenant
         }
     }
 

--- a/src/meta/app/src/share/share.rs
+++ b/src/meta/app/src/share/share.rs
@@ -783,36 +783,25 @@ mod kvapi_key_impl {
             Some(k)
         }
 
-        fn to_string_key(&self) -> String {
-            match *self {
-                ShareGrantObject::Database(db_id) => kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                    .push_raw("db")
-                    .push_u64(db_id)
-                    .done(),
-                ShareGrantObject::Table(table_id) => kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                    .push_raw("table")
-                    .push_u64(table_id)
-                    .done(),
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            match self {
+                ShareGrantObject::Database(db_id) => b.push_raw("db").push_u64(*db_id),
+                ShareGrantObject::Table(table_id) => b.push_raw("table").push_u64(*table_id),
             }
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let kind = parser.next_raw()?;
+            let id = parser.next_u64()?;
 
-            let kind = p.next_raw()?;
-            let id = p.next_u64()?;
-            p.done()?;
-
-            if kind == "db" {
-                Ok(ShareGrantObject::Database(id))
-            } else if kind == "table" {
-                Ok(ShareGrantObject::Table(id))
-            } else {
-                return Err(kvapi::KeyError::InvalidSegment {
+            match kind {
+                "db" => Ok(ShareGrantObject::Database(id)),
+                "table" => Ok(ShareGrantObject::Table(id)),
+                _ => Err(kvapi::KeyError::InvalidSegment {
                     i: 1,
                     expect: "db or table".to_string(),
                     got: kind.to_string(),
-                });
+                }),
             }
         }
     }
@@ -827,19 +816,14 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.share_id)
-                .done()
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.share_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let share_id = parser.next_u64()?;
 
-            let share_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(ShareId { share_id })
+            Ok(Self { share_id })
         }
     }
 
@@ -854,29 +838,22 @@ mod kvapi_key_impl {
             Some(kvapi::Key::to_string_key(&self.tenant))
         }
 
-        fn to_string_key(&self) -> String {
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            let b = b.push_str(self.tenant.tenant_name());
             if self.share_id != 0 {
-                kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                    .push_str(self.tenant.tenant_name())
-                    .push_u64(self.share_id)
-                    .done()
+                b.push_u64(self.share_id)
             } else {
-                kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                    .push_str(self.tenant.tenant_name())
-                    .done()
+                b
             }
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
-
-            let tenant = p.next_nonempty()?;
-            let share_id = p.next_u64()?;
-            p.done()?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let tenant = parser.next_nonempty()?;
+            let share_id = parser.next_u64()?;
 
             let tenant = Tenant::new_nonempty(tenant);
 
-            Ok(ShareConsumer { tenant, share_id })
+            Ok(Self { tenant, share_id })
         }
     }
 
@@ -890,19 +867,14 @@ mod kvapi_key_impl {
             Some(ShareId::new(self.share_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.share_id)
-                .done()
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.share_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let share_id = parser.next_u64()?;
 
-            let share_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(ShareIdToName { share_id })
+            Ok(Self { share_id })
         }
     }
 
@@ -916,19 +888,14 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.share_endpoint_id)
-                .done()
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.share_endpoint_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let share_endpoint_id = parser.next_u64()?;
 
-            let share_endpoint_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(ShareEndpointId { share_endpoint_id })
+            Ok(Self { share_endpoint_id })
         }
     }
 
@@ -944,19 +911,14 @@ mod kvapi_key_impl {
             Some(ShareEndpointId::new(self.share_endpoint_id).to_string_key())
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_u64(self.share_endpoint_id)
-                .done()
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.share_endpoint_id)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, kvapi::KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let share_endpoint_id = parser.next_u64()?;
 
-            let share_endpoint_id = p.next_u64()?;
-            p.done()?;
-
-            Ok(ShareEndpointIdToName { share_endpoint_id })
+            Ok(Self { share_endpoint_id })
         }
     }
 

--- a/src/meta/app/src/tenant/tenant.rs
+++ b/src/meta/app/src/tenant/tenant.rs
@@ -93,6 +93,7 @@ mod kvapi_key_impl {
     use std::convert::Infallible;
 
     use databend_common_meta_kvapi::kvapi;
+    use databend_common_meta_kvapi::kvapi::KeyBuilder;
     use databend_common_meta_kvapi::kvapi::KeyError;
 
     use crate::tenant::tenant::Tenant;
@@ -105,19 +106,16 @@ mod kvapi_key_impl {
             None
         }
 
-        fn to_string_key(&self) -> String {
-            kvapi::KeyBuilder::new_prefixed(Self::PREFIX)
-                .push_str(&self.tenant)
-                .done()
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_str(&self.tenant)
         }
 
-        fn from_str_key(s: &str) -> Result<Self, KeyError> {
-            let mut p = kvapi::KeyParser::new_prefixed(s, Self::PREFIX)?;
+        fn decode_key(p: &mut kvapi::KeyParser) -> Result<Self, KeyError> {
+            let tenant = p.next_nonempty()?;
 
-            let tenant = p.next_str()?;
-            p.done()?;
-
-            Ok(Self { tenant })
+            Ok(Self {
+                tenant: tenant.to_string(),
+            })
         }
     }
 }

--- a/src/meta/kvapi/src/kvapi/key.rs
+++ b/src/meta/kvapi/src/kvapi/key.rs
@@ -60,6 +60,7 @@ where Self: Sized
     type ValueType: kvapi::Value;
 
     /// Return the root prefix of this key: `"<PREFIX>/"`.
+    // TODO: consider the tenant config, it should be a instance method.
     fn root_prefix() -> String {
         format!("{}/", Self::PREFIX)
     }
@@ -150,6 +151,16 @@ impl<K> DirName<K> {
 
     pub fn into_key(self) -> K {
         self.key
+    }
+}
+
+impl<K> DirName<K>
+where K: kvapi::Key
+{
+    /// Return a string with a suffix slash "/"
+    pub fn dir_name_with_slash(&self) -> String {
+        let prefix = self.to_string_key();
+        format!("{}/", prefix)
     }
 }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: avoid using PREFIX directly. use method to build list-prefix

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15243)
<!-- Reviewable:end -->
