### PR TITLE
fix: Enable opendal backtrace output to help debug

### DIFF
--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -135,7 +135,7 @@ pub fn build_operator<B: Builder>(builder: B) -> Result<Operator> {
         // Add async backtrace
         .layer(AsyncBacktraceLayer)
         // Add logging
-        .layer(LoggingLayer::default())
+        .layer(LoggingLayer::default().with_backtrace_output(true))
         // Add tracing
         .layer(MinitraceLayer)
         // Add PrometheusClientLayer


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

opendal's backtrace output is not enabled, makes it hard to debug opendal related issues.

Before:

![image](https://github.com/datafuselabs/databend/assets/5351546/03532f7f-1d85-4827-beb8-c6de1c93a10b)

After:

![image](https://github.com/datafuselabs/databend/assets/5351546/290cfbfe-0c68-412e-b9c6-23bbaaa31136)


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15521)
<!-- Reviewable:end -->
