### PR TITLE
fix(query): ensure all inputs pull all data that less than max partition count in new agg singleton

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/aggregator/new_transform_partition_bucket.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/new_transform_partition_bucket.rs
@@ -145,6 +145,7 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
             // in singleton, the partition is 8, 32, 128.
             // We pull the first data to ensure the max partition,
             // and then pull all data that is less than the max partition
+            let mut refresh_index = 0;
             for index in 0..self.inputs.len() {
                 if self.inputs[index].port.is_finished() {
                     continue;
@@ -185,15 +186,16 @@ impl<Method: HashMethodBounds, V: Copy + Send + Sync + 'static>
                     && before_max_partition_count != self.max_partition_count
                 {
                     // set need data for inputs which is less than the max partition
-                    for index in 0..self.inputs.len() {
-                        if !self.inputs[index].port.is_finished()
-                            && !self.inputs[index].port.has_data()
-                            && self.inputs[index].max_partition_count != self.max_partition_count
+                    for i in refresh_index..index {
+                        if !self.inputs[i].port.is_finished()
+                            && !self.inputs[i].port.has_data()
+                            && self.inputs[i].max_partition_count != self.max_partition_count
                         {
-                            self.inputs[index].port.set_need_data();
+                            self.inputs[i].port.set_need_data();
                             self.initialized_all_inputs = false;
                         }
                     }
+                    refresh_index = index;
                 }
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix bug on new agg singleton `TransformPartitionBucket' initialize_all_inputs, ensure all inputs pull all data that less than max partition count  and ensure partition count are same when all_inputs_init

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15418)
<!-- Reviewable:end -->
