### PR TITLE
fix: Respond with `SnapshotMismatch` error instead of internal error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10153,9 +10153,9 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb93143b31c03885eadbd8b2d1bb63c250302113618d8c0db647ab49171736f"
+checksum = "8d2207f55c562d269b93ed659d15bec46e511c39ad248f829d43908bdd4b7767"
 dependencies = [
  "anyerror",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafus
 
 # openraft for debugging
 #openraft = { git = "https://github.com/drmingdrmer/openraft", branch = "release-0.9", features = [
-openraft = { version = "0.9.7", features = [
+openraft = { version = "0.9.8", features = [
     "serde",
     "tracing-log",
     "generic-snapshot-data",

--- a/src/meta/service/tests/it/tests/service.rs
+++ b/src/meta/service/tests/it/tests/service.rs
@@ -219,7 +219,7 @@ impl MetaSrvTestContext {
         let addr = self.config.raft_config.raft_api_addr().await?;
 
         // retry 3 times until server starts listening.
-        for _ in 0..4 {
+        for _ in 0..3 {
             let client = RaftServiceClient::connect(format!("http://{}", addr)).await;
             match client {
                 Ok(x) => return Ok(x),


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: Respond with `SnapshotMismatch` error instead of internal error

This fix updates OpenRaft to version 0.9.8 to address an issue where,
upon receiving a `SnapshotMismatch` error, the snapshot should be resent
from the beginning. This ensures that the leader can correctly reset and
reinitiate the snapshot transmission process.

And meta-service should return `SnapshotMismatch` error instead of
returning an internal gRPC error.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15391)
<!-- Reviewable:end -->
