### PR TITLE
chore: polish error message  NDJSON.

### DIFF
--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_on_error.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_on_error.test
@@ -7,8 +7,8 @@ CREATE TABLE wrong_ndjson (a Boolean, b Int, c Float, d String, e Date, f Timest
 query 
 copy /*+ set_var(max_threads=1) */ into wrong_ndjson from @data/ndjson/ pattern = 'wrong_sample.*[.]ndjson' file_format = (type = NDJSON) ON_ERROR=continue
 ----
-ndjson/wrong_sample.ndjson 3 1 Invalid JSON row: key must be a string at line 1 column 89 2
-ndjson/wrong_sample2.ndjson 3 1 Invalid JSON row: key must be a string at line 1 column 89 2
+ndjson/wrong_sample.ndjson 3 1 Invalid JSON row: key must be a string at pos 88 of size 114, next byte is 'h' 2
+ndjson/wrong_sample2.ndjson 3 1 Invalid JSON row: key must be a string at pos 88 of size 114, next byte is 'h' 2
 
 query 
 select * from wrong_ndjson order by a


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The origin JSON error format "{} at line {} column {}" is misleading for NDJSON in DB context.
- rm `line {}`
- rename `column {}` to `pos {}`, 1-based to 0 based
- add info for size and next byte


Use test in case of changes of serde_json.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15502)
<!-- Reviewable:end -->
