### PR TITLE
fix(query): NDJSON copy into allow cast bool and number to string

### DIFF
--- a/src/query/formats/src/field_decoder/json_ast.rs
+++ b/src/query/formats/src/field_decoder/json_ast.rs
@@ -236,11 +236,24 @@ impl FieldJsonAstDecoder {
         match value {
             Value::String(s) => {
                 column.put_str(s.as_str());
-                column.commit_row();
-                Ok(())
             }
-            _ => Err(ErrorCode::BadBytes("Incorrect json value, must be string")),
+            Value::Bool(v) => {
+                if *v {
+                    column.put_str("true");
+                } else {
+                    column.put_str("false");
+                }
+            }
+            Value::Number(n) => {
+                column.put_str(n.to_string().as_str());
+            }
+            Value::Null => {
+                column.put_str("null");
+            }
+            _ => return Err(ErrorCode::BadBytes("Incorrect json value, must be string")),
         }
+        column.commit_row();
+        Ok(())
     }
 
     fn read_date(&self, column: &mut Vec<i32>, value: &Value) -> Result<()> {

--- a/tests/data/ndjson/cast_sample.ndjson
+++ b/tests/data/ndjson/cast_sample.ndjson
@@ -1,0 +1,3 @@
+{"name":"data1","tags":{"env":"test1","length":"ok"}}
+{"name":"data2","tags":{"env":"test2","length":true}}
+{"name":"data3","tags":{"env":"test3","length":10}}

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_cast.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_cast.test
@@ -1,0 +1,17 @@
+statement ok
+drop table if exists cast_ndjson
+
+statement ok
+CREATE TABLE cast_ndjson (name String, tags Map(String, String))
+
+query 
+copy into cast_ndjson from @data/ndjson/cast_sample.ndjson file_format = (type = NDJSON) ON_ERROR=continue
+----
+ndjson/cast_sample.ndjson 3 0 NULL NULL
+
+query 
+select * from cast_ndjson
+----
+data1 {'env':'test1','length':'ok'}
+data2 {'env':'test2','length':'true'}
+data3 {'env':'test3','length':'10'}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

NDJSON copy into allow cast bool and number to string, avoid panic if the value is not string

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15308)
<!-- Reviewable:end -->
