### PR TITLE
chore: Fix opendal upstream commit missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "opendal"
 version = "0.45.1"
-source = "git+https://github.com/apache/opendal?rev=53377ca#53377ca873c2928ce519ca57a939f89af1a76c47"
+source = "git+https://github.com/Xuanwo/opendal?rev=53377ca#53377ca873c2928ce519ca57a939f89af1a76c47"
 dependencies = [
  "anyhow",
  "async-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,6 +279,6 @@ z3 = { git = "https://github.com/prove-rs/z3.rs", rev = "247d308" }
 z3-sys = { git = "https://github.com/prove-rs/z3.rs", rev = "247d308" }
 geozero = { git = "https://github.com/georust/geozero", rev = "1d78b36" }
 # Hot fix for cos, remove this during opendal 0.46 upgrade.
-opendal = { git = "https://github.com/apache/opendal", rev = "53377ca" }
+opendal = { git = "https://github.com/Xuanwo/opendal", rev = "53377ca" }
 reqsign = { git = "https://github.com/Xuanwo/reqsign", rev = "122dc12" }
 # proj = { git = "https://github.com/ariesdevil/proj", rev = "51e1c60" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix opendal upstream commit missing

We depends on commit https://github.com/Xuanwo/opendal/commit/53377ca873c2928ce519ca57a939f89af1a76c47, but the upstream has already merge it into main with breaking changes. This PR is used to make sure we can build as before.

We will bump opendal to 0.46 once upstream is ready.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15393)
<!-- Reviewable:end -->
