### PR TITLE
refactor: session_ctx.client_ip refactor to Option<String>

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -17,7 +17,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Display;
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -77,7 +76,7 @@ pub struct ProcessInfo {
     pub database: String,
     pub user: Option<UserInfo>,
     pub settings: Arc<Settings>,
-    pub client_address: Option<SocketAddr>,
+    pub client_address: Option<String>,
     pub session_extra_info: Option<String>,
     pub memory_usage: i64,
     /// storage metrics for persisted data reading.

--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -129,7 +129,7 @@ impl InterpreterQueryLog {
 
         // Client.
         let client_address = match ctx.get_client_address() {
-            Some(addr) => format!("{:?}", addr),
+            Some(addr) => addr,
             None => "".to_string(),
         };
         let user_agent = ctx.get_ua();
@@ -286,7 +286,7 @@ impl InterpreterQueryLog {
 
         // Client.
         let client_address = match ctx.get_client_address() {
-            Some(addr) => format!("{:?}", addr),
+            Some(addr) => addr,
             None => "".to_string(),
         };
         let user_agent = ctx.get_ua();

--- a/src/query/service/src/servers/admin/v1/queries_queue.rs
+++ b/src/query/service/src/servers/admin/v1/queries_queue.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashSet;
-use std::net::SocketAddr;
 use std::time::Duration;
 
 use databend_common_meta_app::principal::UserInfo;
@@ -78,7 +77,7 @@ fn user_identity(user: &Option<UserInfo>) -> String {
         .unwrap_or("".to_string())
 }
 
-fn client_address(address: &Option<SocketAddr>) -> String {
+fn client_address(address: &Option<String>) -> String {
     address
         .as_ref()
         .map(|addr| addr.to_string())

--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -256,10 +256,7 @@ impl<E> HTTPSessionEndpoint<E> {
             .get(TRACE_PARENT)
             .map(|id| id.to_str().unwrap().to_string());
         let baggage = extract_baggage_from_headers(req.headers());
-        let client_host = match req.remote_addr().0 {
-            Addr::SocketAddr(addr) => Some(addr),
-            _ => None,
-        };
+        let client_host = get_client_ip(req);
         Ok(HttpQueryContext::new(
             session,
             query_id,

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -407,7 +407,7 @@ impl HttpQuery {
         let user_agent = &ctx.user_agent;
         let query_id = ctx.query_id.clone();
 
-        session.set_client_host(ctx.client_host);
+        session.set_client_host(ctx.client_host.clone());
 
         let http_ctx = ctx;
         let ctx = session.create_query_context().await?;

--- a/src/query/service/src/servers/http/v1/query/http_query_context.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_context.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use http::StatusCode;
@@ -36,7 +35,7 @@ pub struct HttpQueryContext {
     pub opentelemetry_baggage: Option<Vec<(String, String)>>,
     pub http_method: String,
     pub uri: String,
-    pub client_host: Option<SocketAddr>,
+    pub client_host: Option<String>,
 }
 
 impl HttpQueryContext {
@@ -50,7 +49,7 @@ impl HttpQueryContext {
         open_telemetry_baggage: Option<Vec<(String, String)>>,
         http_method: String,
         uri: String,
-        client_host: Option<SocketAddr>,
+        client_host: Option<String>,
     ) -> Self {
         HttpQueryContext {
             session,

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::future::Future;
-use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -252,7 +251,7 @@ impl QueryContext {
     }
 
     /// Get the client socket address.
-    pub fn get_client_address(&self) -> Option<SocketAddr> {
+    pub fn get_client_address(&self) -> Option<String> {
         self.shared.session.session_ctx.get_client_host()
     }
 

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -175,12 +175,8 @@ impl Session {
 
     pub fn attach<F>(self: &Arc<Self>, host: Option<SocketAddr>, io_shutdown: F)
     where F: FnOnce() + Send + Sync + 'static {
-        let ip = if let Some(host) = host {
-            Some(host.ip().to_string())
-        } else {
-            None
-        };
-        self.session_ctx.set_client_host(ip);
+        self.session_ctx
+            .set_client_host(host.map(|host| host.ip().to_string()));
         self.session_ctx.set_io_shutdown_tx(io_shutdown);
     }
 

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -175,11 +175,16 @@ impl Session {
 
     pub fn attach<F>(self: &Arc<Self>, host: Option<SocketAddr>, io_shutdown: F)
     where F: FnOnce() + Send + Sync + 'static {
-        self.session_ctx.set_client_host(host);
+        let ip = if let Some(host) = host {
+            Some(host.ip().to_string())
+        } else {
+            None
+        };
+        self.session_ctx.set_client_host(ip);
         self.session_ctx.set_io_shutdown_tx(io_shutdown);
     }
 
-    pub fn set_client_host(self: &Arc<Self>, host: Option<SocketAddr>) {
+    pub fn set_client_host(self: &Arc<Self>, host: Option<String>) {
         self.session_ctx.set_client_host(host);
     }
 

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashSet;
-use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -60,7 +59,7 @@ pub struct SessionContext {
     // 2. The role is intentionally restricted by the sql client, to run SQLs with a restricted privileges.
     secondary_roles: RwLock<Option<Vec<String>>>,
     // The client IP from the client.
-    client_host: RwLock<Option<SocketAddr>>,
+    client_host: RwLock<Option<String>>,
     io_shutdown_tx: RwLock<Option<Box<dyn FnOnce() + Send + Sync + 'static>>>,
     query_context_shared: RwLock<Weak<QueryContextShared>>,
     // We store `query_id -> query_result_cache_key` to session context, so that we can fetch
@@ -200,12 +199,12 @@ impl SessionContext {
         *lock = secondary_roles;
     }
 
-    pub fn get_client_host(&self) -> Option<SocketAddr> {
+    pub fn get_client_host(&self) -> Option<String> {
         let lock = self.client_host.read();
-        *lock
+        *lock.clone()
     }
 
-    pub fn set_client_host(&self, sock: Option<SocketAddr>) {
+    pub fn set_client_host(&self, sock: Option<String>) {
         let mut lock = self.client_host.write();
         *lock = sock
     }

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -201,7 +201,7 @@ impl SessionContext {
 
     pub fn get_client_host(&self) -> Option<String> {
         let lock = self.client_host.read();
-        *lock.clone()
+        lock.clone()
     }
 
     pub fn set_client_host(&self, sock: Option<String>) {

--- a/src/query/service/tests/it/sessions/session_context.rs
+++ b/src/query/service/tests/it/sessions/session_context.rs
@@ -12,8 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::net::SocketAddr;
-
 use databend_common_base::base::tokio;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::UserInfo;
@@ -47,7 +45,7 @@ async fn test_session_context() -> Result<()> {
         session_ctx.set_client_host(Some(demo.to_string()));
 
         let val = session_ctx.get_client_host();
-        assert_eq!(Some(demo), val);
+        assert_eq!(Some(demo), val.as_deref());
     }
 
     // Current user.

--- a/src/query/service/tests/it/sessions/session_context.rs
+++ b/src/query/service/tests/it/sessions/session_context.rs
@@ -43,12 +43,11 @@ async fn test_session_context() -> Result<()> {
 
     // Client host.
     {
-        let demo = "127.0.0.1:80";
-        let server: SocketAddr = demo.parse().unwrap();
-        session_ctx.set_client_host(Some(server));
+        let demo = "127.0.0.1";
+        session_ctx.set_client_host(Some(demo.to_string()));
 
         let val = session_ctx.get_client_host();
-        assert_eq!(Some(server), val);
+        assert_eq!(Some(demo), val);
     }
 
     // Current user.

--- a/src/query/storages/system/src/processes_table.rs
+++ b/src/query/storages/system/src/processes_table.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -86,7 +85,7 @@ impl SyncSystemTable for ProcessesTable {
             processes_type.push(process_info.typ.clone());
             processes_state.push(process_info.state.to_string());
             processes_database.push(process_info.database.clone());
-            processes_host.push(ProcessesTable::process_host(&process_info.client_address));
+            processes_host.push(process_info.client_address.clone());
             processes_user
                 .push(ProcessesTable::process_option_value(process_info.user.clone()).name);
             processes_extra_info.push(ProcessesTable::process_option_value(
@@ -184,10 +183,6 @@ impl ProcessesTable {
         };
 
         SyncOneBlockSystemTable::create(ProcessesTable { table_info })
-    }
-
-    fn process_host(client_address: &Option<SocketAddr>) -> Option<String> {
-        client_address.as_ref().map(|s| s.to_string())
     }
 
     fn process_option_value<T>(opt: Option<T>) -> T

--- a/src/query/storages/system/src/queries_queue.rs
+++ b/src/query/storages/system/src/queries_queue.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -72,7 +71,7 @@ impl SyncSystemTable for QueriesQueueTable {
             nodes.push(local_node.clone());
             processes_id.push(process_info.id.clone());
             processes_type.push(process_info.typ.clone());
-            processes_host.push(Self::process_host(&process_info.client_address));
+            processes_host.push(process_info.client_address.clone());
             processes_user.push(Self::process_option_value(process_info.user.clone()).name);
             processes_mysql_connection_id.push(process_info.mysql_connection_id);
             processes_time.push(time);
@@ -122,10 +121,6 @@ impl QueriesQueueTable {
         };
 
         SyncOneBlockSystemTable::create(QueriesQueueTable { table_info })
-    }
-
-    fn process_host(client_address: &Option<SocketAddr>) -> Option<String> {
-        client_address.as_ref().map(|s| s.to_string())
     }
 
     fn process_option_value<T>(opt: Option<T>) -> T

--- a/tests/sqllogictests/suites/base/06_show/06_0013_show_processlist.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0013_show_processlist.test
@@ -9,7 +9,7 @@ SHOW PROCESSLIST WHERE database='default' LIMIT 2
 
 onlyif http
 query T
-select get(split(host, ':'), 1) from system.processes where type='HTTPQuery' limit 1;
+select host from system.processes where type='HTTPQuery' limit 1;
 ----
 127.0.0.1
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

session_ctx.client_ip refactor to Option<String>

Old version client_ip: Option<SocketAddr>

This appears to be CK-compatible behavior. But the port should be meaningless information.

- Fixes #15367

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15368)
<!-- Reviewable:end -->
