### PR TITLE
chore: improve distributed plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,7 @@ dependencies = [
  "rand 0.8.5",
  "rmp-serde",
  "roaring",
+ "scroll 0.12.0",
  "serde",
  "wkt",
 ]
@@ -3611,6 +3612,7 @@ dependencies = [
  "chrono-tz",
  "convert_case 0.6.0",
  "databend-common-expression",
+ "databend-common-io",
  "databend-common-meta-app",
  "databend-common-meta-types",
  "databend-common-protos",
@@ -3661,6 +3663,7 @@ dependencies = [
  "databend-common-base",
  "databend-common-config",
  "databend-common-exception",
+ "databend-common-io",
  "databend-common-meta-app",
  "databend-common-meta-types",
  "databend-common-users",
@@ -6184,7 +6187,7 @@ dependencies = [
  "geojson",
  "geos",
  "log",
- "scroll",
+ "scroll 0.11.0",
  "serde_json",
  "thiserror",
  "wkt",
@@ -8612,7 +8615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2caa5afb8bf9f3a2652760ce7d4f62d21c4d5a423e68466fca30df82f2330164"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -12089,6 +12092,12 @@ name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 
 [[package]]
 name = "scrypt"

--- a/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
@@ -51,19 +51,19 @@ python3 scripts/ci/wait_tcp.py --timeout 30 --port 28302
 sleep 1
 
 echo 'Start databend-query node-1'
-nohup env RUST_BACKTRACE=1 target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml --internal-enable-sandbox-tenant >./.databend/query-1.out 2>&1 &
+nohup  target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml --internal-enable-sandbox-tenant >./.databend/query-1.out 2>&1 &
 
 echo "Waiting on node-1..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9091
 
 echo 'Start databend-query node-2'
-env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-2.toml --internal-enable-sandbox-tenant >./.databend/query-2.out 2>&1 &
+nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-2.toml --internal-enable-sandbox-tenant >./.databend/query-2.out 2>&1 &
 
 echo "Waiting on node-2..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9092
 
 echo 'Start databend-query node-3'
-env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-3.toml --internal-enable-sandbox-tenant >./.databend/query-3.out 2>&1 &
+ nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-3.toml --internal-enable-sandbox-tenant >./.databend/query-3.out 2>&1 &
 
 echo "Waiting on node-3..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9093

--- a/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
+++ b/scripts/ci/deploy/databend-query-cluster-3-nodes.sh
@@ -51,19 +51,19 @@ python3 scripts/ci/wait_tcp.py --timeout 30 --port 28302
 sleep 1
 
 echo 'Start databend-query node-1'
-nohup  target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml --internal-enable-sandbox-tenant >./.databend/query-1.out 2>&1 &
+nohup env RUST_BACKTRACE=1 target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml --internal-enable-sandbox-tenant >./.databend/query-1.out 2>&1 &
 
 echo "Waiting on node-1..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9091
 
 echo 'Start databend-query node-2'
-nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-2.toml --internal-enable-sandbox-tenant >./.databend/query-2.out 2>&1 &
+env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-2.toml --internal-enable-sandbox-tenant >./.databend/query-2.out 2>&1 &
 
 echo "Waiting on node-2..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9092
 
 echo 'Start databend-query node-3'
- nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-3.toml --internal-enable-sandbox-tenant >./.databend/query-3.out 2>&1 &
+env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-3.toml --internal-enable-sandbox-tenant >./.databend/query-3.out 2>&1 &
 
 echo "Waiting on node-3..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9093

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -619,16 +619,6 @@ impl Operator for Join {
             ]);
         }
 
-        // (Serial, Serial)
-        children_required.push(vec![
-            RequiredProperty {
-                distribution: Distribution::Serial,
-            },
-            RequiredProperty {
-                distribution: Distribution::Serial,
-            },
-        ]);
-
         Ok(children_required)
     }
 }

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -619,6 +619,18 @@ impl Operator for Join {
             ]);
         }
 
+        if children_required.is_empty() {
+            // (Serial, Serial)
+            children_required.push(vec![
+                RequiredProperty {
+                    distribution: Distribution::Serial,
+                },
+                RequiredProperty {
+                    distribution: Distribution::Serial,
+                },
+            ]);
+        }
+
         Ok(children_required)
     }
 }

--- a/tests/sqllogictests/suites/mode/cluster/memo/aggregate_property.test
+++ b/tests/sqllogictests/suites/mode/cluster/memo/aggregate_property.test
@@ -26,45 +26,37 @@ where t_10.a = t_1000.a and t_100.a = t_1000.a
 ----
 Memo
 ├── root group: #8
