### PR TITLE
refactor: get_table_by_id() returns an `Option<Seqv<TableMeta>>`

### DIFF
--- a/src/common/hashtable/src/traits.rs
+++ b/src/common/hashtable/src/traits.rs
@@ -556,7 +556,7 @@ pub trait HashJoinHashtableLike {
     /// 3. `vec_ptr` is RowPtr Array, we use this one to record the matched row in chunks
     /// 4. `occupied` is the length for vec_ptr
     /// 5. `capacity` is the capacity of vec_ptr
-    /// 6. return macthed rows count and next ptr which need to test in the future.
+    /// 6. return matched rows count and next ptr which need to test in the future.
     /// if the capacity is enough, the next ptr is zero, otherwise next ptr is valid.
     fn next_probe(
         &self,

--- a/src/common/hashtable/src/utils.rs
+++ b/src/common/hashtable/src/utils.rs
@@ -214,7 +214,7 @@ pub mod sse {
 // potentially leading to the target table being unsuitable for use as a build table in the future.
 //      2. Requires a significant amount of memory to be efficient and currently does not support spill operations.
 // for now we just support sql like below:
-// `merge into t using source on xxx when matched then update xxx when not macthed then insert xxx.
+// `merge into t using source on xxx when matched then update xxx when not matched then insert xxx.
 // for merge into:
 // we use MergeIntoBlockInfoIndex to maintain an index for the block info in chunks.
 
@@ -331,7 +331,7 @@ impl MergeIntoBlockInfoIndex {
             let left = self.search_idx(start as u32);
             let right = self.search_idx((end - 1) as u32);
             if left == right {
-                // macthed only one block.
+                // matched only one block.
                 if self.intervals[left].0 == (start as u32)
                     && self.intervals[right].1 == (end - 1) as u32
                 {

--- a/src/common/metrics/src/metrics/storage.rs
+++ b/src/common/metrics/src/metrics/storage.rs
@@ -416,12 +416,12 @@ pub fn metrics_inc_merge_into_split_milliseconds(c: u64) {
     MERGE_INTO_SPLIT_MILLISECONDS.observe(c as f64);
 }
 
-// after merge_source_split, record the time of not macthed clauses (processor_merge_into_not_matched)
+// after merge_source_split, record the time of not matched clauses (processor_merge_into_not_matched)
 pub fn merge_into_not_matched_operation_milliseconds(c: u64) {
     MERGE_INTO_NOT_MATCHED_OPERATION_MILLISECONDS.observe(c as f64);
 }
 
-// after merge_source_split, record the time of macthed clauses (processor_merge_into_matched_and_split)
+// after merge_source_split, record the time of matched clauses (processor_merge_into_matched_and_split)
 pub fn merge_into_matched_operation_milliseconds(c: u64) {
     MERGE_INTO_MATCHED_OPERATION_MILLISECONDS.observe(c as f64);
 }

--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -76,7 +76,6 @@ use databend_common_meta_app::schema::SetLVTReply;
 use databend_common_meta_app::schema::SetLVTReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
-use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -96,7 +95,9 @@ use databend_common_meta_app::schema::UpdateVirtualColumnReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
+use databend_common_meta_types::MetaError;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::SeqV;
 
 use crate::kv_app_error::KVAppError;
 
@@ -203,10 +204,11 @@ pub trait SchemaApi: Send + Sync {
 
     async fn list_tables(&self, req: ListTableReq) -> Result<Vec<Arc<TableInfo>>, KVAppError>;
 
-    async fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-    ) -> Result<(TableIdent, Arc<TableMeta>), KVAppError>;
+    /// Return TableMeta by table_id.
+    ///
+    /// It returns None instead of KVAppError, if table_id does not exist
+    async fn get_table_by_id(&self, table_id: MetaId)
+    -> Result<Option<SeqV<TableMeta>>, MetaError>;
 
     async fn mget_table_names_by_ids(
         &self,

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -226,6 +226,7 @@ use crate::get_share_table_info;
 use crate::get_u64_value;
 use crate::is_db_need_to_be_remove;
 use crate::kv_app_error::KVAppError;
+use crate::kv_pb_api::KVPbApi;
 use crate::list_keys;
 use crate::list_u64_value;
 use crate::remove_db_from_share;
@@ -2235,25 +2236,13 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
     async fn get_table_by_id(
         &self,
         table_id: MetaId,
-    ) -> Result<(TableIdent, Arc<TableMeta>), KVAppError> {
+    ) -> Result<Option<SeqV<TableMeta>>, MetaError> {
         debug!(req :? =(&table_id); "SchemaApi: {}", func_name!());
 
-        let tbid = TableId { table_id };
+        let id = TableId { table_id };
 
-        let (tb_meta_seq, table_meta): (_, Option<TableMeta>) = get_pb_value(self, &tbid).await?;
-
-        debug!(ident :% =(&tbid); "get_table_by_id");
-
-        if tb_meta_seq == 0 || table_meta.is_none() {
-            return Err(KVAppError::AppError(AppError::UnknownTableId(
-                UnknownTableId::new(table_id, "get_table_by_id"),
-            )));
-        }
-
-        Ok((
-            TableIdent::new(table_id, tb_meta_seq),
-            Arc::new(table_meta.unwrap()),
-        ))
+        let seq_table_meta = self.get_pb(&id).await?;
+        Ok(seq_table_meta)
     }
 
     #[logcall::logcall("debug")]

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -5029,10 +5029,9 @@ impl SchemaApiTestSuite {
                     .await
                     .unwrap();
 
-                let (table_id, table_meta) = mt.get_table_by_id(table.ident.table_id).await?;
-
+                let seqv = mt.get_table_by_id(table.ident.table_id).await?.unwrap();
+                let table_meta = seqv.data;
                 assert_eq!(table_meta.options.get("opt‐1"), Some(&"val-1".into()));
-                assert_eq!(table_id.table_id, table.ident.table_id);
             }
 
             info!("--- get_table_by_id with not exists table_id");
@@ -5910,7 +5909,8 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- check table index");
-            let (_, table_meta) = mt.get_table_by_id(table_id).await?;
+            let seqv = mt.get_table_by_id(table_id).await?.unwrap();
+            let table_meta = seqv.data;
             assert_eq!(table_meta.indexes.len(), 2);
 
             let index1 = table_meta.indexes.get(&index_name_1);
@@ -5953,7 +5953,8 @@ impl SchemaApiTestSuite {
 
         {
             info!("--- check table index after drop");
-            let (_, table_meta) = mt.get_table_by_id(table_id).await?;
+            let seqv = mt.get_table_by_id(table_id).await?.unwrap();
+            let table_meta = seqv.data;
             assert_eq!(table_meta.indexes.len(), 1);
 
             let index1 = table_meta.indexes.get(&index_name_1);

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -5036,12 +5036,9 @@ impl SchemaApiTestSuite {
 
             info!("--- get_table_by_id with not exists table_id");
             {
-                let got = mt.get_table_by_id(1024).await;
+                let got = mt.get_table_by_id(1024).await?;
 
-                let err = got.unwrap_err();
-                let err = ErrorCode::from(err);
-
-                assert_eq!(ErrorCode::UNKNOWN_TABLE_ID, err.code());
+                assert!(got.is_none());
             }
         }
         Ok(())

--- a/src/meta/raft-store/tests/it/state_machine/mod.rs
+++ b/src/meta/raft-store/tests/it/state_machine/mod.rs
@@ -236,7 +236,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
             "wow",
             MatchSeq::GE(0),
             "y",
-            Some(1000),
+            Some(5_000),
             None,
             Some((6, "y")),
             now_ms,

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -73,7 +73,6 @@ use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
-use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -95,6 +94,7 @@ use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::SeqV;
 use dyn_clone::DynClone;
 
 use crate::database::Database;
@@ -195,8 +195,8 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     // Build a `Arc<dyn Table>` from `TableInfo`.
     fn get_table_by_info(&self, table_info: &TableInfo) -> Result<Arc<dyn Table>>;
 
-    // Get the table meta by meta id.
-    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)>;
+    /// Get the table meta by table id.
+    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<Option<SeqV<TableMeta>>>;
 
     // Get the table name by meta id.
     async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String>;

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -28,6 +28,7 @@ use databend_common_expression::TableSchema;
 use databend_common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
 use databend_common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
 use databend_common_io::constants::DEFAULT_BLOCK_MIN_ROWS;
+use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::UpdateStreamMetaReq;
 use databend_common_meta_app::schema::UpsertTableCopiedFileReq;
@@ -414,10 +415,15 @@ pub trait TableExt: Table {
         let table_info = self.get_table_info();
         let tid = table_info.ident.table_id;
         let catalog = ctx.get_catalog(table_info.catalog()).await?;
-        let (ident, meta) = catalog.get_table_meta_by_id(tid).await?;
+
+        let seqv = catalog.get_table_meta_by_id(tid).await?.ok_or_else(|| {
+            let err = UnknownTableId::new(tid, "TableExt::refresh");
+            AppError::from(err)
+        })?;
+
         let table_info = TableInfo {
-            ident,
-            meta: meta.as_ref().clone(),
+            ident: TableIdent::new(tid, seqv.seq),
+            meta: seqv.data,
             ..table_info.clone()
         };
         catalog.get_table_by_info(&table_info)
@@ -514,6 +520,9 @@ pub struct NavigationDescriptor {
 }
 
 use std::collections::HashMap;
+
+use databend_common_meta_app::app_error::AppError;
+use databend_common_meta_app::app_error::UnknownTableId;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default)]
 pub struct ParquetTableColumnStatisticsProvider {

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -80,7 +80,6 @@ use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
-use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -103,6 +102,7 @@ use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::SeqV;
 use log::info;
 
 use crate::catalogs::default::ImmutableCatalog;
@@ -261,7 +261,7 @@ impl Catalog for DatabaseCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)> {
+    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<Option<SeqV<TableMeta>>> {
         let res = self.immutable_catalog.get_table_meta_by_id(table_id).await;
 
         if let Ok(x) = res {

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -85,7 +85,6 @@ use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
-use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -109,6 +108,7 @@ use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_store::MetaStoreProvider;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::SeqV;
 use log::info;
 use minitrace::func_name;
 
@@ -366,7 +366,7 @@ impl Catalog for MutableCatalog {
     async fn get_table_meta_by_id(
         &self,
         table_id: MetaId,
-    ) -> databend_common_exception::Result<(TableIdent, Arc<TableMeta>)> {
+    ) -> databend_common_exception::Result<Option<SeqV<TableMeta>>> {
         let res = self.ctx.meta.get_table_by_id(table_id).await?;
         Ok(res)
     }

--- a/src/query/service/src/interpreters/common/grant.rs
+++ b/src/query/service/src/interpreters/common/grant.rs
@@ -67,7 +67,7 @@ pub async fn validate_grant_object_exists(
         GrantObject::TableById(catalog_name, db_id, table_id) => {
             let catalog = ctx.get_catalog(catalog_name).await?;
 
-            if catalog.get_table_name_by_id(*table_id).await.is_err() {
+            if catalog.get_table_meta_by_id(*table_id).await?.is_none() {
                 return Err(databend_common_exception::ErrorCode::UnknownTableId(
                     format!(
                         "table id `{}`.`{}` not exists in catalog '{}'",

--- a/src/query/service/src/interpreters/interpreter_merge_into.rs
+++ b/src/query/service/src/interpreters/interpreter_merge_into.rs
@@ -166,12 +166,12 @@ impl MergeIntoInterpreter {
         // important flag:
         //      I. change join order: if true, target table as build side, if false, source as build side.
         //      II. distributed: this merge into is executed at a distributed stargety.
-        // 2.1 Left: there are macthed and not macthed, and change join order is true.
+        // 2.1 Left: there are matched and not matched, and change join order is true.
         // 2.2 Left Anti: change join order is true, but it's insert-only.
         // 2.3 Inner: this is matched only case.
         //      2.3.1 change join order is true, target table as build side,it's matched-only.
         //      2.3.2 change join order is false, source data as build side,it's matched-only.
-        // 2.4 Right: change join order is false, there are macthed and not macthed
+        // 2.4 Right: change join order is false, there are matched and not matched
         // 2.5 Right Anti: change join order is false, but it's insert-only.
         // distributed execution stargeties:
         // I. change join order is true, we use the `optimize_distributed_query`'s result.
@@ -256,7 +256,7 @@ impl MergeIntoInterpreter {
         }
 
         // we use `merge_into_split_idx` to specify a column from target table to spilt a block
-        // from join into macthed part and unmacthed part.
+        // from join into matched part and unmatched part.
         let mut merge_into_split_idx = DUMMY_COLUMN_INDEX;
         if matches!(merge_type, MergeIntoType::FullOperation) {
             for (idx, data_field) in join_output_schema.fields().iter().enumerate() {
@@ -288,7 +288,7 @@ impl MergeIntoInterpreter {
         let table_info = fuse_table.get_table_info().clone();
         let catalog_ = self.ctx.get_catalog(catalog).await?;
 
-        // merge_into_source is used to recv join's datablocks and split them into macthed and not matched
+        // merge_into_source is used to recv join's datablocks and split them into matched and not matched
         // datablocks.
         let merge_into_source = if !*distributed && extract_exchange {
             // if we doesn't support distributed merge into, we should give the exchange merge back.

--- a/src/query/service/src/pipelines/builders/builder_merge_into.rs
+++ b/src/query/service/src/pipelines/builders/builder_merge_into.rs
@@ -171,7 +171,7 @@ impl PipelineBuilder {
             ];
             self.main_pipeline.add_pipe(Pipe::create(2, 2, pipe_items));
 
-            // not macthed operation
+            // not matched operation
             let merge_into_not_matched_processor = MergeIntoNotMatchedProcessor::create(
                 unmatched.clone(),
                 input_schema.clone(),
@@ -526,13 +526,13 @@ impl PipelineBuilder {
         // the complete pipeline(with matched and unmatched) below:
         // row_id port0_1
         // matched update data port0_2
-        // not macthed insert data port0_3
+        // not matched insert data port0_3
         // row_id port1_1
         // matched update data port1_2
-        // not macthed insert data port1_3
+        // not matched insert data port1_3
         // ......
         // 1.for matched only, there are no not matched ports
-        // 2.for unmatched only/insert only, there are no macthed update ports and row_id ports
+        // 2.for unmatched only/insert only, there are no matched update ports and row_id ports
         let mut ranges = Vec::with_capacity(self.main_pipeline.output_len());
         if !*distributed {
             // complete pipeline

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/merge_into_hash_join_optimization.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/merge_into_hash_join_optimization.rs
@@ -118,7 +118,7 @@ impl HashJoinBuildState {
     }
 
     pub(crate) fn merge_into_try_generate_matched_memory(&self) {
-        // generate macthed offsets memory.
+        // generate matched offsets memory.
         if self
             .hash_join_state
             .merge_into_need_target_partial_modified_scan()

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -102,7 +102,6 @@ use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
-use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -122,6 +121,7 @@ use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::SeqV;
 use databend_common_pipeline_core::InputError;
 use databend_common_pipeline_core::PlanProfile;
 use databend_common_settings::Settings;
@@ -188,7 +188,7 @@ impl Catalog for FakedCatalog {
         self.cat.get_table_by_info(table_info)
     }
 
-    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)> {
+    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<Option<SeqV<TableMeta>>> {
         self.cat.get_table_meta_by_id(table_id).await
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -101,7 +101,6 @@ use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
-use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -121,6 +120,7 @@ use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::SeqV;
 use databend_common_pipeline_core::InputError;
 use databend_common_pipeline_core::PlanProfile;
 use databend_common_settings::Settings;
@@ -828,7 +828,7 @@ impl Catalog for FakedCatalog {
         self.cat.get_table_by_info(table_info)
     }
 
-    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)> {
+    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<Option<SeqV<TableMeta>>> {
         self.cat.get_table_meta_by_id(table_id).await
     }
 

--- a/src/query/sql/src/planner/binder/merge_into.rs
+++ b/src/query/sql/src/planner/binder/merge_into.rs
@@ -71,7 +71,7 @@ pub enum MergeIntoType {
 // for now we think right source table is small table in default.
 // 1. insert only:
 //      right anti join
-// 2. (macthed and unmatched)
+// 2. (matched and unmatched)
 //      right outer
 // 3. matched only:
 //      inner join
@@ -721,7 +721,7 @@ fn get_merge_type(matched_len: usize, unmatched_len: usize) -> Result<MergeIntoT
         Ok(MergeIntoType::FullOperation)
     } else {
         Err(ErrorCode::SemanticError(
-            "we must have macthed or unmatched clause at least one",
+            "we must have matched or unmatched clause at least one",
         ))
     }
 }

--- a/src/query/sql/src/planner/format/display_plan.rs
+++ b/src/query/sql/src/planner/format/display_plan.rs
@@ -336,7 +336,7 @@ fn format_merge_into(merge_into: &MergeInto) -> Result<String> {
         "can_try_update_column_only: {}",
         merge_into.can_try_update_column_only
     ));
-    // add macthed clauses
+    // add matched clauses
     let mut matched_children = Vec::with_capacity(merge_into.matched_evaluators.len());
     let taregt_schema = table_entry.table().schema_with_stream();
     for evaluator in &merge_into.matched_evaluators {
@@ -371,7 +371,7 @@ fn format_merge_into(merge_into: &MergeInto) -> Result<String> {
             )));
         }
     }
-    // add unmacthed clauses
+    // add unmatched clauses
     let mut unmatched_children = Vec::with_capacity(merge_into.unmatched_evaluators.len());
     for evaluator in &merge_into.unmatched_evaluators {
         let condition_format = evaluator.condition.as_ref().map_or_else(

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -416,7 +416,7 @@ async fn optimize_merge_into(opt_ctx: OptimizerContext, plan: Box<MergeInto>) ->
     };
 
     // we just support left join to use MergeIntoBlockInfoHashTable, we
-    // don't support spill for now, and we need the macthed clauses' count
+    // don't support spill for now, and we need the matched clauses' count
     // is one, just support `merge into t using source when matched then
     // update xx when not matched then insert xx`.
     let flag = plan.matched_evaluators.len() == 1

--- a/src/query/sql/src/planner/plans/update.rs
+++ b/src/query/sql/src/planner/plans/update.rs
@@ -171,7 +171,7 @@ pub fn generate_update_list(
                 let right = right.ok_or_else(|| ErrorCode::Internal("It's a bug"))?;
 
                 // corner case: for merge into, if target_table's fields are not null, when after bind_join, it will
-                // change into nullable, so we need to cast this. but we will do cast after all macthed clauses,please
+                // change into nullable, so we need to cast this. but we will do cast after all matched clauses,please
                 // see `cast_data_type_for_merge()`.
 
                 ScalarExpr::FunctionCall(FunctionCall {

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
@@ -167,7 +167,7 @@ impl MatchedAggregator {
                 {
                     // we can get duplicated partial unmodified blocks,this is not an error
                     // |----------------------------block----------------------------------------|
-                    // |----partial-unmodified----|-----macthed------|----partial-unmodified-----|
+                    // |----partial-unmodified----|-----matched------|----partial-unmodified-----|
                     info!(
                         "duplicated block: segment_idx: {}, block_idx: {}",
                         meta_index.segment_idx, meta_index.block_idx

--- a/src/query/storages/fuse/src/operations/merge_into/processors/processor_merge_into_matched_and_split.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/processor_merge_into_matched_and_split.rs
@@ -50,7 +50,7 @@ use crate::operations::BlockMetaIndex;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct SourceFullMatched;
 
-#[typetag::serde(name = "source_full_macthed")]
+#[typetag::serde(name = "source_full_matched")]
 impl BlockMetaInfo for SourceFullMatched {
     fn equals(&self, info: &Box<dyn BlockMetaInfo>) -> bool {
         SourceFullMatched::downcast_ref_from(info).is_some_and(|other| self == other)

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -79,7 +79,6 @@ use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
-use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -351,10 +350,7 @@ impl Catalog for HiveCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn get_table_meta_by_id(
-        &self,
-        _table_id: MetaId,
-    ) -> Result<(TableIdent, Arc<TableMeta>)> {
+    async fn get_table_meta_by_id(&self, _table_id: MetaId) -> Result<Option<SeqV<TableMeta>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get table by id in HIVE catalog",
         ))

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -77,7 +77,6 @@ use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
-use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -97,6 +96,7 @@ use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MetaId;
+use databend_common_meta_types::SeqV;
 use databend_common_storage::DataOperator;
 use futures::TryStreamExt;
 use minitrace::func_name;
@@ -261,10 +261,7 @@ impl Catalog for IcebergCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn get_table_meta_by_id(
-        &self,
-        _table_id: MetaId,
-    ) -> Result<(TableIdent, Arc<TableMeta>)> {
+    async fn get_table_meta_by_id(&self, _table_id: MetaId) -> Result<Option<SeqV<TableMeta>>> {
         unimplemented!()
     }
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0035_merge_into_separate_pipeline_without_distributed_enable.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0035_merge_into_separate_pipeline_without_distributed_enable.test
@@ -116,7 +116,7 @@ select * from t1_separate;
 8 a8 b8
 9 a9 b9
 
-## test macthed-only cluster by
+## test matched-only cluster by
 query T
 merge into t1_separate as t1 using (select * from t2_separate) as t2 on t1.a = t2.a when matched then update *;
 ----

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0036_merge_into_without_distributed_enable.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0036_merge_into_without_distributed_enable.test
@@ -378,7 +378,7 @@ select * from target_table order by a,b,c;
 3 a3 b3
 
 ## NULL test, for join, if join_expr result is
-## NULL, it will be treated as not macthed.
+## NULL, it will be treated as not matched.
 statement ok
 truncate table t1;
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: get_table_by_id() returns an `Option<Seqv<TableMeta>>`

Make `get` methods behave in a conventional way: return `None` if the
subject is not found.

Other changes:
Extend expire time to survive slow CI

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15388)
<!-- Reviewable:end -->
