### PR TITLE
feat(query): add new setting parse_datetime_ignore_remainder.

### DIFF
--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -106,6 +106,8 @@ pub struct FunctionContext {
 
     pub external_server_connect_timeout_secs: u64,
     pub external_server_request_timeout_secs: u64,
+
+    pub parse_datetime_ignore_remainder: bool,
 }
 
 #[derive(Clone)]

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -607,18 +607,18 @@ impl TableContext for QueryContext {
     }
 
     fn get_function_context(&self) -> Result<FunctionContext> {
-        let external_server_connect_timeout_secs = self
-            .get_settings()
-            .get_external_server_connect_timeout_secs()?;
-        let external_server_request_timeout_secs = self
-            .get_settings()
-            .get_external_server_request_timeout_secs()?;
+        let settings = self.get_settings();
+        let external_server_connect_timeout_secs =
+            settings.get_external_server_connect_timeout_secs()?;
+        let external_server_request_timeout_secs =
+            settings.get_external_server_request_timeout_secs()?;
 
-        let tz = self.get_settings().get_timezone()?;
+        let tz = settings.get_timezone()?;
         let tz = TzFactory::instance().get_by_name(&tz)?;
-        let numeric_cast_option = self.get_settings().get_numeric_cast_option()?;
+        let numeric_cast_option = settings.get_numeric_cast_option()?;
         let rounding_mode = numeric_cast_option.as_str() == "rounding";
-        let disable_variant_check = self.get_settings().get_disable_variant_check()?;
+        let disable_variant_check = settings.get_disable_variant_check()?;
+        let parse_datetime_ignore_remainder = settings.get_parse_datetime_ignore_remainder()?;
 
         let query_config = &GlobalConfig::instance().query;
 
@@ -636,6 +636,8 @@ impl TableContext for QueryContext {
 
             external_server_connect_timeout_secs,
             external_server_request_timeout_secs,
+
+            parse_datetime_ignore_remainder,
         })
     }
 

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -672,6 +672,12 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("parse_datetime_ignore_remainder", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1),
+                    desc: "Ignore trailing chars when parse string to datetime(disable by default)",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("disable_variant_check", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "Disable variant check to allow insert invalid JSON values",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -588,6 +588,10 @@ impl Settings {
         )
     }
 
+    pub fn get_parse_datetime_ignore_remainder(&self) -> Result<bool> {
+        Ok(self.try_get_u64("parse_datetime_ignore_remainder")? != 0)
+    }
+
     pub fn get_disable_variant_check(&self) -> Result<bool> {
         Ok(self.try_get_u64("disable_variant_check")? != 0)
     }

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -453,4 +453,79 @@ select to_date('1941-03-15 02:00:00');
 1941-03-15
 
 statement ok
+set parse_datetime_ignore_remainder=1;
+
+statement ok
+set timezone='Asia/Shanghai';
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H');
+----
+2022-02-04 16:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+----
+NULL
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时');
+----
+2022-02-04 16:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 08:58:59.000000
+
+statement ok
+set timezone='America/Los_Angeles';
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H');
+----
+2022-02-04 00:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+----
+NULL
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时');
+----
+2022-02-04 00:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-03 16:58:59.000000
+
+statement ok
+set timezone='UTC';
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H');
+----
+2022-02-04 08:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+----
+NULL
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时');
+----
+2022-02-04 08:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 00:58:59.000000
+
+statement ok
 unset timezone;
+
+statement ok
+unset parse_datetime_ignore_remainder;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Added a new setting parse_datetime_ignore_remainder.

When enabled, this setting allows parsing strings into time according to the specified format and ignores any excess string.

This setting is disabled by default.


- Fixes #15257

## Tests


- [x] Logic Test


## Type of change


- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15260)
<!-- Reviewable:end -->
