### PR TITLE
fix: when listing-kv, limit the right bound if possible

### DIFF
--- a/src/meta/raft-store/src/lib.rs
+++ b/src/meta/raft-store/src/lib.rs
@@ -28,3 +28,4 @@ pub mod ondisk;
 pub mod sm_v002;
 pub mod state;
 pub mod state_machine;
+pub mod utils;

--- a/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/level.rs
@@ -112,7 +112,7 @@ impl MapApiRO<String> for Level {
 
         if vec.len() > 1000 {
             warn!(
-                "Level::<ExpireKey>::range() returns big range of len={}",
+                "Level::<String>::range() returns big range of len={}",
                 vec.len()
             );
         }

--- a/src/meta/raft-store/src/utils.rs
+++ b/src/meta/raft-store/src/utils.rs
@@ -1,0 +1,40 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Return the right bound of the prefix, so that `p..right` will cover all strings with prefix `p`.
+pub fn prefix_right_bound(p: &str) -> Option<String> {
+    let last = p.chars().last()?;
+    let mut next_str = p[..p.len() - last.len_utf8()].to_owned();
+    let next_char = char::from_u32(last as u32 + 1)?;
+    next_str.push(next_char);
+    Some(next_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prefix_right_bound;
+
+    #[test]
+    fn test_next_string() {
+        assert_eq!(None, prefix_right_bound(""));
+        assert_eq!(Some(s("b")), prefix_right_bound("a"));
+        assert_eq!(Some(s("{")), prefix_right_bound("z"));
+        assert_eq!(Some(s("foo0")), prefix_right_bound("foo/"));
+        assert_eq!(Some(s("foo💰")), prefix_right_bound("foo💯"));
+    }
+
+    fn s(s: impl ToString) -> String {
+        s.to_string()
+    }
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: when listing-kv, limit the right bound if possible

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15372)
<!-- Reviewable:end -->
