### PR TITLE
chore: log file_name name for short

### DIFF
--- a/src/common/tracing/src/loggers.rs
+++ b/src/common/tracing/src/loggers.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::io::BufWriter;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -231,7 +232,10 @@ fn format_text_log(out: FormatCallback, message: &fmt::Arguments, record: &log::
                 humantime::format_rfc3339_micros(SystemTime::now()),
                 record.level(),
                 record.module_path().unwrap_or(""),
-                record.file().unwrap_or(""),
+                Path::new(record.file().unwrap_or_default())
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or_default(),
                 record.line().unwrap_or(0),
                 message,
                 KvDisplay::new(record.key_values()),
@@ -244,7 +248,10 @@ fn format_text_log(out: FormatCallback, message: &fmt::Arguments, record: &log::
                 humantime::format_rfc3339_micros(SystemTime::now()),
                 record.level(),
                 record.module_path().unwrap_or(""),
-                record.file().unwrap_or(""),
+                Path::new(record.file().unwrap_or_default())
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or_default(),
                 record.line().unwrap_or(0),
                 message,
                 KvDisplay::new(record.key_values()),

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -220,7 +220,6 @@ impl QueryResponse {
 /// 1. check `next_uri` before refer to other fields of the response.
 ///
 /// the client in sql logic tests should follow this.
-
 #[poem::handler]
 async fn query_final_handler(
     ctx: &HttpQueryContext,
@@ -381,14 +380,14 @@ pub(crate) async fn query_handler(
                 Ok(QueryResponse::from_internal(query.id.to_string(), resp, false).into_response())
             }
             Err(e) => {
-                error!("{}: http query fail to start sql, error: {:?}", &ctx.query_id, e);
+                error!("http query fail to start sql, error: {:?}", e);
                 ctx.set_fail();
                 Ok(req.fail_to_start_sql(&e).into_response())
             }
         }
     }
-    .in_span(root)
-    .await
+        .in_span(root)
+        .await
 }
 
 pub fn query_route() -> Route {
@@ -420,6 +419,7 @@ fn query_id_removed(query_id: &str, remove_reason: RemoveReason) -> PoemError {
         StatusCode::BAD_REQUEST,
     )
 }
+
 fn query_id_not_found(query_id: &str, node_id: &str) -> PoemError {
     PoemError::from_string(
         format!("query id {query_id} not found on {node_id}"),
@@ -437,7 +437,6 @@ fn query_id_to_trace_id(query_id: &str) -> TraceId {
 /// log it.
 struct SlowRequestLogTracker {
     started_at: std::time::Instant,
-    query_id: String,
     method: String,
     uri: String,
 }
@@ -446,7 +445,6 @@ impl SlowRequestLogTracker {
     fn new(ctx: &HttpQueryContext) -> Self {
         Self {
             started_at: std::time::Instant::now(),
-            query_id: ctx.query_id.clone(),
             method: ctx.http_method.clone(),
             uri: ctx.uri.clone(),
         }
@@ -459,8 +457,7 @@ impl Drop for SlowRequestLogTracker {
             let elapsed = self.started_at.elapsed();
             if elapsed.as_secs_f64() > 60.0 {
                 warn!(
-                    "{}: slow http query request on {} {}, elapsed: {:.2}s",
-                    self.query_id,
+                    "slow http query request on {} {}, elapsed: {:.2}s",
                     self.method,
                     self.uri,
                     elapsed.as_secs_f64()

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -379,10 +379,7 @@ impl HttpQuery {
                         .set_setting(k.to_string(), v.to_string())
                         .or_else(|e| {
                             if e.code() == ErrorCode::UNKNOWN_VARIABLE {
-                                warn!(
-                                    "{}: http query unknown session setting: {}",
-                                    &ctx.query_id, k
-                                );
+                                warn!("http query unknown session setting: {}", k);
                                 Ok(())
                             } else {
                                 Err(e)
@@ -458,7 +455,6 @@ impl HttpQuery {
         let state_clone = state.clone();
         let ctx_clone = ctx.clone();
         let sql = request.sql.clone();
-        let query_id_clone = query_id.clone();
 
         let http_query_runtime_instance = GlobalQueryRuntime::instance();
         let span = if let Some(parent) = SpanContext::current_local_parent() {
@@ -493,10 +489,7 @@ impl HttpQuery {
                         affect: ctx_clone.get_affect(),
                         warnings: ctx_clone.pop_warnings(),
                     };
-                    info!(
-                        "{}: http query change state to Stopped, fail to start {:?}",
-                        &query_id_clone, e
-                    );
+                    info!("http query change state to Stopped, fail to start {:?}", e);
                     Executor::start_to_stop(&state_clone, ExecuteState::Stopped(Box::new(state)))
                         .await;
                     block_sender_closer.close();
@@ -506,7 +499,6 @@ impl HttpQuery {
         )?;
 
         let data = Arc::new(TokioMutex::new(PageManager::new(
-            query_id.clone(),
             request.pagination.max_rows_per_page,
             block_receiver,
             format_settings,

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -407,7 +407,7 @@ impl TableContext for QueryContext {
     fn set_status_info(&self, info: &str) {
         // set_status_info is not called frequently, so we can use info! here.
         // make it easier to match the status to the log.
-        info!("{}: {}", self.get_id(), info);
+        info!("{}", info);
         let mut status = self.shared.status.write();
         *status = info.to_string();
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* `... INFO databend_query::sessions::query_ctx: src/query/service/src/sessions/query_ctx.rs:410 xx` to `...  INFO databend_query::sessions::query_ctx: query_ctx.rs:410 xx`
* remove some query_id from logs

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15487)
<!-- Reviewable:end -->
