### PR TITLE
chore: if a txn log is too long, display only the first 5 items

### DIFF
--- a/src/meta/kvapi/src/kvapi/message.rs
+++ b/src/meta/kvapi/src/kvapi/message.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+use std::fmt::Formatter;
+
 use databend_common_meta_types::Change;
 use databend_common_meta_types::SeqV;
 use databend_common_meta_types::UpsertKV;
+use databend_common_meta_types::VecDisplay;
 
 pub type UpsertKVReq = UpsertKV;
 
@@ -41,6 +45,12 @@ impl MGetKVReq {
         Self {
             keys: keys.into_iter().map(|x| x.to_string()).collect(),
         }
+    }
+}
+
+impl fmt::Display for MGetKVReq {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", VecDisplay::new_at_most(&self.keys, 5))
     }
 }
 

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -184,7 +184,7 @@ impl MetaServiceImpl {
         let forward_res = self
             .meta_node
             .handle_forwardable_request(forward_req)
-            .info_elapsed(format!("TxnRequest: {:?}", txn))
+            .info_elapsed(format!("TxnRequest: {}", txn))
             .await;
 
         let (endpoint, txn_reply) = match forward_res {

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -84,6 +84,7 @@ pub use match_seq::MatchSeq;
 pub use match_seq::MatchSeqExt;
 pub use operation::MetaId;
 pub use operation::Operation;
+pub use proto_display::VecDisplay;
 pub use protobuf::txn_condition;
 pub use protobuf::txn_condition::ConditionResult;
 pub use protobuf::txn_op;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: if a txn log is too long, display only the first 5 items

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15392)
<!-- Reviewable:end -->
