### PR TITLE
refactor: Extract `kvapi::KeyCodec` trait from `kvapi::Key`

### DIFF
--- a/src/meta/app/src/background/background_job.rs
+++ b/src/meta/app/src/background/background_job.rs
@@ -366,15 +366,7 @@ mod kvapi_key_impl {
     use crate::background::background_job::BackgroundJobId;
     use crate::background::BackgroundJobInfo;
 
-    impl kvapi::Key for BackgroundJobId {
-        const PREFIX: &'static str = "__fd_background_job_by_id";
-
-        type ValueType = BackgroundJobInfo;
-
-        fn parent(&self) -> Option<String> {
-            None
-        }
-
+    impl kvapi::KeyCodec for BackgroundJobId {
         fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
             b.push_u64(self.id)
         }
@@ -382,6 +374,16 @@ mod kvapi_key_impl {
         fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
             let id = parser.next_u64()?;
             Ok(BackgroundJobId { id })
+        }
+    }
+
+    impl kvapi::Key for BackgroundJobId {
+        const PREFIX: &'static str = "__fd_background_job_by_id";
+
+        type ValueType = BackgroundJobInfo;
+
+        fn parent(&self) -> Option<String> {
+            None
         }
     }
 

--- a/src/meta/app/src/data_mask/mod.rs
+++ b/src/meta/app/src/data_mask/mod.rs
@@ -110,6 +110,18 @@ mod kvapi_key_impl {
     use super::DatamaskId;
     use crate::data_mask::DatamaskMeta;
 
+    impl kvapi::KeyCodec for DatamaskId {
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.id)
+        }
+
+        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError>
+        where Self: Sized {
+            let id = parser.next_u64()?;
+            Ok(Self { id })
+        }
+    }
+
     /// "__fd_datamask_by_id/<id>"
     impl kvapi::Key for DatamaskId {
         const PREFIX: &'static str = "__fd_datamask_by_id";
@@ -118,15 +130,6 @@ mod kvapi_key_impl {
 
         fn parent(&self) -> Option<String> {
             None
-        }
-
-        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
-            b.push_u64(self.id)
-        }
-
-        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
-            let id = parser.next_u64()?;
-            Ok(Self { id })
         }
     }
 

--- a/src/meta/app/src/id_generator.rs
+++ b/src/meta/app/src/id_generator.rs
@@ -99,15 +99,7 @@ impl IdGenerator {
     }
 }
 
-impl kvapi::Key for IdGenerator {
-    const PREFIX: &'static str = "__fd_id_gen";
-
-    type ValueType = Infallible;
-
-    fn parent(&self) -> Option<String> {
-        None
-    }
-
+impl kvapi::KeyCodec for IdGenerator {
     fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
         b.push_raw(&self.resource)
     }
@@ -118,6 +110,16 @@ impl kvapi::Key for IdGenerator {
         Ok(IdGenerator {
             resource: resource.to_string(),
         })
+    }
+}
+
+impl kvapi::Key for IdGenerator {
+    const PREFIX: &'static str = "__fd_id_gen";
+
+    type ValueType = Infallible;
+
+    fn parent(&self) -> Option<String> {
+        None
     }
 }
 

--- a/src/meta/app/src/principal/user_grant.rs
+++ b/src/meta/app/src/principal/user_grant.rs
@@ -468,14 +468,7 @@ mod kvapi_key_impl {
     use crate::tenant::Tenant;
     use crate::KeyWithTenant;
 
-    impl kvapi::Key for TenantOwnershipObject {
-        const PREFIX: &'static str = "__fd_object_owners";
-        type ValueType = OwnershipInfo;
-
-        fn parent(&self) -> Option<String> {
-            Some(self.tenant.to_string_key())
-        }
-
+    impl kvapi::KeyCodec for TenantOwnershipObject {
         fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
             let b = b.push_str(self.tenant_name());
             self.object.build_key(b)
@@ -489,6 +482,15 @@ mod kvapi_key_impl {
                 tenant: Tenant::new_nonempty(tenant),
                 object: subject,
             })
+        }
+    }
+
+    impl kvapi::Key for TenantOwnershipObject {
+        const PREFIX: &'static str = "__fd_object_owners";
+        type ValueType = OwnershipInfo;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
         }
     }
 

