### PR TITLE
fix(query): fix `array_concat` function domain panic

### DIFF
--- a/src/query/functions/src/scalars/array.rs
+++ b/src/query/functions/src/scalars/array.rs
@@ -16,6 +16,8 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::sync::Arc;
 
+use databend_common_expression::type_check::common_super_type;
+use databend_common_expression::types::array::ArrayColumn;
 use databend_common_expression::types::array::ArrayColumnBuilder;
 use databend_common_expression::types::boolean::BooleanDomain;
 use databend_common_expression::types::nullable::NullableDomain;
@@ -70,6 +72,7 @@ use siphasher::sip128::SipHasher24;
 
 use crate::aggregates::eval_aggr;
 use crate::AggregateFunctionFactory;
+use crate::BUILTIN_FUNCTIONS;
 
 const ARRAY_AGGREGATE_FUNCTIONS: &[(&str, &str); 14] = &[
     ("array_avg", "avg"),
@@ -248,9 +251,24 @@ pub fn register(registry: &mut FunctionRegistry) {
 
     registry.register_passthrough_nullable_2_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
         "array_concat",
-        |_, _, _| FunctionDomain::Full,
+        |_, domain1, domain2| {
+            FunctionDomain::Domain(
+                match (domain1, domain2) {
+                    (Some(domain1), Some(domain2)) => Some(domain1.merge(domain2)),
+                    (Some(domain1), None) => Some(domain1).cloned(),
+                    (None, Some(domain2)) => Some(domain2).cloned(),
+                    (None, None) => None,
+                }
+            )
+        },
         vectorize_with_builder_2_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(
-            |lhs, rhs, output, _| {
+            |lhs, rhs, output, ctx| {
+                if let Some(validity) = &ctx.validity {
+                    if !validity.get_bit(output.len()) {
+                        output.commit_row();
+                        return;
+                    }
+                }
                 output.builder.append_column(&lhs);
                 output.builder.append_column(&rhs);
                 output.commit_row()
@@ -261,15 +279,15 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry
         .register_passthrough_nullable_1_arg::<ArrayType<ArrayType<GenericType<0>>>, ArrayType<GenericType<0>>, _, _>(
             "array_flatten",
-            |_, _| FunctionDomain::Full,
+            |_, domain| FunctionDomain::Domain(domain.clone().flatten()),
             vectorize_1_arg::<ArrayType<ArrayType<GenericType<0>>>, ArrayType<GenericType<0>>>(
-            |a, b| {
-                let mut builder = ColumnBuilder::with_capacity(&b.generics[0], a.len());
-                for a in a.iter() {
-                    builder.append_column(&a);
+                |arr, ctx| {
+                    let mut builder = ColumnBuilder::with_capacity(&ctx.generics[0], arr.len());
+                    for v in arr.iter() {
+                        builder.append_column(&v);
+                    }
+                    builder.build()
                 }
-                builder.build()
-            }
             ),
         );
 
@@ -278,7 +296,13 @@ pub fn register(registry: &mut FunctionRegistry) {
             "array_to_string",
             |_, _, _| FunctionDomain::Full,
             vectorize_with_builder_2_arg::<ArrayType<StringType>, StringType, StringType>(
-                |lhs, rhs, output, _| {
+                |lhs, rhs, output, ctx| {
+                    if let Some(validity) = &ctx.validity {
+                        if !validity.get_bit(output.len()) {
+                            output.commit_row();
+                            return;
+                        }
+                    }
                     for (i, d) in lhs.iter().enumerate() {
                         if i != 0 {
                             output.put_str(rhs);
@@ -407,29 +431,183 @@ pub fn register(registry: &mut FunctionRegistry) {
         ),
     );
 
-    registry.register_2_arg_core::<GenericType<0>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
-        "array_prepend",
-        |_, _, _| FunctionDomain::Full,
-        vectorize_2_arg::<GenericType<0>, ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(|val, arr, _| {
-            let data_type = arr.data_type();
-            let mut builder = ColumnBuilder::with_capacity(&data_type, arr.len() + 1);
-            builder.push(val);
-            builder.append_column(&arr);
-            builder.build()
-        }),
-    );
+    registry.register_function_factory("array_prepend", |_, args_type| {
+        if args_type.len() != 2 {
+            return None;
+        }
+        let (common_type, return_type) = match args_type[1].remove_nullable() {
+            DataType::EmptyArray => (
+                args_type[0].clone(),
+                DataType::Array(Box::new(args_type[0].clone())),
+            ),
+            DataType::Array(box inner_type) => {
+                let common_type = common_super_type(
+                    inner_type.clone(),
+                    args_type[0].clone(),
+                    &BUILTIN_FUNCTIONS.default_cast_rules,
+                )?;
+                (common_type.clone(), DataType::Array(Box::new(common_type)))
+            }
+            _ => {
+                return None;
+            }
+        };
+        let args_type = vec![
+            common_type,
+            if args_type[1].is_nullable() {
+                return_type.wrap_nullable()
+            } else {
+                return_type.clone()
+            },
+        ];
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "array_prepend".to_string(),
+                args_type,
+                return_type: return_type.clone(),
+            },
+            eval: FunctionEval::Scalar {
+                calc_domain: Box::new(|_, args_domain| {
+                    let array_domain = match &args_domain[1] {
+                        Domain::Nullable(nullable_domain) => nullable_domain.value.clone(),
+                        other => Some(Box::new(other.clone())),
+                    };
+                    let inner_domain = match array_domain {
+                        Some(box Domain::Array(Some(box inner_domain))) => {
+                            inner_domain.merge(&args_domain[0])
+                        }
+                        _ => args_domain[0].clone(),
+                    };
+                    FunctionDomain::Domain(Domain::Array(Some(Box::new(inner_domain))))
+                }),
+                eval: Box::new(move |args, _| {
+                    let len = args.iter().find_map(|arg| match arg {
+                        ValueRef::Column(col) => Some(col.len()),
+                        _ => None,
+                    });
 
-    registry.register_2_arg_core::<ArrayType<GenericType<0>>, GenericType<0>, ArrayType<GenericType<0>>, _, _>(
-        "array_append",
-        |_, _, _| FunctionDomain::Full,
-        vectorize_2_arg::<ArrayType<GenericType<0>>, GenericType<0>, ArrayType<GenericType<0>>>(|arr, val, _| {
-            let data_type = arr.data_type();
-            let mut builder = ColumnBuilder::with_capacity(&data_type, arr.len() + 1);
-            builder.append_column(&arr);
-            builder.push(val);
-            builder.build()
-        }),
-    );
+                    let mut offsets = Vec::with_capacity(len.unwrap_or(1) + 1);
+                    offsets.push(0);
+                    let inner_type = return_type.as_array().unwrap();
+                    let mut builder = ColumnBuilder::with_capacity(inner_type, len.unwrap_or(1));
+
+                    for idx in 0..(len.unwrap_or(1)) {
+                        let val = match &args[0] {
+                            ValueRef::Scalar(scalar) => scalar.clone(),
+                            ValueRef::Column(col) => unsafe { col.index_unchecked(idx) },
+                        };
+                        builder.push(val.clone());
+                        let array_col = match &args[1] {
+                            ValueRef::Scalar(scalar) => scalar.clone(),
+                            ValueRef::Column(col) => unsafe { col.index_unchecked(idx).clone() },
+                        };
+                        if let ScalarRef::Array(col) = array_col {
+                            for val in col.iter() {
+                                builder.push(val.clone());
+                            }
+                        }
+                        offsets.push(builder.len() as u64);
+                    }
+                    match len {
+                        Some(_) => Value::Column(Column::Array(Box::new(ArrayColumn {
+                            values: builder.build(),
+                            offsets: offsets.into(),
+                        }))),
+                        None => Value::Scalar(Scalar::Array(builder.build())),
+                    }
+                }),
+            },
+        }))
+    });
+
+    registry.register_function_factory("array_append", |_, args_type| {
+        if args_type.len() != 2 {
+            return None;
+        }
+        let (common_type, return_type) = match args_type[0].remove_nullable() {
+            DataType::EmptyArray => (
+                args_type[1].clone(),
+                DataType::Array(Box::new(args_type[1].clone())),
+            ),
+            DataType::Array(box inner_type) => {
+                let common_type = common_super_type(
+                    inner_type.clone(),
+                    args_type[1].clone(),
+                    &BUILTIN_FUNCTIONS.default_cast_rules,
+                )?;
+                (common_type.clone(), DataType::Array(Box::new(common_type)))
+            }
+            _ => {
+                return None;
+            }
+        };
+        let args_type = vec![
+            if args_type[0].is_nullable() {
+                return_type.wrap_nullable()
+            } else {
+                return_type.clone()
+            },
+            common_type,
+        ];
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "array_append".to_string(),
+                args_type,
+                return_type: return_type.clone(),
+            },
+            eval: FunctionEval::Scalar {
+                calc_domain: Box::new(|_, args_domain| {
+                    let array_domain = match &args_domain[0] {
+                        Domain::Nullable(nullable_domain) => nullable_domain.value.clone(),
+                        other => Some(Box::new(other.clone())),
+                    };
+                    let inner_domain = match array_domain {
+                        Some(box Domain::Array(Some(box inner_domain))) => {
+                            inner_domain.merge(&args_domain[1])
+                        }
+                        _ => args_domain[1].clone(),
+                    };
+                    FunctionDomain::Domain(Domain::Array(Some(Box::new(inner_domain))))
+                }),
+                eval: Box::new(move |args, _| {
+                    let len = args.iter().find_map(|arg| match arg {
+                        ValueRef::Column(col) => Some(col.len()),
+                        _ => None,
+                    });
+
+                    let mut offsets = Vec::with_capacity(len.unwrap_or(1) + 1);
+                    offsets.push(0);
+                    let inner_type = return_type.as_array().unwrap();
+                    let mut builder = ColumnBuilder::with_capacity(inner_type, len.unwrap_or(1));
+
+                    for idx in 0..(len.unwrap_or(1)) {
+                        let array_col = match &args[0] {
+                            ValueRef::Scalar(scalar) => scalar.clone(),
+                            ValueRef::Column(col) => unsafe { col.index_unchecked(idx).clone() },
+                        };
+                        if let ScalarRef::Array(col) = array_col {
+                            for val in col.iter() {
+                                builder.push(val.clone());
+                            }
+                        }
+                        let val = match &args[1] {
+                            ValueRef::Scalar(scalar) => scalar.clone(),
+                            ValueRef::Column(col) => unsafe { col.index_unchecked(idx) },
+                        };
+                        builder.push(val.clone());
+                        offsets.push(builder.len() as u64);
+                    }
+                    match len {
+                        Some(_) => Value::Column(Column::Array(Box::new(ArrayColumn {
+                            values: builder.build(),
+                            offsets: offsets.into(),
+                        }))),
+                        None => Value::Scalar(Scalar::Array(builder.build())),
+                    }
+                }),
+            },
+        }))
+    });
 
     fn eval_contains<T: ArgType>(
         lhs: ValueRef<ArrayType<T>>,
@@ -494,11 +672,11 @@ pub fn register(registry: &mut FunctionRegistry) {
 
     registry.register_passthrough_nullable_2_arg::<ArrayType<StringType>, StringType, BooleanType, _, _>(
         "contains",
-         |_, lhs, rhs| {
-                        lhs.as_ref().map(|lhs| {
-                            lhs.domain_contains(rhs)
-                        }).unwrap_or(FunctionDomain::Full)
-                    },
+        |_, lhs, rhs| {
+            lhs.as_ref().map(|lhs| {
+                lhs.domain_contains(rhs)
+            }).unwrap_or(FunctionDomain::Full)
+        },
         |lhs, rhs, _| {
             match lhs {
                 ValueRef::Scalar(array) => {
@@ -551,15 +729,15 @@ pub fn register(registry: &mut FunctionRegistry) {
         );
 
     registry.register_passthrough_nullable_2_arg::<ArrayType<TimestampType>, TimestampType, BooleanType, _, _>(
-            "contains",
-            |_, lhs, rhs| {
-                let has_true = lhs.is_some_and(|lhs| !(lhs.min > rhs.max || lhs.max < rhs.min));
-                FunctionDomain::Domain(BooleanDomain {
-                    has_false: true,
-                    has_true,
-                })
-            },
-            |lhs, rhs, _| eval_contains::<TimestampType>(lhs, rhs)
+        "contains",
+        |_, lhs, rhs| {
+            let has_true = lhs.is_some_and(|lhs| !(lhs.min > rhs.max || lhs.max < rhs.min));
+            FunctionDomain::Domain(BooleanDomain {
+                has_false: true,
+                has_true,
+            })
+        },
+        |lhs, rhs, _| eval_contains::<TimestampType>(lhs, rhs)
     );
 
     registry.register_passthrough_nullable_2_arg::<ArrayType<BooleanType>, BooleanType, BooleanType, _, _>(
@@ -657,7 +835,7 @@ pub fn register(registry: &mut FunctionRegistry) {
 
     registry.register_passthrough_nullable_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>, _, _>(
         "array_distinct",
-        |_, _| FunctionDomain::Full,
+        |_, domain| FunctionDomain::Domain(domain.clone()),
         vectorize_1_arg::<ArrayType<GenericType<0>>, ArrayType<GenericType<0>>>(|arr, _| {
             if arr.len() > 0 {
                 let data_type = arr.data_type();

--- a/src/query/functions/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions/tests/it/scalars/testdata/array.txt
@@ -777,16 +777,16 @@ raw expr       : array_concat(array(1, 2, 3, 4, 5, NULL), array(nullable_col::In
 checked expr   : array_concat<T0=Int64 NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8 NULL><T0, T0, T0, T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL), CAST(5_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int64 NULL)), array<T0=Int64 NULL><T0>(nullable_col))
 optimized expr : array_concat<T0=Int64 NULL><Array(T0), Array(T0)>([1, 2, 3, 4, 5, NULL], array<T0=Int64 NULL><T0>(nullable_col))
 evaluation:
-+--------+-------------------+---------------------------------------------------------+
-|        | nullable_col      | Output                                                  |
-+--------+-------------------+---------------------------------------------------------+
-| Type   | Int64 NULL        | Array(Int64 NULL)                                       |
-| Domain | {9..=12} ∪ {NULL} | [{-9223372036854775808..=9223372036854775807} ∪ {NULL}] |
-| Row 0  | 9                 | [1, 2, 3, 4, 5, NULL, 9]                                |
-| Row 1  | 10                | [1, 2, 3, 4, 5, NULL, 10]                               |
-| Row 2  | NULL              | [1, 2, 3, 4, 5, NULL, NULL]                             |
-| Row 3  | NULL              | [1, 2, 3, 4, 5, NULL, NULL]                             |
-+--------+-------------------+---------------------------------------------------------+
++--------+-------------------+-----------------------------+
+|        | nullable_col      | Output                      |
++--------+-------------------+-----------------------------+
+| Type   | Int64 NULL        | Array(Int64 NULL)           |
+| Domain | {9..=12} ∪ {NULL} | [{0..=12} ∪ {NULL}]         |
+| Row 0  | 9                 | [1, 2, 3, 4, 5, NULL, 9]    |
+| Row 1  | 10                | [1, 2, 3, 4, 5, NULL, 10]   |
+| Row 2  | NULL              | [1, 2, 3, 4, 5, NULL, NULL] |
+| Row 3  | NULL              | [1, 2, 3, 4, 5, NULL, NULL] |
++--------+-------------------+-----------------------------+
 evaluation (internal):
 +--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column       | Data                                                                                                                                                                                                                                     |
@@ -801,16 +801,16 @@ raw expr       : array_concat(array(1, 2, NULL), array(int8_col::Int8))
 checked expr   : array_concat<T0=Int16 NULL><Array(T0), Array(T0)>(CAST(array<T0=UInt8 NULL><T0, T0, T0>(CAST(1_u8 AS UInt8 NULL), CAST(2_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL)) AS Array(Int16 NULL)), CAST(array<T0=Int8><T0>(int8_col) AS Array(Int16 NULL)))
 optimized expr : array_concat<T0=Int16 NULL><Array(T0), Array(T0)>([1, 2, NULL], CAST(array<T0=Int8><T0>(int8_col) AS Array(Int16 NULL)))
 evaluation:
-+--------+----------+-----------------------------+
-|        | int8_col | Output                      |
-+--------+----------+-----------------------------+
-| Type   | Int8     | Array(Int16 NULL)           |
-| Domain | {1..=8}  | [{-32768..=32767} ∪ {NULL}] |
-| Row 0  | 1        | [1, 2, NULL, 1]             |
-| Row 1  | 2        | [1, 2, NULL, 2]             |
-| Row 2  | 7        | [1, 2, NULL, 7]             |
-| Row 3  | 8        | [1, 2, NULL, 8]             |
-+--------+----------+-----------------------------+
++--------+----------+--------------------+
+|        | int8_col | Output             |
++--------+----------+--------------------+
+| Type   | Int8     | Array(Int16 NULL)  |
+| Domain | {1..=8}  | [{0..=8} ∪ {NULL}] |
+| Row 0  | 1        | [1, 2, NULL, 1]    |
+| Row 1  | 2        | [1, 2, NULL, 2]    |
+| Row 2  | 7        | [1, 2, NULL, 7]    |
+| Row 3  | 8        | [1, 2, NULL, 8]    |
++--------+----------+--------------------+
 evaluation (internal):
 +----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Column   | Data                                                                                                                                                                       |
@@ -822,7 +822,7 @@ evaluation (internal):
 
 ast            : array_prepend(1, [])
 raw expr       : array_prepend(1, array())
-checked expr   : array_prepend<T0=UInt8><T0, Array(T0)>(1_u8, CAST(array<>() AS Array(UInt8)))
+checked expr   : array_prepend<UInt8, Array(UInt8)>(1_u8, CAST(array<>() AS Array(UInt8)))
 optimized expr : [1]
 output type    : Array(UInt8)
 output domain  : [{1..=1}]
@@ -831,7 +831,7 @@ output         : [1]
 
 ast            : array_prepend(1, [2, 3, NULL, 4])
 raw expr       : array_prepend(1, array(2, 3, NULL, 4))
-checked expr   : array_prepend<T0=UInt8 NULL><T0, Array(T0)>(CAST(1_u8 AS UInt8 NULL), array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL)))
+checked expr   : array_prepend<UInt8 NULL, Array(UInt8 NULL)>(CAST(1_u8 AS UInt8 NULL), array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL)))
 optimized expr : [1, 2, 3, NULL, 4]
 output type    : Array(UInt8 NULL)
 output domain  : [{0..=4} ∪ {NULL}]
@@ -840,7 +840,7 @@ output         : [1, 2, 3, NULL, 4]
 
 ast            : array_prepend('a', ['b', NULL, NULL, 'c', 'd'])
 raw expr       : array_prepend('a', array('b', NULL, NULL, 'c', 'd'))
-checked expr   : array_prepend<T0=String NULL><T0, Array(T0)>(CAST("a" AS String NULL), array<T0=String NULL><T0, T0, T0, T0, T0>(CAST("b" AS String NULL), CAST(NULL AS String NULL), CAST(NULL AS String NULL), CAST("c" AS String NULL), CAST("d" AS String NULL)))
+checked expr   : array_prepend<String NULL, Array(String NULL)>(CAST("a" AS String NULL), array<T0=String NULL><T0, T0, T0, T0, T0>(CAST("b" AS String NULL), CAST(NULL AS String NULL), CAST(NULL AS String NULL), CAST("c" AS String NULL), CAST("d" AS String NULL)))
 optimized expr : ['a', 'b', NULL, NULL, 'c', 'd']
 output type    : Array(String NULL)
 output domain  : [{""..="d"} ∪ {NULL}]
@@ -849,17 +849,17 @@ output         : ['a', 'b', NULL, NULL, 'c', 'd']
 
 ast            : array_prepend(a, [b, c])
 raw expr       : array_prepend(a::Int16, array(b::Int16, c::Int16))
-checked expr   : array_prepend<T0=Int16><T0, Array(T0)>(a, array<T0=Int16><T0, T0>(b, c))
+checked expr   : array_prepend<Int16, Array(Int16)>(a, array<T0=Int16><T0, T0>(b, c))
 evaluation:
-+--------+---------+---------+---------+--------------------+
-|        | a       | b       | c       | Output             |
-+--------+---------+---------+---------+--------------------+
-| Type   | Int16   | Int16   | Int16   | Array(Int16)       |
-| Domain | {0..=2} | {3..=5} | {6..=8} | [{-32768..=32767}] |
-| Row 0  | 0       | 3       | 6       | [0, 3, 6]          |
-| Row 1  | 1       | 4       | 7       | [1, 4, 7]          |
-| Row 2  | 2       | 5       | 8       | [2, 5, 8]          |
-+--------+---------+---------+---------+--------------------+
++--------+---------+---------+---------+--------------+
+|        | a       | b       | c       | Output       |
++--------+---------+---------+---------+--------------+
+| Type   | Int16   | Int16   | Int16   | Array(Int16) |
+| Domain | {0..=2} | {3..=5} | {6..=8} | [{0..=8}]    |
+| Row 0  | 0       | 3       | 6       | [0, 3, 6]    |
+| Row 1  | 1       | 4       | 7       | [1, 4, 7]    |
+| Row 2  | 2       | 5       | 8       | [2, 5, 8]    |
++--------+---------+---------+---------+--------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------------------+
 | Column | Data                                                                              |
@@ -873,7 +873,7 @@ evaluation (internal):
 
 ast            : array_append([], 1)
 raw expr       : array_append(array(), 1)
-checked expr   : array_append<T0=UInt8><Array(T0), T0>(CAST(array<>() AS Array(UInt8)), 1_u8)
+checked expr   : array_append<Array(UInt8), UInt8>(CAST(array<>() AS Array(UInt8)), 1_u8)
 optimized expr : [1]
 output type    : Array(UInt8)
 output domain  : [{1..=1}]
@@ -882,7 +882,7 @@ output         : [1]
 
 ast            : array_append([2, 3, NULL, 4], 5)
 raw expr       : array_append(array(2, 3, NULL, 4), 5)
-checked expr   : array_append<T0=UInt8 NULL><Array(T0), T0>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL)), CAST(5_u8 AS UInt8 NULL))
+checked expr   : array_append<Array(UInt8 NULL), UInt8 NULL>(array<T0=UInt8 NULL><T0, T0, T0, T0>(CAST(2_u8 AS UInt8 NULL), CAST(3_u8 AS UInt8 NULL), CAST(NULL AS UInt8 NULL), CAST(4_u8 AS UInt8 NULL)), CAST(5_u8 AS UInt8 NULL))
 optimized expr : [2, 3, NULL, 4, 5]
 output type    : Array(UInt8 NULL)
 output domain  : [{0..=5} ∪ {NULL}]
@@ -891,7 +891,7 @@ output         : [2, 3, NULL, 4, 5]
 
 ast            : array_append(['b', NULL, NULL, 'c', 'd'], 'e')
 raw expr       : array_append(array('b', NULL, NULL, 'c', 'd'), 'e')
-checked expr   : array_append<T0=String NULL><Array(T0), T0>(array<T0=String NULL><T0, T0, T0, T0, T0>(CAST("b" AS String NULL), CAST(NULL AS String NULL), CAST(NULL AS String NULL), CAST("c" AS String NULL), CAST("d" AS String NULL)), CAST("e" AS String NULL))
+checked expr   : array_append<Array(String NULL), String NULL>(array<T0=String NULL><T0, T0, T0, T0, T0>(CAST("b" AS String NULL), CAST(NULL AS String NULL), CAST(NULL AS String NULL), CAST("c" AS String NULL), CAST("d" AS String NULL)), CAST("e" AS String NULL))
 optimized expr : ['b', NULL, NULL, 'c', 'd', 'e']
 output type    : Array(String NULL)
 output domain  : [{""..="e"} ∪ {NULL}]
@@ -900,17 +900,17 @@ output         : ['b', NULL, NULL, 'c', 'd', 'e']
 
 ast            : array_append([b, c], a)
 raw expr       : array_append(array(b::Int16, c::Int16), a::Int16)
-checked expr   : array_append<T0=Int16><Array(T0), T0>(array<T0=Int16><T0, T0>(b, c), a)
+checked expr   : array_append<Array(Int16), Int16>(array<T0=Int16><T0, T0>(b, c), a)
 evaluation:
-+--------+---------+---------+---------+--------------------+
-|        | a       | b       | c       | Output             |
-+--------+---------+---------+---------+--------------------+
-| Type   | Int16   | Int16   | Int16   | Array(Int16)       |
-| Domain | {0..=2} | {3..=5} | {6..=8} | [{-32768..=32767}] |
-| Row 0  | 0       | 3       | 6       | [3, 6, 0]          |
-| Row 1  | 1       | 4       | 7       | [4, 7, 1]          |
-| Row 2  | 2       | 5       | 8       | [5, 8, 2]          |
-+--------+---------+---------+---------+--------------------+
++--------+---------+---------+---------+--------------+
+|        | a       | b       | c       | Output       |
++--------+---------+---------+---------+--------------+
+| Type   | Int16   | Int16   | Int16   | Array(Int16) |
+| Domain | {0..=2} | {3..=5} | {6..=8} | [{0..=8}]    |
+| Row 0  | 0       | 3       | 6       | [3, 6, 0]    |
+| Row 1  | 1       | 4       | 7       | [4, 7, 1]    |
+| Row 2  | 2       | 5       | 8       | [5, 8, 2]    |
++--------+---------+---------+---------+--------------+
 evaluation (internal):
 +--------+-----------------------------------------------------------------------------------+
 | Column | Data                                                                              |
@@ -1129,16 +1129,16 @@ ast            : array_distinct([a, b, c, d])
 raw expr       : array_distinct(array(a::Int16, b::Int16, c::Int16, d::Int16))
 checked expr   : array_distinct<T0=Int16><Array(T0)>(array<T0=Int16><T0, T0, T0, T0>(a, b, c, d))
 evaluation:
-+--------+---------+---------+---------+---------+--------------------+
-|        | a       | b       | c       | d       | Output             |
-+--------+---------+---------+---------+---------+--------------------+
-| Type   | Int16   | Int16   | Int16   | Int16   | Array(Int16)       |
-| Domain | {1..=4} | {1..=4} | {1..=4} | {2..=4} | [{-32768..=32767}] |
-| Row 0  | 1       | 2       | 3       | 4       | [1, 2, 3, 4]       |
-| Row 1  | 1       | 1       | 1       | 2       | [1, 2]             |
-| Row 2  | 2       | 2       | 3       | 3       | [2, 3]             |
-| Row 3  | 4       | 4       | 4       | 4       | [4]                |
-+--------+---------+---------+---------+---------+--------------------+
++--------+---------+---------+---------+---------+--------------+
+|        | a       | b       | c       | d       | Output       |
++--------+---------+---------+---------+---------+--------------+
+| Type   | Int16   | Int16   | Int16   | Int16   | Array(Int16) |
+| Domain | {1..=4} | {1..=4} | {1..=4} | {2..=4} | [{1..=4}]    |
+| Row 0  | 1       | 2       | 3       | 4       | [1, 2, 3, 4] |
+| Row 1  | 1       | 1       | 1       | 2       | [1, 2]       |
+| Row 2  | 2       | 2       | 3       | 3       | [2, 3]       |
+| Row 3  | 4       | 4       | 4       | 4       | [4]          |
++--------+---------+---------+---------+---------+--------------+
 evaluation (internal):
 +--------+--------------------------------------------------------------------------------------+
 | Column | Data                                                                                 |

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -115,7 +115,7 @@ Functions overloads:
 0 array() :: Array(Nothing)
 1 array FACTORY
 0 array_any FACTORY
-0 array_append(Array(T0), T0) :: Array(T0)
+0 array_append FACTORY
 0 array_approx_count_distinct FACTORY
 0 array_avg FACTORY
 0 array_concat(Array(Nothing) NULL, Array(Nothing) NULL) :: Array(Nothing)
@@ -135,7 +135,7 @@ Functions overloads:
 0 array_max FACTORY
 0 array_median FACTORY
 0 array_min FACTORY
-0 array_prepend(T0, Array(T0)) :: Array(T0)
+0 array_prepend FACTORY
 0 array_remove_first(Array(Nothing)) :: Array(Nothing)
 1 array_remove_first(Array(Nothing) NULL) :: Array(Nothing) NULL
 2 array_remove_first(Array(T0)) :: Array(T0)

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -285,6 +285,9 @@ select array_reduce(col1,(x,y)->x+y+1) from t
 12
 
 statement ok
+DROP TABLE IF EXISTS t1
+
+statement ok
 create table t1(col1 Array(Int Null) not null, col2 Array(Float Null) not null, col3 Array(Decimal (10,5)Null) not null, col4 Array(String Null) not null)
 
 statement ok
@@ -300,6 +303,46 @@ query IIII
 select length(col1), length(col2), length(col3), length(col4) from t
 ----
 4 4 1 1
+
+statement ok
+DROP TABLE IF EXISTS t2
+
+statement ok
+create table t2(col1 Array(Int Null) Null, col2 Array(String Null) Null, col3 Array(Array(String Null) NOT NULL) Null)
+
+statement ok
+insert into t2 values([1,2,3], ['a','b','c'], [['k1','k2'],['k3']]), (null, null, null), ([5,6,null], ['x',null,'y'], [['k4'],['k5']])
+
+query TT
+select array_concat(col1, [10,11]), array_concat(['x','y'], col2) from t2
+----
+[1,2,3,10,11] ['x','y','a','b','c']
+NULL NULL
+[5,6,NULL,10,11] ['x','y','x',NULL,'y']
+
+query T
+select array_flatten(col3) from t2
+----
+['k1','k2','k3']
+NULL
+['k4','k5']
+
+query TT
+select array_prepend(0, col1), array_prepend('v', col2) from t2
+----
+[0,1,2,3] ['v','a','b','c']
+[0] ['v']
+[0,5,6,NULL] ['v','x',NULL,'y']
+
+query TT
+select array_append(col1, 10), array_append(col2, 'z') from t2
+----
+[1,2,3,10] ['a','b','c','z']
+[10] ['z']
+[5,6,NULL,10] ['x',NULL,'y','z']
+
+statement ok
+USE default
 
 statement ok
 DROP DATABASE array_func_test


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Modify the domain calculation of `array_concat`, `array_distinct`, `array_flatten` functions to avoid generic type domain panic.
- Reimplement `array_prepend` and `array_append` functions to support the case where the inner type is nullable.

* Fixes #15408

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15424)
<!-- Reviewable:end -->
