### PR TITLE
refactor: define DbIdListKey with TIdent, and rename it to DatabaseIdHistoryIdent

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -86,6 +86,7 @@ use databend_common_meta_app::schema::CreateVirtualColumnReply;
 use databend_common_meta_app::schema::CreateVirtualColumnReq;
 use databend_common_meta_app::schema::DBIdTableName;
 use databend_common_meta_app::schema::DatabaseId;
+use databend_common_meta_app::schema::DatabaseIdHistoryIdent;
 use databend_common_meta_app::schema::DatabaseIdToName;
 use databend_common_meta_app::schema::DatabaseIdent;
 use databend_common_meta_app::schema::DatabaseInfo;
@@ -93,7 +94,6 @@ use databend_common_meta_app::schema::DatabaseInfoFilter;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::schema::DatabaseType;
 use databend_common_meta_app::schema::DbIdList;
-use databend_common_meta_app::schema::DbIdListKey;
 use databend_common_meta_app::schema::DeleteLockRevReq;
 use databend_common_meta_app::schema::DropCatalogReply;
 use databend_common_meta_app::schema::DropCatalogReq;
@@ -318,10 +318,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             };
 
             // get db id list from _fd_db_id_list/db_id
-            let dbid_idlist = DbIdListKey {
-                tenant: name_key.tenant().clone(),
-                db_name: name_key.database_name().to_string(),
-            };
+            let dbid_idlist =
+                DatabaseIdHistoryIdent::new(name_key.tenant(), name_key.database_name());
             let (db_id_list_seq, db_id_list_opt): (_, Option<DbIdList>) =
                 get_pb_value(self, &dbid_idlist).await?;
 
@@ -461,7 +459,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             }
 
             // get db id list from _fd_db_id_list/<tenant>/<db_name>
-            let dbid_idlist = DbIdListKey::new(name_key.tenant(), name_key.database_name());
+            let dbid_idlist =
+                DatabaseIdHistoryIdent::new(name_key.tenant(), name_key.database_name());
             let (db_id_list_seq, db_id_list_opt): (_, Option<DbIdList>) =
                 get_pb_value(self, &dbid_idlist).await?;
 
@@ -571,10 +570,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 get_pb_value(self, &db_id_key).await?;
 
             // get db id list from _fd_db_id_list/<tenant>/<db_name>
-            let dbid_idlist = DbIdListKey {
-                tenant: tenant_dbname.tenant().clone(),
-                db_name: tenant_dbname.database_name().to_string(),
-            };
+            let dbid_idlist =
+                DatabaseIdHistoryIdent::new(tenant_dbname.tenant(), tenant_dbname.database_name());
             let (db_id_list_seq, db_id_list_opt): (_, Option<DbIdList>) =
                 get_pb_value(self, &dbid_idlist).await?;
             let mut db_id_list: DbIdList;
@@ -617,7 +614,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 )));
             }
 
-            let new_dbid_idlist = DbIdListKey::new(tenant_dbname.tenant(), &req.new_db_name);
+            let new_dbid_idlist =
+                DatabaseIdHistoryIdent::new(tenant_dbname.tenant(), &req.new_db_name);
             let (new_db_id_list_seq, new_db_id_list_opt): (_, Option<DbIdList>) =
                 get_pb_value(self, &new_dbid_idlist).await?;
             let mut new_db_id_list: DbIdList;
@@ -704,11 +702,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
         // List tables by tenant, db_id, table_name.
-        let dbid_tbname_idlist = DbIdListKey {
-            tenant: req.tenant.clone(),
-            // Using a empty db to to list all
-            db_name: "".to_string(),
-        };
+        let dbid_tbname_idlist = DatabaseIdHistoryIdent::new(&req.tenant, "");
         let db_id_list_keys = list_keys(self, &dbid_tbname_idlist).await?;
 
         let mut db_info_list = vec![];
@@ -765,10 +759,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                                 db_id,
                                 seq: db_meta_seq,
                             },
