### PR TITLE
chore: adjust row count assertion in table compaction

### DIFF
--- a/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
@@ -110,10 +110,10 @@ impl SnapshotGenerator for MutationGenerator {
 
                     if matches!(self.mutation_kind, MutationKind::Compact) {
                         // for compaction, a basic but very important verification:
-                        // the number of rows should not be changed
+                        // the number of rows should be the same
                         assert_eq!(
-                            new_snapshot.summary.row_count,
-                            self.base_snapshot.summary.row_count
+                            ctx.merged_statistics.row_count,
+                            ctx.removed_statistics.row_count
                         );
                     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Correct the assertion to check that the row count remains unchanged during table compaction, instead of comparing it(new snapshot) to the pre-compaction snapshot. This change accounts for scenarios where the new snapshot results from a combination of compaction and insertion, potentially increasing the total number of rows.


- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - only a defensive runtime assertion changed

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): only a defensive runtime assertion changed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15380)
<!-- Reviewable:end -->
