### PR TITLE
refactor: move DirName to separate file; add peek() to KeyParser

### DIFF
--- a/src/meta/kvapi/src/kvapi/dir_name.rs
+++ b/src/meta/kvapi/src/kvapi/dir_name.rs
@@ -1,0 +1,160 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::kvapi;
+use crate::kvapi::Key;
+use crate::kvapi::KeyCodec;
+use crate::kvapi::KeyError;
+
+/// The dir name of a key.
+///
+/// For example, the dir name of a key `a/b/c` is `a/b`.
+///
+/// Note that the dir name of `a` is still `a`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DirName<K> {
+    key: K,
+    level: usize,
+}
+
+impl<K> DirName<K> {
+    pub fn new(key: K) -> Self {
+        DirName { key, level: 1 }
+    }
+
+    pub fn new_with_level(key: K, level: usize) -> Self {
+        DirName { key, level }
+    }
+
+    pub fn with_level(&mut self, level: usize) -> &mut Self {
+        self.level = level;
+        self
+    }
+
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    pub fn into_key(self) -> K {
+        self.key
+    }
+}
+
+impl<K> DirName<K>
+where K: kvapi::Key
+{
+    /// Return a string with a suffix slash "/"
+    pub fn dir_name_with_slash(&self) -> String {
+        let prefix = self.to_string_key();
+        format!("{}/", prefix)
+    }
+}
+
+impl<K: Key> KeyCodec for DirName<K> {
+    /// DirName can not be encoded as a key directly
+    fn encode_key(&self, _b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+        unimplemented!()
+    }
+
+    /// DirName can not be encoded as a key directly
+    fn decode_key(_p: &mut kvapi::KeyParser) -> Result<Self, KeyError> {
+        unimplemented!()
+    }
+}
+
+impl<K: Key> Key for DirName<K> {
+    const PREFIX: &'static str = K::PREFIX;
+    type ValueType = K::ValueType;
+
+    fn parent(&self) -> Option<String> {
+        unimplemented!("DirName is not a record thus it has no parent")
+    }
+
+    fn to_string_key(&self) -> String {
+        let k = self.key.to_string_key();
+        k.rsplitn(self.level + 1, '/').last().unwrap().to_string()
+    }
+
+    fn from_str_key(s: &str) -> Result<Self, KeyError> {
+        let k = K::from_str_key(s)?;
+        let d = DirName::new_with_level(k, 0);
+        Ok(d)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::kvapi::dir_name::DirName;
+    use crate::kvapi::testing::FooKey;
+    use crate::kvapi::Key;
+
+    #[test]
+    fn test_dir_name_from_key() {
+        let d = DirName::<FooKey>::from_str_key("pref/9/x/8").unwrap();
+        assert_eq!(
+            FooKey {
+                a: 9,
+                b: "x".to_string(),
+                c: 8,
+            },
+            d.into_key()
+        );
+    }
+
+    #[test]
+    fn test_dir_name() {
+        let k = FooKey {
+            a: 1,
+            b: "b".to_string(),
+            c: 2,
+        };
+
+        let dir = DirName::new(k);
+        assert_eq!("pref/1/b", dir.to_string_key());
+
+        let dir = DirName::new(dir);
+        assert_eq!("pref/1", dir.to_string_key());
+
+        let dir = DirName::new(dir);
+        assert_eq!("pref", dir.to_string_key());
+
+        let dir = DirName::new(dir);
+        assert_eq!("pref", dir.to_string_key(), "root dir should be the same");
+    }
+
+    #[test]
+    fn test_dir_name_with_level() {
+        let k = FooKey {
+            a: 1,
+            b: "b".to_string(),
+            c: 2,
+        };
+
+        let mut dir = DirName::new(k);
+        assert_eq!("pref/1/b", dir.to_string_key());
+
+        dir.with_level(0);
+        assert_eq!("pref/1/b/2", dir.to_string_key());
+
+        dir.with_level(2);
+        assert_eq!("pref/1", dir.to_string_key());
+
+        dir.with_level(3);
+        assert_eq!("pref", dir.to_string_key());
+
+        dir.with_level(4);
+        assert_eq!("pref", dir.to_string_key(), "root dir should be the same");
+    }
+}

--- a/src/meta/kvapi/src/kvapi/key_parser.rs
+++ b/src/meta/kvapi/src/kvapi/key_parser.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::iter::Peekable;
 use std::str::Split;
 use std::string::FromUtf8Error;
 
@@ -29,7 +30,7 @@ pub struct KeyParser<'s> {
     i: usize,
     /// The index of char for the next return.
     index: usize,
-    elements: Split<'s, char>,
+    elements: Peekable<Split<'s, char>>,
 }
 
 impl<'s> KeyParser<'s> {
@@ -39,20 +40,19 @@ impl<'s> KeyParser<'s> {
             str_key: source,
             i: 0,
             index: 0,
-            elements: source.split('/'),
+            elements: source.split('/').peekable(),
         }
     }
 
     /// Similar to `new()` but expect the specified prefix as the first part.
     pub fn new_prefixed(source: &'s str, prefix: &str) -> Result<Self, KeyError> {
-        let mut s = Self {
-            str_key: source,
-            i: 0,
-            index: 0,
-            elements: source.split('/'),
-        };
+        let mut s = Self::new(source);
         s.next_literal(prefix)?;
         Ok(s)
+    }
+
+    pub fn source(&self) -> &str {
+        self.str_key
     }
 
     /// Get the index of the last returned element.