--- a/src/meta/app/src/principal/user_identity.rs
+++ b/src/meta/app/src/principal/user_identity.rs
@@ -96,14 +96,7 @@ mod kvapi_key_impl {
     use crate::tenant::Tenant;
     use crate::KeyWithTenant;
 
-    impl kvapi::Key for TenantUserIdent {
-        const PREFIX: &'static str = "__fd_users";
-        type ValueType = UserInfo;
-
-        fn parent(&self) -> Option<String> {
-            Some(self.tenant.to_string_key())
-        }
-
+    impl kvapi::KeyCodec for TenantUserIdent {
         fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
             b.push_str(self.tenant_name())
                 .push_str(&self.user.to_string())
@@ -119,6 +112,15 @@ mod kvapi_key_impl {
                 tenant: Tenant::new_nonempty(tenant),
                 user,
             })
+        }
+    }
+
+    impl kvapi::Key for TenantUserIdent {
+        const PREFIX: &'static str = "__fd_users";
+        type ValueType = UserInfo;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
         }
     }
 

--- a/src/meta/app/src/principal/user_stage_file_ident.rs
+++ b/src/meta/app/src/principal/user_stage_file_ident.rs
@@ -42,14 +42,7 @@ mod kvapi_key_impl {
     use crate::tenant::Tenant;
     use crate::KeyWithTenant;
 
-    impl kvapi::Key for StageFileIdent {
-        const PREFIX: &'static str = "__fd_stage_files";
-        type ValueType = StageFile;
-
-        fn parent(&self) -> Option<String> {
-            Some(self.stage.to_string_key())
-        }
-
+    impl kvapi::KeyCodec for StageFileIdent {
         fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
             b.push_str(self.stage.tenant_name())
                 .push_str(self.stage.name())
@@ -60,6 +53,15 @@ mod kvapi_key_impl {
             let stage = StageIdent::decode_key(p)?;
             let path = p.next_str()?;
             Ok(StageFileIdent::new(stage, path))
+        }
+    }
+
+    impl kvapi::Key for StageFileIdent {
+        const PREFIX: &'static str = "__fd_stage_files";
+        type ValueType = StageFile;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.stage.to_string_key())
         }
     }
 

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -283,6 +283,18 @@ mod kvapi_key_impl {
     use crate::schema::CatalogMeta;
     use crate::schema::CatalogNameIdent;
 
+    impl kvapi::KeyCodec for CatalogId {
+        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
+            b.push_u64(self.catalog_id)
+        }
+
+        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
+            let catalog_id = parser.next_u64()?;
+
+            Ok(Self { catalog_id })
+        }
+    }
+
     /// "__fd_catalog_by_id/<catalog_id>"
     impl kvapi::Key for CatalogId {
         const PREFIX: &'static str = "__fd_catalog_by_id";
@@ -292,7 +304,9 @@ mod kvapi_key_impl {
         fn parent(&self) -> Option<String> {
             None
         }
+    }
 
+    impl kvapi::KeyCodec for CatalogIdToName {
         fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
             b.push_u64(self.catalog_id)
         }
@@ -312,16 +326,6 @@ mod kvapi_key_impl {
 
         fn parent(&self) -> Option<String> {
             Some(CatalogId::new(self.catalog_id).to_string_key())
-        }
-
-        fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
-            b.push_u64(self.catalog_id)
-        }
-
-        fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError> {
-            let catalog_id = parser.next_u64()?;
-
-            Ok(Self { catalog_id })
         }
     }
 

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -240,6 +240,18 @@ mod kvapi_key_impl {
     use crate::schema::IndexMeta;
     use crate::schema::IndexNameIdentRaw;
 
+    impl kvapi::KeyCodec for IndexId {
+        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+            b.push_u64(self.index_id)
+        }
+
+        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
+            let index_id = parser.next_u64()?;
+
+            Ok(Self { index_id })
+        }
+    }
+
     /// "<prefix>/<index_id>"
     impl kvapi::Key for IndexId {
         const PREFIX: &'static str = "__fd_index_by_id";
@@ -249,7 +261,9 @@ mod kvapi_key_impl {
         fn parent(&self) -> Option<String> {
             None
         }
+    }
 
+    impl kvapi::KeyCodec for IndexIdToName {
         fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
             b.push_u64(self.index_id)
         }
@@ -269,16 +283,6 @@ mod kvapi_key_impl {
 
         fn parent(&self) -> Option<String> {
             Some(IndexId::new(self.index_id).to_string_key())
-        }
-
-        fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
-            b.push_u64(self.index_id)
-        }
-
-        fn decode_key(parser: &mut kvapi::KeyParser) -> Result<Self, kvapi::KeyError> {
-            let index_id = parser.next_u64()?;
-
-            Ok(Self { index_id })
         }
     }
 

