### PR TITLE
chore: remove breakline for log

### DIFF
--- a/src/query/service/src/interpreters/interpreter_select.rs
+++ b/src/query/service/src/interpreters/interpreter_select.rs
@@ -259,7 +259,7 @@ impl Interpreter for SelectInterpreter {
             .format(self.metadata.clone(), Default::default())?
             .format_pretty()?;
         info!(
-            "Query id: {}, query plan: \n{}",
+            "Query id: {}, query plan: {}",
             self.ctx.get_id(),
             query_plan
         );

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -330,7 +330,7 @@ impl ExecuteState {
         block_sender: SizedChannelSender<DataBlock>,
         format_settings: Arc<parking_lot::RwLock<Option<FormatSettings>>>,
     ) -> Result<()> {
-        info!("{}: http query prepare to plan sql", &ctx.get_id());
+        info!("http query prepare to plan sql");
 
         // Use interpreter_plan_sql, we can write the query log if an error occurs.
         let (plan, extras) = interpreter_plan_sql(ctx.clone(), &sql)
@@ -340,8 +340,7 @@ impl ExecuteState {
         let query_queue_manager = QueriesQueueManager::instance();
 
         info!(
-            "{}: http query preparing to acquire from query queue, length: {}",
-            &ctx.get_id(),
+            "http query preparing to acquire from query queue, length: {}",
             query_queue_manager.length()
         );
 
@@ -353,8 +352,7 @@ impl ExecuteState {
             *guard = Some(ctx.get_format_settings()?);
         }
         info!(
-            "{}: http query finished acquiring from queue, length: {}",
-            &ctx.get_id(),
+            "http query finished acquiring from queue, length: {}",
             query_queue_manager.length()
         );
 
@@ -373,7 +371,7 @@ impl ExecuteState {
             schema,
             has_result_set,
         };
-        info!("{}: http query change state to Running", &ctx.get_id());
+        info!("http query change state to Running");
         Executor::start_to_running(&executor, Running(running_state)).await;
 
         let executor_clone = executor.clone();

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -327,7 +327,7 @@ impl Spiller {
                 .format(2);
             let files = self.partition_location.get(p_id).unwrap().len();
             info.push_str(&format!(
-                "Partition {}: spilled {}, {} files \n",
+                " [Partition {}: spilled {}, {} files] ",
                 p_id, spill_gb, files
             ));
         }

--- a/src/query/sql/src/planner/plans/copy_into_table.rs
+++ b/src/query/sql/src/planner/plans/copy_into_table.rs
@@ -102,6 +102,7 @@ impl Display for CopyIntoTableMode {
         }
     }
 }
+
 impl CopyIntoTableMode {
     pub fn is_overwrite(&self) -> bool {
         match self {
@@ -121,8 +122,10 @@ pub struct CopyIntoTablePlan {
     pub table_name: String,
     pub from_attachment: bool,
 
-    pub required_values_schema: DataSchemaRef, // ... into table(<columns>) ..  -> <columns>
-    pub values_consts: Vec<Scalar>,            // (1, ?, 'a', ?) -> (1, 'a')
+    pub required_values_schema: DataSchemaRef,
+    // ... into table(<columns>) ..  -> <columns>
+    pub values_consts: Vec<Scalar>,
+    // (1, ?, 'a', ?) -> (1, 'a')
     pub required_source_schema: DataSchemaRef, // (1, ?, 'a', ?) -> (?, ?)
 
     pub write_mode: CopyIntoTableMode,
@@ -189,10 +192,8 @@ impl CopyIntoTablePlan {
                 return Err(ErrorCode::Internal(COPY_MAX_FILES_COMMIT_MSG));
             }
             info!(
-                "{}: force mode, ignore file filtering. ({}.{})",
-                ctx.get_id(),
-                &self.database_name,
-                &self.table_name
+                "force mode, ignore file filtering. ({}.{})",
+                &self.database_name, &self.table_name
             );
             (all_source_file_infos, vec![])
         } else {
@@ -231,8 +232,7 @@ impl CopyIntoTablePlan {
         let sum: u64 = need_copy_file_infos.iter().map(|i| i.size).sum();
 
         info!(
-            "{}: collect files with max_files={:?} finished, need to copy {} files, {} bytes; skip {} duplicated files, time used:{:?}",
-            ctx.get_id(),
+            "collect files with max_files={:?} finished, need to copy {} files, {} bytes; skip {} duplicated files, time used:{:?}",
             max_files,
             need_copy_file_infos.len(),
             num_all_files - len,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* Remove breakline for some info logs, this will show the full log messages in the grafana.
* Remove some logs with query_id prefix. After the pull request https://github.com/datafuselabs/databend/pull/15466 , there's no need to manually add the query_id prefix to the log; it will be done automatically.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15476)
<!-- Reviewable:end -->
