### PR TITLE
refactor: dispatch load to 16 threads when installing snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,11 +3614,13 @@ dependencies = [
  "futures-async-stream",
  "futures-util",
  "hostname",
+ "itertools 0.10.5",
  "log",
  "maplit",
  "minitrace",
  "num",
  "openraft",
+ "ordq",
  "pretty_assertions",
  "semver",
  "serde",
@@ -10347,6 +10349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordq"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e535e05b861598cac4abfbe696573e5b0ae72ca55f4c55ec02a3dd22cef2faa"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+]
+
+[[package]]
 name = "os_info"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13940,18 +13952,18 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,6 @@ byteorder = "1.4.3"
 chrono = { version = "0.4.31", features = ["serde"] }
 chrono-tz = { version = "0.8", features = ["serde"] }
 clap = { version = "4.4.2", features = ["derive"] }
-dashmap = "5.4.0"
 derive_more = "0.99.17"
 enumflags2 = { version = "0.7.7", features = ["serde"] }
 ethnum = { git = "https://github.com/ariesdevil/ethnum-rs", rev = "4cb05f1" }
@@ -157,9 +156,7 @@ match-template = "0.0.1"
 metrics = "0.20.1"
 minitrace = { version = "0.6", features = ["enable"] }
 mysql_async = { version = "0.33", default-features = false, features = ["rustls-tls"] }
-once_cell = "1.15.0"
 ordered-float = { version = "4.1.0", default-features = false }
-parking_lot = "0.12.1"
 poem = { version = "~1.3.57", features = ["rustls", "multipart", "compression"] }
 prometheus-client = "0.22"
 rand = { version = "0.8.5", features = ["small_rng"] }
@@ -181,6 +178,12 @@ typetag = "0.2.3"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 walkdir = "2.3.2"
 derive-visitor = "0.3.0"
+
+# Synchronization
+dashmap = "5.4.0"
+once_cell = "1.15.0"
+ordq = "0.2.0"
+parking_lot = "0.12.1"
 
 # Future and async
 futures = "0.3.24"

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -37,10 +37,12 @@ futures = { workspace = true }
 futures-async-stream = { workspace = true }
 futures-util = { workspace = true }
 hostname = "0.3.1"
+itertools = { workspace = true }
 log = { workspace = true }
 maplit = "1.0.2"
 minitrace = { workspace = true }
 num = "0.4.0"
+ordq = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: dispatch load to 16 threads when installing snapshot

To reduce delay caused by installing snapshot on startup.
The major work load is deserializing data, and this part of job is
dispatched into 16 threads in this commit.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15381)
<!-- Reviewable:end -->
