### PR TITLE
refactor: remove `MergeIntoSource` operator

### DIFF
--- a/src/query/service/src/interpreters/interpreter_merge_into.rs
+++ b/src/query/service/src/interpreters/interpreter_merge_into.rs
@@ -40,7 +40,6 @@ use databend_common_sql::executor::physical_plans::Exchange;
 use databend_common_sql::executor::physical_plans::FragmentKind;
 use databend_common_sql::executor::physical_plans::MergeInto;
 use databend_common_sql::executor::physical_plans::MergeIntoAppendNotMatched;
-use databend_common_sql::executor::physical_plans::MergeIntoSource;
 use databend_common_sql::executor::physical_plans::MutationKind;
 use databend_common_sql::executor::PhysicalPlan;
 use databend_common_sql::executor::PhysicalPlanBuilder;
@@ -69,7 +68,6 @@ use crate::stream::DataBlockStream;
 
 // predicate_index should not be conflict with update expr's column_binding's index.
 pub const PREDICATE_COLUMN_INDEX: IndexType = MAX as usize;
-const DUMMY_COL_INDEX: usize = MAX as usize;
 pub struct MergeIntoInterpreter {
     ctx: Arc<QueryContext>,
     plan: MergePlan,
@@ -222,8 +220,7 @@ impl MergeIntoInterpreter {
         };
 
         let mut builder = PhysicalPlanBuilder::new(meta_data.clone(), self.ctx.clone(), false);
-        // build source for MergeInto
-        let join_input = builder.build(&input, *columns_set.clone()).await?;
+        let mut join_input = builder.build(&input, *columns_set.clone()).await?;
 
         // find row_id column index
         let join_output_schema = join_input.output_schema()?;
@@ -243,7 +240,7 @@ impl MergeIntoInterpreter {
                 Some(row_id_idx) => row_id_idx,
             }
         } else {
-            DUMMY_COL_INDEX
+            DUMMY_COLUMN_INDEX
         };
 
         let mut found_row_id = false;
