### PR TITLE
refactor: set enable_experimental_rbac_check default 1

### DIFF
--- a/src/query/service/src/interpreters/common/grant.rs
+++ b/src/query/service/src/interpreters/common/grant.rs
@@ -78,9 +78,9 @@ pub async fn validate_grant_object_exists(
         }
         GrantObject::UDF(udf) => {
             if !UserApiProvider::instance().exists_udf(&tenant, udf).await? {
-                return Err(databend_common_exception::ErrorCode::UnknownStage(format!(
-                    "udf {udf} not exists"
-                )));
+                return Err(databend_common_exception::ErrorCode::UnknownFunction(
+                    format!("udf {udf} not exists"),
+                ));
             }
         }
         GrantObject::Stage(stage) => {

--- a/src/query/service/src/interpreters/interpreter_user_stage_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_user_stage_drop.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_management::RoleApi;
 use databend_common_meta_app::principal::OwnershipObject;

--- a/src/query/service/src/interpreters/interpreter_user_stage_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_user_stage_drop.rs
@@ -62,13 +62,6 @@ impl Interpreter for DropUserStageInterpreter {
         let tenant = self.ctx.get_tenant();
         let user_mgr = UserApiProvider::instance();
 
-        // Check user stage.
-        if plan.name == "~" {
-            return Err(ErrorCode::StagePermissionDenied(
-                "user stage is not allowed to be dropped",
-            ));
-        }
-
         let stage = user_mgr.get_stage(&tenant, &plan.name).await;
         user_mgr
             .drop_stage(&tenant, &plan.name, plan.if_exists)

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -649,7 +649,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::String(vec!["rounding".into(), "truncating".into()])),
                 }),
                 ("enable_experimental_rbac_check", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
+                    value: UserSettingValue::UInt64(1),
                     desc: "experiment setting disables stage and udf privilege check(disable by default).",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -380,10 +380,17 @@ impl<'a> Binder {
             Statement::DropStage {
                 stage_name,
                 if_exists,
-            } => Plan::DropStage(Box::new(DropStagePlan {
+            } => {
+                // Check user stage.
+                if stage_name == "~" {
+                    return Err(ErrorCode::StagePermissionDenied(
+                        "user stage is not allowed to be dropped",
+                    ));
+                }
+                Plan::DropStage(Box::new(DropStagePlan {
                 if_exists: *if_exists,
                 name: stage_name.clone(),
-            })),
+            }))},
             Statement::RemoveStage { location, pattern } => {
                 self.bind_remove_stage(location, pattern).await?
             }

--- a/tests/suites/0_stateless/18_rbac/18_0001_udf_priv.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0001_udf_priv.sh
@@ -7,8 +7,6 @@ echo "=== test UDF priv"
 export TEST_USER_PASSWORD="password"
 export TEST_USER_CONNECT="bendsql --user=test-user --password=password --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
 
-echo "set global enable_experimental_rbac_check=1" | $BENDSQL_CLIENT_CONNECT
-
 echo "drop user if exists 'test-user'" | $BENDSQL_CLIENT_CONNECT
 echo "DROP FUNCTION IF EXISTS f1;" |  $BENDSQL_CLIENT_CONNECT
 echo "DROP FUNCTION IF EXISTS f2;" |  $BENDSQL_CLIENT_CONNECT
@@ -141,4 +139,3 @@ echo "drop function if exists a;" | $BENDSQL_CLIENT_CONNECT
 echo "drop function if exists b;" | $BENDSQL_CLIENT_CONNECT
 echo "drop table if exists default.t;" | $BENDSQL_CLIENT_CONNECT
 echo "drop table if exists default.t2;" | $BENDSQL_CLIENT_CONNECT
-echo "unset enable_experimental_rbac_check" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
@@ -69,7 +69,6 @@ echo 'select * from @hello' | $TEST_USER_CONNECT
 echo "select * from d_0002.t" | $TEST_USER_CONNECT
 
 ## cleanup
-echo "=== cleanup ==="
 echo "drop database d_0002;" | $BENDSQL_CLIENT_CONNECT
 echo "drop stage hello;" | $TEST_TRANSFER_USER_CONNECT
 echo "drop stage if exists noexistshello;" | $TEST_TRANSFER_USER_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