-                            name_ident: DatabaseNameIdent::new(
-                                db_id_list_key.tenant(),
-                                &db_id_list_key.db_name,
-                            ),
+                            name_ident: DatabaseNameIdent::new_from(db_id_list_key.clone()),
                             meta: db_meta,
                         };
 
@@ -3418,11 +3409,10 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         for drop_id in req.drop_ids {
             match drop_id {
                 DroppedId::Db(db_id, db_name) => {
-                    gc_dropped_db_by_id(self, db_id, req.tenant.clone(), db_name).await?
+                    gc_dropped_db_by_id(self, db_id, &req.tenant, db_name).await?
                 }
                 DroppedId::Table(db_id, table_id, table_name) => {
-                    gc_dropped_table_by_id(self, req.tenant.clone(), db_id, table_id, table_name)
-                        .await?
+                    gc_dropped_table_by_id(self, &req.tenant, db_id, table_id, table_name).await?
                 }
             }
         }
@@ -4294,10 +4284,8 @@ async fn drop_database_meta(
         );
 
         // if remove db, MUST also removed db id from db id list
-        let dbid_idlist = DbIdListKey {
-            tenant: tenant_dbname.tenant().clone(),
-            db_name: tenant_dbname.database_name().to_string(),
-        };
+        let dbid_idlist =
+            DatabaseIdHistoryIdent::new(tenant_dbname.tenant(), tenant_dbname.database_name());
         let (db_id_list_seq, db_id_list_opt): (_, Option<DbIdList>) =
             get_pb_value(kv_api, &dbid_idlist).await?;
 
@@ -4342,10 +4330,8 @@ async fn drop_database_meta(
         }
 
         // add DbIdListKey if not exists
-        let dbid_idlist = DbIdListKey {
-            tenant: tenant_dbname.tenant().clone(),
-            db_name: tenant_dbname.database_name().to_string(),
-        };
+        let dbid_idlist =
+            DatabaseIdHistoryIdent::new(tenant_dbname.tenant(), tenant_dbname.database_name());
         let (db_id_list_seq, db_id_list_opt): (_, Option<DbIdList>) =
             get_pb_value(kv_api, &dbid_idlist).await?;
 
