### PR TITLE
refactor: add right bound when listing expired keys to avoid unnecessary data copy

### DIFF
--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -469,7 +469,7 @@ impl<'a> Applier<'a> {
         info!("to clean expired kvs, log_time_ts: {}", log_time_ms);
 
         let mut to_clean = vec![];
-        let mut strm = self.sm.list_expire_index().await?;
+        let mut strm = self.sm.list_expire_index(log_time_ms).await?;
 
         {
             let mut strm = std::pin::pin!(strm);

--- a/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
@@ -19,6 +19,7 @@ use std::ops::RangeBounds;
 
 use databend_common_meta_types::KVMeta;
 use futures_util::StreamExt;
+use log::warn;
 
 use crate::sm_v002::leveled_store::map_api::AsMap;
 use crate::sm_v002::leveled_store::map_api::KVResultStream;
@@ -109,6 +110,13 @@ impl MapApiRO<String> for Level {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect::<Vec<_>>();
 
+        if vec.len() > 1000 {
+            warn!(
+                "Level::<ExpireKey>::range() returns big range of len={}",
+                vec.len()
+            );
+        }
+
         let strm = futures::stream::iter(vec).map(Ok).boxed();
         Ok(strm)
     }
@@ -158,6 +166,13 @@ impl MapApiRO<ExpireKey> for Level {
             .range(range)
             .map(|(k, v)| (*k, v.clone()))
             .collect::<Vec<_>>();
+
+        if vec.len() > 1000 {
+            warn!(
+                "Level::<ExpireKey>::range() returns big range of len={}",
+                vec.len()
+            );
+        }
 
         let strm = futures::stream::iter(vec).map(Ok).boxed();
         Ok(strm)


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add right bound when listing expired keys to avoid unnecessary data copy

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15334)
<!-- Reviewable:end -->