-├── estimated memory: 11.00 KiB
+├── estimated memory: 9.00 KiB
 ├── Group #0
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1000.000, children: []
-│   │   ├── { dist: Hash(t_1000.a (#2)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 351000.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_1000.a (#2)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_1000.a (#2)::Int32 NULL)) [#0]
-│   └── #2 Exchange: (Merge) [#0]
+│   └── #1 Exchange: (Hash(t_1000.a (#2)::Int32 NULL)) [#0]
 ├── Group #1
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 100.000, children: []
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 35100.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#1]
-│   └── #2 Exchange: (Merge) [#1]
+│   └── #1 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#1]
 ├── Group #2
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 10.000, children: []
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 1010.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #3, cost: 3510.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
 │   ├── #1 Exchange: (Broadcast) [#2]
-│   ├── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#2]
-│   └── #3 Exchange: (Merge) [#2]
+│   └── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#2]
 ├── Group #3
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1310.000, children: [{ dist: Any }, { dist: Broadcast }]
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 2310.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #3, cost: 1820.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #0, cost: 6410.000, children: [{ dist: Hash(t_100.a (#1)::Int32 NULL) }, { dist: Hash(t_10.a (#0)::Int32 NULL) }]
-│   │   └── { dist: Serial }: expr: #0, cost: 38810.000, children: [{ dist: Serial }, { dist: Serial }]
+│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 1820.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #0, cost: 6410.000, children: [{ dist: Hash(t_100.a (#1)::Int32 NULL) }, { dist: Hash(t_10.a (#0)::Int32 NULL) }]
 │   ├── #0 Join [#1, #2]
 │   ├── #1 Exchange: (Broadcast) [#3]
-│   ├── #2 Exchange: (Merge) [#3]
-│   ├── #3 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#3]
-│   └── #4 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#3]
+│   ├── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#3]
+│   └── #3 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#3]
 ├── Group #4
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 4410.000, children: [{ dist: Any }, { dist: Broadcast }]
@@ -97,45 +89,37 @@ group by t_10.a, t_100.a
 ----
 Memo
 ├── root group: #8
-├── estimated memory: 25.50 KiB
+├── estimated memory: 22.50 KiB
 ├── Group #0
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1000.000, children: []
-│   │   ├── { dist: Hash(t_1000.a (#2)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 351000.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_1000.a (#2)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_1000.a (#2)::Int32 NULL)) [#0]
-│   └── #2 Exchange: (Merge) [#0]
+│   └── #1 Exchange: (Hash(t_1000.a (#2)::Int32 NULL)) [#0]
 ├── Group #1
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 100.000, children: []
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 35100.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#1]
-│   └── #2 Exchange: (Merge) [#1]
+│   └── #1 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#1]
 ├── Group #2
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 10.000, children: []
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 1010.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #3, cost: 3510.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
 │   ├── #1 Exchange: (Broadcast) [#2]
-│   ├── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#2]
-│   └── #3 Exchange: (Merge) [#2]
+│   └── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#2]
 ├── Group #3
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1310.000, children: [{ dist: Any }, { dist: Broadcast }]
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 2310.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #3, cost: 1820.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #0, cost: 5920.000, children: [{ dist: Hash(t_100.a (#1)::Int32 NULL) }, { dist: Hash(t_10.a (#0)::Int32 NULL) }]
-│   │   └── { dist: Serial }: expr: #0, cost: 38810.000, children: [{ dist: Serial }, { dist: Serial }]
+│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 1820.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #0, cost: 5920.000, children: [{ dist: Hash(t_100.a (#1)::Int32 NULL) }, { dist: Hash(t_10.a (#0)::Int32 NULL) }]
 │   ├── #0 Join [#1, #2]
 │   ├── #1 Exchange: (Broadcast) [#3]
-│   ├── #2 Exchange: (Merge) [#3]
-│   ├── #3 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#3]
-│   └── #4 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#3]
+│   ├── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#3]
+│   └── #3 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#3]
 ├── Group #4
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 4410.000, children: [{ dist: Any }, { dist: Broadcast }]
@@ -176,11 +160,9 @@ Memo
 ├── Group #11
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 63000.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_1000.a (#2)::Int32 NULL) }: expr: #1, cost: 114000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 413000.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_1000.a (#2)::Int32 NULL) }: expr: #1, cost: 114000.000, children: [{ dist: Any }]
 │   ├── #0 Aggregate [#10]
-│   ├── #1 Exchange: (Hash(t_1000.a (#2)::Int32 NULL)) [#11]
-│   └── #2 Exchange: (Merge) [#11]
+│   └── #1 Exchange: (Hash(t_1000.a (#2)::Int32 NULL)) [#11]
 ├── Group #12
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 66410.000, children: [{ dist: Any }, { dist: Broadcast }]
@@ -204,13 +186,11 @@ Memo
 │   │   ├── { dist: Any }: expr: #0, cost: 1920.000, children: [{ dist: Any }]
 │   │   ├── { dist: Broadcast }: expr: #3, cost: 2920.000, children: [{ dist: Any }]
 │   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #1, cost: 2430.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #2, cost: 2430.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #4, cost: 5420.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #2, cost: 2430.000, children: [{ dist: Any }]
 │   ├── #0 Aggregate [#15]
 │   ├── #1 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#16]
 │   ├── #2 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#16]
-│   ├── #3 Exchange: (Broadcast) [#16]
-│   └── #4 Exchange: (Merge) [#16]
+│   └── #3 Exchange: (Broadcast) [#16]
 ├── Group #17
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 5020.000, children: [{ dist: Any }, { dist: Broadcast }]

--- a/tests/sqllogictests/suites/mode/cluster/memo/join_property.test
+++ b/tests/sqllogictests/suites/mode/cluster/memo/join_property.test
@@ -25,45 +25,37 @@ select * from t_10, t_100, t_1000 where t_10.a = t_1000.a and t_100.a = t_1000.a
 ----
 Memo
 ├── root group: #5
-├── estimated memory: 9.00 KiB
+├── estimated memory: 7.00 KiB
 ├── Group #0
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1000.000, children: []
-│   │   ├── { dist: Hash(t_1000.a (#2)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 351000.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_1000.a (#2)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_1000.a (#2)::Int32 NULL)) [#0]
-│   └── #2 Exchange: (Merge) [#0]
+│   └── #1 Exchange: (Hash(t_1000.a (#2)::Int32 NULL)) [#0]
 ├── Group #1
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 100.000, children: []
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 35100.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#1]
-│   └── #2 Exchange: (Merge) [#1]
+│   └── #1 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#1]
 ├── Group #2
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 10.000, children: []
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 1010.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #3, cost: 3510.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
 │   ├── #1 Exchange: (Broadcast) [#2]
-│   ├── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#2]
-│   └── #3 Exchange: (Merge) [#2]
+│   └── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#2]
 ├── Group #3
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1310.000, children: [{ dist: Any }, { dist: Broadcast }]
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 2310.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #3, cost: 1820.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #0, cost: 6410.000, children: [{ dist: Hash(t_100.a (#1)::Int32 NULL) }, { dist: Hash(t_10.a (#0)::Int32 NULL) }]
-│   │   └── { dist: Serial }: expr: #0, cost: 38810.000, children: [{ dist: Serial }, { dist: Serial }]
+│   │   ├── { dist: Hash(t_10.a (#0)::Int32 NULL) }: expr: #2, cost: 1820.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #0, cost: 6410.000, children: [{ dist: Hash(t_100.a (#1)::Int32 NULL) }, { dist: Hash(t_10.a (#0)::Int32 NULL) }]
 │   ├── #0 Join [#1, #2]
 │   ├── #1 Exchange: (Broadcast) [#3]
-│   ├── #2 Exchange: (Merge) [#3]
-│   ├── #3 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#3]
-│   └── #4 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#3]
+│   ├── #2 Exchange: (Hash(t_10.a (#0)::Int32 NULL)) [#3]
+│   └── #3 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#3]
 ├── Group #4
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 4410.000, children: [{ dist: Any }, { dist: Broadcast }]
@@ -81,43 +73,35 @@ select * from t_1000 left join t_10 on t_1000.a = t_10.a left join t_100 on t_10
 ----
 Memo
 ├── root group: #5
-├── estimated memory: 8.50 KiB
+├── estimated memory: 6.50 KiB
 ├── Group #0
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1000.000, children: []
-│   │   ├── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 351000.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#0]
-│   └── #2 Exchange: (Merge) [#0]
+│   └── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#0]
 ├── Group #1
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 10.000, children: []
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 1010.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#1)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #3, cost: 3510.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_10.a (#1)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
 │   ├── #1 Exchange: (Broadcast) [#1]
-│   ├── #2 Exchange: (Hash(t_10.a (#1)::Int32 NULL)) [#1]
-│   └── #3 Exchange: (Merge) [#1]
+│   └── #2 Exchange: (Hash(t_10.a (#1)::Int32 NULL)) [#1]
 ├── Group #2
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 3110.000, children: [{ dist: Any }, { dist: Broadcast }]
-│   │   ├── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 54110.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #0, cost: 355610.000, children: [{ dist: Serial }, { dist: Serial }]
+│   │   └── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 54110.000, children: [{ dist: Any }]
 │   ├── #0 Join [#0, #1]
-│   ├── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#2]
-│   └── #2 Exchange: (Merge) [#2]
+│   └── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#2]
 ├── Group #3
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 100.000, children: []
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 10100.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_100.a (#2)::Int32 NULL) }: expr: #3, cost: 5200.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 35100.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#2)::Int32 NULL) }: expr: #1, cost: 10100.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
 │   ├── #1 Exchange: (Broadcast) [#3]
-│   ├── #2 Exchange: (Merge) [#3]
-│   └── #3 Exchange: (Hash(t_100.a (#2)::Int32 NULL)) [#3]
+│   └── #2 Exchange: (Hash(t_100.a (#2)::Int32 NULL)) [#3]
 ├── Group #4
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 15210.000, children: [{ dist: Any }, { dist: Broadcast }]
@@ -135,39 +119,31 @@ select * from t_1000 right join t_10 on t_1000.a = t_10.a right join t_100 on t_
 ----
 Memo
 ├── root group: #5
-├── estimated memory: 7.50 KiB
+├── estimated memory: 5.50 KiB
 ├── Group #0
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1000.000, children: []
-│   │   ├── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 351000.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#0]
-│   └── #2 Exchange: (Merge) [#0]
+│   └── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#0]
 ├── Group #1
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 10.000, children: []
-│   │   ├── { dist: Hash(t_10.a (#1)::Int32 NULL) }: expr: #1, cost: 520.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 3510.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_10.a (#1)::Int32 NULL) }: expr: #1, cost: 520.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_10.a (#1)::Int32 NULL)) [#1]
-│   └── #2 Exchange: (Merge) [#1]
+│   └── #1 Exchange: (Hash(t_10.a (#1)::Int32 NULL)) [#1]
 ├── Group #2
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 53620.000, children: [{ dist: Hash(t_1000.a (#0)::Int32 NULL) }, { dist: Hash(t_10.a (#1)::Int32 NULL) }]
-│   │   ├── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 54130.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #0, cost: 355610.000, children: [{ dist: Serial }, { dist: Serial }]
+│   │   └── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 54130.000, children: [{ dist: Any }]
 │   ├── #0 Join [#0, #1]
-│   ├── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#2]
-│   └── #2 Exchange: (Merge) [#2]
+│   └── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#2]
 ├── Group #3
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 100.000, children: []
-│   │   ├── { dist: Hash(t_100.a (#2)::Int32 NULL) }: expr: #2, cost: 5200.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #1, cost: 35100.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#2)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Merge) [#3]
-│   └── #2 Exchange: (Hash(t_100.a (#2)::Int32 NULL)) [#3]
+│   └── #1 Exchange: (Hash(t_100.a (#2)::Int32 NULL)) [#3]
 ├── Group #4
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 60340.000, children: [{ dist: Hash(t_1000.a (#0)::Int32 NULL) }, { dist: Hash(t_100.a (#2)::Int32 NULL) }]
@@ -185,39 +161,31 @@ select * from t_1000 full join t_10 on t_1000.a = t_10.a full join t_100 on t_10
 ----
 Memo
 ├── root group: #5
-├── estimated memory: 7.50 KiB
+├── estimated memory: 5.50 KiB
 ├── Group #0
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1000.000, children: []
-│   │   ├── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 351000.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#0]
-│   └── #2 Exchange: (Merge) [#0]
+│   └── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#0]
 ├── Group #1
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 10.000, children: []
-│   │   ├── { dist: Hash(t_10.a (#1)::Int32 NULL) }: expr: #1, cost: 520.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 3510.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_10.a (#1)::Int32 NULL) }: expr: #1, cost: 520.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_10.a (#1)::Int32 NULL)) [#1]
-│   └── #2 Exchange: (Merge) [#1]
+│   └── #1 Exchange: (Hash(t_10.a (#1)::Int32 NULL)) [#1]
 ├── Group #2
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 53620.000, children: [{ dist: Hash(t_1000.a (#0)::Int32 NULL) }, { dist: Hash(t_10.a (#1)::Int32 NULL) }]
-│   │   ├── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 104620.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #0, cost: 355610.000, children: [{ dist: Serial }, { dist: Serial }]
+│   │   └── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 104620.000, children: [{ dist: Any }]
 │   ├── #0 Join [#0, #1]
-│   ├── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#2]
-│   └── #2 Exchange: (Merge) [#2]
+│   └── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#2]
 ├── Group #3
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 100.000, children: []
-│   │   ├── { dist: Hash(t_100.a (#2)::Int32 NULL) }: expr: #2, cost: 5200.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #1, cost: 35100.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#2)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Merge) [#3]
-│   └── #2 Exchange: (Hash(t_100.a (#2)::Int32 NULL)) [#3]
+│   └── #1 Exchange: (Hash(t_100.a (#2)::Int32 NULL)) [#3]
 ├── Group #4
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 111820.000, children: [{ dist: Hash(t_1000.a (#0)::Int32 NULL) }, { dist: Hash(t_100.a (#2)::Int32 NULL) }]
@@ -235,35 +203,27 @@ select * from t_10, t_100, t_1000
 ----
 Memo
 ├── root group: #5
-├── estimated memory: 6.50 KiB
+├── estimated memory: 4.50 KiB
 ├── Group #0
 │   ├── Best properties
-│   │   ├── { dist: Any }: expr: #0, cost: 10.000, children: []
-│   │   └── { dist: Serial }: expr: #1, cost: 3510.000, children: [{ dist: Any }]
-│   ├── #0 Scan []
-│   └── #1 Exchange: (Merge) [#0]
+│   │   └── { dist: Any }: expr: #0, cost: 10.000, children: []
+│   └── #0 Scan []
 ├── Group #1
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 100.000, children: []
-│   │   ├── { dist: Broadcast }: expr: #1, cost: 10100.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 35100.000, children: [{ dist: Any }]
+│   │   └── { dist: Broadcast }: expr: #1, cost: 10100.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Broadcast) [#1]
-│   └── #2 Exchange: (Merge) [#1]
+│   └── #1 Exchange: (Broadcast) [#1]
 ├── Group #2
 │   ├── Best properties
-│   │   ├── { dist: Any }: expr: #0, cost: 11120.000, children: [{ dist: Any }, { dist: Broadcast }]
-│   │   └── { dist: Serial }: expr: #0, cost: 39620.000, children: [{ dist: Serial }, { dist: Serial }]
-│   ├── #0 Join [#0, #1]
-│   └── #1 Exchange: (Merge) [#2]
+│   │   └── { dist: Any }: expr: #0, cost: 11120.000, children: [{ dist: Any }, { dist: Broadcast }]
+│   └── #0 Join [#0, #1]
 ├── Group #3
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1000.000, children: []
-│   │   ├── { dist: Broadcast }: expr: #1, cost: 101000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 351000.000, children: [{ dist: Any }]
+│   │   └── { dist: Broadcast }: expr: #1, cost: 101000.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Broadcast) [#3]
-│   └── #2 Exchange: (Merge) [#3]
+│   └── #1 Exchange: (Broadcast) [#3]
 ├── Group #4
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 123120.000, children: [{ dist: Any }, { dist: Broadcast }]

--- a/tests/sqllogictests/suites/mode/cluster/memo/mix_property.test
+++ b/tests/sqllogictests/suites/mode/cluster/memo/mix_property.test
@@ -29,45 +29,37 @@ limit 10
 ----
 Memo
 ├── root group: #10
-├── estimated memory: 12.00 KiB
+├── estimated memory: 10.00 KiB
 ├── Group #0
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1000.000, children: []
-│   │   ├── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 351000.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_1000.a (#0)::Int32 NULL) }: expr: #1, cost: 52000.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#0]
-│   └── #2 Exchange: (Merge) [#0]
+│   └── #1 Exchange: (Hash(t_1000.a (#0)::Int32 NULL)) [#0]
 ├── Group #1
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 100.000, children: []
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #2, cost: 35100.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #1, cost: 5200.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
-│   ├── #1 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#1]
-│   └── #2 Exchange: (Merge) [#1]
+│   └── #1 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#1]
 ├── Group #2
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 10.000, children: []
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 1010.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#2)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
-│   │   └── { dist: Serial }: expr: #3, cost: 3510.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_10.a (#2)::Int32 NULL) }: expr: #2, cost: 520.000, children: [{ dist: Any }]
 │   ├── #0 Scan []
 │   ├── #1 Exchange: (Broadcast) [#2]
-│   ├── #2 Exchange: (Hash(t_10.a (#2)::Int32 NULL)) [#2]
-│   └── #3 Exchange: (Merge) [#2]
+│   └── #2 Exchange: (Hash(t_10.a (#2)::Int32 NULL)) [#2]
 ├── Group #3
 │   ├── Best properties
 │   │   ├── { dist: Any }: expr: #0, cost: 1310.000, children: [{ dist: Any }, { dist: Broadcast }]
 │   │   ├── { dist: Broadcast }: expr: #1, cost: 2310.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_10.a (#2)::Int32 NULL) }: expr: #3, cost: 1820.000, children: [{ dist: Any }]
-│   │   ├── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #0, cost: 6410.000, children: [{ dist: Hash(t_100.a (#1)::Int32 NULL) }, { dist: Hash(t_10.a (#2)::Int32 NULL) }]
-│   │   └── { dist: Serial }: expr: #0, cost: 38810.000, children: [{ dist: Serial }, { dist: Serial }]
+│   │   ├── { dist: Hash(t_10.a (#2)::Int32 NULL) }: expr: #2, cost: 1820.000, children: [{ dist: Any }]
+│   │   └── { dist: Hash(t_100.a (#1)::Int32 NULL) }: expr: #0, cost: 6410.000, children: [{ dist: Hash(t_100.a (#1)::Int32 NULL) }, { dist: Hash(t_10.a (#2)::Int32 NULL) }]
 │   ├── #0 Join [#1, #2]
 │   ├── #1 Exchange: (Broadcast) [#3]
-│   ├── #2 Exchange: (Merge) [#3]
-│   ├── #3 Exchange: (Hash(t_10.a (#2)::Int32 NULL)) [#3]
-│   └── #4 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#3]
+│   ├── #2 Exchange: (Hash(t_10.a (#2)::Int32 NULL)) [#3]
+│   └── #3 Exchange: (Hash(t_100.a (#1)::Int32 NULL)) [#3]
 ├── Group #4
 │   ├── Best properties
 │   │   └── { dist: Any }: expr: #0, cost: 4410.000, children: [{ dist: Any }, { dist: Broadcast }]

--- a/tests/sqllogictests/suites/mode/cluster/window.test
+++ b/tests/sqllogictests/suites/mode/cluster/window.test
@@ -1,0 +1,122 @@
+statement ok
+drop table if exists employees;
+
+statement ok
+drop table if exists departments;
+
+statement ok
+CREATE TABLE employees (
+    employee_id INT,
+    name VARCHAR(100),
+    department_id INT,
+    salary DECIMAL(10, 2)
+);
+
+statement ok
+CREATE TABLE departments (
+    department_id INT,
+    department_name VARCHAR(100)
+);
+
+statement ok
+INSERT INTO departments (department_id, department_name) VALUES
+(1, 'Human Resources'),
+(2, 'Marketing'),
+(3, 'Finance'),
+(4, 'IT');
+
+statement ok
+INSERT INTO employees (employee_id, name, department_id, salary) VALUES
+(1, 'Alice', 1, 50000.00),
+(2, 'Bob', 1, 52000.00),
+(3, 'Charlie', 2, 55000.00),
+(4, 'David', 2, 50000.00),
+(5, 'Eve', 3, 75000.00),
+(6, 'Frank', 3, 82000.00),
+(7, 'Grace', 4, 72000.00),
+(8, 'Hannah', 4, 69000.00),
+(9, 'Ian', 4, 67000.00),
+(10, 'Jack', 3, 70000.00);
+
+
+query TT?I
+SELECT
+    e.name AS EmployeeName,
+    d.department_name AS DepartmentName,
+    e.salary AS Salary,
+    ROW_NUMBER() OVER (PARTITION BY d.department_id ORDER BY e.salary DESC) AS SalaryRank
+FROM
+    employees e
+JOIN
+    departments d ON e.department_id = d.department_id
+ORDER BY
+    DepartmentName,
+    SalaryRank;
+----
+Frank Finance 82000.00 1
+Eve Finance 75000.00 2
+Jack Finance 70000.00 3
+Bob Human Resources 52000.00 1
+Alice Human Resources 50000.00 2
+Grace IT 72000.00 1
+Hannah IT 69000.00 2
+Ian IT 67000.00 3
+Charlie Marketing 55000.00 1
+David Marketing 50000.00 2
+
+
+query 
+explain SELECT e.name AS EmployeeName,
+    d.department_name AS DepartmentName,
+    e.salary AS Salary,
+    ROW_NUMBER() OVER (PARTITION BY d.department_id ORDER BY e.salary DESC) AS SalaryRank
+FROM
+    employees e
+JOIN
+    departments d ON e.department_id = d.department_id;
+----
+Window
+├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), d.department_id (#4), ROW_NUMBER() OVER ( PARTITION BY d.department_id ORDER BY e.salary DESC ) (#6)]
+├── aggregate function: [row_number]
+├── partition by: [department_id]
+├── order by: [salary]
+├── frame: [Range: Preceding(None) ~ CurrentRow]
+└── Exchange
+    ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), d.department_id (#4)]
+    ├── exchange type: Merge
+    └── HashJoin
+        ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), d.department_id (#4)]
+        ├── join type: INNER
+        ├── build keys: [d.department_id (#4)]
+        ├── probe keys: [e.department_id (#2)]
+        ├── filters: []
+        ├── estimated rows: 8.00
+        ├── Exchange(Build)
+        │   ├── output columns: [d.department_id (#4), d.department_name (#5)]
+        │   ├── exchange type: Broadcast
+        │   └── TableScan
+        │       ├── table: default.default.departments
+        │       ├── output columns: [department_id (#4), department_name (#5)]
+        │       ├── read rows: 4
+        │       ├── read size: < 1 KiB
+        │       ├── partitions total: 1
+        │       ├── partitions scanned: 1
+        │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        │       ├── push downs: [filters: [], limit: NONE]
+        │       └── estimated rows: 4.00
+        └── TableScan(Probe)
+            ├── table: default.default.employees
+            ├── output columns: [name (#1), department_id (#2), salary (#3)]
+            ├── read rows: 10
+            ├── read size: < 1 KiB
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 10.00
+
+statement ok
+DROP TABLE employees;
+
+statement ok
+DROP TABLE departments;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`Serial` is bad for distribution execution, we should avoid it as much as possible.

Before
```
mysql> explain SELECT
    ->     e.name AS EmployeeName,
    ->     d.department_name AS DepartmentName,
    ->     e.salary AS Salary,
    ->     ROW_NUMBER() OVER (PARTITION BY d.department_id ORDER BY e.salary DESC) AS SalaryRank
    -> FROM
    ->     employees e
    -> JOIN
    ->     departments d ON e.department_id = d.department_id
    -> ORDER BY
    ->     DepartmentName,
    ->     SalaryRank;
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                                                                                  |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Sort                                                                                                                                                                                     |
| ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), ROW_NUMBER() OVER ( PARTITION BY d.department_id ORDER BY e.salary DESC ) (#6)]                                 |
| ├── sort keys: [department_name ASC NULLS LAST, ROW_NUMBER() OVER ( PARTITION BY d.department_id ORDER BY e.salary DESC ) ASC NULLS LAST]                                                |
| ├── estimated rows: 4.00                                                                                                                                                                 |
| └── Window                                                                                                                                                                               |
|     ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), d.department_id (#4), ROW_NUMBER() OVER ( PARTITION BY d.department_id ORDER BY e.salary DESC ) (#6)]       |
|     ├── aggregate function: [row_number]                                                                                                                                                 |
|     ├── partition by: [department_id]                                                                                                                                                    |
|     ├── order by: [salary]                                                                                                                                                               |
|     ├── frame: [Range: Preceding(None) ~ CurrentRow]                                                                                                                                     |
|     └── HashJoin                                                                                                                                                                         |
|         ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), d.department_id (#4)]                                                                                   |
|         ├── join type: INNER                                                                                                                                                             |
|         ├── build keys: [d.department_id (#4)]                                                                                                                                           |
|         ├── probe keys: [e.department_id (#2)]                                                                                                                                           |
|         ├── filters: []                                                                                                                                                                  |
|         ├── estimated rows: 8.00                                                                                                                                                         |
|         ├── Exchange(Build)                                                                                                                                                              |
|         │   ├── output columns: [d.department_id (#4), d.department_name (#5)]                                                                                                           |
|         │   ├── exchange type: Merge                                                                                                                                                     |
|         │   └── TableScan                                                                                                                                                                |
|         │       ├── table: default.default.departments                                                                                                                                   |
|         │       ├── output columns: [department_id (#4), department_name (#5)]                                                                                                           |
|         │       ├── read rows: 4                                                                                                                                                         |
|         │       ├── read size: < 1 KiB                                                                                                                                                   |
|         │       ├── partitions total: 1                                                                                                                                                  |
|         │       ├── partitions scanned: 1                                                                                                                                                |
|         │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]                                                                                  |
|         │       ├── push downs: [filters: [], limit: NONE]                                                                                                                               |
|         │       └── estimated rows: 4.00                                                                                                                                                 |
|         └── Exchange(Probe)                                                                                                                                                              |
|             ├── output columns: [e.name (#1), e.department_id (#2), e.salary (#3)]                                                                                                       |
|             ├── exchange type: Merge                                                                                                                                                     |
|             └── TableScan                                                                                                                                                                |
|                 ├── table: default.default.employees                                                                                                                                     |
|                 ├── output columns: [name (#1), department_id (#2), salary (#3)]                                                                                                         |
|                 ├── read rows: 10                                                                                                                                                        |
|                 ├── read size: < 1 KiB                                                                                                                                                   |
|                 ├── partitions total: 1                                                                                                                                                  |
|                 ├── partitions scanned: 1                                                                                                                                                |
|                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]                                                                                  |
|                 ├── push downs: [filters: [], limit: NONE]                                                                                                                               |
|                 └── estimated rows: 10.00                                                                                                                                                |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
43 rows in set (0.10 sec)
Read 0 rows, 0.00 B in 0.003 sec., 0 rows/sec., 0.00 B/sec.
```

Now
```
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                                                                                  |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Sort                                                                                                                                                                                     |
| ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), ROW_NUMBER() OVER ( PARTITION BY d.department_id ORDER BY e.salary DESC ) (#6)]                                 |
| ├── sort keys: [department_name ASC NULLS LAST, ROW_NUMBER() OVER ( PARTITION BY d.department_id ORDER BY e.salary DESC ) ASC NULLS LAST]                                                |
| ├── estimated rows: 4.00                                                                                                                                                                 |
| └── Window                                                                                                                                                                               |
|     ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), d.department_id (#4), ROW_NUMBER() OVER ( PARTITION BY d.department_id ORDER BY e.salary DESC ) (#6)]       |
|     ├── aggregate function: [row_number]                                                                                                                                                 |
|     ├── partition by: [department_id]                                                                                                                                                    |
|     ├── order by: [salary]                                                                                                                                                               |
|     ├── frame: [Range: Preceding(None) ~ CurrentRow]                                                                                                                                     |
|     └── Exchange                                                                                                                                                                         |
|         ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), d.department_id (#4)]                                                                                   |
|         ├── exchange type: Merge                                                                                                                                                         |
|         └── HashJoin                                                                                                                                                                     |
|             ├── output columns: [e.name (#1), e.salary (#3), d.department_name (#5), d.department_id (#4)]                                                                               |
|             ├── join type: INNER                                                                                                                                                         |
|             ├── build keys: [d.department_id (#4)]                                                                                                                                       |
|             ├── probe keys: [e.department_id (#2)]                                                                                                                                       |
|             ├── filters: []                                                                                                                                                              |
|             ├── estimated rows: 8.00                                                                                                                                                     |
|             ├── Exchange(Build)                                                                                                                                                          |
|             │   ├── output columns: [d.department_id (#4), d.department_name (#5)]                                                                                                       |
|             │   ├── exchange type: Broadcast                                                                                                                                             |
|             │   └── TableScan                                                                                                                                                            |
|             │       ├── table: default.default.departments                                                                                                                               |
|             │       ├── output columns: [department_id (#4), department_name (#5)]                                                                                                       |
|             │       ├── read rows: 4                                                                                                                                                     |
|             │       ├── read size: < 1 KiB                                                                                                                                               |
|             │       ├── partitions total: 1                                                                                                                                              |
|             │       ├── partitions scanned: 1                                                                                                                                            |
|             │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]                                                                              |
|             │       ├── push downs: [filters: [], limit: NONE]                                                                                                                           |
|             │       └── estimated rows: 4.00                                                                                                                                             |
|             └── TableScan(Probe)                                                                                                                                                         |
|                 ├── table: default.default.employees                                                                                                                                     |
|                 ├── output columns: [name (#1), department_id (#2), salary (#3)]                                                                                                         |
|                 ├── read rows: 10                                                                                                                                                        |
|                 ├── read size: < 1 KiB                                                                                                                                                   |
|                 ├── partitions total: 1                                                                                                                                                  |
|                 ├── partitions scanned: 1                                                                                                                                                |
|                 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]                                                                                  |
|                 ├── push downs: [filters: [], limit: NONE]                                                                                                                               |
|                 └── estimated rows: 10.00                                                                                                                                                |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
43 rows in set (0.37 sec)
Read 0 rows, 0.00 B in 0.009 sec., 0 rows/sec., 0.00 B/sec.
```

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15296)
<!-- Reviewable:end -->
