### PR TITLE
refactor: `SessionContext::current_tenant` should not be changed at runtime

### DIFF
--- a/src/query/ee/src/background_service/background_service_handler.rs
+++ b/src/query/ee/src/background_service/background_service_handler.rs
@@ -265,11 +265,17 @@ impl RealBackgroundService {
     }
 
     async fn check_license(&self) -> Result<()> {
-        let settings = SessionManager::create(&self.conf)
+        let session_manager = SessionManager::create(&self.conf);
+
+        let session = session_manager
             .create_session(SessionType::Dummy)
             .await
-            .unwrap()
-            .get_settings();
+            .unwrap();
+
+        let session = session_manager.register_session(session)?;
+
+        let settings = session.get_settings();
+
         // check for valid license
         get_license_manager().manager.check_enterprise_enabled(
             unsafe { settings.get_enterprise_license().unwrap_or_default() },

--- a/src/query/ee/src/background_service/background_service_handler.rs
+++ b/src/query/ee/src/background_service/background_service_handler.rs
@@ -267,10 +267,7 @@ impl RealBackgroundService {
     async fn check_license(&self) -> Result<()> {
         let session_manager = SessionManager::create(&self.conf);
 
-        let session = session_manager
-            .create_session(SessionType::Dummy)
-            .await
-            .unwrap();
+        let session = session_manager.create_session(SessionType::Dummy).await?;
 
         let session = session_manager.register_session(session)?;
 

--- a/src/query/ee/src/background_service/session.rs
+++ b/src/query/ee/src/background_service/session.rs
@@ -25,9 +25,13 @@ use databend_query::sessions::SessionManager;
 use databend_query::sessions::SessionType;
 
 pub async fn create_session(conf: &InnerConfig) -> Result<Arc<Session>> {
-    let session = SessionManager::instance()
+    let session_manager = SessionManager::instance();
+    let session = session_manager
         .create_session(SessionType::FlightSQL)
         .await?;
+
+    let session = session_manager.register_session(session)?;
+
     let user = get_background_service_user(conf);
     session
         .set_authed_user(user.clone(), Some(BUILTIN_ROLE_ACCOUNT_ADMIN.to_string()))

--- a/src/query/ee/src/storage_encryption/handler.rs
+++ b/src/query/ee/src/storage_encryption/handler.rs
@@ -31,11 +31,16 @@ pub struct RealStorageEncryptionHandler {
 #[async_trait::async_trait]
 impl StorageEncryptionHandler for RealStorageEncryptionHandler {
     async fn check_license(&self) -> Result<()> {
-        let settings = SessionManager::create(&self.cfg)
+        let session_manager = SessionManager::create(&self.cfg);
+        let session = session_manager
             .create_session(SessionType::Dummy)
             .await
-            .unwrap()
-            .get_settings();
+            .unwrap();
+
+        let session = session_manager.register_session(session)?;
+
+        let settings = session.get_settings();
+
         // check for valid license
         get_license_manager().manager.check_enterprise_enabled(
             unsafe { settings.get_enterprise_license().unwrap_or_default() },

--- a/src/query/ee/src/storage_encryption/handler.rs
+++ b/src/query/ee/src/storage_encryption/handler.rs
@@ -32,10 +32,8 @@ pub struct RealStorageEncryptionHandler {
 impl StorageEncryptionHandler for RealStorageEncryptionHandler {
     async fn check_license(&self) -> Result<()> {
         let session_manager = SessionManager::create(&self.cfg);
-        let session = session_manager
-            .create_session(SessionType::Dummy)
-            .await
-            .unwrap();
+
+        let session = session_manager.create_session(SessionType::Dummy).await?;
 
         let session = session_manager.register_session(session)?;
 

--- a/src/query/ee/src/storage_quota/handler.rs
+++ b/src/query/ee/src/storage_quota/handler.rs
@@ -33,10 +33,7 @@ impl StorageQuotaHandler for RealStorageQuotaHandler {
     async fn check_license(&self) -> Result<StorageQuota> {
         let session_manager = SessionManager::create(&self.cfg);
 
-        let session = session_manager
-            .create_session(SessionType::Dummy)
-            .await
-            .unwrap();
+        let session = session_manager.create_session(SessionType::Dummy).await?;
 
         let session = session_manager.register_session(session)?;
 

--- a/src/query/ee/src/storage_quota/handler.rs
+++ b/src/query/ee/src/storage_quota/handler.rs
@@ -31,11 +31,16 @@ pub struct RealStorageQuotaHandler {
 #[async_trait::async_trait]
 impl StorageQuotaHandler for RealStorageQuotaHandler {
     async fn check_license(&self) -> Result<StorageQuota> {
-        let settings = SessionManager::create(&self.cfg)
+        let session_manager = SessionManager::create(&self.cfg);
+
+        let session = session_manager
             .create_session(SessionType::Dummy)
             .await
-            .unwrap()
-            .get_settings();
+            .unwrap();
+
+        let session = session_manager.register_session(session)?;
+
+        let settings = session.get_settings();
         // check for valid license
         get_license_manager()
             .manager

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -65,7 +65,7 @@ impl AuthMgr {
     }
 
     #[async_backtrace::framed]
-    pub async fn auth(&self, session: Arc<Session>, credential: &Credential) -> Result<()> {
+    pub async fn auth(&self, session: &mut Session, credential: &Credential) -> Result<()> {
         let user_api = UserApiProvider::instance();
         match credential {
             Credential::Jwt {

--- a/src/query/service/src/local/executor.rs
+++ b/src/query/service/src/local/executor.rs
@@ -66,10 +66,14 @@ static PROMPT_SQL: &str = "select name from system.tables union all select name 
 impl SessionExecutor {
     pub async fn try_new(is_repl: bool, output_format: &str) -> Result<Self> {
         let mut keywords = Vec::with_capacity(1024);
-        let session = SessionManager::instance()
+        let session_manager = SessionManager::instance();
+
+        let session = session_manager
             .create_session(SessionType::Local)
             .await
             .unwrap();
+
+        let session = session_manager.register_session(session)?;
 
         let mut user = UserInfo::new_no_auth("root", "%");
         user.grants.grant_privileges(

--- a/src/query/service/src/servers/admin/v1/cluster.rs
+++ b/src/query/service/src/servers/admin/v1/cluster.rs
@@ -43,10 +43,13 @@ pub async fn cluster_list_handler() -> poem::Result<impl IntoResponse> {
     Ok(Json(nodes))
 }
 
-async fn list_nodes(sessions: &Arc<SessionManager>) -> Result<Vec<Arc<NodeInfo>>> {
-    let watch_cluster_session = sessions
+async fn list_nodes(session_manager: &Arc<SessionManager>) -> Result<Vec<Arc<NodeInfo>>> {
+    let session = session_manager
         .create_session(SessionType::HTTPAPI("WatchCluster".to_string()))
         .await?;
-    let watch_cluster_context = watch_cluster_session.create_query_context().await?;
+
+    let session = session_manager.register_session(session)?;
+
+    let watch_cluster_context = session.create_query_context().await?;
     Ok(watch_cluster_context.get_cluster().get_nodes())
 }

--- a/src/query/service/src/servers/flight/v1/flight_service.rs
+++ b/src/query/service/src/servers/flight/v1/flight_service.rs
@@ -172,6 +172,7 @@ impl FlightService for DatabendQueryFlightService {
                     }
                     let session =
                         session_manager.create_with_settings(SessionType::FlightRPC, settings)?;
+                    let session = session_manager.register_session(session)?;
 
                     let ctx = session.create_query_context().await?;
                     // Keep query id
@@ -228,9 +229,14 @@ impl FlightService for DatabendQueryFlightService {
                 FlightAction::TruncateTable(truncate_table) => {
                     let config = GlobalConfig::instance();
                     let session_manager = SessionManager::instance();
+
                     let settings = Settings::create(config.query.tenant_id.clone());
+
                     let session =
                         session_manager.create_with_settings(SessionType::FlightRPC, settings)?;
+
+                    let session = session_manager.register_session(session)?;
+
                     let ctx = session.create_query_context().await?;
 
                     let interpreter =
@@ -241,9 +247,14 @@ impl FlightService for DatabendQueryFlightService {
                 FlightAction::KillQuery(kill_query) => {
                     let config = GlobalConfig::instance();
                     let session_manager = SessionManager::instance();
+
                     let settings = Settings::create(config.query.tenant_id.clone());
+
                     let session =
                         session_manager.create_with_settings(SessionType::FlightRPC, settings)?;
+
+                    let session = session_manager.register_session(session)?;
+
                     let ctx = session.create_query_context().await?;
 
                     let interpreter = KillInterpreter::from_flight(ctx, kill_query.packet)?;
@@ -253,9 +264,14 @@ impl FlightService for DatabendQueryFlightService {
                 FlightAction::SetPriority(set_priority) => {
                     let config = GlobalConfig::instance();
                     let session_manager = SessionManager::instance();
+
                     let settings = Settings::create(config.query.tenant_id.clone());
+
                     let session =
                         session_manager.create_with_settings(SessionType::FlightRPC, settings)?;
+
+                    let session = session_manager.register_session(session)?;
+
                     let ctx = session.create_query_context().await?;
 
                     let interpreter =

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/session.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/session.rs
@@ -89,10 +89,14 @@ impl FlightSqlServiceImpl {
         password: String,
         client_ip: Option<&str>,
     ) -> Result<Arc<Session>, Status> {
-        let session = SessionManager::instance()
+        let session_manager = SessionManager::instance();
+        let session = session_manager
             .create_session(SessionType::FlightSQL)
             .await
             .map_err(|e| status!("Could not create session", e))?;
+
+        let session = session_manager.register_session(session)?;
+
         let tenant = session.get_current_tenant();
 
         let identity = UserIdentity::new(&user, "%");

--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -238,19 +238,23 @@ impl<E> HTTPSessionEndpoint<E> {
     #[async_backtrace::framed]
     async fn auth(&self, req: &Request, query_id: String) -> Result<HttpQueryContext> {
         let credential = get_credential(req, self.kind)?;
+
         let session_manager = SessionManager::instance();
-        let session = session_manager.create_session(SessionType::Dummy).await?;
-        let ctx = session.create_query_context().await?;
+
+        let mut session = session_manager.create_session(SessionType::Dummy).await?;
+
         if let Some(tenant_id) = req.headers().get("X-DATABEND-TENANT") {
             let tenant_id = tenant_id.to_str().unwrap().to_string();
             let tenant = Tenant::new_or_err(tenant_id.clone(), func_name!())?;
             session.set_current_tenant(tenant);
         }
-        let node_id = ctx.get_cluster().local_id.clone();
 
-        self.auth_manager
-            .auth(ctx.get_current_session(), &credential)
-            .await?;
+        self.auth_manager.auth(&mut session, &credential).await?;
+
+        let session = session_manager.register_session(session)?;
+
+        let ctx = session.create_query_context().await?;
+        let node_id = ctx.get_cluster().local_id.clone();
 
         let deduplicate_label = req
             .headers()

--- a/src/query/service/src/servers/mysql/mysql_handler.rs
+++ b/src/query/service/src/servers/mysql/mysql_handler.rs
@@ -103,14 +103,14 @@ impl MySQLHandler {
     }
 
     fn accept_socket(
-        sessions: Arc<SessionManager>,
+        session_manager: Arc<SessionManager>,
         executor: Arc<Runtime>,
         socket: TcpStream,
         keepalive: TcpKeepalive,
         tls: Option<Arc<ServerConfig>>,
     ) {
         executor.spawn(async move {
-            match sessions.create_session(SessionType::MySQL).await {
+            match session_manager.create_session(SessionType::MySQL).await {
                 Err(error) => {
                     warn!("create session failed, {:?}", error);
                     Self::reject_session(socket, error).await
@@ -118,14 +118,23 @@ impl MySQLHandler {
                 Ok(session) => {
                     info!("MySQL connection coming: {:?}", socket.peer_addr());
 
-                    // TcpStream must implement AsFd for socket2 0.5, wait https://github.com/tokio-rs/tokio/pull/5514
-                    if let Err(e) = SockRef::from(&socket).set_tcp_keepalive(&keepalive) {
-                        warn!("failed to set socket option keepalive {}", e);
-                    }
+                    match session_manager.register_session(session) {
+                        Ok(session) => {
+                            // TcpStream must implement AsFd for socket2 0.5, wait https://github.com/tokio-rs/tokio/pull/5514
+                            if let Err(e) = SockRef::from(&socket).set_tcp_keepalive(&keepalive) {
+                                warn!("failed to set socket option keepalive {}", e);
+                            }
 
-                    if let Err(error) = MySQLConnection::run_on_stream(session, socket, tls) {
-                        error!("Unexpected error occurred during query: {:?}", error);
-                    };
+                            if let Err(error) = MySQLConnection::run_on_stream(session, socket, tls)
+                            {
+                                error!("Unexpected error occurred during query: {:?}", error);
+                            };
+                        }
+                        Err(error) => {
+                            warn!("fail to register session, {:?}", error);
+                            Self::reject_session(socket, error).await
+                        }
+                    }
                 }
             }
         });

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -274,10 +274,6 @@ impl QueryContextShared {
         self.session.get_current_role()
     }
 
-    pub fn set_current_tenant(&self, tenant: Tenant) {
-        self.session.set_current_tenant(tenant);
-    }
-
     /// Get all tables that already attached in this query.
     pub fn get_tables_refs(&self) -> Vec<Arc<dyn Table>> {
         let tables = self.tables_refs.lock();

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -58,19 +58,19 @@ impl Session {
         typ: SessionType,
         session_ctx: Box<SessionContext>,
         mysql_connection_id: Option<u32>,
-    ) -> Result<Arc<Session>> {
+    ) -> Result<Session> {
         let status = Arc::new(Default::default());
-        Ok(Arc::new(Session {
+        Ok(Session {
             id,
             typ: RwLock::new(typ),
             status,
             session_ctx,
             mysql_connection_id,
             format_settings: FormatSettings::default(),
-        }))
+        })
     }
 
-    pub fn to_minitrace_properties(self: &Arc<Self>) -> Vec<(String, String)> {
+    pub fn to_minitrace_properties(&self) -> Vec<(String, String)> {
         let mut properties = vec![
             ("session_id".to_string(), self.id.clone()),
             ("session_database".to_string(), self.get_current_database()),
@@ -88,11 +88,11 @@ impl Session {
         properties
     }
 
-    pub fn get_mysql_conn_id(self: &Arc<Self>) -> Option<u32> {
+    pub fn get_mysql_conn_id(&self) -> Option<u32> {
         self.mysql_connection_id
     }
 
-    pub fn get_id(self: &Arc<Self>) -> String {
+    pub fn get_id(&self) -> String {
         self.id.clone()
     }
 
@@ -106,11 +106,11 @@ impl Session {
         *lock = typ;
     }
 
-    pub fn is_aborting(self: &Arc<Self>) -> bool {
+    pub fn is_aborting(&self) -> bool {
         self.session_ctx.get_abort()
     }
 
-    pub fn quit(self: &Arc<Self>) {
+    pub fn quit(&self) {
         let session_ctx = self.session_ctx.as_ref();
 
         if session_ctx.get_current_query_id().is_some() {
@@ -123,19 +123,19 @@ impl Session {
         http_queries_manager.kill_session(&self.id);
     }
 
-    pub fn kill(self: &Arc<Self>) {
+    pub fn kill(&self) {
         self.session_ctx.set_abort(true);
         self.quit();
     }
 
-    pub fn force_kill_session(self: &Arc<Self>) {
+    pub fn force_kill_session(&self) {
         self.force_kill_query(ErrorCode::AbortedQuery(
             "Aborted query, because the server is shutting down or the query was killed",
         ));
         self.kill(/* shutdown io stream */);
     }
 
-    pub fn force_kill_query(self: &Arc<Self>, cause: ErrorCode) {
+    pub fn force_kill_query(&self, cause: ErrorCode) {
         if let Some(context_shared) = self.session_ctx.get_query_context_shared() {
             context_shared.kill(cause);
         }
@@ -169,38 +169,38 @@ impl Session {
         self.session_ctx.get_current_query_id()
     }
 
-    pub fn attach<F>(self: &Arc<Self>, host: Option<SocketAddr>, io_shutdown: F)
+    pub fn attach<F>(&self, host: Option<SocketAddr>, io_shutdown: F)
     where F: FnOnce() + Send + Sync + 'static {
         self.session_ctx
             .set_client_host(host.map(|host| host.ip().to_string()));
         self.session_ctx.set_io_shutdown_tx(io_shutdown);
     }
 
-    pub fn set_client_host(self: &Arc<Self>, host: Option<String>) {
+    pub fn set_client_host(&self, host: Option<String>) {
         self.session_ctx.set_client_host(host);
     }
 
-    pub fn set_current_database(self: &Arc<Self>, database_name: String) {
+    pub fn set_current_database(&self, database_name: String) {
         self.session_ctx.set_current_database(database_name);
     }
 
-    pub fn get_current_database(self: &Arc<Self>) -> String {
+    pub fn get_current_database(&self) -> String {
         self.session_ctx.get_current_database()
     }
 
-    pub fn get_current_catalog(self: &Arc<Self>) -> String {
+    pub fn get_current_catalog(&self) -> String {
         self.session_ctx.get_current_catalog()
     }
 
-    pub fn get_current_tenant(self: &Arc<Self>) -> Tenant {
+    pub fn get_current_tenant(&self) -> Tenant {
         self.session_ctx.get_current_tenant()
     }
 
-    pub fn set_current_tenant(self: &Arc<Self>, tenant: Tenant) {
+    pub fn set_current_tenant(&mut self, tenant: Tenant) {
         self.session_ctx.set_current_tenant(tenant);
     }
 
-    pub fn get_current_user(self: &Arc<Self>) -> Result<UserInfo> {
+    pub fn get_current_user(&self) -> Result<UserInfo> {
         self.privilege_mgr().get_current_user()
     }
 
@@ -214,7 +214,7 @@ impl Session {
     // becomes the CURRENT ROLE if not set X-DATABEND-ROLE.
     #[async_backtrace::framed]
     pub async fn set_authed_user(
-        self: &Arc<Self>,
+        &self,
         user: UserInfo,
         restricted_role: Option<String>,
     ) -> Result<()> {
@@ -224,7 +224,7 @@ impl Session {
     }
 
     #[async_backtrace::framed]
-    pub async fn validate_available_role(self: &Arc<Self>, role_name: &str) -> Result<RoleInfo> {
+    pub async fn validate_available_role(&self, role_name: &str) -> Result<RoleInfo> {
         self.privilege_mgr()
             .validate_available_role(role_name)
             .await
@@ -233,30 +233,27 @@ impl Session {
     // Only the available role can be set as current role. The current role can be set by the SET
     // ROLE statement, or by the `session.role` field in the HTTP query request body.
     #[async_backtrace::framed]
-    pub async fn set_current_role_checked(self: &Arc<Self>, role_name: &str) -> Result<()> {
+    pub async fn set_current_role_checked(&self, role_name: &str) -> Result<()> {
         self.privilege_mgr()
             .set_current_role(Some(role_name.to_string()))
             .await
     }
 
     #[async_backtrace::framed]
-    pub async fn set_secondary_roles_checked(
-        self: &Arc<Self>,
-        role_names: Option<Vec<String>>,
-    ) -> Result<()> {
+    pub async fn set_secondary_roles_checked(&self, role_names: Option<Vec<String>>) -> Result<()> {
         self.privilege_mgr().set_secondary_roles(role_names).await
     }
 
-    pub fn get_current_role(self: &Arc<Self>) -> Option<RoleInfo> {
+    pub fn get_current_role(&self) -> Option<RoleInfo> {
         self.privilege_mgr().get_current_role()
     }
 
-    pub fn get_secondary_roles(self: &Arc<Self>) -> Option<Vec<String>> {
+    pub fn get_secondary_roles(&self) -> Option<Vec<String>> {
         self.privilege_mgr().get_secondary_roles()
     }
 
     #[async_backtrace::framed]
-    pub async fn unset_current_role(self: &Arc<Self>) -> Result<()> {
+    pub async fn unset_current_role(&self) -> Result<()> {
         self.privilege_mgr().set_current_role(None).await
     }
 
@@ -264,18 +261,18 @@ impl Session {
     // the other roles will be ignored.
     // On executing SET ROLE, the role have to be one of the available roles.
     #[async_backtrace::framed]
-    pub async fn get_all_available_roles(self: &Arc<Self>) -> Result<Vec<RoleInfo>> {
+    pub async fn get_all_available_roles(&self) -> Result<Vec<RoleInfo>> {
         self.privilege_mgr().get_all_available_roles().await
     }
 
     #[async_backtrace::framed]
-    pub async fn get_all_effective_roles(self: &Arc<Self>) -> Result<Vec<RoleInfo>> {
+    pub async fn get_all_effective_roles(&self) -> Result<Vec<RoleInfo>> {
         self.privilege_mgr().get_all_effective_roles().await
     }
 
     #[async_backtrace::framed]
     pub async fn validate_privilege(
-        self: &Arc<Self>,
+        &self,
         object: &GrantObject,
         privilege: UserPrivilegeType,
     ) -> Result<()> {
@@ -288,7 +285,7 @@ impl Session {
     }
 
     #[async_backtrace::framed]
-    pub async fn has_ownership(self: &Arc<Self>, object: &OwnershipObject) -> Result<bool> {
+    pub async fn has_ownership(&self, object: &OwnershipObject) -> Result<bool> {
         if matches!(self.get_type(), SessionType::Local) {
             return Ok(true);
         }
@@ -300,24 +297,24 @@ impl Session {
         self.privilege_mgr().get_visibility_checker().await
     }
 
-    pub fn get_settings(self: &Arc<Self>) -> Arc<Settings> {
+    pub fn get_settings(&self) -> Arc<Settings> {
         self.session_ctx.get_settings()
     }
 
-    pub fn get_memory_usage(self: &Arc<Self>) -> usize {
+    pub fn get_memory_usage(&self) -> usize {
         // TODO(winter): use thread memory tracker
         0
     }
 
-    pub fn get_status(self: &Arc<Self>) -> Arc<RwLock<SessionStatus>> {
+    pub fn get_status(&self) -> Arc<RwLock<SessionStatus>> {
         self.status.clone()
     }
 
-    pub fn get_query_result_cache_key(self: &Arc<Self>, query_id: &str) -> Option<String> {
+    pub fn get_query_result_cache_key(&self, query_id: &str) -> Option<String> {
         self.session_ctx.get_query_result_cache_key(query_id)
     }
 
-    pub fn update_query_ids_results(self: &Arc<Self>, query_id: String, result_cache_key: String) {
+    pub fn update_query_ids_results(&self, query_id: String, result_cache_key: String) {
         self.session_ctx
             .update_query_ids_results(query_id, Some(result_cache_key))
     }

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -37,33 +37,35 @@ pub struct SessionContext {
     settings: Arc<Settings>,
     current_catalog: RwLock<String>,
     current_database: RwLock<String>,
-    // The current tenant can be determined by databend-query's config file, or by X-DATABEND-TENANT
-    // if it's in management mode. If databend-query is not in management mode, the current tenant
-    // can not be modified at runtime.
-    current_tenant: RwLock<Option<Tenant>>,
-    // The current user is determined by the authentication phase on each connection. It will not be
-    // changed during a session.
+
+    /// The current tenant can be determined by databend-query's config file, or by X-DATABEND-TENANT
+    /// if it's in management mode.
+    /// If databend-query is not in management mode, the current tenant can **NOT** be modified at runtime.
+    current_tenant: Option<Tenant>,
+
+    /// The current user is determined by the authentication phase on each connection. It will not be
+    /// changed during a session.
     current_user: RwLock<Option<UserInfo>>,
-    // Each session has a current role, by default all the users' granted roles will take effect,
-    // and the current role will become the owner of the database/table that the user created.
-    // The user can switch to another available role by `SET ROLE`. If the current_role is not set,
-    // it takes the user's default role.
+    /// Each session has a current role, by default all the users' granted roles will take effect,
+    /// and the current role will become the owner of the database/table that the user created.
+    /// The user can switch to another available role by `SET ROLE`. If the current_role is not set,
+    /// it takes the user's default role.
     current_role: RwLock<Option<RoleInfo>>,
-    // When an user comes from an external authenticator, the session is usually mapped to a single role.
+    /// When an user comes from an external authenticator, the session is usually mapped to a single role.
     auth_role: RwLock<Option<String>>,
-    // To SET SECONDARY ROLES ALL, the session will have all the roles take effect. On the other hand,
-    // SET SEONCDARY ROLES NONE will disable all the roles except the current role.
-    // By default, the SECONDARY ROLES is ALL, which is None here. There're a few cases that the SECONDARY
-    // ROLES is preferred to be empty, which is Some([]) here:
-    // 1. The user comes from an external authenticator, which maps to a single role.
-    // 2. The role is intentionally restricted by the sql client, to run SQLs with a restricted privileges.
+    /// To SET SECONDARY ROLES ALL, the session will have all the roles take effect. On the other hand,
+    /// SET SEONCDARY ROLES NONE will disable all the roles except the current role.
+    /// By default, the SECONDARY ROLES is ALL, which is None here. There're a few cases that the SECONDARY
+    /// ROLES is preferred to be empty, which is Some([]) here:
+    /// 1. The user comes from an external authenticator, which maps to a single role.
+    /// 2. The role is intentionally restricted by the sql client, to run SQLs with a restricted privileges.
     secondary_roles: RwLock<Option<Vec<String>>>,
-    // The client IP from the client.
+    /// The client IP from the client.
     client_host: RwLock<Option<String>>,
     io_shutdown_tx: RwLock<Option<Box<dyn FnOnce() + Send + Sync + 'static>>>,
     query_context_shared: RwLock<Weak<QueryContextShared>>,
-    // We store `query_id -> query_result_cache_key` to session context, so that we can fetch
-    // query result through previous query_id easily.
+    /// We store `query_id -> query_result_cache_key` to session context, so that we can fetch
+    /// query result through previous query_id easily.
     query_ids_results: RwLock<Vec<(String, Option<String>)>>,
     typ: SessionType,
     txn_mgr: Mutex<TxnManagerRef>,
@@ -161,8 +163,7 @@ impl SessionContext {
         }
 
         if conf.query.management_mode || self.typ == SessionType::Local {
-            let lock = self.current_tenant.read();
-            if let Some(tenant) = &*lock {
+            if let Some(tenant) = &self.current_tenant {
                 return tenant.clone();
             }
         }
@@ -170,9 +171,8 @@ impl SessionContext {
         conf.query.tenant_id.clone()
     }
 
-    pub fn set_current_tenant(&self, tenant: Tenant) {
-        let mut lock = self.current_tenant.write();
-        *lock = Some(tenant);
+    pub(in crate::sessions) fn set_current_tenant(&mut self, tenant: Tenant) {
+        self.current_tenant = Some(tenant);
     }
 
     // Get current user

--- a/src/query/service/src/test_kits/fixture.rs
+++ b/src/query/service/src/test_kits/fixture.rs
@@ -173,6 +173,29 @@ impl TestFixture {
         .await
     }
 
+    /// Create a non-shared dummy session.
+    pub async fn create_dummy_session() -> Session {
+        let session_manager = SessionManager::instance();
+        let session = session_manager
+            .create_session(SessionType::Dummy)
+            .await
+            .unwrap();
+
+        let mut user_info = UserInfo::new("root", "%", AuthInfo::Password {
+            hash_method: PasswordHashMethod::Sha256,
+            hash_value: Vec::from("pass"),
+        });
+
+        user_info.grants.grant_privileges(
+            &GrantObject::Global,
+            UserPrivilegeSet::available_privileges_on_global(),
+        );
+
+        session.set_authed_user(user_info, None).await.unwrap();
+        session.get_settings().set_max_threads(8).unwrap();
+        session
+    }
+
     async fn create_session(session_type: SessionType) -> Result<Arc<Session>> {
         let mut user_info = UserInfo::new("root", "%", AuthInfo::Password {
             hash_method: PasswordHashMethod::Sha256,
@@ -184,14 +207,16 @@ impl TestFixture {
             UserPrivilegeSet::available_privileges_on_global(),
         );
 
-        let dummy_session = SessionManager::instance()
-            .create_session(session_type)
-            .await?;
+        let session_manager = SessionManager::instance();
 
-        dummy_session.set_authed_user(user_info, None).await?;
-        dummy_session.get_settings().set_max_threads(8)?;
+        let dummy_session = session_manager.create_session(session_type).await?;
 
-        Ok(dummy_session)
+        let session = session_manager.register_session(dummy_session)?;
+
+        session.set_authed_user(user_info, None).await?;
+        session.get_settings().set_max_threads(8)?;
+
+        Ok(session)
     }
 
     /// Setup the test environment.

--- a/src/query/service/tests/it/sessions/session.rs
+++ b/src/query/service/tests/it/sessions/session.rs
@@ -15,14 +15,13 @@
 use databend_common_base::base::tokio;
 use databend_common_exception::Result;
 use databend_common_meta_app::tenant::Tenant;
-use databend_query::sessions::SessionType;
 use databend_query::test_kits::ConfigBuilder;
 use databend_query::test_kits::TestFixture;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_session() -> Result<()> {
-    let fixture = TestFixture::setup().await?;
-    let session = fixture.new_session_with_type(SessionType::Dummy).await?;
+    let _fixture = TestFixture::setup().await?;
+    let mut session = TestFixture::create_dummy_session().await;
 
     // Tenant.
     {
@@ -49,8 +48,9 @@ async fn test_session() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_session_in_management_mode() -> Result<()> {
     let config = ConfigBuilder::create().with_management_mode().build();
-    let fixture = TestFixture::setup_with_config(&config).await?;
-    let session = fixture.new_session_with_type(SessionType::Dummy).await?;
+    let _fixture = TestFixture::setup_with_config(&config).await?;
+
+    let mut session = TestFixture::create_dummy_session().await;
 
     // Tenant.
     {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### Refactor: `SessionContext::current_tenant` should not be changed at runtime

Due to the design principle that `SessionContext::current_tenant` should
not be modified at runtime, this commit transitions
`SessionContext::current_tenant` from a shared `RwLock<Option<Tenant>>`
to a non-shared `Option<Tenant>`.

Additionally, the process of constructing a `Session` has been divided
into two distinct steps:

1. Initially build an instance and set up initial values, including
   `current_tenant`.

2. Convert the `Session` instance into a readonly `Arc<Session>` to
   facilitate sharing across `QueryContext` and other components.

Other Changes:

- Methods of `Session` are now bound to `&self` instead of `&Arc<Self>`.

- The method `SessionCtx::set_current_tenant()` has been made private
  within its module.

- The function `SessionManager::register_session()` has been extracted from
  `SessionManager::create_with_settings()`. Because `Session` creation
  and registration must be two distinct steps.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15504)
<!-- Reviewable:end -->
