### PR TITLE
feat: add setting `script_max_steps`

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -720,6 +720,12 @@ impl DefaultSettings {
                     desc: "The maximum waiting seconds in the queue. The default value is 0(no limit).",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
+                }),
+                ("script_max_steps", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(10000),
+                    desc: "The maximum steps allowed in a single execution of script.",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 })
             ]);
 

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -627,4 +627,8 @@ impl Settings {
     pub fn get_statement_queued_timeout(&self) -> Result<u64> {
         self.try_get_u64("statement_queued_timeout_in_seconds")
     }
+
+    pub fn get_script_max_steps(&self) -> Result<u64> {
+        self.try_get_u64("script_max_steps")
+    }
 }

--- a/tests/sqllogictests/suites/base/15_procedure/15_0001_execute_immediate.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0001_execute_immediate.test
@@ -128,6 +128,37 @@ END;
 $$;
 ----
 
+statement ok
+set script_max_steps = 100;
+
+query error exceeded the limit
+EXECUTE IMMEDIATE $$
+BEGIN
+    LET sum := 0;
+    WHILE sum < 100 DO
+        sum := sum +1;
+    END WHILE;
+    RETURN sum;
+END;
+$$;
+----
+
+statement ok
+set script_max_steps = 1000;
+
+query
+EXECUTE IMMEDIATE $$
+BEGIN
+    LET sum := 0;
+    WHILE sum < 100 DO
+        sum := sum +1;
+    END WHILE;
+    RETURN sum;
+END;
+$$;
+----
+100
+
 
 statement ok
 drop database test_procedure;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```sql
set script_max_steps = 1000;
```

Related https://github.com/datafuselabs/databend/issues/14904

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15244)
<!-- Reviewable:end -->
