### PR TITLE
fix: check all partitions for small files instead of the last only.

### DIFF
--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/read.rs
@@ -38,14 +38,14 @@ impl ParquetRSTable {
     ) -> Result<()> {
         let table_schema: TableSchemaRef = self.table_info.schema();
         // If there is a `ParquetFilesPart`, we should create pruner for it.
-        // `ParquetFilesPart`s are always staying at the end of `parts`.
-        let has_files_part = matches!(
-            plan.parts
-                .partitions
-                .last()
-                .map(|p| p.as_any().downcast_ref::<ParquetPart>().unwrap()),
-            Some(ParquetPart::ParquetFiles(_)),
-        );
+        // Although `ParquetFilesPart`s are always staying at the end of `parts` when `do_read_partitions`,
+        // but parts are reshuffled when `redistribute_source_fragment`, so let us check all of them.
+        let has_files_part = plan.parts.partitions.iter().any(|p| {
+            matches!(
+                p.as_any().downcast_ref::<ParquetPart>().unwrap(),
+                ParquetPart::ParquetFiles(_)
+            )
+        });
         let pruner = if has_files_part {
             Some(ParquetRSPruner::try_create(
                 ctx.get_function_context()?,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Although `ParquetFilesPart`s are always staying at the end of `parts` when `do_read_partitions`,
but parts are reshuffled when `redistribute_source_fragment`, so let us check all of them.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15360)
<!-- Reviewable:end -->
