### PR TITLE
ci: Bump version to 2024-02-08 (the same commit with 1.78)

### DIFF
--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-01-23"
+channel = "nightly-2024-02-08"
 components = ["rustfmt", "clippy", "rust-src", "miri", "rust-analyzer"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR will bump our rust version to `2024-02-08`, ths same commit to rust 1.78 to make  https://github.com/datafuselabs/databend/pull/15426 happy.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other: CI staffs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15455)
<!-- Reviewable:end -->
