### PR TITLE
chore: Increase default io timeout for behavior changes

### DIFF
--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -114,7 +114,7 @@ pub fn build_operator<B: Builder>(builder: B) -> Result<Operator> {
             let retry_io_timeout = env::var("_DATABEND_INTERNAL_RETRY_IO_TIMEOUT")
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
-                .unwrap_or(10);
+                .unwrap_or(60);
 
             let mut timeout_layer = TimeoutLayer::new();
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

After opendal 0.46, io_timeout represents for a whole read request of nearly 4MiB, we should increase the io timeout to allow possible io idle time.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15493)
<!-- Reviewable:end -->
