### PR TITLE
fix(storage): change tracking with alias update row_version bug in merge into

### DIFF
--- a/src/query/sql/src/planner/binder/merge_into.rs
+++ b/src/query/sql/src/planner/binder/merge_into.rs
@@ -365,6 +365,9 @@ impl Binder {
             columns_set = columns_set.union(&join_column_set).cloned().collect();
         }
 
+        // If the table alias is not None, after the binding phase, the bound columns will have
+        // a database of 'None' and the table named as the alias. 
+        // Thus, we adjust them accordingly.
         let target_name = if let Some(target_identify) = target_alias {
             normalize_identifier(&target_identify.name, &self.name_resolution_ctx)
                 .name

--- a/src/query/sql/src/planner/binder/merge_into.rs
+++ b/src/query/sql/src/planner/binder/merge_into.rs
@@ -366,7 +366,7 @@ impl Binder {
         }
 
         // If the table alias is not None, after the binding phase, the bound columns will have
-        // a database of 'None' and the table named as the alias. 
+        // a database of 'None' and the table named as the alias.
         // Thus, we adjust them accordingly.
         let target_name = if let Some(target_identify) = target_alias {
             normalize_identifier(&target_identify.name, &self.name_resolution_ctx)

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
@@ -173,7 +173,7 @@ statement ok
 replace into t3 on(a) delete when c = 0 select * from t4
 
 query III
-merge into t3 tt using t4 on tt.a = t4.a when matched and t4.a = 4 then delete when matched then update set tt.b = t4.c when not matched then insert values(t4.a, t4.c)
+merge into t3 using t4 on t3.a = t4.a when matched and t4.a = 4 then delete when matched then update set t3.b = t4.c when not matched then insert values(t4.a, t4.c)
 ----
 1 1 1
 
@@ -193,6 +193,28 @@ drop table t3 all
 
 ######################
 # end of issue 14955 #
+######################
+
+###############
+# issue 15412 #
+###############
+
+statement ok
+CREATE TABLE test_select (id Int64, name STRING)
+
+statement ok
+insert into test_select values(1, 'Wu')
+
+query I
+merge into db1.test_select t1 using (select * from db1.test_select) t2 on t1.id = t2.id when matched then update set t1.id=t2.id, t1.name='{}'
+----
+1
+
+statement ok
+drop table test_select all
+
+######################
+# end of issue 15412 #
 ######################
 
 statement ok

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
@@ -173,7 +173,7 @@ statement ok
 replace into t3 on(a) delete when c = 0 select * from t4
 
 query III
-merge into t3 using t4 on t3.a = t4.a when matched and t4.a = 4 then delete when matched then update set t3.b = t4.c when not matched then insert values(t4.a, t4.c)
+merge into t3 tt using t4 on tt.a = t4.a when matched and t4.a = 4 then delete when matched then update set tt.b = t4.c when not matched then insert values(t4.a, t4.c)
 ----
 1 1 1
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
@@ -200,7 +200,7 @@ drop table t3 all
 ###############
 
 statement ok
-CREATE TABLE test_select (id Int64, name STRING)
+CREATE TABLE test_select (id Int64, name STRING) change_tracking = true
 
 statement ok
 insert into test_select values(1, 'Wu')
@@ -209,6 +209,11 @@ query I
 merge into db1.test_select t1 using (select * from db1.test_select) t2 on t1.id = t2.id when matched then update set t1.id=t2.id, t1.name='{}'
 ----
 1
+
+query ITI
+select id, name, _row_version from test_select
+----
+1 {} 1
 
 statement ok
 drop table test_select all


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The bug fixed by this PR:

```sql
mysql> create table t3(a int, b int) cluster by(a+1) change_tracking=true ;
Query OK, 0 rows affected (0.15 sec)

mysql> insert into t3 values(1, 1), (3, 3), (2, 3);
Query OK, 3 rows affected (0.20 sec)

mysql> create table t4(a int, b int, c int) ;
Query OK, 0 rows affected (0.08 sec)

mysql> insert into t4 values(0, 1, 0), (3, 4, 3), (4, 5, 4) ;
Query OK, 3 rows affected (0.17 sec)

mysql> merge into t3 tt using t4 on tt.a = t4.a when matched and t4.a = 4 then delete when matched then update set tt.b = t4.c when not matched then insert values(t4.a, t4.c) ;
ERROR 1105 (HY000): Internal. Code: 1001, Text = row_version It's a bug.
```

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15412)
<!-- Reviewable:end -->
