### PR TITLE
fix: ExistsTable should has_result_set.

### DIFF
--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -494,6 +494,7 @@ impl Plan {
                 | Plan::ExplainAst { .. }
                 | Plan::ExplainSyntax { .. }
                 | Plan::ExplainAnalyze { .. }
+                | Plan::ExistsTable(_)
                 | Plan::ShowCreateDatabase(_)
                 | Plan::ShowCreateTable(_)
                 | Plan::ShowCreateCatalog(_)

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -479,51 +479,11 @@ impl Plan {
             Plan::ExecuteImmediate(plan) => plan.schema(),
             Plan::InsertMultiTable(plan) => plan.schema(),
 
-            other => {
-                debug_assert!(!other.has_result_set());
-                Arc::new(DataSchema::empty())
-            }
+            _ => Arc::new(DataSchema::empty()),
         }
     }
 
     pub fn has_result_set(&self) -> bool {
-        matches!(
-            self,
-            Plan::Query { .. }
-                | Plan::Explain { .. }
-                | Plan::ExplainAst { .. }
-                | Plan::ExplainSyntax { .. }
-                | Plan::ExplainAnalyze { .. }
-                | Plan::ExistsTable(_)
-                | Plan::ShowCreateDatabase(_)
-                | Plan::ShowCreateTable(_)
-                | Plan::ShowCreateCatalog(_)
-                | Plan::ShowFileFormats(_)
-                | Plan::ShowRoles(_)
-                | Plan::DescShare(_)
-                | Plan::ShowShares(_)
-                | Plan::ShowShareEndpoint(_)
-                | Plan::ShowObjectGrantPrivileges(_)
-                | Plan::ShowGrantTenantsOfShare(_)
-                | Plan::DescribeTable(_)
-                | Plan::ShowGrants(_)
-                | Plan::Presign(_)
-                | Plan::VacuumTable(_)
-                | Plan::VacuumDropTable(_)
-                | Plan::VacuumTemporaryFiles(_)
-                | Plan::DescDatamaskPolicy(_)
-                | Plan::DescNetworkPolicy(_)
-                | Plan::ShowNetworkPolicies(_)
-                | Plan::DescPasswordPolicy(_)
-                | Plan::CopyIntoTable(_)
-                | Plan::CopyIntoLocation(_)
-                | Plan::ShowTasks(_)
-                | Plan::DescribeTask(_)
-                | Plan::DescConnection(_)
-                | Plan::ShowConnections(_)
-                | Plan::MergeInto(_)
-                | Plan::ExecuteImmediate(_)
-                | Plan::InsertMultiTable(_)
-        )
+        !self.schema().fields().is_empty()
     }
 }

--- a/tests/sqllogictests/suites/base/05_ddl/05_0023_exists_table.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0023_exists_table.test
@@ -7,20 +7,28 @@ CREATE DATABASE db_05_0023_v2
 statement ok
 USE db_05_0023_v2
 
-statement ok
+query I
 EXISTS TABLE t
+----
+0
 
-statement ok
+query I
 EXISTS TABLE db_05_0023_v2.t
+----
+0
 
 statement ok
 CREATE TABLE t(c1 int) ENGINE = Fuse
 
-statement ok
+query I
 EXISTS TABLE t
+----
+1
 
-statement ok
+query I
 EXISTS TABLE db_05_0023_v2.t
+----
+1
 
 statement ok
 DROP TABLE t ALL
@@ -28,9 +36,10 @@ DROP TABLE t ALL
 statement ok
 EXISTS TABLE db_05_0023_v2.t
 
-statement ok
+query I
 EXISTS TABLE t
+----
+0
 
 statement ok
 DROP database db_05_0023_v2
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


- Fixes https://github.com/datafuselabs/databend/issues/15420

the bug is due to https://github.com/datafuselabs/databend/pull/15330/files. 
before that pr,  for http handler, has_result_set=false does not matter as long as the plan return a none empty schema.
after that, they should  be consistent.

for mysql handler,  has_result_set always counts, this pr fix it too.


- [x] fix the `exists_table.test`


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15431)
<!-- Reviewable:end -->