@@ -4924,14 +4910,11 @@ pub(crate) async fn get_index_or_err(
 async fn gc_dropped_db_by_id(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     db_id: u64,
-    tenant: Tenant,
+    tenant: &Tenant,
     db_name: String,
 ) -> Result<(), KVAppError> {
     // List tables by tenant, db_id, table_name.
-    let dbid_idlist = DbIdListKey {
-        tenant: tenant.clone(),
-        db_name,
-    };
+    let dbid_idlist = DatabaseIdHistoryIdent::new(tenant, db_name);
     let (db_id_list_seq, db_id_list_opt): (_, Option<DbIdList>) =
         get_pb_value(kv_api, &dbid_idlist).await?;
 
@@ -4989,7 +4972,7 @@ async fn gc_dropped_db_by_id(
 
                 for tb_id in tb_id_list.id_list {
                     gc_dropped_table_data(kv_api, tb_id, &mut condition, &mut if_then).await?;
-                    gc_dropped_table_index(kv_api, &tenant, tb_id, &mut if_then).await?;
+                    gc_dropped_table_index(kv_api, tenant, tb_id, &mut if_then).await?;
                 }
 
                 let id_key = iter.next().unwrap();
@@ -5029,7 +5012,7 @@ async fn gc_dropped_db_by_id(
 
 async fn gc_dropped_table_by_id(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
-    tenant: Tenant,
+    tenant: &Tenant,
     db_id: u64,
     table_id: u64,
     table_name: String,
@@ -5065,7 +5048,7 @@ async fn gc_dropped_table_by_id(
             ));
         }
         gc_dropped_table_data(kv_api, table_id, &mut condition, &mut if_then).await?;
-        gc_dropped_table_index(kv_api, &tenant, table_id, &mut if_then).await?;
+        gc_dropped_table_index(kv_api, tenant, table_id, &mut if_then).await?;
 
         let txn_req = TxnRequest {
             condition,

--- a/src/meta/app/src/background/job_ident.rs
+++ b/src/meta/app/src/background/job_ident.rs
@@ -30,6 +30,7 @@ mod kvapi_impl {
     pub struct Resource;
     impl TenantResource for Resource {
         const PREFIX: &'static str = "__fd_background_job";
+        const TYPE: &'static str = "BackgroundJobIdent";
         type ValueType = BackgroundJobId;
     }
 
@@ -39,6 +40,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     //     fn from(err: ExistError<Resource>) -> Self {
     //         ErrorCode::ConnectionAlreadyExists(err.to_string())

--- a/src/meta/app/src/background/task_ident.rs
+++ b/src/meta/app/src/background/task_ident.rs
@@ -29,6 +29,7 @@ mod kvapi_impl {
     pub struct Resource;
     impl TenantResource for Resource {
         const PREFIX: &'static str = "__fd_background_task_by_name";
+        const TYPE: &'static str = "BackgroundTaskIdent";
         type ValueType = BackgroundTaskInfo;
     }
 
@@ -38,6 +39,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     // impl From<UnknownError<Resource>> for ErrorCode {
 }

--- a/src/meta/app/src/principal/role_ident.rs
+++ b/src/meta/app/src/principal/role_ident.rs
@@ -54,6 +54,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     // impl From<UnknownError<Resource>> for ErrorCode {
 }

--- a/src/meta/app/src/principal/udf_ident.rs
+++ b/src/meta/app/src/principal/udf_ident.rs
@@ -54,6 +54,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     // impl From<UnknownError<Resource>> for ErrorCode {
 }

--- a/src/meta/app/src/schema/catalog_name_ident.rs
+++ b/src/meta/app/src/schema/catalog_name_ident.rs
@@ -31,6 +31,7 @@ mod kvapi_impl {
     pub struct Resource;
     impl TenantResource for Resource {
         const PREFIX: &'static str = "__fd_catalog";
+        const TYPE: &'static str = "CatalogNameIdent";
         type ValueType = CatalogId;
     }
 
@@ -40,6 +41,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     // impl From<UnknownError<Resource>> for ErrorCode {
 }

--- a/src/meta/app/src/schema/database_id_history_ident.rs
+++ b/src/meta/app/src/schema/database_id_history_ident.rs
@@ -13,23 +13,24 @@
 // limitations under the License.
 
 use crate::tenant_key::ident::TIdent;
-use crate::tenant_key::raw::TIdentRaw;
 
-pub type ShareEndpointIdent = TIdent<Resource>;
-
-pub type ShareEndpointIdentRaw = TIdentRaw<Resource>;
+/// The key of the list of database ids that have been used in history by a database name.
+pub type DatabaseIdHistoryIdent = TIdent<Resource>;
+pub type DatabaseIdHistoryIdentRaw = TIdentRaw<Resource>;
 
 pub use kvapi_impl::Resource;
 
-impl ShareEndpointIdent {
-    pub fn share_endpoint_name(&self) -> &str {
-        self.name()
+use crate::tenant_key::raw::TIdentRaw;
+
+impl DatabaseIdHistoryIdent {
+    pub fn database_name(&self) -> &str {
+        self.name().as_str()
     }
 }
 
-impl ShareEndpointIdentRaw {
-    pub fn share_endpoint_name(&self) -> &str {
-        self.name()
+impl DatabaseIdHistoryIdentRaw {
+    pub fn database_name(&self) -> &str {
+        self.name().as_str()
     }
 }
 
@@ -38,19 +39,22 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
     use databend_common_meta_kvapi::kvapi::Key;
 
-    use crate::share::ShareEndpointId;
+    use crate::schema::DatabaseId;
+    use crate::schema::DbIdList;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
     impl TenantResource for Resource {
-        const PREFIX: &'static str = "__fd_share_endpoint";
-        const TYPE: &'static str = "ShareEndpointIdent";
-        type ValueType = ShareEndpointId;
+        const PREFIX: &'static str = "__fd_db_id_list";
+        const TYPE: &'static str = "DatabaseIdHistoryIdent";
+        type ValueType = DbIdList;
     }
 
-    impl kvapi::Value for ShareEndpointId {
+    impl kvapi::Value for DbIdList {
         fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
-            [self.to_string_key()]
+            self.id_list
+                .iter()
+                .map(|id| DatabaseId::new(*id).to_string_key())
         }
     }
 
@@ -63,17 +67,17 @@ mod kvapi_impl {
 mod tests {
     use databend_common_meta_kvapi::kvapi::Key;
 
-    use super::ShareEndpointIdent;
+    use super::DatabaseIdHistoryIdent;
     use crate::tenant::Tenant;
 
     #[test]
-    fn test_ident() {
+    fn test_database_id_history_ident() {
         let tenant = Tenant::new_literal("test");
-        let ident = ShareEndpointIdent::new(tenant, "test1");
+        let ident = DatabaseIdHistoryIdent::new(tenant, "3");
 
         let key = ident.to_string_key();
-        assert_eq!(key, "__fd_share_endpoint/test/test1");
+        assert_eq!(key, "__fd_db_id_list/test/3");
 
-        assert_eq!(ident, ShareEndpointIdent::from_str_key(&key).unwrap());
+        assert_eq!(ident, DatabaseIdHistoryIdent::from_str_key(&key).unwrap());
     }
 }

--- a/src/meta/app/src/schema/database_name_ident.rs
+++ b/src/meta/app/src/schema/database_name_ident.rs
@@ -53,6 +53,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     // impl From<UnknownError<Resource>> for ErrorCode {
 }

--- a/src/meta/app/src/schema/index_name_ident.rs
+++ b/src/meta/app/src/schema/index_name_ident.rs
@@ -57,6 +57,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     // impl From<UnknownError<Resource>> for ErrorCode {
 }

--- a/src/meta/app/src/schema/mod.rs
+++ b/src/meta/app/src/schema/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod catalog;
 pub mod catalog_name_ident;
+pub mod database_id_history_ident;
 pub mod database_name_ident;
 pub mod index_name_ident;
 pub mod virtual_column_ident;
@@ -42,7 +43,6 @@ pub use database::DatabaseInfo;
 pub use database::DatabaseInfoFilter;
 pub use database::DatabaseMeta;
 pub use database::DbIdList;
-pub use database::DbIdListKey;
 pub use database::DropDatabaseReply;
 pub use database::DropDatabaseReq;
 pub use database::GetDatabaseReq;
@@ -51,6 +51,7 @@ pub use database::RenameDatabaseReply;
 pub use database::RenameDatabaseReq;
 pub use database::UndropDatabaseReply;
 pub use database::UndropDatabaseReq;
+pub use database_id_history_ident::DatabaseIdHistoryIdent;
 pub use index::*;
 pub use index_name_ident::IndexNameIdent;
 pub use index_name_ident::IndexNameIdentRaw;

--- a/src/meta/app/src/share/share_consumer_ident.rs
+++ b/src/meta/app/src/share/share_consumer_ident.rs
@@ -45,6 +45,7 @@ mod kvapi_impl {
     pub struct Resource;
     impl TenantResource for Resource {
         const PREFIX: &'static str = "__fd_share_account_id";
+        const TYPE: &'static str = "ShareConsumerIdent";
         type ValueType = ShareAccountMeta;
     }
 
@@ -54,6 +55,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     // impl From<UnknownError<Resource>> for ErrorCode {
 }

--- a/src/meta/app/src/share/share_name_ident.rs
+++ b/src/meta/app/src/share/share_name_ident.rs
@@ -56,6 +56,7 @@ mod kvapi_impl {
         }
     }
 
+    // // Use these error types to replace usage of ErrorCode if possible.
     // impl From<ExistError<Resource>> for ErrorCode {
     // impl From<UnknownError<Resource>> for ErrorCode {
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: define DbIdListKey with TIdent, and rename it to DatabaseIdHistoryIdent

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15287)
<!-- Reviewable:end -->
