### PR TITLE
fix(query): show processlit host is null in HTTPQuery

### DIFF
--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -256,6 +256,10 @@ impl<E> HTTPSessionEndpoint<E> {
             .get(TRACE_PARENT)
             .map(|id| id.to_str().unwrap().to_string());
         let baggage = extract_baggage_from_headers(req.headers());
+        let client_host = match req.remote_addr().0 {
+            Addr::SocketAddr(addr) => Some(addr),
+            _ => None,
+        };
         Ok(HttpQueryContext::new(
             session,
             query_id,
@@ -266,6 +270,7 @@ impl<E> HTTPSessionEndpoint<E> {
             baggage,
             req.method().to_string(),
             req.uri().to_string(),
+            client_host,
         ))
     }
 }

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -406,6 +406,9 @@ impl HttpQuery {
         let deduplicate_label = &ctx.deduplicate_label;
         let user_agent = &ctx.user_agent;
         let query_id = ctx.query_id.clone();
+
+        session.set_client_host(ctx.client_host);
+
         let http_ctx = ctx;
         let ctx = session.create_query_context().await?;
 

--- a/src/query/service/src/servers/http/v1/query/http_query_context.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_context.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use http::StatusCode;
@@ -35,6 +36,7 @@ pub struct HttpQueryContext {
     pub opentelemetry_baggage: Option<Vec<(String, String)>>,
     pub http_method: String,
     pub uri: String,
+    pub client_host: Option<SocketAddr>,
 }
 
 impl HttpQueryContext {
@@ -48,6 +50,7 @@ impl HttpQueryContext {
         open_telemetry_baggage: Option<Vec<(String, String)>>,
         http_method: String,
         uri: String,
+        client_host: Option<SocketAddr>,
     ) -> Self {
         HttpQueryContext {
             session,
@@ -59,6 +62,7 @@ impl HttpQueryContext {
             opentelemetry_baggage: open_telemetry_baggage,
             http_method,
             uri,
+            client_host,
         }
     }
 

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -179,6 +179,10 @@ impl Session {
         self.session_ctx.set_io_shutdown_tx(io_shutdown);
     }
 
+    pub fn set_client_host(self: &Arc<Self>, host: Option<SocketAddr>) {
+        self.session_ctx.set_client_host(host);
+    }
+
     pub fn set_current_database(self: &Arc<Self>, database_name: String) {
         self.session_ctx.set_current_database(database_name);
     }

--- a/tests/sqllogictests/suites/base/06_show/06_0013_show_processlist.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0013_show_processlist.test
@@ -7,5 +7,11 @@ SHOW PROCESSLIST LIKE 't%' LIMIT 2
 statement ok
 SHOW PROCESSLIST WHERE database='default' LIMIT 2
 
+onlyif http
+query T
+select get(split(host, ':'), 1) from system.processes where type='HTTPQuery' limit 1;
+----
+127.0.0.1
+
 statement error
 SHOW PROCESSLIST WHERE tt='default' LIMIT 2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix show processlit host is null in HTTPQuery.

In HTTP auth , init the client addr.

- Fixes #15359

## Tests


- [x] Logic Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15363)
<!-- Reviewable:end -->
