### PR TITLE
refactor: migrate TSV input format to new framework.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,6 +4418,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-expression",
  "databend-common-formats",
+ "databend-common-io",
  "databend-common-meta-app",
  "databend-common-pipeline-core",
  "databend-common-pipeline-sources",

--- a/src/query/storages/stage/Cargo.toml
+++ b/src/query/storages/stage/Cargo.toml
@@ -18,6 +18,7 @@ databend-common-compress = { path = "../../../common/compress" }
 databend-common-exception = { path = "../../../common/exception" }
 databend-common-expression = { path = "../../expression" }
 databend-common-formats = { path = "../../formats" }
+databend-common-io = { path = "../../../common/io" }
 databend-common-meta-app = { path = "../../../meta/app" }
 databend-common-pipeline-core = { path = "../../pipeline/core" }
 databend-common-pipeline-sources = { path = "../../pipeline/sources" }

--- a/src/query/storages/stage/src/read/row_based/format.rs
+++ b/src/query/storages/stage/src/read/row_based/format.rs
@@ -26,6 +26,7 @@ use super::processors::BlockBuilderState;
 use crate::read::load_context::LoadContext;
 use crate::read::row_based::formats::CsvInputFormat;
 use crate::read::row_based::formats::NdJsonInputFormat;
+use crate::read::row_based::formats::TsvInputFormat;
 
 pub trait SeparatorState: Send + Sync {
     fn append(&mut self, batch: BytesBatch) -> Result<(Vec<RowBatchWithPosition>, FileStatus)>;
@@ -56,6 +57,7 @@ pub fn create_row_based_file_format(params: &FileFormatParams) -> Arc<dyn RowBas
     match params {
         FileFormatParams::Csv(p) => Arc::new(CsvInputFormat { params: p.clone() }),
         FileFormatParams::NdJson(p) => Arc::new(NdJsonInputFormat { params: p.clone() }),
+        FileFormatParams::Tsv(p) => Arc::new(TsvInputFormat { params: p.clone() }),
         _ => {
             unreachable!("Unsupported row based file format")
         }

--- a/src/query/storages/stage/src/read/row_based/formats/tsv/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/tsv/block_builder.rs
@@ -1,0 +1,224 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Cursor;
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+use databend_common_expression::ColumnBuilder;
+use databend_common_expression::DataBlock;
+use databend_common_formats::SeparatedTextDecoder;
+use databend_common_io::cursor_ext::BufferReadStringExt;
+use databend_common_pipeline_sources::input_formats::error_utils::get_decode_error_by_pos;
+use databend_common_storage::FileParseError;
+
+use crate::read::load_context::LoadContext;
+use crate::read::row_based::batch::RowBatchWithPosition;
+use crate::read::row_based::format::RowDecoder;
+use crate::read::row_based::formats::tsv::format::TsvInputFormat;
+use crate::read::row_based::processors::BlockBuilderState;
+
+pub struct TsvDecoder {
+    pub load_context: Arc<LoadContext>,
+    pub fmt: TsvInputFormat,
+    pub field_decoder: SeparatedTextDecoder,
+
+    pub field_delimiter: u8,
+
+    pub record_delimiter: u8,
+    pub trim_cr: bool,
+}
+
+impl TsvDecoder {
+    pub fn create(fmt: TsvInputFormat, load_context: Arc<LoadContext>) -> Self {
+        let field_decoder =
+            SeparatedTextDecoder::create_tsv(&fmt.params, &load_context.file_format_options_ext);
+        let field_delimiter = fmt.params.field_delimiter.as_bytes()[0];
+
+        // we only accept \r\n when len > 1
+        let trim_cr = fmt.params.field_delimiter.as_bytes().len() > 1;
+        // safe to unwrap, params are checked
+        let record_delimiter = *fmt.params.record_delimiter.as_bytes().last().unwrap();
+        Self {
+            load_context,
+            fmt,
+            field_decoder,
+            field_delimiter,
+            record_delimiter,
+            trim_cr,
+        }
+    }
+
+    fn trim_record_delimiter<'a>(&self, mut row: &'a [u8]) -> &'a [u8] {
+        let len = row.len();
+        if len > 0 && row[len - 1] == self.record_delimiter {
+            row = &row[..(len - 1)];
+            if self.trim_cr && len > 2 && row[len - 2] == b'\r' {
+                row = &row[..(len - 2)];
+            }
+        }
+        row
+    }
+
+    fn read_column(
+        &self,
+        builder: &mut ColumnBuilder,
+        col_data: &[u8],
+        column_index: usize,
+    ) -> std::result::Result<(), FileParseError> {
+        if col_data.is_empty() {
+            match &self.load_context.default_values {
+                None => {
+                    builder.push_default();
+                }
+                Some(values) => {
+                    builder.push(values[column_index].as_ref());
+                }
+            }
+            Ok(())
+        } else {
+            // todo(youngsofun): optimize this later after refactor.
+            let mut cursor = Cursor::new(col_data);
+            let mut data = vec![];
+            cursor.read_escaped_string_text(&mut data).map_err(|e| {
+                get_decode_error_by_pos(
+                    column_index,
+                    &self.load_context.schema,
+                    &e.to_string(),
+                    col_data,
+                )
+            })?;
+            if let Err(e) = self.field_decoder.read_field(builder, &data) {
+                return Err(get_decode_error_by_pos(
+                    column_index,
+                    &self.load_context.schema,
+                    &e.message(),
+                    col_data,
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    fn read_row(
+        &self,
+        buf: &[u8],
+        columns: &mut [ColumnBuilder],
+    ) -> std::result::Result<(), FileParseError> {
+        let num_columns = columns.len();
+        let mut column_index = 0;
+        let mut field_start = 0;
+        let mut field_end = 0;
+        let mut error = None;
+        let buf_len = buf.len();
+        let mut last_is_delimiter = false;
+        if let Some(columns_to_read) = &self.load_context.pos_projection {
+            while field_end <= buf_len && column_index < num_columns {
+                if field_end == buf_len
+                    || (buf[field_end] == self.field_delimiter && !last_is_delimiter)
+                {
+                    if columns_to_read.contains(&column_index) {
+                        if let Err(e) = self.read_column(
+                            &mut columns[column_index],
+                            &buf[field_start..field_end],
+                            column_index,
+                        ) {
+                            error = Some(e);
+                            break;
+                        }
+                    }
+                    column_index += 1;
+                    field_start = field_end + 1;
+                }
+                if field_end < buf_len {
+                    last_is_delimiter = (buf[field_end] == b'\\') && !last_is_delimiter
+                }
+                field_end += 1;
+            }
+            if error.is_none() {
+                while column_index < num_columns {
+                    columns[column_index].push_default();
+                    column_index += 1;
+                }
+            }
+        } else {
+            while field_end <= buf_len && column_index < num_columns {
+                if field_end == buf_len
+                    || (buf[field_end] == self.field_delimiter && !last_is_delimiter)
+                {
+                    if let Err(err) = self.read_column(
+                        &mut columns[column_index],
+                        &buf[field_start..field_end],
+                        column_index,
+                    ) {
+                        error = Some(err);
+                        break;
+                    }
+                    column_index += 1;
+                    field_start = field_end + 1;
+                }
+                if field_end < buf_len {
+                    last_is_delimiter = (buf[field_end] == b'\\') && !last_is_delimiter
+                }
+                field_end += 1;
+            }
+            if error.is_none() {
+                // expect: field_end > buf_len && column_index == num_columns
+                if column_index < num_columns {
+                    error = Some(FileParseError::NumberOfColumnsMismatch {
+                        table: num_columns,
+                        file: column_index,
+                    });
+                } else if field_end <= buf_len {
+                    error = Some(FileParseError::NumberOfColumnsMismatch {
+                        table: num_columns,
+                        file: num_columns + 1,
+                    });
+                }
+            }
+        }
+        if let Some(e) = error { Err(e) } else { Ok(()) }
+    }
+}
+
+impl RowDecoder for TsvDecoder {
+    fn add(
+        &self,
+        state: &mut BlockBuilderState,
+        batch: RowBatchWithPosition,
+    ) -> Result<Vec<DataBlock>> {
+        let columns = &mut state.mutable_columns;
+        let data = batch.data.into_nd_json().unwrap();
+
+        for (row_id, mut row) in data.iter().enumerate() {
+            // trim the record delimiter
+            row = self.trim_record_delimiter(row);
+            if !row.is_empty() {
+                if let Err(e) = self.read_row(row, columns) {
+                    self.load_context.error_handler.on_error(
+                        e,
+                        Some((columns, state.num_rows)),
+                        &mut state.file_status,
+                        &batch.start_pos.path,
+                        batch.start_pos.rows + row_id,
+                    )?
+                } else {
+                    state.num_rows += 1;
+                    state.file_status.num_rows_loaded += 1;
+                }
+            }
+        }
+        Ok(vec![])
+    }
+}

--- a/src/query/storages/stage/src/read/row_based/formats/tsv/format.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/tsv/format.rs
@@ -1,0 +1,48 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+use databend_common_meta_app::principal::TsvFileFormatParams;
+
+use crate::read::load_context::LoadContext;
+use crate::read::row_based::format::RowBasedFileFormat;
+use crate::read::row_based::format::RowDecoder;
+use crate::read::row_based::format::SeparatorState;
+use crate::read::row_based::formats::tsv::block_builder::TsvDecoder;
+use crate::read::row_based::formats::tsv::separator::TsvRowSeparator;
+
+#[derive(Clone)]
+pub struct TsvInputFormat {
+    pub(crate) params: TsvFileFormatParams,
+}
+
+impl RowBasedFileFormat for TsvInputFormat {
+    fn try_create_separator(
+        &self,
+        _load_ctx: Arc<LoadContext>,
+        path: &str,
+    ) -> Result<Box<dyn SeparatorState>> {
+        Ok(Box::new(TsvRowSeparator::try_create(
+            path,
+            *self.params.record_delimiter.as_bytes().last().unwrap(),
+            self.params.headers,
+        )?))
+    }
+
+    fn try_create_decoder(&self, load_ctx: Arc<LoadContext>) -> Result<Arc<dyn RowDecoder>> {
+        Ok(Arc::new(TsvDecoder::create(self.clone(), load_ctx.clone())))
+    }
+}

--- a/src/query/storages/stage/src/read/row_based/formats/tsv/mod.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/tsv/mod.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod csv;
-mod ndjson;
-mod tsv;
+mod block_builder;
+mod format;
+mod separator;
 
-pub use csv::CsvInputFormat;
-pub use ndjson::NdJsonInputFormat;
-pub use tsv::TsvInputFormat;
+pub use format::TsvInputFormat;

--- a/src/query/storages/stage/src/read/row_based/formats/tsv/separator.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/tsv/separator.rs
@@ -1,0 +1,250 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::default::Default;
+
+use databend_common_exception::Result;
+use databend_common_storage::FileStatus;
+
+use crate::read::row_based::batch::BytesBatch;
+use crate::read::row_based::batch::NdjsonRowBatch;
+use crate::read::row_based::batch::Position;
+use crate::read::row_based::batch::RowBatch;
+use crate::read::row_based::batch::RowBatchWithPosition;
+use crate::read::row_based::format::SeparatorState;
+
+pub struct TsvRowSeparator {
+    // remain from last read batch
+    last_partial_row: Vec<u8>,
+    pos: Position,
+    record_delimiter: u8,
+    in_escape: bool,
+    rows_to_skip: u64,
+}
+
+/// Like ndjson, we try to pass the buf read to RowBatch (for parallelism) directly, benefits are:
+/// - avoid realloc.
+/// - able to get the original data for diagnostic.
+///
+/// TsvRowSeparator is more complicated than NdJsonRowSeparator:
+/// delimiter in content can present as '\<delimiter>',
+/// which means \n can also present as '\<a_real_newline>' ( the default of mysql)
+impl SeparatorState for TsvRowSeparator {
+    fn append(&mut self, batch: BytesBatch) -> Result<(Vec<RowBatchWithPosition>, FileStatus)> {
+        self.separate(batch)
+    }
+}
+
+impl TsvRowSeparator {
+    pub fn try_create(path: &str, record_delimiter: u8, rows_to_skip: u64) -> Result<Self> {
+        Ok(Self {
+            last_partial_row: vec![],
+            pos: Position::new(path.to_string()),
+            record_delimiter,
+            in_escape: false,
+            rows_to_skip,
+        })
+    }
+
+    fn separate(
+        &mut self,
+        mut batch: BytesBatch,
+    ) -> Result<(Vec<RowBatchWithPosition>, FileStatus)> {
+        let mut data = std::mem::take(&mut batch.data);
+        let mut rows: NdjsonRowBatch = Default::default();
+        let mut check_first = !self.last_partial_row.is_empty();
+        let mut end = 0;
+        for (i, b) in data.iter().enumerate() {
+            // here we only care about the escape of record_delimiter
+            if *b == self.record_delimiter && !self.in_escape {
+                if check_first {
+                    let mut tail_of_last_batch = std::mem::take(&mut self.last_partial_row);
+                    tail_of_last_batch.extend_from_slice(&data[..i]);
+                    rows.tail_of_last_batch = Some(tail_of_last_batch);
+                    rows.start = i + 1;
+                    check_first = false;
+                } else if self.rows_to_skip > 0 {
+                    self.rows_to_skip -= 1;
+                    if self.rows_to_skip == 0 {
+                        rows.start = i + 1;
+                    }
+                } else {
+                    rows.row_ends.push(i + 1)
+                }
+                end = i + 1;
+                // keep self.in_escape = false
+            } else {
+                self.in_escape = (*b == b'\\') && !self.in_escape
+            }
+        }
+
+        if batch.is_eof {
+            if end < data.len() {
+                if self.last_partial_row.is_empty() {
+                    // make the last line end with record_delimiter,
+                    // so we can trim all rows in the same way.
+                    // most of the time, it will not lead to realloc.
+                    data.push(self.record_delimiter);
+                    rows.row_ends.push(data.len());
+                } else {
+                    self.last_partial_row.extend_from_slice(&data);
+                    rows.tail_of_last_batch = Some(std::mem::take(&mut self.last_partial_row));
+                }
+            }
+        } else {
+            self.last_partial_row.extend_from_slice(&data[end..]);
+        }
+
+        let batch = if rows.rows() == 0 {
+            vec![]
+        } else {
+            rows.data = data;
+            let out_pos = self.pos.clone();
+            self.pos.rows += rows.rows();
+            vec![RowBatchWithPosition::new(RowBatch::NDJson(rows), out_pos)]
+        };
+        Ok((batch, FileStatus::default()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn helper(
+        last: &[u8],
+        new: &[u8],
+        is_eof: bool,
+        exp_last: &[u8],
+        exp_rows: usize,
+        exp_output: Option<NdjsonRowBatch>,
+    ) -> Result<()> {
+        let mut sep = TsvRowSeparator::try_create("test", b'\n', 0).unwrap();
+        sep.last_partial_row = last.to_vec();
+
+        let input = BytesBatch {
+            data: new.to_vec(),
+            path: "".to_string(),
+            offset: 0,
+            is_eof,
+        };
+
+        let (batches, _) = sep.append(input).unwrap();
+        assert_eq!(sep.last_partial_row, exp_last);
+        assert_eq!(sep.pos.rows, exp_rows);
+        if let Some(output) = exp_output {
+            assert_eq!(batches.len(), 1);
+            if let RowBatch::NDJson(rows) = &batches[0].data {
+                assert_eq!(rows.rows(), output.rows());
+                assert_eq!(rows.row_ends, output.row_ends);
+                assert_eq!(rows.tail_of_last_batch, output.tail_of_last_batch);
+            } else {
+                panic!()
+            }
+        } else {
+            assert_eq!(batches.len(), 0);
+        }
+        Ok(())
+    }
+
+    // same as NdjsoneRowSeparator
+    #[test]
+    fn test_tsv_row_separator() -> Result<()> {
+        helper(
+            b"",
+            b"1\n2\n3\n4\n5\n",
+            false,
+            b"",
+            5,
+            Some(NdjsonRowBatch {
+                data: b"1\n2\n3\n4\n5\n".to_vec(),
+                row_ends: vec![2, 4, 6, 8, 10],
+                tail_of_last_batch: None,
+                start: 0,
+            }),
+        )?;
+        helper(
+            b"",
+            b"1\n2\n3\n4\n5",
+            false,
+            b"5",
+            4,
+            Some(NdjsonRowBatch {
+                data: b"1\n2\n3\n4\n5\n".to_vec(),
+                row_ends: vec![2, 4, 6, 8],
+                tail_of_last_batch: None,
+                start: 0,
+            }),
+        )?;
+        helper(
+            b"",
+            b"1\n2\n3\n4\n5",
+            true,
+            b"",
+            5,
+            Some(NdjsonRowBatch {
+                data: b"1\n2\n3\n4\n5\n".to_vec(),
+                row_ends: vec![2, 4, 6, 8, 10],
+                tail_of_last_batch: None,
+                start: 0,
+            }),
+        )?;
+        helper(
+            b"0",
+            b"1\n2\n3\n4\n5\n",
+            true,
+            b"",
+            5,
+            Some(NdjsonRowBatch {
+                data: b"1\n2\n3\n4\n5\n".to_vec(),
+                row_ends: vec![4, 6, 8, 10],
+                tail_of_last_batch: Some(b"01".to_vec()),
+                start: 2,
+            }),
+        )?;
+        helper(b"0", b"1", false, b"01", 0, None)?;
+        helper(
+            b"0",
+            b"1",
+            true,
+            b"",
+            1,
+            Some(NdjsonRowBatch {
+                data: b"".to_vec(),
+                row_ends: vec![],
+                tail_of_last_batch: Some(b"01".to_vec()),
+                start: 0,
+            }),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_tsv_row_separator_newline() -> Result<()> {
+        helper(
+            b"",
+            b"\\\n\n2\n3\n4\n5\n",
+            false,
+            b"",
+            5,
+            Some(NdjsonRowBatch {
+                data: b"\\\n\n2\n3\n4\n5\n".to_vec(),
+                row_ends: vec![3, 5, 7, 9, 11],
+                tail_of_last_batch: None,
+                start: 0,
+            }),
+        )?;
+        Ok(())
+    }
+}

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -154,7 +154,7 @@ impl Table for StageTable {
             FileFormatParams::Parquet(_) => {
                 ParquetTableForCopy::do_read_partitions(stage_table_info, ctx, _push_downs).await
             }
-            FileFormatParams::Csv(_) | FileFormatParams::NdJson(_)
+            FileFormatParams::Csv(_) | FileFormatParams::NdJson(_) | FileFormatParams::Tsv(_)
                 if settings.get_enable_new_copy_for_text_formats()? == 1 =>
             {
                 self.read_partitions_simple(ctx, stage_table_info).await
@@ -185,7 +185,7 @@ impl Table for StageTable {
             FileFormatParams::Parquet(_) => {
                 ParquetTableForCopy::do_read_data(ctx, plan, pipeline, _put_cache)
             }
-            FileFormatParams::Csv(_) | FileFormatParams::NdJson(_)
+            FileFormatParams::Csv(_) | FileFormatParams::NdJson(_) | FileFormatParams::Tsv(_)
                 if settings.get_enable_new_copy_for_text_formats()? == 1 =>
             {
                 let compact_threshold = ctx.get_read_block_thresholds();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1.  no longer tries to `read` big TSV in parallel to make it simple and always able to get row id, but still can be deserialized in parallel after cutting into RowBatches.
2.  simplify the handling of skip headers.
3.  minimal reallocating of file data.
 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15506)
<!-- Reviewable:end -->