@@ -9,8 +9,6 @@ export TEST_USER_CONNECT="bendsql --user=owner --password=password --host=${QUER
 
 export TEST_TRANSFER_USER_CONNECT="bendsql --user=owner1 --password=password --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
 
-echo "set global enable_experimental_rbac_check=1" | $BENDSQL_CLIENT_CONNECT
-
 ## cleanup
 echo "drop database if exists d_0002;" | $BENDSQL_CLIENT_CONNECT
 echo "drop user if exists '${TEST_USER_NAME}'" | $BENDSQL_CLIENT_CONNECT
@@ -71,14 +69,16 @@ echo 'select * from @hello' | $TEST_USER_CONNECT
 echo "select * from d_0002.t" | $TEST_USER_CONNECT
 
 ## cleanup
+echo "=== cleanup ==="
 echo "drop database d_0002;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage hello;" | $BENDSQL_CLIENT_CONNECT
-echo "drop function a;" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage hello;" | $TEST_TRANSFER_USER_CONNECT
+echo "drop stage if exists noexistshello;" | $TEST_TRANSFER_USER_CONNECT
+echo "drop function a;" | $TEST_TRANSFER_USER_CONNECT
+echo "drop function if exists noexistsa;" | $TEST_TRANSFER_USER_CONNECT
 echo "drop user '${TEST_USER_NAME}'" | $BENDSQL_CLIENT_CONNECT
 echo "drop user 'owner1'" | $BENDSQL_CLIENT_CONNECT
 echo "drop role 'r_0002_1'" | $BENDSQL_CLIENT_CONNECT
 echo "drop role 'r_0002'" | $BENDSQL_CLIENT_CONNECT
-echo "unset enable_experimental_rbac_check" | $BENDSQL_CLIENT_CONNECT
 
 echo "=== test ownership: show stmt ==="
 echo "drop user if exists a;" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
@@ -7,8 +7,6 @@ export TEST_USER_PASSWORD="password"
 export TEST_USER_CONNECT="bendsql --user=test-user --password=password --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
 export RM_UUID="sed -E ""s/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/UUID/g"""
 
-echo "set global enable_experimental_rbac_check=1" | $BENDSQL_CLIENT_CONNECT
-
 stmt "drop database if exists db01;"
 stmt "create database db01;"
 stmt "drop database if exists dbnotexists;"
@@ -275,5 +273,3 @@ echo "drop table if exists t1" | $BENDSQL_CLIENT_CONNECT
 echo "drop table if exists t2" | $BENDSQL_CLIENT_CONNECT
 echo "drop stage if exists s3;" | $BENDSQL_CLIENT_CONNECT
 echo "drop database if exists db01" | $BENDSQL_CLIENT_CONNECT
-
-echo "unset enable_experimental_rbac_check" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/00_stage/00_0012_stage_priv.sh
+++ b/tests/suites/1_stateful/00_stage/00_0012_stage_priv.sh
@@ -9,8 +9,6 @@ export TEST_USER_CONNECT="bendsql --user=u1 --password=password --host=${QUERY_M
 export USER_B_CONNECT="bendsql --user=b --password=password --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
 export RM_UUID="sed -E ""s/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/UUID/g"""
 
-echo "set global enable_experimental_rbac_check=1" | $BENDSQL_CLIENT_CONNECT
-
 echo "drop table if exists test_table;" | $BENDSQL_CLIENT_CONNECT
 echo "drop user if exists u1;" | $BENDSQL_CLIENT_CONNECT
 echo "drop STAGE if exists s2;" | $BENDSQL_CLIENT_CONNECT
@@ -144,5 +142,3 @@ echo "insert into t select \$1 from 'fs:///tmp/00_0020/' (FILE_FORMAT => 'CSV');
 echo "drop table if exists t" | $BENDSQL_CLIENT_CONNECT
 echo "drop user if exists b" | $BENDSQL_CLIENT_CONNECT
 rm -rf /tmp/00_0012
-
-echo "unset enable_experimental_rbac_check" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

set enable_experimental_rbac_check default 1

In the default setting of enable_experimental_rbac_check

User can drop udf/stage that is owned by themself role.

Note:

Because of the flag `if exists`, need to get udf/stage in privilege_access.rs .

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15436)
<!-- Reviewable:end -->
