### PR TITLE
chore(query): refine set sql_dialect error message

### DIFF
--- a/src/query/ast/src/parser/common.rs
+++ b/src/query/ast/src/parser/common.rs
@@ -546,7 +546,7 @@ macro_rules! declare_experimental_feature {
                             ErrorKind::Other(
                                 concat!(
                                     $feature_name,
-                                    " only works in experimental dialect, try `set sql_dialect = experimental`"
+                                    " only works in experimental dialect, try `set sql_dialect = 'experimental'`"
                                 )
                             ),
                         );

--- a/src/query/ast/tests/it/testdata/expr-error.txt
+++ b/src/query/ast/tests/it/testdata/expr-error.txt
@@ -67,7 +67,7 @@ error:
 1 | a.add(b)
   | -^
   | ||
-  | |chain function only works in experimental dialect, try `set sql_dialect = experimental`
+  | |chain function only works in experimental dialect, try `set sql_dialect = 'experimental'`
   | |while parsing x.function(...)
   | while parsing expression
 
@@ -81,7 +81,7 @@ error:
 1 | [ x * 100 FOR x in [1,2,3] if x % 2 = 0 ]
   | ^
   | |
-  | list comprehension only works in experimental dialect, try `set sql_dialect = experimental`
+  | list comprehension only works in experimental dialect, try `set sql_dialect = 'experimental'`
   | while parsing expression
   | while parsing [expr for x in ... [if ...]]
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Refine set sql_dialect error message: `set sql_dialect = experimental` -> `set sql_dialect = 'experimental'`.

- Related to #13800 

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - Change error message, no need test.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): change error message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15282)
<!-- Reviewable:end -->
