### PR TITLE
refactor: move snapshot building io to other task.

### DIFF
--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -81,10 +81,10 @@ impl<'a> Applier<'a> {
     /// And publish kv change events to subscriber.
     #[minitrace::trace]
     pub async fn apply(&mut self, entry: &Entry) -> Result<AppliedState, io::Error> {
-        info!("apply: entry: {}", entry,);
-
         let log_id = &entry.log_id;
         let log_time_ms = Self::get_log_time(entry);
+
+        info!("apply: entry: {}, log_time_ms: {}", entry, log_time_ms);
 
         self.cmd_ctx = CmdContext::from_millis(log_time_ms);
 
@@ -130,7 +130,7 @@ impl<'a> Applier<'a> {
     /// The `cmd` is always committed by raft before applying.
     #[minitrace::trace]
     pub async fn apply_cmd(&mut self, cmd: &Cmd) -> Result<AppliedState, io::Error> {
-        info!("apply_cmd: {}", cmd);
+        debug!("apply_cmd: {}", cmd);
 
         let res = match cmd {
             Cmd::AddNode {
@@ -466,7 +466,7 @@ impl<'a> Applier<'a> {
             return Ok(());
         }
 
-        info!("to clean expired kvs, log_time_ts: {}", log_time_ms);
+        debug!("to clean expired kvs, log_time_ts: {}", log_time_ms);
 
         let mut to_clean = vec![];
         let mut strm = self.sm.list_expire_index(log_time_ms).await?;
@@ -530,7 +530,7 @@ impl<'a> Applier<'a> {
                 }
                 Some(ms) => {
                     let t = SystemTime::UNIX_EPOCH + Duration::from_millis(ms);
-                    info!("apply: raft-log time: {:?}", t);
+                    debug!("apply: raft-log time: {:?}", t);
                     ms
                 }
             },

--- a/src/meta/raft-store/src/sm_v002/sm_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002.rs
@@ -265,7 +265,6 @@ impl SMV002 {
         let mut res = vec![];
 
         for ent in entries.into_iter() {
-            info!("apply: {}", *ent.get_log_id());
             let log_id = *ent.get_log_id();
             let r = applier
                 .apply(&ent)

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -58,7 +58,7 @@ use databend_common_meta_types::SnapshotMeta;
 use databend_common_meta_types::StorageError;
 use databend_common_meta_types::StorageIOError;
 use databend_common_meta_types::Vote;
-use futures::Stream;
+use futures::TryStreamExt;
 use log::debug;
 use log::info;
 use log::warn;
@@ -229,27 +229,63 @@ impl StoreInner {
 
         info!("do_build_snapshot writing snapshot start");
 
-        let mut snapshot_store = self.snapshot_store();
+        let mut ss_store = self.snapshot_store();
 
-        let strm = snapshot_view.export().await.map_err(|e| {
+        let mut strm = snapshot_view.export().await.map_err(|e| {
             SnapshotStoreError::read(e).with_meta("export state machine", &snapshot_meta)
         })?;
 
-        // Move heavy load to a blocking thread pool.
-        let (snapshot_id, snapshot_size) = tokio::task::block_in_place({
-            let sto = &mut snapshot_store;
-            let meta = snapshot_meta.clone();
-            let sleep = self.get_delay_config("write").await;
+        let meta = snapshot_meta.clone();
 
-            move || {
-                Self::testing_sleep("write", sleep);
-                futures::executor::block_on(Self::write_snapshot(sto, meta, strm))
-            }
-        })?;
+        let (tx, rx) = tokio::sync::mpsc::channel(64 * 1024);
+
+        // Spawn another thread to write entries to disk.
+        let th = databend_common_base::runtime::spawn_blocking(move || {
+            let mut writer = ss_store.new_writer()?;
+
+            info!("do_build_snapshot writer start");
+
+            writer
+                .write_entries_sync(rx)
+                .map_err(|e| SnapshotStoreError::write(e).with_meta("serialize entries", &meta))?;
+
+            info!("do_build_snapshot commit start");
+
+            let (snapshot_id, snapshot_size) = writer
+                .commit(None)
+                .map_err(|e| SnapshotStoreError::write(e).with_meta("writer.commit", &meta))?;
+
+            Ok::<(SnapshotStoreV002, MetaSnapshotId, u64), SnapshotStoreError>((
+                ss_store,
+                snapshot_id,
+                snapshot_size,
+            ))
+        });
+
+        // Pipe entries to the writer.
+        while let Some(ent) = strm
+            .try_next()
+            .await
+            .map_err(|e| StorageIOError::write_snapshot(Some(snapshot_meta.signature()), &e))?
+        {
+            tx.send(ent).await.map_err(|e| {
+                let e = StorageIOError::write_snapshot(Some(snapshot_meta.signature()), &e);
+                StorageError::from(e)
+            })?;
+        }
+
+        // Close the channel tx so that the io thread `th` can be finished.
+        drop(tx);
+
+        let (ss_store, snapshot_id, snapshot_size) = th
+            .await
+            .map_err(|e| StorageIOError::write_snapshot(None, &e))??;
 
         info!(snapshot_size :% =(snapshot_size); "do_build_snapshot complete");
 
-        snapshot_store.clean_old_snapshots().await?;
+        ss_store.clean_old_snapshots().await?;
+
+        info!("do_build_snapshot clean_old_snapshots complete");
 
         assert_eq!(
             snapshot_id.last_applied, snapshot_meta.last_log_id,
@@ -267,7 +303,7 @@ impl StoreInner {
             *current_snapshot = Some(snapshot);
         }
 
-        let r = snapshot_store
+        let r = ss_store
             .load_snapshot(&snapshot_meta.snapshot_id)
             .await
             .map_err(|e| {
@@ -344,27 +380,6 @@ impl StoreInner {
         }
 
         Ok(snapshot_view)
-    }
-
-    async fn write_snapshot(
-        snapshot_store: &mut SnapshotStoreV002,
-        snapshot_meta: SnapshotMeta,
-        entry_stream: impl Stream<Item = Result<RaftStoreEntry, io::Error>>,
-    ) -> Result<(MetaSnapshotId, u64), SnapshotStoreError> {
-        let mut writer = snapshot_store.new_writer()?;
-
-        writer
-            .write_entry_results::<io::Error>(entry_stream)
-            .await
-            .map_err(|e| {
-                SnapshotStoreError::write(e).with_meta("serialize entries", &snapshot_meta)
-            })?;
-
-        let (snapshot_id, file_size) = writer
-            .commit(None)
-            .map_err(|e| SnapshotStoreError::write(e).with_meta("writer.commit", &snapshot_meta))?;
-
-        Ok((snapshot_id, file_size))
     }
 
     /// Install a snapshot to build a state machine from it and replace the old state machine with the new one.


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: move snapshot building io to other task.

Add short sleep to avoid starving sled IO.

This commit is meant to address the issue when building a snapshot,
other IO such as appending log to sled db is delay significantly.

Remove several unnecessary INFO level log.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15351)
<!-- Reviewable:end -->
