### PR TITLE
refactor: define `ShareConsumer` with `TIdent`

### DIFF
--- a/src/meta/api/src/share_api_impl.rs
+++ b/src/meta/api/src/share_api_impl.rs
@@ -342,7 +342,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> ShareApi for KV {
             let mut add_share_account_keys = vec![];
             for account in req.accounts.iter() {
                 if !share_meta.has_account(account) {
-                    add_share_account_keys.push(ShareConsumer::new(
+                    add_share_account_keys.push(ShareConsumerIdent::new(
                         Tenant::new_or_err(account, "add_share_tenants")?,
                         share_id,
                     ));
@@ -374,7 +374,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> ShareApi for KV {
                     condition.push(txn_cond_seq(share_account_key, Eq, 0));
 
                     let share_account_meta = ShareAccountMeta::new(
-                        share_account_key.tenant.tenant_name().to_string(),
+                        share_account_key.tenant_name().to_string(),
                         share_id,
                         req.share_on,
                     );
@@ -384,7 +384,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> ShareApi for KV {
                         serialize_struct(&share_account_meta)?,
                     )); /* (account, share_id) -> share_account_meta */
 
-                    share_meta.add_account(share_account_key.tenant.tenant_name().to_string());
+                    share_meta.add_account(share_account_key.tenant_name().to_string());
                 }
                 if_then.push(txn_op_put(&id_key, serialize_struct(&share_meta)?)); /* (share_id) -> share_meta */
 
@@ -453,7 +453,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> ShareApi for KV {
                     continue;
                 }
                 if share_meta.has_account(account) {
-                    let share_account_key = ShareConsumer::new(
+                    let share_account_key = ShareConsumerIdent::new(
                         Tenant::new_or_err(account, "remove_share_tenants")?,
                         share_id,
                     );
@@ -501,7 +501,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> ShareApi for KV {
 
                     if_then.push(txn_op_del(&share_account_key_and_seq.0)); // del (account, share_id)
 
-                    share_meta.del_account(share_account_key_and_seq.0.tenant.tenant_name());
+                    share_meta.del_account(share_account_key_and_seq.0.tenant_name());
                 }
                 if_then.push(txn_op_put(&id_key, serialize_struct(&share_meta)?)); /* (share_id) -> share_meta */
 
@@ -1375,7 +1375,7 @@ async fn get_outbound_share_tenants_by_name(
 
     let mut accounts = vec![];
     for account in share_meta.get_accounts() {
-        let share_account_key = ShareConsumer::new(
+        let share_account_key = ShareConsumerIdent::new(
             Tenant::new_or_err(&account, "get_outbound_share_tenants_by_name")?,
             share_id,
         );
@@ -1661,7 +1661,7 @@ async fn drop_accounts_granted_from_share(
 ) -> Result<(), KVAppError> {
     // get all accounts seq from share_meta
     for account in share_meta.get_accounts() {
-        let share_account_key = ShareConsumer::new(
+        let share_account_key = ShareConsumerIdent::new(
             Tenant::new_or_err(&account, "drop_accounts_granted_from_share")?,
             share_id,
         );

--- a/src/meta/api/src/share_api_impl.rs
+++ b/src/meta/api/src/share_api_impl.rs
@@ -342,10 +342,10 @@ impl<KV: kvapi::KVApi<Error = MetaError>> ShareApi for KV {
             let mut add_share_account_keys = vec![];
             for account in req.accounts.iter() {
                 if !share_meta.has_account(account) {
-                    add_share_account_keys.push(ShareConsumer {
-                        tenant: Tenant::new_or_err(account, "add_share_tenants")?,
+                    add_share_account_keys.push(ShareConsumer::new(
+                        Tenant::new_or_err(account, "add_share_tenants")?,
                         share_id,
-                    });
+                    ));
                 }
             }
             if add_share_account_keys.is_empty() {
@@ -453,10 +453,10 @@ impl<KV: kvapi::KVApi<Error = MetaError>> ShareApi for KV {
                     continue;
                 }
                 if share_meta.has_account(account) {
-                    let share_account_key = ShareConsumer {
-                        tenant: Tenant::new_or_err(account, "remove_share_tenants")?,
+                    let share_account_key = ShareConsumer::new(
+                        Tenant::new_or_err(account, "remove_share_tenants")?,
                         share_id,
-                    };
+                    );
 
                     let res = get_share_account_meta_or_err(
                         self,
@@ -1375,10 +1375,10 @@ async fn get_outbound_share_tenants_by_name(
 
     let mut accounts = vec![];
     for account in share_meta.get_accounts() {
-        let share_account_key = ShareConsumer {
-            tenant: Tenant::new_or_err(&account, "get_outbound_share_tenants_by_name")?,
+        let share_account_key = ShareConsumer::new(
+            Tenant::new_or_err(&account, "get_outbound_share_tenants_by_name")?,
             share_id,
-        };
+        );
 
         let (_seq, meta) = get_share_account_meta_or_err(
             kv_api,
@@ -1661,10 +1661,10 @@ async fn drop_accounts_granted_from_share(
 ) -> Result<(), KVAppError> {
     // get all accounts seq from share_meta
     for account in share_meta.get_accounts() {
-        let share_account_key = ShareConsumer {
-            tenant: Tenant::new_or_err(&account, "drop_accounts_granted_from_share")?,
+        let share_account_key = ShareConsumer::new(
+            Tenant::new_or_err(&account, "drop_accounts_granted_from_share")?,
             share_id,
-        };
+        );
         let ret = get_share_account_meta_or_err(
             kv_api,
             &share_account_key,

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -84,7 +84,7 @@ async fn is_all_share_data_removed(
     }
 
     for account in share_meta.get_accounts() {
-        let share_account_key = ShareConsumer::new(
+        let share_account_key = ShareConsumerIdent::new(
             Tenant::new_or_err(account, "is_all_share_data_removed")?,
             share_id,
         );
@@ -574,7 +574,7 @@ impl ShareApiTestSuite {
             assert!(share_meta.has_account(&account.to_string()));
 
             // get and check share account meta
-            let share_account_name = ShareConsumer::new(
+            let share_account_name = ShareConsumerIdent::new(
                 Tenant::new_or_err(account, "share_add_remove_account")?,
                 share_id,
             );
@@ -700,7 +700,7 @@ impl ShareApiTestSuite {
             assert!(!share_meta.has_account(&account2.to_string()));
 
             // check share account meta has been removed
-            let share_account_name = ShareConsumer::new(
+            let share_account_name = ShareConsumerIdent::new(
                 Tenant::new_or_err(account2, "share_add_remove_account")?,
                 share_id,
             );
@@ -723,7 +723,7 @@ impl ShareApiTestSuite {
             assert!(res.is_ok());
 
             // check share account meta has been removed
-            let share_account_name = ShareConsumer::new(
+            let share_account_name = ShareConsumerIdent::new(
                 Tenant::new_or_err(account, "share_add_remove_account")?,
                 share_id,
             );

--- a/src/meta/api/src/share_api_test_suite.rs
+++ b/src/meta/api/src/share_api_test_suite.rs
@@ -84,10 +84,10 @@ async fn is_all_share_data_removed(
     }
 
     for account in share_meta.get_accounts() {
-        let share_account_key = ShareConsumer {
-            tenant: Tenant::new_or_err(account, "is_all_share_data_removed")?,
+        let share_account_key = ShareConsumer::new(
+            Tenant::new_or_err(account, "is_all_share_data_removed")?,
             share_id,
-        };
+        );
         let res = get_share_account_meta_or_err(kv_api, &share_account_key, "").await;
         if res.is_ok() {
             return Ok(false);
@@ -574,10 +574,10 @@ impl ShareApiTestSuite {
             assert!(share_meta.has_account(&account.to_string()));
 
             // get and check share account meta
-            let share_account_name = ShareConsumer {
-                tenant: Tenant::new_or_err(account, "share_add_remove_account")?,
+            let share_account_name = ShareConsumer::new(
+                Tenant::new_or_err(account, "share_add_remove_account")?,
                 share_id,
-            };
+            );
             let (_share_account_meta_seq, share_account_meta) =
                 get_share_account_meta_or_err(mt.as_kv_api(), &share_account_name, "").await?;
             assert_eq!(share_account_meta.share_id, share_id);
@@ -700,10 +700,10 @@ impl ShareApiTestSuite {
             assert!(!share_meta.has_account(&account2.to_string()));
 
             // check share account meta has been removed
-            let share_account_name = ShareConsumer {
-                tenant: Tenant::new_or_err(account2, "share_add_remove_account")?,
+            let share_account_name = ShareConsumer::new(
+                Tenant::new_or_err(account2, "share_add_remove_account")?,
                 share_id,
-            };
+            );
             let res = get_share_account_meta_or_err(mt.as_kv_api(), &share_account_name, "").await;
             let err = res.unwrap_err();
             assert_eq!(
@@ -723,10 +723,10 @@ impl ShareApiTestSuite {
             assert!(res.is_ok());
 
             // check share account meta has been removed
-            let share_account_name = ShareConsumer {
-                tenant: Tenant::new_or_err(account, "share_add_remove_account")?,
+            let share_account_name = ShareConsumer::new(
+                Tenant::new_or_err(account, "share_add_remove_account")?,
                 share_id,
-            };
+            );
             let res = get_share_account_meta_or_err(mt.as_kv_api(), &share_account_name, "").await;
             let err = res.unwrap_err();
             assert_eq!(

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -626,7 +626,7 @@ fn share_has_to_exist(
 /// Returns (share_account_meta_seq, share_account_meta)
 pub async fn get_share_account_meta_or_err(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
-    name_key: &ShareConsumer,
+    name_key: &ShareConsumerIdent,
     msg: impl Display,
 ) -> Result<(u64, ShareAccountMeta), KVAppError> {
     let (share_account_meta_seq, share_account_meta): (u64, Option<ShareAccountMeta>) =
@@ -645,7 +645,7 @@ pub async fn get_share_account_meta_or_err(
 /// Otherwise returns UnknownShareAccounts error
 fn share_account_meta_has_to_exist(
     seq: u64,
-    name_key: &ShareConsumer,
+    name_key: &ShareConsumerIdent,
     msg: impl Display,
 ) -> Result<(), KVAppError> {
     if seq == 0 {
@@ -653,9 +653,9 @@ fn share_account_meta_has_to_exist(
 
         Err(KVAppError::AppError(AppError::UnknownShareAccounts(
             UnknownShareAccounts::new(
-                &[name_key.tenant.tenant_name().to_string()],
-                name_key.share_id,
-                format!("{}: {}", msg, name_key),
+                &[name_key.tenant_name().to_string()],
+                name_key.share_id(),
+                format!("{}: {}", msg, name_key.display()),
             ),
         )))
     } else {

--- a/src/meta/app/src/share/mod.rs
+++ b/src/meta/app/src/share/mod.rs
@@ -15,9 +15,9 @@
 #[allow(clippy::module_inception)]
 mod share;
 
-pub mod share_name_ident;
-
+pub mod share_consumer_ident;
 pub mod share_end_point_ident;
+pub mod share_name_ident;
 
 pub use share::AddShareAccountsReply;
 pub use share::AddShareAccountsReq;
@@ -48,7 +48,6 @@ pub use share::RevokeShareObjectReply;
 pub use share::RevokeShareObjectReq;
 pub use share::ShareAccountMeta;
 pub use share::ShareAccountReply;
-pub use share::ShareConsumer;
 pub use share::ShareDatabaseSpec;
 pub use share::ShareEndpointId;
 pub use share::ShareEndpointIdToName;
@@ -72,4 +71,5 @@ pub use share::ShowSharesReq;
 pub use share::TableInfoMap;
 pub use share::UpsertShareEndpointReply;
 pub use share::UpsertShareEndpointReq;
+pub use share_consumer_ident::ShareConsumerIdent;
 pub use share_end_point_ident::ShareEndpointIdent;

--- a/src/meta/app/src/share/share_consumer_ident.rs
+++ b/src/meta/app/src/share/share_consumer_ident.rs
@@ -1,0 +1,78 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tenant_key::ident::TIdent;
+
+/// The share consuming key describes that the `tenant`, who is a consumer of a shared object,
+/// which is created by another tenant and is identified by `share_id`.
+pub type ShareConsumerIdent = TIdent<Resource, u64>;
+pub type ShareConsumerIdentRaw = TIdentRaw<Resource, u64>;
+
+pub use kvapi_impl::Resource;
+
+use crate::tenant_key::raw::TIdentRaw;
+
+impl ShareConsumerIdent {
+    pub fn share_id(&self) -> u64 {
+        *self.name()
+    }
+}
+
+impl ShareConsumerIdentRaw {
+    pub fn share_id(&self) -> u64 {
+        *self.name()
+    }
+}
+
+mod kvapi_impl {
+
+    use databend_common_meta_kvapi::kvapi;
+
+    use crate::share::ShareAccountMeta;
+    use crate::tenant_key::resource::TenantResource;
+
+    pub struct Resource;
+    impl TenantResource for Resource {
+        const PREFIX: &'static str = "__fd_share_account_id";
+        type ValueType = ShareAccountMeta;
+    }
+
+    impl kvapi::Value for ShareAccountMeta {
+        fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+
+    // impl From<ExistError<Resource>> for ErrorCode {
+    // impl From<UnknownError<Resource>> for ErrorCode {
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use super::ShareConsumerIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_share_consumer_ident() {
+        let tenant = Tenant::new_literal("test");
+        let ident = ShareConsumerIdent::new(tenant, 3);
+
+        let key = ident.to_string_key();
+        assert_eq!(key, "__fd_share_account_id/test/3");
+
+        assert_eq!(ident, ShareConsumerIdent::from_str_key(&key).unwrap());
+    }
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: define `ShareConsumer` with `TIdent`

Remove the logic of not embedding `share_id` if it is 0.
Because `share_id` is always non-zero.


##### chore: Use ShareConsumer::new() for construction

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15280)
<!-- Reviewable:end -->