@@ -258,15 +255,14 @@ impl MergeIntoInterpreter {
 
         // we use `merge_into_split_idx` to specify a column from target table to spilt a block
         // from join into matched part and unmatched part.
-        let mut merge_into_split_idx = DUMMY_COLUMN_INDEX;
+        let mut merge_into_split_idx = None;
         if matches!(merge_type, MergeIntoType::FullOperation) {
             for (idx, data_field) in join_output_schema.fields().iter().enumerate() {
                 if *data_field.name() == split_idx.to_string() {
-                    merge_into_split_idx = idx;
+                    merge_into_split_idx = Some(idx);
                     break;
                 }
             }
-            assert!(merge_into_split_idx != DUMMY_COLUMN_INDEX);
         }
 
         if *distributed && !*change_join_order {
@@ -289,11 +285,8 @@ impl MergeIntoInterpreter {
         let table_info = fuse_table.get_table_info().clone();
         let catalog_ = self.ctx.get_catalog(catalog).await?;
 
-        // merge_into_source is used to recv join's datablocks and split them into matched and not matched
-        // datablocks.
-        let merge_into_source = if !*distributed && extract_exchange {
-            // if we doesn't support distributed merge into, we should give the exchange merge back.
-            let rollback_join_input = PhysicalPlan::Exchange(Exchange {
+        if !*distributed && extract_exchange {
+            join_input = PhysicalPlan::Exchange(Exchange {
                 plan_id: 0,
                 input: Box::new(join_input),
                 kind: FragmentKind::Merge,
@@ -301,21 +294,6 @@ impl MergeIntoInterpreter {
                 allow_adjust_parallelism: true,
                 ignore_exchange: false,
             });
-            PhysicalPlan::MergeIntoSource(MergeIntoSource {
-                input: Box::new(rollback_join_input),
-                row_id_idx: row_id_idx as u32,
-                merge_type: merge_type.clone(),
-                merge_into_split_idx: merge_into_split_idx as u32,
-                plan_id: u32::MAX,
-            })
-        } else {
-            PhysicalPlan::MergeIntoSource(MergeIntoSource {
-                input: Box::new(join_input),
-                row_id_idx: row_id_idx as u32,
-                merge_type: merge_type.clone(),
-                merge_into_split_idx: merge_into_split_idx as u32,
-                plan_id: u32::MAX,
-            })
         };
 
         // transform unmatched for insert
@@ -371,7 +349,7 @@ impl MergeIntoInterpreter {
             let update_list = if let Some(update_list) = &item.update {
                 // we don't need real col_indices here, just give a
                 // dummy index, that's ok.
-                let col_indices = vec![DUMMY_COL_INDEX];
+                let col_indices = vec![DUMMY_COLUMN_INDEX];
                 let (database, table) = match target_alias {
                     None => (Some(database.as_str()), table_name.clone()),
                     Some(alias) => (None, alias.name.to_string().to_lowercase()),
@@ -437,10 +415,8 @@ impl MergeIntoInterpreter {
             .collect();
 
         let commit_input = if !distributed {
-            // recv datablocks from matched upstream and unmatched upstream
-            // transform and append data
             PhysicalPlan::MergeInto(Box::new(MergeInto {
-                input: Box::new(merge_into_source),
+                input: Box::new(join_input.clone()),
                 table_info: table_info.clone(),
                 catalog_info: catalog_.info(),
                 unmatched,
@@ -455,10 +431,11 @@ impl MergeIntoInterpreter {
                 target_build_optimization,
                 can_try_update_column_only: *can_try_update_column_only,
                 plan_id: u32::MAX,
+                merge_into_split_idx,
             }))
         } else {
             let merge_append = PhysicalPlan::MergeInto(Box::new(MergeInto {
-                input: Box::new(merge_into_source.clone()),
+                input: Box::new(join_input.clone()),
                 table_info: table_info.clone(),
                 catalog_info: catalog_.info(),
                 unmatched: unmatched.clone(),
@@ -483,6 +460,7 @@ impl MergeIntoInterpreter {
                 target_build_optimization: false, // we don't support for distributed mode for now..
                 can_try_update_column_only: *can_try_update_column_only,
                 plan_id: u32::MAX,
+                merge_into_split_idx,
             }));
             // if change_join_order = true, it means the target is build side,
             // in this way, we will do matched operation and not matched operation
@@ -504,7 +482,7 @@ impl MergeIntoInterpreter {
                 table_info: table_info.clone(),
                 catalog_info: catalog_.info(),
                 unmatched: unmatched.clone(),
-                input_schema: merge_into_source.output_schema()?,
+                input_schema: join_input.output_schema()?,
                 merge_type: merge_type.clone(),
                 change_join_order: *change_join_order,
                 segments,

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -99,9 +99,7 @@ impl PipelineBuilder {
     pub(crate) fn add_plan_scope(&mut self, plan: &PhysicalPlan) -> Result<Option<PlanScopeGuard>> {
         match plan {
             PhysicalPlan::EvalScalar(v) if v.exprs.is_empty() => Ok(None),
-            PhysicalPlan::MergeIntoSource(v) if v.merge_type != MergeIntoType::FullOperation => {
-                Ok(None)
-            }
+            PhysicalPlan::MergeInto(v) if v.merge_type != MergeIntoType::FullOperation => Ok(None),
             _ => {
                 let desc = plan.get_desc()?;
                 let plan_labels = plan.get_labels()?;
@@ -170,9 +168,6 @@ impl PipelineBuilder {
 
             // Merge into.
             PhysicalPlan::MergeInto(merge_into) => self.build_merge_into(merge_into),
-            PhysicalPlan::MergeIntoSource(merge_into_source) => {
-                self.build_merge_into_source(merge_into_source)
-            }
             PhysicalPlan::MergeIntoAppendNotMatched(merge_into_append_not_matched) => {
                 self.build_merge_into_append_not_matched(merge_into_append_not_matched)
             }

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -241,7 +241,6 @@ fn to_format_tree(
         }
         PhysicalPlan::ReplaceInto(_) => Ok(FormatTreeNode::new("Replace".to_string())),
         PhysicalPlan::MergeInto(_) => Ok(FormatTreeNode::new("MergeInto".to_string())),
-        PhysicalPlan::MergeIntoSource(_) => Ok(FormatTreeNode::new("MergeIntoSource".to_string())),
         PhysicalPlan::MergeIntoAddRowNumber(_) => {
             Ok(FormatTreeNode::new("MergeIntoAddRowNumber".to_string()))
         }

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -54,7 +54,6 @@ use crate::executor::physical_plans::MaterializedCte;
 use crate::executor::physical_plans::MergeInto;
 use crate::executor::physical_plans::MergeIntoAddRowNumber;
 use crate::executor::physical_plans::MergeIntoAppendNotMatched;
-use crate::executor::physical_plans::MergeIntoSource;
 use crate::executor::physical_plans::Project;
 use crate::executor::physical_plans::ProjectSet;
 use crate::executor::physical_plans::RangeJoin;
@@ -116,7 +115,6 @@ pub enum PhysicalPlan {
     ReplaceInto(Box<ReplaceInto>),
 
     /// MergeInto
-    MergeIntoSource(MergeIntoSource),
     MergeInto(Box<MergeInto>),
     MergeIntoAppendNotMatched(Box<MergeIntoAppendNotMatched>),
     MergeIntoAddRowNumber(Box<MergeIntoAddRowNumber>),
@@ -303,11 +301,6 @@ impl PhysicalPlan {
                 *next_id += 1;
                 plan.input.adjust_plan_id(next_id);
             }
-            PhysicalPlan::MergeIntoSource(plan) => {
-                plan.plan_id = *next_id;
-                *next_id += 1;
-                plan.input.adjust_plan_id(next_id);
-            }
             PhysicalPlan::MergeIntoAppendNotMatched(plan) => {
                 plan.plan_id = *next_id;
                 *next_id += 1;
@@ -422,7 +415,6 @@ impl PhysicalPlan {
             PhysicalPlan::DeleteSource(v) => v.plan_id,
             PhysicalPlan::MergeInto(v) => v.plan_id,
             PhysicalPlan::MergeIntoAddRowNumber(v) => v.plan_id,
-            PhysicalPlan::MergeIntoSource(v) => v.plan_id,
             PhysicalPlan::MergeIntoAppendNotMatched(v) => v.plan_id,
             PhysicalPlan::CommitSink(v) => v.plan_id,
             PhysicalPlan::CopyIntoTable(v) => v.plan_id,
@@ -473,7 +465,6 @@ impl PhysicalPlan {
             PhysicalPlan::MaterializedCte(plan) => plan.output_schema(),
             PhysicalPlan::ConstantTableScan(plan) => plan.output_schema(),
             PhysicalPlan::Udf(plan) => plan.output_schema(),
-            PhysicalPlan::MergeIntoSource(plan) => plan.input.output_schema(),
             PhysicalPlan::MergeInto(plan) => Ok(plan.output_schema.clone()),
             PhysicalPlan::MergeIntoAddRowNumber(plan) => plan.output_schema(),
             PhysicalPlan::ReplaceAsyncSourcer(_)
@@ -535,7 +526,6 @@ impl PhysicalPlan {
             PhysicalPlan::ReplaceDeduplicate(_) => "ReplaceDeduplicate".to_string(),
             PhysicalPlan::ReplaceInto(_) => "Replace".to_string(),
             PhysicalPlan::MergeInto(_) => "MergeInto".to_string(),
-            PhysicalPlan::MergeIntoSource(_) => "MergeIntoSource".to_string(),
             PhysicalPlan::MergeIntoAppendNotMatched(_) => "MergeIntoAppendNotMatched".to_string(),
             PhysicalPlan::CteScan(_) => "PhysicalCteScan".to_string(),
             PhysicalPlan::MaterializedCte(_) => "PhysicalMaterializedCte".to_string(),
@@ -604,7 +594,6 @@ impl PhysicalPlan {
             PhysicalPlan::MergeIntoAddRowNumber(plan) => {
                 Box::new(std::iter::once(plan.input.as_ref()))
             }
-            PhysicalPlan::MergeIntoSource(plan) => Box::new(std::iter::once(plan.input.as_ref())),
             PhysicalPlan::MergeIntoAppendNotMatched(plan) => {
                 Box::new(std::iter::once(plan.input.as_ref()))
             }
@@ -663,7 +652,6 @@ impl PhysicalPlan {
             | PhysicalPlan::MergeInto(_)
             | PhysicalPlan::MergeIntoAddRowNumber(_)
             | PhysicalPlan::MergeIntoAppendNotMatched(_)
-            | PhysicalPlan::MergeIntoSource(_)
             | PhysicalPlan::ConstantTableScan(_)
             | PhysicalPlan::CteScan(_)
             | PhysicalPlan::ReclusterSource(_)

--- a/src/query/sql/src/executor/physical_plan_display.rs
+++ b/src/query/sql/src/executor/physical_plan_display.rs
@@ -42,7 +42,6 @@ use crate::executor::physical_plans::MaterializedCte;
 use crate::executor::physical_plans::MergeInto;
 use crate::executor::physical_plans::MergeIntoAddRowNumber;
 use crate::executor::physical_plans::MergeIntoAppendNotMatched;
-use crate::executor::physical_plans::MergeIntoSource;
 use crate::executor::physical_plans::Project;
 use crate::executor::physical_plans::ProjectSet;
 use crate::executor::physical_plans::RangeJoin;
@@ -105,7 +104,6 @@ impl<'a> Display for PhysicalPlanIndentFormatDisplay<'a> {
             PhysicalPlan::ReplaceAsyncSourcer(async_sourcer) => write!(f, "{}", async_sourcer)?,
             PhysicalPlan::ReplaceDeduplicate(deduplicate) => write!(f, "{}", deduplicate)?,
             PhysicalPlan::ReplaceInto(replace) => write!(f, "{}", replace)?,
-            PhysicalPlan::MergeIntoSource(merge_into_source) => write!(f, "{}", merge_into_source)?,
             PhysicalPlan::MergeInto(merge_into) => write!(f, "{}", merge_into)?,
             PhysicalPlan::MergeIntoAppendNotMatched(merge_into_row_id_apply) => {
                 write!(f, "{}", merge_into_row_id_apply)?
@@ -504,12 +502,6 @@ impl Display for MergeIntoAddRowNumber {
 impl Display for MergeIntoAppendNotMatched {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "MergeIntoAppendNotMatched")
-    }
-}
-
-impl Display for MergeIntoSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MergeIntoSource")
     }
 }
 

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -46,7 +46,6 @@ use crate::executor::physical_plans::MaterializedCte;
 use crate::executor::physical_plans::MergeInto;
 use crate::executor::physical_plans::MergeIntoAddRowNumber;
 use crate::executor::physical_plans::MergeIntoAppendNotMatched;
-use crate::executor::physical_plans::MergeIntoSource;
 use crate::executor::physical_plans::Project;
 use crate::executor::physical_plans::ProjectSet;
 use crate::executor::physical_plans::RangeJoin;
@@ -97,7 +96,6 @@ pub trait PhysicalPlanReplacer {
             PhysicalPlan::ReplaceInto(plan) => self.replace_replace_into(plan),
             PhysicalPlan::MergeInto(plan) => self.replace_merge_into(plan),
             PhysicalPlan::MergeIntoAddRowNumber(plan) => self.replace_add_row_number(plan),
-            PhysicalPlan::MergeIntoSource(plan) => self.replace_merge_into_source(plan),
             PhysicalPlan::MergeIntoAppendNotMatched(plan) => {
                 self.replace_merge_into_row_id_apply(plan)
             }
@@ -486,14 +484,6 @@ pub trait PhysicalPlanReplacer {
         )))
     }
 
-    fn replace_merge_into_source(&mut self, plan: &MergeIntoSource) -> Result<PhysicalPlan> {
-        let input = self.replace(&plan.input)?;
-        Ok(PhysicalPlan::MergeIntoSource(MergeIntoSource {
-            input: Box::new(input),
-            ..plan.clone()
-        }))
-    }
-
     fn replace_merge_into_row_id_apply(
         &mut self,
         plan: &MergeIntoAppendNotMatched,
@@ -706,9 +696,6 @@ impl PhysicalPlan {
                     Self::traverse(&plan.input, pre_visit, visit, post_visit);
                 }
                 PhysicalPlan::ReplaceInto(plan) => {
-                    Self::traverse(&plan.input, pre_visit, visit, post_visit);
-                }
-                PhysicalPlan::MergeIntoSource(plan) => {
                     Self::traverse(&plan.input, pre_visit, visit, post_visit);
                 }
                 PhysicalPlan::MergeInto(plan) => {

--- a/src/query/sql/src/executor/physical_plans/physical_merge_into.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_merge_into.rs
@@ -27,16 +27,6 @@ use crate::executor::physical_plan::PhysicalPlan;
 pub type MatchExpr = Vec<(Option<RemoteExpr>, Option<Vec<(FieldIndex, RemoteExpr)>>)>;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct MergeIntoSource {
-    pub plan_id: u32,
-    // join result:  source_columns, target_columns, target_table._row_id
-    pub input: Box<PhysicalPlan>,
-    pub row_id_idx: u32,
-    pub merge_type: MergeIntoType,
-    pub merge_into_split_idx: u32,
-}
-
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct MergeInto {
     pub plan_id: u32,
     pub input: Box<PhysicalPlan>,
@@ -57,6 +47,7 @@ pub struct MergeInto {
     pub change_join_order: bool,
     pub target_build_optimization: bool,
     pub can_try_update_column_only: bool,
+    pub merge_into_split_idx: Option<usize>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/src/query/sql/src/planner/binder/merge_into.rs
+++ b/src/query/sql/src/planner/binder/merge_into.rs
@@ -324,20 +324,18 @@ impl Binder {
             true,
         )?;
 
-        target_expr = SExpr::add_internal_column_index(
-            &target_expr,
-            table_index,
-            column_binding.index,
-            &None,
-        );
+        let row_id_index = column_binding.index;
+
+        target_expr =
+            SExpr::add_internal_column_index(&target_expr, table_index, row_id_index, &None);
 
         self.metadata
             .write()
-            .set_table_row_id_index(table_index, column_binding.index);
+            .set_table_row_id_index(table_index, row_id_index);
 
         // add row_id_idx
         if merge_type != MergeIntoType::InsertOnly {
-            columns_set.insert(column_binding.index);
+            columns_set.insert(row_id_index);
         }
 
         // add join, we use _row_id to check_duplicate join row.
@@ -446,11 +444,13 @@ impl Binder {
         }
         let mut split_idx = DUMMY_COLUMN_INDEX;
         // find any target table column index for merge_into_split
-        for column in self.metadata.read().columns() {
-            if column.table_index().is_some()
-                && *column.table_index().as_ref().unwrap() == table_index
-                && column.index() != column_binding.index
-            {
+        for column in self
+            .metadata
+            .read()
+            .columns_by_table_index(table_index)
+            .iter()
+        {
+            if column.index() != row_id_index {
                 split_idx = column.index();
                 break;
             }
@@ -474,7 +474,7 @@ impl Binder {
             merge_type,
             distributed: false,
             change_join_order: false,
-            row_id_index: column_binding.index,
+            row_id_index,
             split_idx,
             can_try_update_column_only: self.can_try_update_column_only(&matched_clauses),
         })

--- a/src/query/storages/fuse/src/operations/merge.rs
+++ b/src/query/storages/fuse/src/operations/merge.rs
@@ -40,7 +40,7 @@ impl FuseTable {
     //                                            |                       +---+--------------->|    MatchedSplitProcessor    |                        |                   |               |
     //                                            |                       |   |                |                             +----------+             +-------------------+               |
     //         +----------------------+           |                       +---+                +-----------------------------+          |                                                 |
-    //         |   MergeIntoSource    +---------->|MergeIntoSplitProcessor|                                                       output_port_updated                                     |
+    //         |       MergeInto      +---------->|MergeIntoSplitProcessor|                                                       output_port_updated                                     |
     //         +----------------------+           |                       +---+                +-----------------------------+          |             +-------------------+               |
     //                                            |                       |   | NotMatched     |                             |          |             |                   |               |
     //                                            |                       +---+--------------->| MergeIntoNotMatchedProcessor+----------+------------->-ResizeProcessor(1)+-----------+   |

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/update_by_expr_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/update_by_expr_mutator.rs
@@ -74,7 +74,6 @@ impl UpdateByExprMutator {
             self.expr.clone().unwrap()
         };
         expr = cast_expr_to_non_null_boolean(expr)?;
-        assert_eq!(expr.data_type(), &DataType::Boolean);
 
         // it's the first update, after update, we need to add a filter column
         if data_block.num_columns() == self.origin_input_columns {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

It's not necessary to introduce `MergeIntoSource` operator.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15435)
<!-- Reviewable:end -->
