### PR TITLE
fix(query): ensure partition count are same when all_inputs_init  

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/aggregator/new_transform_partition_bucket.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/new_transform_partition_bucket.rs
@@ -291,7 +291,7 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
             ));
         }
 
-        if self.all_inputs_init {
+        if self.all_inputs_init && self.max_partition_count == partition_count {
             match self.buckets_blocks.entry(bucket) {
                 Entry::Vacant(v) => {
                     v.insert(vec![data_block]);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(query): ensure partition count are same when all_inputs_init  
- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15416)
<!-- Reviewable:end -->
