### PR TITLE
chore: adjust elapsed time of various log messages

### DIFF
--- a/src/query/ee/src/storages/fuse/io/snapshots.rs
+++ b/src/query/ee/src/storages/fuse/io/snapshots.rs
@@ -78,11 +78,11 @@ where
         {
             count += chunk.len();
             let status = format!(
-                "gc orphan: read snapshot files:{}/{}, segment files: {}, cost:{} sec",
+                "gc orphan: read snapshot files:{}/{}, segment files: {}, cost:{:?}",
                 count,
                 snapshot_files.len(),
                 segments.len(),
-                start.elapsed().as_secs()
+                start.elapsed()
             );
             info!("{}", status);
             (status_callback)(status);

--- a/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
@@ -74,10 +74,10 @@ pub async fn do_vacuum_drop_table(
         };
 
         info!(
-            "vacuum drop table {:?} dir {:?}, cost:{} sec",
+            "vacuum drop table {:?} dir {:?}, cost:{:?}",
             table_info.name,
             dir,
-            start.elapsed().as_secs()
+            start.elapsed()
         );
     }
     Ok(if dry_run_limit.is_some() {
@@ -150,9 +150,9 @@ pub async fn do_vacuum_drop_tables(
     };
 
     info!(
-        "do_vacuum_drop_tables {} tables, cost:{} sec",
+        "do_vacuum_drop_tables {} tables, cost:{:?}",
         tables_len,
-        start.elapsed().as_secs()
+        start.elapsed()
     );
 
     Ok(result)

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
@@ -177,11 +177,11 @@ pub async fn do_gc_orphan_files(
         None => return Ok(()),
     };
     let status = format!(
-        "gc orphan: read referenced files:{},{},{}, cost:{} sec",
+        "gc orphan: read referenced files:{},{},{}, cost:{:?}",
         referenced_files.segments.len(),
         referenced_files.blocks.len(),
         referenced_files.blocks_index.len(),
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -191,9 +191,9 @@ pub async fn do_gc_orphan_files(
         get_orphan_files_to_be_purged(fuse_table, referenced_files.segments, retention_time)
             .await?;
     let status = format!(
-        "gc orphan: read segment_locations_to_be_purged:{}, cost:{} sec, retention_time: {}",
+        "gc orphan: read segment_locations_to_be_purged:{}, cost:{:?}, retention_time: {}",
         segment_locations_to_be_purged.len(),
-        start.elapsed().as_secs(),
+        start.elapsed(),
         retention_time
     );
     ctx.set_status_info(&status);
@@ -207,9 +207,9 @@ pub async fn do_gc_orphan_files(
         )
         .await?;
     let status = format!(
-        "gc orphan: purged segment files:{}, cost:{} sec",
+        "gc orphan: purged segment files:{}, cost:{:?}",
         purged_file_num,
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -218,9 +218,9 @@ pub async fn do_gc_orphan_files(
     let block_locations_to_be_purged =
         get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks, retention_time).await?;
     let status = format!(
-        "gc orphan: read block_locations_to_be_purged:{}, cost:{} sec",
+        "gc orphan: read block_locations_to_be_purged:{}, cost:{:?}",
         block_locations_to_be_purged.len(),
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -233,9 +233,9 @@ pub async fn do_gc_orphan_files(
         )
         .await?;
     let status = format!(
-        "gc orphan: purged block files:{}, cost:{} sec",
+        "gc orphan: purged block files:{}, cost:{:?}",
         purged_file_num,
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -245,9 +245,9 @@ pub async fn do_gc_orphan_files(
         get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks_index, retention_time)
             .await?;
     let status = format!(
-        "gc orphan: read index_locations_to_be_purged:{}, cost:{} sec",
+        "gc orphan: read index_locations_to_be_purged:{}, cost:{:?}",
         index_locations_to_be_purged.len(),
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -260,9 +260,9 @@ pub async fn do_gc_orphan_files(
         )
         .await?;
     let status = format!(
-        "gc orphan: purged block index files:{}, cost:{} sec",
+        "gc orphan: purged block index files:{}, cost:{:?}",
         purged_file_num,
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -284,11 +284,11 @@ pub async fn do_dry_run_orphan_files(
         None => return Ok(()),
     };
     let status = format!(
-        "dry_run orphan: read referenced files:{},{},{}, cost:{} sec",
+        "dry_run orphan: read referenced files:{},{},{}, cost:{:?}",
         referenced_files.segments.len(),
         referenced_files.blocks.len(),
         referenced_files.blocks_index.len(),
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -297,9 +297,9 @@ pub async fn do_dry_run_orphan_files(
         get_orphan_files_to_be_purged(fuse_table, referenced_files.segments, retention_time)
             .await?;
     let status = format!(
-        "dry_run orphan: read segment_locations_to_be_purged:{}, cost:{} sec",
+        "dry_run orphan: read segment_locations_to_be_purged:{}, cost:{:?}",
         segment_locations_to_be_purged.len(),
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -312,9 +312,9 @@ pub async fn do_dry_run_orphan_files(
     let block_locations_to_be_purged =
         get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks, retention_time).await?;
     let status = format!(
-        "dry_run orphan: read block_locations_to_be_purged:{}, cost:{} sec",
+        "dry_run orphan: read block_locations_to_be_purged:{}, cost:{:?}",
         block_locations_to_be_purged.len(),
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
     purge_files.extend(block_locations_to_be_purged);
@@ -327,9 +327,9 @@ pub async fn do_dry_run_orphan_files(
         get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks_index, retention_time)
             .await?;
     let status = format!(
-        "dry_run orphan: read index_locations_to_be_purged:{}, cost:{} sec",
+        "dry_run orphan: read index_locations_to_be_purged:{}, cost:{:?}",
         index_locations_to_be_purged.len(),
-        start.elapsed().as_secs()
+        start.elapsed()
     );
     ctx.set_status_info(&status);
 
@@ -352,10 +352,7 @@ pub async fn do_vacuum(
     let purge_files_opt = fuse_table
         .purge(ctx.clone(), instant, dry_run_limit, true, dry_run)
         .await?;
-    let status = format!(
-        "do_vacuum: purged table, cost:{} sec",
-        start.elapsed().as_secs()
-    );
+    let status = format!("do_vacuum: purged table, cost:{:?}", start.elapsed());
     ctx.set_status_info(&status);
     let retention = Duration::days(ctx.get_settings().get_data_retention_time_in_days()? as i64);
     // use min(now - get_retention_period(), retention_time) as gc orphan files retention time

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -184,9 +184,8 @@ impl Interpreter for ReclusterTableInterpreter {
             // Status.
             {
                 let status = format!(
-                    "recluster: run recluster tasks:{} times, cost:{} sec",
-                    times,
-                    elapsed_time.as_secs()
+                    "recluster: run recluster tasks:{} times, cost:{:?}",
+                    times, elapsed_time
                 );
                 ctx.set_status_info(&status);
             }
@@ -197,8 +196,8 @@ impl Interpreter for ReclusterTableInterpreter {
 
             if elapsed_time >= timeout {
                 warn!(
-                    "Recluster stopped because the runtime was over {} secs",
-                    timeout.as_secs()
+                    "Recluster stopped because the runtime was over {:?}",
+                    timeout
                 );
                 break;
             }

--- a/src/query/storages/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/src/io/snapshots.rs
@@ -192,10 +192,10 @@ impl SnapshotsIO {
             {
                 count += chunk.len();
                 let status = format!(
-                    "read snapshot files:{}/{}, cost:{} sec",
+                    "read snapshot files:{}/{}, cost:{:?}",
                     count,
                     snapshot_files.len(),
-                    start.elapsed().as_secs()
+                    start.elapsed()
                 );
                 info!("{}", status);
                 (status_callback)(status);

--- a/src/query/storages/fuse/src/operations/analyze.rs
+++ b/src/query/storages/fuse/src/operations/analyze.rs
@@ -263,10 +263,10 @@ pub async fn regenerate_statistics(
         {
             read_segment_count += chunk.len();
             let status = format!(
-                "analyze: read segment files:{}/{}, cost:{} sec",
+                "analyze: read segment files:{}/{}, cost:{:?}",
                 read_segment_count,
                 number_segments,
-                start.elapsed().as_secs()
+                start.elapsed()
             );
             ctx.set_status_info(&status);
         }

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -296,9 +296,9 @@ impl FuseTable {
         let pruning_stats = pruner.pruning_stats();
 
         info!(
-            "prune snapshot block end, final block numbers:{}, cost:{}",
+            "prune snapshot block end, final block numbers:{}, cost:{:?}",
             block_metas.len(),
-            start.elapsed().as_secs()
+            start.elapsed()
         );
 
         let block_metas = block_metas

--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -430,12 +430,12 @@ where F: SnapshotGenerator + Send + 'static
                         }
                         metrics_inc_commit_mutation_success();
                         {
-                            let elapsed_time = self.start_time.elapsed().as_millis();
+                            let elapsed_time = self.start_time.elapsed();
                             let status = format!(
-                                "commit mutation success after {} retries, which took {} ms",
+                                "commit mutation success after {} retries, which took {:?}",
                                 self.retries, elapsed_time
                             );
-                            metrics_inc_commit_milliseconds(elapsed_time);
+                            metrics_inc_commit_milliseconds(elapsed_time.as_millis());
                             self.ctx.set_status_info(&status);
                         }
                         if let Some(files) = &self.copied_files {

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -136,10 +136,10 @@ impl TableMutationAggregator {
         // Refresh status
         {
             let status = format!(
-                "{}: run tasks:{}, cost:{} sec",
+                "{}: run tasks:{}, cost:{:?}",
                 self.kind,
                 self.finished_tasks,
-                self.start_time.elapsed().as_secs()
+                self.start_time.elapsed()
             );
             self.ctx.set_status_info(&status);
         }
@@ -262,11 +262,11 @@ impl TableMutationAggregator {
                     {
                         count += chunk.len();
                         let status = format!(
-                            "{}: generate new segment files:{}/{}, cost:{} sec",
+                            "{}: generate new segment files:{}/{}, cost:{:?}",
                             self.kind,
                             count,
                             segment_indices.len(),
-                            start.elapsed().as_secs()
+                            start.elapsed()
                         );
                         self.ctx.set_status_info(&status);
                     }

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -181,10 +181,10 @@ impl FuseTable {
             {
                 read_snapshot_count += chunk.len();
                 let status = format!(
-                    "gc: read snapshot files:{}/{}, cost:{} sec",
+                    "gc: read snapshot files:{}/{}, cost:{:?}",
                     read_snapshot_count,
                     snapshot_files.len(),
-                    counter.start.elapsed().as_secs()
+                    counter.start.elapsed()
                 );
                 ctx.set_status_info(&status);
             }
@@ -461,10 +461,10 @@ impl FuseTable {
             {
                 count += chunk.len();
                 let status = format!(
-                    "gc: read purged segment files:{}/{}, cost:{} sec",
+                    "gc: read purged segment files:{}/{}, cost:{:?}",
                     count,
                     segment_locations.len(),
-                    counter.start.elapsed().as_secs()
+                    counter.start.elapsed()
                 );
                 ctx.set_status_info(&status);
             }
@@ -656,13 +656,13 @@ impl FuseTable {
         // 5. Refresh status.
         {
             let status = format!(
-                "gc: block files purged:{}, bloom files purged:{}, segment files purged:{}, table statistic files purged:{}, snapshots purged:{}, take:{} sec",
+                "gc: block files purged:{}, bloom files purged:{}, segment files purged:{}, table statistic files purged:{}, snapshots purged:{}, take:{:?}",
                 counter.blocks,
                 counter.blooms,
                 counter.segments,
                 counter.table_statistics,
                 counter.snapshots,
-                counter.start.elapsed().as_secs()
+                counter.start.elapsed()
             );
             ctx.set_status_info(&status);
         }

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -163,10 +163,10 @@ impl BlockCompactMutator {
             // Status.
             {
                 let status = format!(
-                    "compact: read segment files:{}/{}, cost:{} sec",
+                    "compact: read segment files:{}/{}, cost:{:?}",
                     segment_idx,
                     number_segments,
-                    start.elapsed().as_secs()
+                    start.elapsed()
                 );
                 self.ctx.set_status_info(&status);
             }
@@ -184,14 +184,14 @@ impl BlockCompactMutator {
         );
 
         // Status.
-        let elapsed_time = start.elapsed().as_millis() as u64;
+        let elapsed_time = start.elapsed();
         self.ctx.set_status_info(&format!(
-            "compact: end to build lazy compact parts:{}, segments to be compacted:{}, cost:{} ms",
+            "compact: end to build lazy compact parts:{}, segments to be compacted:{}, cost:{:?}",
             parts.len(),
             checker.compacted_segment_cnt,
             elapsed_time
         ));
-        metrics_inc_compact_block_build_lazy_part_milliseconds(elapsed_time);
+        metrics_inc_compact_block_build_lazy_part_milliseconds(elapsed_time.as_millis() as u64);
 
         let cluster = self.ctx.get_cluster();
         let max_threads = self.ctx.get_settings().get_max_threads()? as usize;
@@ -281,13 +281,15 @@ impl BlockCompactMutator {
                 let parts = res.into_iter().flatten().collect::<Vec<_>>();
                 // Status.
                 {
-                    let elapsed_time = start.elapsed().as_millis() as u64;
+                    let elapsed_time = start.elapsed();
                     ctx.set_status_info(&format!(
-                        "compact: end to build compact parts:{}, cost:{} ms",
+                        "compact: end to build compact parts:{}, cost:{:?}",
                         parts.len(),
                         elapsed_time,
                     ));
-                    metrics_inc_compact_block_build_task_milliseconds(elapsed_time);
+                    metrics_inc_compact_block_build_task_milliseconds(
+                        elapsed_time.as_millis() as u64
+                    );
                 }
                 Ok(parts)
             }

--- a/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
@@ -266,10 +266,10 @@ impl<'a> SegmentCompactor<'a> {
             // Status.
             {
                 let status = format!(
-                    "compact segment: read segment files:{}/{}, cost:{} sec",
+                    "compact segment: read segment files:{}/{}, cost:{:?}",
                     checked_end_at,
                     number_segments,
-                    start.elapsed().as_secs()
+                    start.elapsed()
                 );
                 info!("{}", &status);
                 (status_callback)(status);

--- a/src/query/storages/fuse/src/operations/mutation/processors/recluster_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/recluster_aggregator.rs
@@ -80,9 +80,9 @@ impl AsyncAccumulatingTransform for ReclusterAggregator {
             {
                 metrics_inc_recluster_write_block_nums();
                 let status = format!(
-                    "recluster: generate new blocks:{}, cost:{} sec",
+                    "recluster: generate new blocks:{}, cost:{:?}",
                     self.abort_operation.blocks.len(),
-                    self.start_time.elapsed().as_secs()
+                    self.start_time.elapsed()
                 );
                 self.ctx.set_status_info(&status);
             }

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -160,9 +160,9 @@ impl FuseTable {
             if let Some(cache) = CacheItem::cache() {
                 if let Some(data) = cache.get(cache_key) {
                     info!(
-                        "prune snapshot block from cache, final block numbers:{}, cost:{}",
+                        "prune snapshot block from cache, final block numbers:{}, cost:{:?}",
                         data.1.len(),
-                        start.elapsed().as_secs()
+                        start.elapsed()
                     );
                     return Ok((data.0.clone(), data.1.clone()));
                 }
@@ -194,9 +194,9 @@ impl FuseTable {
         let pruning_stats = pruner.pruning_stats();
 
         info!(
-            "prune snapshot block end, final block numbers:{}, cost:{}",
+            "prune snapshot block end, final block numbers:{}, cost:{:?}",
             block_metas.len(),
-            start.elapsed().as_secs()
+            start.elapsed()
         );
 
         let block_metas = block_metas

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -146,10 +146,10 @@ impl FuseTable {
             {
                 segment_idx += chunk.len();
                 let status = format!(
-                    "recluster: read segment files:{}/{}, cost:{} sec",
+                    "recluster: read segment files:{}/{}, cost:{:?}",
                     segment_idx,
                     number_segments,
-                    start.elapsed().as_secs()
+                    start.elapsed()
                 );
                 ctx.set_status_info(&status);
             }
@@ -206,14 +206,14 @@ impl FuseTable {
         }
 
         {
-            let elapsed_time = start.elapsed().as_millis() as u64;
+            let elapsed_time = start.elapsed();
             ctx.set_status_info(&format!(
-                "recluster: end to build recluster tasks, recluster segments count: {}, blocks count: {}, cost:{} ms",
+                "recluster: end to build recluster tasks, recluster segments count: {}, blocks count: {}, cost:{:?}",
                 recluster_seg_num,
                 mutator.recluster_blocks_count,
                 elapsed_time,
             ));
-            metrics_inc_recluster_build_task_milliseconds(elapsed_time);
+            metrics_inc_recluster_build_task_milliseconds(elapsed_time.as_millis() as u64);
             metrics_inc_recluster_segment_nums_scheduled(recluster_seg_num as u64);
         }
         Ok(Some(mutator))

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/table.rs
@@ -294,9 +294,9 @@ impl Table for ParquetRSTable {
         .await?;
         let elapsed = now.elapsed();
         log::info!(
-            "end read {} parquet file metas, use {} secs",
+            "end read {} parquet file metas, use {:?}",
             file_locations.len(),
-            elapsed.as_secs_f32()
+            elapsed
         );
 
         let provider = create_stats_provider(&metas, num_columns);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- adjust the time part in the log to use `Duration` instead of specific precision time (e.g., seconds), to avoid imprecise log information such as '0s'.

- add timing log of some schema api

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15517)
<!-- Reviewable:end -->