--- a/src/meta/app/src/schema/lock.rs
+++ b/src/meta/app/src/schema/lock.rs
@@ -211,20 +211,10 @@ mod kvapi_key_impl {
     use databend_common_meta_kvapi::kvapi;
 
     use crate::schema::LockMeta;
-    use crate::schema::TableId;
     use crate::schema::TableLockKey;
     use crate::tenant::Tenant;
 
-    /// __fd_table_lock/<tenant>/table_id/revision -> LockMeta
-    impl kvapi::Key for TableLockKey {
-        const PREFIX: &'static str = "__fd_table_lock";
-
-        type ValueType = LockMeta;
-
-        fn parent(&self) -> Option<String> {
-            Some(TableId::new(self.table_id).to_string_key())
-        }
-
+    impl kvapi::KeyCodec for TableLockKey {
         fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
             b.push_str(self.tenant.tenant_name())
                 .push_u64(self.table_id)
@@ -242,6 +232,17 @@ mod kvapi_key_impl {
                 table_id,
                 revision,
             })
+        }
+    }
+
+    /// __fd_table_lock/<tenant>/table_id/revision -> LockMeta
+    impl kvapi::Key for TableLockKey {
+        const PREFIX: &'static str = "__fd_table_lock";
+
+        type ValueType = LockMeta;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
         }
     }
 

