### PR TITLE
feat: add version metrics for meta & query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,6 +2858,7 @@ dependencies = [
  "databend-common-meta-sled-store",
  "databend-common-meta-store",
  "databend-common-meta-types",
+ "databend-common-metrics",
  "databend-common-storage",
  "databend-common-tracing",
  "databend-enterprise-background-service",

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -46,6 +46,7 @@ databend-common-meta-raft-store = { path = "../meta/raft-store" }
 databend-common-meta-sled-store = { path = "../meta/sled-store" }
 databend-common-meta-store = { path = "../meta/store" }
 databend-common-meta-types = { path = "../meta/types" }
+databend-common-metrics = { path = "../common/metrics" }
 databend-common-storage = { path = "../common/storage" }
 databend-common-tracing = { path = "../common/tracing" }
 databend-enterprise-query = { path = "../query/ee" }

--- a/src/binaries/meta/entry.rs
+++ b/src/binaries/meta/entry.rs
@@ -38,9 +38,12 @@ use databend_meta::api::GrpcServer;
 use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
 use databend_meta::meta_service::MetaNode;
+use databend_meta::metrics::server_metrics;
 use databend_meta::version::raft_client_requires;
 use databend_meta::version::raft_server_provides;
 use databend_meta::version::METASRV_COMMIT_VERSION;
+use databend_meta::version::METASRV_GIT_SEMVER;
+use databend_meta::version::METASRV_GIT_SHA;
 use databend_meta::version::METASRV_SEMVER;
 use databend_meta::version::MIN_METACLI_SEMVER;
 use log::info;
@@ -176,6 +179,7 @@ pub async fn entry(conf: Config) -> anyhow::Result<()> {
 
     // HTTP API service.
     {
+        server_metrics::set_version(METASRV_GIT_SEMVER.to_string(), METASRV_GIT_SHA.to_string());
         let mut srv = HttpService::create(conf.clone(), meta_node.clone());
         info!("HTTP API server listening on {}", conf.admin_api_address);
         srv.start().await.expect("Failed to start http server");

--- a/src/binaries/query/entry.rs
+++ b/src/binaries/query/entry.rs
@@ -21,10 +21,13 @@ use databend_common_base::runtime::GLOBAL_MEM_STAT;
 use databend_common_config::Commands;
 use databend_common_config::InnerConfig;
 use databend_common_config::DATABEND_COMMIT_VERSION;
+use databend_common_config::QUERY_GIT_SEMVER;
+use databend_common_config::QUERY_GIT_SHA;
 use databend_common_config::QUERY_SEMVER;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_client::MIN_METASRV_SEMVER;
+use databend_common_metrics::system::set_system_version;
 use databend_common_storage::DataOperator;
 use databend_common_tracing::set_panic_hook;
 use databend_enterprise_background_service::get_background_service_handler;
@@ -184,6 +187,7 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
 
     // Metric API service.
     {
+        set_system_version("query", QUERY_GIT_SEMVER.as_str(), QUERY_GIT_SHA.as_str());
         let address = conf.query.metric_api_address.clone();
         let mut srv = MetricService::create();
         let listening = srv.start(address.parse()?).await?;

--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -32,3 +32,4 @@ pub use crate::metrics::mysql;
 pub use crate::metrics::openai;
 pub use crate::metrics::session;
 pub use crate::metrics::storage;
+pub use crate::metrics::system;

--- a/src/common/metrics/src/metrics/system.rs
+++ b/src/common/metrics/src/metrics/system.rs
@@ -12,13 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod cache;
-pub mod cluster;
-pub mod http;
-pub mod interpreter;
-pub mod lock;
-pub mod mysql;
-pub mod openai;
-pub mod session;
-pub mod storage;
-pub mod system;
+use std::sync::LazyLock;
+
+use databend_common_base::runtime::metrics::register_gauge_family;
+use databend_common_base::runtime::metrics::FamilyGauge;
+
+pub static SYSTEM_VERSION_GAUGE: LazyLock<FamilyGauge<Vec<(&'static str, String)>>> =
+    LazyLock::new(|| register_gauge_family("system_version"));
+
+pub fn set_system_version(component: &str, semver: &str, sha: &str) {
+    let labels = &vec![
+        ("component", component.to_string()),
+        ("semver", semver.to_string()),
+        ("sha", sha.to_string()),
+    ];
+
+    SYSTEM_VERSION_GAUGE.get_or_create(labels).set(1);
+}

--- a/src/meta/service/src/version.rs
+++ b/src/meta/service/src/version.rs
@@ -34,6 +34,18 @@ pub static METASRV_COMMIT_VERSION: LazyLock<String> = LazyLock::new(|| {
     }
 });
 
+pub static METASRV_GIT_SEMVER: LazyLock<String> =
+    LazyLock::new(|| match option_env!("DATABEND_GIT_SEMVER") {
+        Some(v) => v.to_string(),
+        None => "unknown".to_string(),
+    });
+
+pub static METASRV_GIT_SHA: LazyLock<String> =
+    LazyLock::new(|| match option_env!("VERGEN_GIT_SHA") {
+        Some(sha) => sha.to_string(),
+        None => "unknown".to_string(),
+    });
+
 pub static METASRV_SEMVER: LazyLock<Version> = LazyLock::new(|| {
     let build_semver = option_env!("DATABEND_GIT_SEMVER");
     let semver = build_semver.expect("DATABEND_GIT_SEMVER can not be None");

--- a/src/query/config/src/lib.rs
+++ b/src/query/config/src/lib.rs
@@ -49,4 +49,6 @@ pub use inner::CatalogHiveConfig;
 pub use inner::InnerConfig;
 pub use inner::ThriftProtocol;
 pub use version::DATABEND_COMMIT_VERSION;
+pub use version::QUERY_GIT_SEMVER;
+pub use version::QUERY_GIT_SHA;
 pub use version::QUERY_SEMVER;

--- a/src/query/config/src/version.rs
+++ b/src/query/config/src/version.rs
@@ -35,6 +35,18 @@ pub static DATABEND_COMMIT_VERSION: LazyLock<String> = LazyLock::new(|| {
     }
 });
 
+pub static QUERY_GIT_SEMVER: LazyLock<String> =
+    LazyLock::new(|| match option_env!("DATABEND_GIT_SEMVER") {
+        Some(v) => v.to_string(),
+        None => "unknown".to_string(),
+    });
+
+pub static QUERY_GIT_SHA: LazyLock<String> =
+    LazyLock::new(|| match option_env!("VERGEN_GIT_SHA") {
+        Some(sha) => sha.to_string(),
+        None => "unknown".to_string(),
+    });
+
 pub static QUERY_SEMVER: LazyLock<Version> = LazyLock::new(|| {
     //
     let build_semver = option_env!("DATABEND_GIT_SEMVER");


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### meta
```
❯ curl localhost:28002/v1/metrics
# HELP metasrv_server_version version.
# TYPE metasrv_server_version gauge
metasrv_server_version{component="metasrv",semver="v1.2.466-nightly",sha="e35722e0a5"} 1
```


### query

```
❯ curl localhost:7070/metrics
# HELP databend_system_version .
# TYPE databend_system_version gauge
databend_system_version{component="query",semver="v1.2.466-nightly",sha="e35722e0a5"} 1
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15522)
<!-- Reviewable:end -->
