### PR TITLE
refactor: improve install-snapshot performance

### DIFF
--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -15,6 +15,7 @@ test = true
 io-uring = ["databend-common-meta-sled-store/io-uring"]
 
 [dependencies]
+databend-common-base = { path = "../../common/base" }
 databend-common-exception = { path = "../../common/exception" }
 databend-common-grpc = { path = "../../common/grpc" }
 databend-common-meta-api = { path = "../api" }

--- a/src/meta/types/src/raft_snapshot_data.rs
+++ b/src/meta/types/src/raft_snapshot_data.rs
@@ -77,6 +77,10 @@ impl SnapshotData {
         &self.path
     }
 
+    pub async fn into_std(self) -> std::fs::File {
+        self.f.into_std().await
+    }
+
     pub async fn sync_all(&mut self) -> Result<(), io::Error> {
         self.f.flush().await?;
         self.f.sync_all().await


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: improve install-snapshot performance

Move the IO into a separate thread and use `std::io` instead of `tokio::io`.

Using `tokio::io` and a default buf size of 8KB, reading 1.4G snapshot takes 60 seconds.
Using `std::io` and a 16MB buffer, reading 1.4G snapshot takes 7 seconds.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15345)
<!-- Reviewable:end -->
