### PR TITLE
chore: correct stream error message

### DIFF
--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -385,7 +385,18 @@ impl QueryContextShared {
                 let source_table = match catalog.get_stream_source_table(stream_desc)? {
                     Some(source_table) => source_table,
                     None => {
-                        let source_table = catalog.get_table(&tenant, database, table_name).await?;
+                        let source_table = catalog
+                            .get_table(&tenant, database, table_name)
+                            .await
+                            .map_err(|err| {
+                            ErrorCode::IllegalStream(format!(
+                                "Cannot get base table '{}'.'{}' from stream {}, cause: {}",
+                                database,
+                                table_name,
+                                stream_desc,
+                                err.message()
+                            ))
+                        })?;
                         catalog.cache_stream_source_table(
                             stream.get_table_info().clone(),
                             source_table.get_table_info().clone(),

--- a/src/query/storages/stream/src/stream_table.rs
+++ b/src/query/storages/stream/src/stream_table.rs
@@ -128,9 +128,8 @@ impl StreamTable {
 
         if table.get_table_info().ident.table_id != self.table_id {
             return Err(ErrorCode::IllegalStream(format!(
-                "Table id mismatch, expect {}, got {}",
-                self.table_id,
-                table.get_table_info().ident.table_id
+                "Base table '{}'.'{}' dropped, cannot read from stream {}",
+                self.table_database, self.table_name, self.stream_info.desc,
             )));
         }
 

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -699,5 +699,15 @@ merge into t1 using t2 on t1.a=t2.a when matched then update set t1.b=t2.b when 
 statement ok
 set enable_experimental_merge_into = 0;
 
+# todo(zhyass): if base table is renamed, the stream will be invalid. Maybe we should allow the scene.
+statement ok
+alter table t1 rename to t1_1
+
+query TTT
+select name, invalid_reason from system.streams where database='test_stream' order by name
+----
+s1 Unknown table 't1'
+s2 Unknown table 't1'
+
 statement ok
 DROP DATABASE IF EXISTS test_stream


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```sql
mysql> create table t(a int);
Query OK, 0 rows affected (0.14 sec)

mysql> create stream s on table t;
Query OK, 0 rows affected (0.12 sec)

mysql> drop table t;
Query OK, 0 rows affected (0.17 sec)

mysql> select * from s;
ERROR 1105 (HY000): IllegalStream. Code: 2733, Text = Cannot get base table 'default'.'t' from stream 'default'.'s', cause: Unknown table 't'.
mysql> create table t(a int);
Query OK, 0 rows affected (0.05 sec)

mysql> select * from s;
ERROR 1105 (HY000): IllegalStream. Code: 2733, Text = Base table 'default'.'t' dropped, cannot read from stream 'default'.'s'.
```
- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15309)
<!-- Reviewable:end -->
