### PR TITLE
refactor: Minimize lock duration during raft-log export

### DIFF
--- a/src/meta/service/src/version.rs
+++ b/src/meta/service/src/version.rs
@@ -100,7 +100,7 @@ pub(crate) mod raft {
             add_provide(("append",           0), "2023-02-16", (0,  9,  41)),
             add_provide(("install_snapshot", 0), "2023-02-16", (0,  9,  41)),
             add_provide(("install_snapshot", 1), "2023-11-16", (1,  2, 212)),
-            add_provide(("install_snapshot", 2), "2024-05-05", (1,  2, 452)),
+            add_provide(("install_snapshot", 2), "2024-05-06", (1,  2, 453)),
         ];
 
         /// The client features that raft server depends on.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Minimize lock duration during raft-log export

Optimize the locking mechanism in the raft-log export process.
Previously, the lock was held until the export was fully completed. With
this refactor:
- For raft-log exports: Release the lock immediately after transferring logs to memory.
- For snapshot exports: Release the lock once the snapshot file is opened.
This change reduces the time the lock is held, potentially improving performance and concurrency.


##### chore: fix snapshot-v2 versions

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15417)
<!-- Reviewable:end -->
