### PR TITLE
chore(planner): fix can_filter_null

### DIFF
--- a/src/query/sql/src/planner/optimizer/rule/rewrite/push_down_filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/push_down_filter_join/outer_join_to_inner_join.rs
@@ -186,6 +186,13 @@ pub fn can_filter_null(
                     Ok(())
                 }
                 ScalarExpr::FunctionCall(func) => {
+                    // If the function is `assume_not_null`, we can not replace
+                    // the column bindings with `Scalar::Null`.
+                    if func.func_name == "assume_not_null" {
+                        self.can_replace = false;
+                        return Ok(());
+                    }
+
                     if func.func_name != "or" {
                         for expr in &mut func.arguments {
                             self.replace(expr, column_set)?;

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/push_down_filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/push_down_filter_join/outer_join_to_inner_join.rs
@@ -186,9 +186,9 @@ pub fn can_filter_null(
                     Ok(())
                 }
                 ScalarExpr::FunctionCall(func) => {
-                    // If the function is `assume_not_null`, we can not replace
+                    // If the function is `assume_not_null` or `remove_nullable`, we cannot replace
                     // the column bindings with `Scalar::Null`.
-                    if func.func_name == "assume_not_null" {
+                    if matches!(&func.func_name, "assume_not_null" | "remove_nullable") {
                         self.can_replace = false;
                         return Ok(());
                     }

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/push_down_filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/push_down_filter_join/outer_join_to_inner_join.rs
@@ -188,7 +188,10 @@ pub fn can_filter_null(
                 ScalarExpr::FunctionCall(func) => {
                     // If the function is `assume_not_null` or `remove_nullable`, we cannot replace
                     // the column bindings with `Scalar::Null`.
-                    if matches!(&func.func_name, "assume_not_null" | "remove_nullable") {
+                    if matches!(
+                        func.func_name.as_str(),
+                        "assume_not_null" | "remove_nullable"
+                    ) {
                         self.can_replace = false;
                         return Ok(());
                     }

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -206,3 +206,55 @@ drop table if exists t1;
 
 statement ok
 drop table if exists t2;
+
+statement ok
+drop table if exists m1;
+
+statement ok
+drop table if exists j1;
+
+statement ok
+create table m1(id varchar, "context" varchar);
+
+statement ok
+create table j1(id varchar);
+
+# In can_filter_null, if the function is `assume_not_null`, we can not replace the column bindings with `Scalar::Null`.
+query T
+explain WITH base AS (SELECT id, context FROM m1), src1 AS (SELECT base.id FROM base WHERE IFNULL(base.context, '') = ''), join1 AS (SELECT id FROM j1) SELECT src1.id FROM src1 LEFT OUTER JOIN join1 ON TRUE;
+----
+HashJoin
+├── output columns: [m1.id (#0)]
+├── join type: LEFT OUTER
+├── build keys: []
+├── probe keys: []
+├── filters: []
+├── estimated rows: 0.00
+├── TableScan(Build)
+│   ├── table: default.default.j1
+│   ├── output columns: []
+│   ├── read rows: 0
+│   ├── read size: 0
+│   ├── partitions total: 0
+│   ├── partitions scanned: 0
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 0.00
+└── Filter(Probe)
+    ├── output columns: [m1.id (#0)]
+    ├── filters: [is_true(if(CAST(is_not_null(base.context (#1)) AS Boolean NULL), CAST(assume_not_null(base.context (#1)) AS String NULL), true, '', NULL) = '')]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.m1
+        ├── output columns: [id (#0), context (#1)]
+        ├── read rows: 0
+        ├── read size: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [is_true(if(CAST(is_not_null(m1.context (#1)) AS Boolean NULL), CAST(assume_not_null(m1.context (#1)) AS String NULL), true, '', NULL) = '')], limit: NONE]
+        └── estimated rows: 0.00
+
+statement ok
+drop table if exists m1;
+
+statement ok
+drop table if exists j1;

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -219,7 +219,7 @@ create table m1(id varchar, "context" varchar);
 statement ok
 create table j1(id varchar);
 
-# In can_filter_null, if the function is `assume_not_null`, we can not replace the column bindings with `Scalar::Null`.
+# In `can_filter_null`, if the function is `assume_not_null` or `remove_nullable`, we cannot replace the column bindings with `Scalar::Null`.
 query T
 explain WITH base AS (SELECT id, context FROM m1), src1 AS (SELECT base.id FROM base WHERE IFNULL(base.context, '') = ''), join1 AS (SELECT id FROM j1) SELECT src1.id FROM src1 LEFT OUTER JOIN join1 ON TRUE;
 ----

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -195,7 +195,7 @@ create table m1(id varchar, "context" varchar);
 statement ok
 create table j1(id varchar);
 
-# In can_filter_null, if the function is `assume_not_null`, we can not replace the column bindings with `Scalar::Null`.
+# In `can_filter_null`, if the function is `assume_not_null` or `remove_nullable`, we cannot replace the column bindings with `Scalar::Null`.
 query T
 explain WITH base AS (SELECT id, context FROM m1), src1 AS (SELECT base.id FROM base WHERE IFNULL(base.context, '') = ''), join1 AS (SELECT id FROM j1) SELECT src1.id FROM src1 LEFT OUTER JOIN join1 ON TRUE;
 ----

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -182,3 +182,51 @@ drop table if exists t1;
 
 statement ok
 drop table if exists t2;
+
+statement ok
+drop table if exists m1;
+
+statement ok
+drop table if exists j1;
+
+statement ok
+create table m1(id varchar, "context" varchar);
+
+statement ok
+create table j1(id varchar);
+
+# In can_filter_null, if the function is `assume_not_null`, we can not replace the column bindings with `Scalar::Null`.
+query T
+explain WITH base AS (SELECT id, context FROM m1), src1 AS (SELECT base.id FROM base WHERE IFNULL(base.context, '') = ''), join1 AS (SELECT id FROM j1) SELECT src1.id FROM src1 LEFT OUTER JOIN join1 ON TRUE;
+----
+HashJoin
+├── output columns: [m1.id (#0)]
+├── join type: LEFT OUTER
+├── build keys: []
+├── probe keys: []
+├── filters: []
+├── estimated rows: 0.00
+├── TableScan(Build)
+│   ├── table: default.default.j1
+│   ├── output columns: []
+│   ├── read rows: 0
+│   ├── read size: 0
+│   ├── partitions total: 0
+│   ├── partitions scanned: 0
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 0.00
+└── TableScan(Probe)
+    ├── table: default.default.m1
+    ├── output columns: [id (#0)]
+    ├── read rows: 0
+    ├── read size: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    ├── push downs: [filters: [is_true(if(CAST(is_not_null(m1.context (#1)) AS Boolean NULL), CAST(assume_not_null(m1.context (#1)) AS String NULL), true, '', NULL) = '')], limit: NONE]
+    └── estimated rows: 0.00
+
+statement ok
+drop table if exists m1;
+
+statement ok
+drop table if exists j1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In `can_filter_null`, if the function is `assume_not_null` or `remove_nullable`, we cannot replace the column bindings with `Scalar::Null`.

- Fixes #15256 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15298)
<!-- Reviewable:end -->