@@ -60,6 +60,27 @@ impl<'s> KeyParser<'s> {
     /// If no element is returned, it will panic.
     pub fn index(&self) -> usize {
         self.i - 1
+    }
+
+    /// Peek the next element in raw `&str` and expect it to be `expect`, without unescaping or decoding.
+    pub fn peek_literal(&mut self, expect: &str) -> Result<(), KeyError> {
+        let next = self
+            .elements
+            .peek()
+            .ok_or_else(|| KeyError::WrongNumberOfSegments {
+                expect: self.i,
+                got: self.str_key.to_string(),
+            })?;
+
+        if *next != expect {
+            return Err(KeyError::InvalidSegment {
+                i: self.i,
+                expect: expect.to_string(),
+                got: next.to_string(),
+            });
+        }
+
+        Ok(())
     }
 
     /// Pop the next element in raw `&str`, without unescaping or decoding.
@@ -288,6 +309,21 @@ mod tests {
         assert!(kp.next_literal("bar%20-").is_ok());
         assert!(kp.next_literal("123").is_ok());
         assert!(kp.done().is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_key_parser_peek_literal() -> anyhow::Result<()> {
+        let s = "_foo/bar%20-/123";
+
+        let mut kp = KeyParser::new(s);
+        assert!(kp.peek_literal("_foo").is_ok());
+        assert_eq!(
+            kp.peek_literal("bar").unwrap_err().to_string(),
+            "Expect 0-th segment to be 'bar', but: '_foo'"
+        );
+        assert!(kp.next_literal("_foo").is_ok());
 
         Ok(())
     }

--- a/src/meta/kvapi/src/kvapi/mod.rs
+++ b/src/meta/kvapi/src/kvapi/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod api;
+mod dir_name;
 mod helper;
 mod item;
 mod key;
@@ -25,13 +26,15 @@ mod test_suite;
 mod value;
 mod value_with_name;
 
+pub(crate) mod testing;
+
 pub use api::ApiBuilder;
 pub use api::AsKVApi;
 pub use api::KVApi;
 pub use api::KVStream;
+pub use dir_name::DirName;
 pub use item::Item;
 pub use item::NonEmptyItem;
-pub use key::DirName;
 pub use key::Key;
 pub use key::KeyError;
 pub use key_builder::KeyBuilder;

--- a/src/meta/kvapi/src/kvapi/testing.rs
+++ b/src/meta/kvapi/src/kvapi/testing.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::convert::Infallible;
 
 use crate::kvapi;

--- a/src/meta/kvapi/src/kvapi/testing.rs
+++ b/src/meta/kvapi/src/kvapi/testing.rs
@@ -1,0 +1,38 @@
+use std::convert::Infallible;
+
+use crate::kvapi;
+use crate::kvapi::Key;
+use crate::kvapi::KeyCodec;
+use crate::kvapi::KeyError;
+use crate::kvapi::KeyParser;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FooKey {
+    pub(crate) a: u64,
+    pub(crate) b: String,
+    pub(crate) c: u64,
+}
+
+impl KeyCodec for FooKey {
+    fn encode_key(&self, b: kvapi::KeyBuilder) -> kvapi::KeyBuilder {
+        b.push_u64(self.a).push_str(&self.b).push_u64(self.c)
+    }
+
+    fn decode_key(parser: &mut KeyParser) -> Result<Self, KeyError>
+    where Self: Sized {
+        let a = parser.next_u64()?;
+        let b = parser.next_str()?;
+        let c = parser.next_u64()?;
+
+        Ok(FooKey { a, b, c })
+    }
+}
+
+impl Key for FooKey {
+    const PREFIX: &'static str = "pref";
+    type ValueType = Infallible;
+
+    fn parent(&self) -> Option<String> {
+        None
+    }
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: move DirName to separate file; add peek() to KeyParser

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15365)
<!-- Reviewable:end -->