--- a/src/meta/app/src/schema/virtual_column.rs
+++ b/src/meta/app/src/schema/virtual_column.rs
@@ -138,17 +138,7 @@ mod kvapi_key_impl {
     use crate::tenant::Tenant;
     use crate::KeyWithTenant;
 
-    /// <prefix>/<tenant>/<table_id>
-    impl kvapi::Key for VirtualColumnNameIdent {
-        const PREFIX: &'static str = "__fd_virtual_column";
-
-        type ValueType = VirtualColumnMeta;
-
-        /// It belongs to a tenant
-        fn parent(&self) -> Option<String> {
-            Some(self.tenant.to_string_key())
-        }
-
+    impl kvapi::KeyCodec for VirtualColumnNameIdent {
         fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
             b.push_str(self.tenant.tenant_name())
                 .push_u64(self.table_id)
@@ -162,6 +152,18 @@ mod kvapi_key_impl {
             let tenant = Tenant::new_nonempty(tenant);
 
             Ok(Self { tenant, table_id })
+        }
+    }
+
+    /// <prefix>/<tenant>/<table_id>
+    impl kvapi::Key for VirtualColumnNameIdent {
+        const PREFIX: &'static str = "__fd_virtual_column";
+
+        type ValueType = VirtualColumnMeta;
+
+        /// It belongs to a tenant
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
         }
     }
 

--- a/src/meta/app/src/tenant/tenant.rs
+++ b/src/meta/app/src/tenant/tenant.rs
@@ -98,14 +98,7 @@ mod kvapi_key_impl {
 
     use crate::tenant::tenant::Tenant;
 
-    impl kvapi::Key for Tenant {
-        const PREFIX: &'static str = "__fd_tenant";
-        type ValueType = Infallible;
-
-        fn parent(&self) -> Option<String> {
-            None
-        }
-
+    impl kvapi::KeyCodec for Tenant {
         fn encode_key(&self, b: KeyBuilder) -> KeyBuilder {
             b.push_str(&self.tenant)
         }
@@ -116,6 +109,15 @@ mod kvapi_key_impl {
             Ok(Self {
                 tenant: tenant.to_string(),
             })
+        }
+    }
+
+    impl kvapi::Key for Tenant {
+        const PREFIX: &'static str = "__fd_tenant";
+        type ValueType = Infallible;
+
+        fn parent(&self) -> Option<String> {
+            None
         }
     }
 }

--- a/src/meta/app/src/tenant/tenant_quota_ident.rs
+++ b/src/meta/app/src/tenant/tenant_quota_ident.rs
@@ -35,14 +35,7 @@ mod kvapi_key_impl {
     use crate::tenant::TenantQuotaIdent;
     use crate::KeyWithTenant;
 
-    impl kvapi::Key for TenantQuotaIdent {
-        const PREFIX: &'static str = "__fd_quotas";
-        type ValueType = TenantQuota;
-
-        fn parent(&self) -> Option<String> {
-            Some(self.tenant.to_string_key())
-        }
-
+    impl kvapi::KeyCodec for TenantQuotaIdent {
         fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
             b.push_str(self.tenant_name())
         }
@@ -50,6 +43,15 @@ mod kvapi_key_impl {
         fn decode_key(p: &mut kvapi::KeyParser) -> Result<Self, KeyError> {
             let tenant = p.next_nonempty()?;
             Ok(TenantQuotaIdent::new(Tenant::new_nonempty(tenant)))
+        }
+    }
+
+    impl kvapi::Key for TenantQuotaIdent {
+        const PREFIX: &'static str = "__fd_quotas";
+        type ValueType = TenantQuota;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
         }
     }
 

--- a/src/meta/app/src/tenant_key/ident.rs
+++ b/src/meta/app/src/tenant_key/ident.rs
@@ -122,16 +122,9 @@ mod kvapi_key_impl {
     use crate::tenant_key::resource::TenantResource;
     use crate::KeyWithTenant;
 
-    impl<R> kvapi::Key for TIdent<R>
+    impl<R> kvapi::KeyCodec for TIdent<R>
     where R: TenantResource
     {
-        const PREFIX: &'static str = R::PREFIX;
-        type ValueType = R::ValueType;
-
-        fn parent(&self) -> Option<String> {
-            Some(self.tenant.to_string_key())
-        }
-
         fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
             b.push_str(self.tenant_name()).push_str(&self.name)
         }
@@ -141,6 +134,17 @@ mod kvapi_key_impl {
             let name = p.next_str()?;
 
             Ok(TIdent::new(Tenant::new_nonempty(tenant), name))
+        }
+    }
+
+    impl<R> kvapi::Key for TIdent<R>
+    where R: TenantResource
+    {
+        const PREFIX: &'static str = R::PREFIX;
+        type ValueType = R::ValueType;
+
+        fn parent(&self) -> Option<String> {
+            Some(self.tenant.to_string_key())
         }
     }
 

--- a/src/meta/kvapi/src/kvapi/mod.rs
+++ b/src/meta/kvapi/src/kvapi/mod.rs
@@ -32,6 +32,7 @@ pub use item::Item;
 pub use item::NonEmptyItem;
 pub use key::DirName;
 pub use key::Key;
+pub use key::KeyCodec;
 pub use key::KeyError;
 pub use key_builder::KeyBuilder;
 pub use key_parser::KeyParser;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Extract `kvapi::KeyCodec` trait from `kvapi::Key`

The `kvapi::Key` trait encompasses various key behaviors, including
prefix, parent, and value type. The key codec functionality,
responsible for encoding and decoding components of a key, operates
independently of these behaviors. This is evident in scenarios like a
database identifier `(tenant, db_name)`, where `db_name` requires its
own distinct codec logic independent of the overarching key structure.

This commit introduces the `kvapi::KeyCodec` trait, which abstracts the
codec functionality with two primary methods: `encode_key()` and
`decode_key()`. This separation enhances modularity and aligns with
single responsibility principles, allowing for more targeted
implementations and testing of key encoding and decoding behaviors.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15262)
<!-- Reviewable:end -->
