### PR TITLE
chore: tweak transient table data retention settings

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -159,6 +159,12 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=data_retention_time_in_days_max)),
                 }),
+                ("transient_data_retention_time_in_minutes", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(60),
+                    desc: "Sets the data retention time in minutes.",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(0..= 24 * 60)),
+                }),
                 ("max_storage_io_requests", DefaultSettingValue {
                     value: UserSettingValue::UInt64(default_max_storage_io_requests),
                     desc: "Sets the maximum number of concurrent I/O requests.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -183,6 +183,10 @@ impl Settings {
         self.try_get_u64("data_retention_time_in_days")
     }
 
+    pub fn get_transient_data_retention_time_in_minutes(&self) -> Result<u64> {
+        self.try_get_u64("transient_data_retention_time_in_minutes")
+    }
+
     pub fn get_max_storage_io_requests(&self) -> Result<u64> {
         self.try_get_u64("max_storage_io_requests")
     }

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -718,7 +718,11 @@ impl Table for FuseTable {
         keep_last_snapshot: bool,
         dry_run: bool,
     ) -> Result<Option<Vec<String>>> {
-        match self.navigate_for_purge(&ctx, instant).await {
+        let by_pass_retention_period_check = false;
+        match self
+            .navigate_for_purge(&ctx, instant, by_pass_retention_period_check)
+            .await
+        {
             Ok((table, files)) => {
                 table
                     .do_purge(&ctx, files, num_snapshot_limit, keep_last_snapshot, dry_run)


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Tweak transient table data retention settings

This PR introduces a new setting, `transient_data_retention_time_in_minutes`, to customize the retention period for transient table. This setting defines how long the historical data should be retained, with a default value of 60 minutes (i.e. 1 hour).

Additionally, when purging data from transient tables, the retention period specified by `transient_data_retention_time_in_minutes` will now be utilized.


- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
