### PR TITLE
chore: change load_file_metadata_expire_hours default from 24*7 to 12 hours

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -345,7 +345,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
                 ("load_file_metadata_expire_hours", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(24 * 7),
+                    value: UserSettingValue::UInt64(24),
                     desc: "Sets the hours that the metadata of files you load data from with COPY INTO will expire in.",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* `load_file_metadata_expire_hours` now is 12 hours

* For optimal COPY operations, it is recommended to use the following syntax: `COPY INTO <table> FROM FILES = ('file1', 'file2')`, no need s3 list. https://docs.databend.com/sql/sql-commands/dml/dml-copy-into-table#files


- Fixes #15500

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - default setting value change

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15514)
<!-- Reviewable:end -->
