### PR TITLE
refactor: remove get_table_name_by_id()

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -215,7 +215,6 @@ pub trait SchemaApi: Send + Sync {
         table_ids: &[MetaId],
     ) -> Result<Vec<Option<String>>, KVAppError>;
 
-    async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String, KVAppError>;
     async fn mget_database_names_by_ids(
         &self,
         db_ids: &[MetaId],

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -2247,27 +2247,6 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
 
     #[logcall::logcall("debug")]
     #[minitrace::trace]
-    async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String, KVAppError> {
-        debug!(req :? =(&table_id); "SchemaApi: {}", func_name!());
-
-        let table_id_to_name_key = TableIdToName { table_id };
-
-        let (tb_meta_seq, table_name): (_, Option<DBIdTableName>) =
-            get_pb_value(self, &table_id_to_name_key).await?;
-
-        debug!(ident :% =(&table_id_to_name_key); "get_table_name_by_id");
-
-        if tb_meta_seq == 0 || table_name.is_none() {
-            return Err(KVAppError::AppError(AppError::UnknownTableId(
-                UnknownTableId::new(table_id, "get_table_name_by_id"),
-            )));
-        }
-
-        Ok(table_name.unwrap().table_name)
-    }
-
-    #[logcall::logcall("debug")]
-    #[minitrace::trace]
     async fn mget_table_names_by_ids(
         &self,
         table_ids: &[MetaId],

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -354,7 +354,6 @@ impl SchemaApiTestSuite {
             .drop_table_without_tableid_to_name(&b.build().await)
             .await?;
 
-        suite.get_table_name_by_id(&b.build().await).await?;
         suite.get_db_name_by_id(&b.build().await).await?;
         suite.test_sequence(&b.build().await).await?;
 
@@ -5039,106 +5038,6 @@ impl SchemaApiTestSuite {
                 let got = mt.get_table_by_id(1024).await?;
 
                 assert!(got.is_none());
-            }
-        }
-        Ok(())
-    }
-
-    #[minitrace::trace]
-    async fn get_table_name_by_id<MT: SchemaApi>(&self, mt: &MT) -> anyhow::Result<()> {
-        let tenant_name = "tenant1";
-        let tenant = Tenant::new_or_err(tenant_name, func_name!())?;
-
-        let db_name = "db1";
-        let tbl_name = "tb2";
-
-        let schema = || {
-            Arc::new(TableSchema::new(vec![TableField::new(
-                "number",
-                TableDataType::Number(NumberDataType::UInt64),
-            )]))
-        };
-
-        let options = || maplit::btreemap! {"opt‐1".into() => "val-1".into()};
-
-        let table_meta = |created_on| TableMeta {
-            schema: schema(),
-            engine: "JSON".to_string(),
-            options: options(),
-            created_on,
-            ..TableMeta::default()
-        };
-
-        info!("--- prepare db");
-        {
-            let plan = CreateDatabaseReq {
-                create_option: CreateOption::Create,
-                name_ident: DatabaseNameIdent::new(&tenant, db_name),
-                meta: DatabaseMeta {
-                    engine: "".to_string(),
-                    ..DatabaseMeta::default()
-                },
-            };
-
-            let res = mt.create_database(plan).await?;
-            info!("create database res: {:?}", res);
-
-            assert_eq!(1, res.db_id, "first database id is 1");
-        }
-
-        info!("--- create and get table");
-        {
-            let created_on = Utc::now();
-
-            let req = CreateTableReq {
-                create_option: CreateOption::Create,
-                name_ident: TableNameIdent {
-                    tenant: Tenant::new_or_err(tenant_name, func_name!())?,
-                    db_name: db_name.to_string(),
-                    table_name: tbl_name.to_string(),
-                },
-                table_meta: table_meta(created_on),
-                as_dropped: false,
-            };
-
-            {
-                let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-                let res = mt.create_table(req.clone()).await?;
-                let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-                assert!(old_db.ident.seq < cur_db.ident.seq);
-                assert!(res.table_id >= 1, "table id >= 1");
-                let tb_id = res.table_id;
-
-                let got = mt.get_table_name_by_id(tb_id).await?;
-
-                let want = tbl_name.to_string();
-                assert_eq!(want, got, "get created table");
-            }
-        }
-
-        info!("--- get_table_name_by_id ");
-        {
-            info!("--- get_table_name_by_id ");
-            {
-                let table = mt
-                    .get_table((tenant_name, "db1", "tb2").into())
-                    .await
-                    .unwrap();
-
-                let want = table.name.clone();
-                let got = mt.get_table_name_by_id(table.ident.table_id).await?;
-
-                assert_eq!(want, got);
-            }
-
-            info!("--- get_table_name_by_id with not exists table_id");
-            {
-                let got = mt.get_table_name_by_id(1024).await;
-
-                let err = got.unwrap_err();
-                let err = ErrorCode::from(err);
-
-                assert_eq!(ErrorCode::UNKNOWN_TABLE_ID, err.code());
             }
         }
         Ok(())

--- a/src/meta/service/src/metrics/meta_metrics.rs
+++ b/src/meta/service/src/metrics/meta_metrics.rs
@@ -97,7 +97,7 @@ pub mod server_metrics {
             );
             registry.register(
                 key!("applying_snapshot"),
-                "applying snapshot",
+                "if this node is applying snapshot",
                 metrics.applying_snapshot.clone(),
             );
             registry.register(
@@ -118,12 +118,12 @@ pub mod server_metrics {
             );
             registry.register(
                 key!("proposals_pending"),
-                "proposals pending",
+                "proposals pending, raft-log is proposed, not yet applied",
                 metrics.proposals_pending.clone(),
             );
             registry.register(
                 key!("proposals_failed"),
-                "proposals failed",
+                "number of failed proposals(raft-log), due to leader change or storage error",
                 metrics.proposals_failed.clone(),
             );
             registry.register(

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -198,9 +198,6 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     /// Get the table meta by table id.
     async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<Option<SeqV<TableMeta>>>;
 
-    // Get the table name by meta id.
-    async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String>;
-
     // List the tables name by meta ids.
     async fn mget_table_names_by_ids(
         &self,

--- a/src/query/catalog/src/catalog/session_catalog.rs
+++ b/src/query/catalog/src/catalog/session_catalog.rs
@@ -240,22 +240,6 @@ impl Catalog for SessionCatalog {
         }
     }
 
-    // Get the table name by meta id.
-    async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String> {
-        let state = self.txn_mgr.lock().state();
-        match state {
-            TxnState::Active => {
-                let mutated_table = self.txn_mgr.lock().get_table_from_buffer_by_id(table_id);
-                if let Some(t) = mutated_table {
-                    Ok(t.name.clone())
-                } else {
-                    self.inner.get_table_name_by_id(table_id).await
-                }
-            }
-            _ => self.inner.get_table_name_by_id(table_id).await,
-        }
-    }
-
     // Mget the dbs name by meta ids.
     async fn mget_table_names_by_ids(
         &self,

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -272,17 +272,6 @@ impl Catalog for DatabaseCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String> {
-        let res = self.immutable_catalog.get_table_name_by_id(table_id).await;
-
-        if let Ok(x) = res {
-            Ok(x)
-        } else {
-            self.mutable_catalog.get_table_name_by_id(table_id).await
-        }
-    }
-
-    #[async_backtrace::framed]
     async fn mget_table_names_by_ids(
         &self,
         tenant: &Tenant,

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -203,14 +203,6 @@ impl Catalog for ImmutableCatalog {
         Ok(Some(seq_table_meta))
     }
 
-    async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String> {
-        let table = self
-            .sys_db_meta
-            .get_by_id(&table_id)
-            .ok_or_else(|| ErrorCode::UnknownTable(format!("Unknown table id: '{}'", table_id)))?;
-        Ok(table.name().to_string())
-    }
-
     async fn mget_table_names_by_ids(
         &self,
         _tenant: &Tenant,

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -371,15 +371,6 @@ impl Catalog for MutableCatalog {
         Ok(res)
     }
 
-    #[async_backtrace::framed]
-    async fn get_table_name_by_id(
-        &self,
-        table_id: MetaId,
-    ) -> databend_common_exception::Result<String> {
-        let res = self.ctx.meta.get_table_name_by_id(table_id).await?;
-        Ok(res)
-    }
-
     async fn mget_table_names_by_ids(
         &self,
         _tenant: &Tenant,

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -188,14 +188,6 @@ impl Catalog for FakedCatalog {
         self.cat.get_table_by_info(table_info)
     }
 
-    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<Option<SeqV<TableMeta>>> {
-        self.cat.get_table_meta_by_id(table_id).await
-    }
-
-    async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String> {
-        self.cat.get_table_name_by_id(table_id).await
-    }
-
     async fn mget_table_names_by_ids(
         &self,
         tenant: &Tenant,
@@ -418,6 +410,10 @@ impl Catalog for FakedCatalog {
 
     async fn drop_sequence(&self, _req: DropSequenceReq) -> Result<DropSequenceReply> {
         unimplemented!()
+    }
+
+    async fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<Option<SeqV<TableMeta>>> {
+        self.cat.get_table_meta_by_id(table_id).await
     }
 }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -832,10 +832,6 @@ impl Catalog for FakedCatalog {
         self.cat.get_table_meta_by_id(table_id).await
     }
 
-    async fn get_table_name_by_id(&self, table_id: MetaId) -> Result<String> {
-        self.cat.get_table_name_by_id(table_id).await
-    }
-
     #[async_backtrace::framed]
     async fn mget_table_names_by_ids(
         &self,

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -356,13 +356,6 @@ impl Catalog for HiveCatalog {
         ))
     }
 
-    #[async_backtrace::framed]
-    async fn get_table_name_by_id(&self, _table_id: MetaId) -> Result<String> {
-        Err(ErrorCode::Unimplemented(
-            "Cannot get table name by id in HIVE catalog",
-        ))
-    }
-
     async fn mget_table_names_by_ids(
         &self,
         _tenant: &Tenant,

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -265,13 +265,6 @@ impl Catalog for IcebergCatalog {
         unimplemented!()
     }
 
-    #[async_backtrace::framed]
-    async fn get_table_name_by_id(&self, _table_id: MetaId) -> Result<String> {
-        Err(ErrorCode::Unimplemented(
-            "Cannot get table name by id in ICEBERG catalog",
-        ))
-    }
-
     async fn mget_table_names_by_ids(
         &self,
         _tenant: &Tenant,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: remove get_table_name_by_id()

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15389)
<!-- Reviewable:end -->
