### PR TITLE
fix: `explain ast` of  multi table insert stmt

### DIFF
--- a/src/query/ast/src/ast/format/ast_format.rs
+++ b/src/query/ast/src/ast/format/ast_format.rs
@@ -1085,6 +1085,58 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
         self.children.push(node);
     }
 
+    fn visit_multi_table_insert(&mut self, insert: &'ast InsertMultiTableStmt) {
+        let mut nodes = Vec::new();
+
+        if insert.is_first {
+            for when_clause in &insert.when_clauses {
+                self.visit_expr(&when_clause.condition);
+                let mut children = vec![self.children.pop().unwrap()];
+                let into_nodes =
+                    self.visit_multi_table_insert_into_clause(&when_clause.into_clauses);
+
+                children.extend(into_nodes);
+
+                let format_ctx = AstFormatContext::with_children("WHEN".to_owned(), children.len());
+                let when_node = FormatTreeNode::with_children(format_ctx, children);
+                nodes.push(when_node);
+            }
+
+            if let Some(else_clause) = &insert.else_clause {
+                let into_nodes =
+                    self.visit_multi_table_insert_into_clause(&else_clause.into_clauses);
+                let format_ctx =
+                    AstFormatContext::with_children("ELSE".to_owned(), into_nodes.len());
+                let else_node = FormatTreeNode::with_children(format_ctx, into_nodes);
+                nodes.push(else_node)
+            }
+        } else {
+            let into_nodes = self.visit_multi_table_insert_into_clause(&insert.into_clauses);
+            let format_ctx = AstFormatContext::with_children("INTO".to_owned(), into_nodes.len());
+            let else_node = FormatTreeNode::with_children(format_ctx, into_nodes);
+            nodes.push(else_node);
+        }
+
+        self.visit_query(&insert.source);
+        nodes.push(self.children.pop().unwrap());
+
+        let mut multi_table_insert_node = if insert.overwrite {
+            "INSERT OVERWRITE".to_string()
+        } else {
+            "INSERT".to_string()
+        };
+
+        if insert.is_first {
+            multi_table_insert_node = format!("{} FIRST", multi_table_insert_node);
+        } else {
+            multi_table_insert_node = format!("{} ALL", multi_table_insert_node);
+        }
+
+        let format_ctx = AstFormatContext::with_children(multi_table_insert_node, nodes.len());
+        let node = FormatTreeNode::with_children(format_ctx, nodes);
+        self.children.push(node);
+    }
+
     fn visit_insert_source(&mut self, insert_source: &'ast InsertSource) {
         match insert_source {
             InsertSource::Streaming { format, .. } => {
@@ -3388,5 +3440,36 @@ impl<'ast> Visitor<'ast> for AstFormatVisitor {
         let format_ctx = AstFormatContext::with_children(name, children.len());
         let node = FormatTreeNode::with_children(format_ctx, children);
         self.children.push(node);
+    }
+}
+
+impl AstFormatVisitor {
+    fn visit_multi_table_insert_into_clause<'ast>(
+        &'ast mut self,
+        clauses: &'ast [IntoClause],
+    ) -> Vec<FormatTreeNode<AstFormatContext>> {
+        let mut into_nodes = Vec::new();
+        for insert in clauses {
+            let mut nodes = Vec::new();
+            self.visit_table_ref(&insert.catalog, &insert.database, &insert.table);
+            nodes.push(self.children.pop().unwrap());
+            if !insert.target_columns.is_empty() {
+                let mut columns_children = Vec::with_capacity(insert.target_columns.len());
+                for column in insert.target_columns.iter() {
+                    self.visit_identifier(column);
+                    columns_children.push(self.children.pop().unwrap());
+                }
+                let columns_format_ctx =
+                    AstFormatContext::with_children("Columns".to_owned(), columns_children.len());
+                let columns_node =
+                    FormatTreeNode::with_children(columns_format_ctx, columns_children);
+                nodes.push(columns_node);
+            }
+
+            let format_ctx = AstFormatContext::with_children("INTO".to_owned(), nodes.len());
+            let into_node = FormatTreeNode::with_children(format_ctx, nodes);
+            into_nodes.push(into_node)
+        }
+        into_nodes
     }
 }

--- a/src/query/ast/src/ast/visitors/visitor.rs
+++ b/src/query/ast/src/ast/visitors/visitor.rs
@@ -835,4 +835,5 @@ pub trait Visitor<'ast>: Sized {
     fn visit_create_sequence(&mut self, _stmt: &'ast CreateSequenceStmt) {}
     fn visit_drop_sequence(&mut self, _stmt: &'ast DropSequenceStmt) {}
     fn visit_set_priority(&mut self, _priority: &'ast Priority, _object_id: &'ast str) {}
+    fn visit_multi_table_insert(&mut self, insert: &'ast InsertMultiTableStmt);
 }

--- a/src/query/ast/src/ast/visitors/walk.rs
+++ b/src/query/ast/src/ast/visitors/walk.rs
@@ -584,7 +584,7 @@ pub fn walk_statement<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Statem
         Statement::Begin => {}
         Statement::Commit => {}
         Statement::Abort => {}
-        Statement::InsertMultiTable(_) => {}
+        Statement::InsertMultiTable(stmt) => visitor.visit_multi_table_insert(stmt),
         Statement::ExecuteImmediate(_) => {}
         Statement::CreateSequence(stmt) => visitor.visit_create_sequence(stmt),
         Statement::DropSequence(stmt) => visitor.visit_drop_sequence(stmt),

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1846,3 +1846,113 @@ TableScan
 ├── push downs: [filters: [], limit: NONE]
 └── estimated rows: 10000000000000000.00
 
+
+
+statement ok
+CREATE OR REPLACE TABLE orders_placed (order_id INT, customer_id INT, order_amount FLOAT, order_date DATE);
+
+query T
+EXPLAIN AST
+INSERT FIRST
+WHEN order_amount > 1000 THEN INTO cat.db1.t1(order_id, update_note) VALUES (order_id, 'PriorityHandling')
+WHEN order_amount > 500 THEN INTO cat2.db2.t2 VALUES (order_id, 'ExpressHandling')
+WHEN order_amount > 100 THEN
+   INTO cat3.db3.t3 VALUES (order_id, 'StandardHandling')
+   INTO cat3.db3.t4 VALUES (order_id, 'StandardHandling')
+ELSE INTO processing_updates VALUES (order_id, 'ReviewNeeded')
+SELECT order_id, order_amount FROM orders_placed;
+----
+INSERT FIRST (children 5)
+├── WHEN (children 2)
+│   ├── Function > (children 2)
+│   │   ├── ColumnIdentifier order_amount
+│   │   └── Literal UInt64(1000)
+│   └── INTO (children 2)
+│       ├── TableIdentifier cat.db1.t1
+│       └── Columns (children 2)
+│           ├── Identifier order_id
+│           └── Identifier update_note
+├── WHEN (children 2)
+│   ├── Function > (children 2)
+│   │   ├── ColumnIdentifier order_amount
+│   │   └── Literal UInt64(500)
+│   └── INTO (children 1)
+│       └── TableIdentifier cat2.db2.t2
+├── WHEN (children 3)
+│   ├── Function > (children 2)
+│   │   ├── ColumnIdentifier order_amount
+│   │   └── Literal UInt64(100)
+│   ├── INTO (children 1)
+│   │   └── TableIdentifier cat3.db3.t3
+│   └── INTO (children 1)
+│       └── TableIdentifier cat3.db3.t4
+├── ELSE (children 1)
+│   └── INTO (children 1)
+│       └── TableIdentifier processing_updates
+└── Query (children 1)
+    └── QueryBody (children 1)
+        └── SelectQuery (children 2)
+            ├── SelectList (children 2)
+            │   ├── Target (children 1)
+            │   │   └── ColumnIdentifier order_id
+            │   └── Target (children 1)
+            │       └── ColumnIdentifier order_amount
+            └── TableList (children 1)
+                └── TableIdentifier orders_placed
+
+query T
+EXPLAIN ast
+INSERT ALL
+   INTO cat.db1.t1 VALUES (order_id, 'PriorityHandling')
+   INTO cat3.db3.t3 VALUES (order_id, 'StandardHandling')
+   INTO cat3.db3.t4 VALUES (order_id, 'StandardHandling')
+SELECT order_id, order_amount FROM orders_placed;
+----
+INSERT ALL (children 2)
+├── INTO (children 3)
+│   ├── INTO (children 1)
+│   │   └── TableIdentifier cat.db1.t1
+│   ├── INTO (children 1)
+│   │   └── TableIdentifier cat3.db3.t3
+│   └── INTO (children 1)
+│       └── TableIdentifier cat3.db3.t4
+└── Query (children 1)
+    └── QueryBody (children 1)
+        └── SelectQuery (children 2)
+            ├── SelectList (children 2)
+            │   ├── Target (children 1)
+            │   │   └── ColumnIdentifier order_id
+            │   └── Target (children 1)
+            │       └── ColumnIdentifier order_amount
+            └── TableList (children 1)
+                └── TableIdentifier orders_placed
+
+query T
+EXPLAIN ast
+INSERT OVERWRITE ALL
+   INTO cat.db1.t1 VALUES (order_id, 'PriorityHandling')
+   INTO cat3.db3.t3 VALUES (order_id, 'StandardHandling')
+   INTO cat3.db3.t4 VALUES (order_id, 'StandardHandling')
+SELECT order_id, order_amount FROM orders_placed;
+----
+INSERT OVERWRITE ALL (children 2)
+├── INTO (children 3)
+│   ├── INTO (children 1)
+│   │   └── TableIdentifier cat.db1.t1
+│   ├── INTO (children 1)
+│   │   └── TableIdentifier cat3.db3.t3
+│   └── INTO (children 1)
+│       └── TableIdentifier cat3.db3.t4
+└── Query (children 1)
+    └── QueryBody (children 1)
+        └── SelectQuery (children 2)
+            ├── SelectList (children 2)
+            │   ├── Target (children 1)
+            │   │   └── ColumnIdentifier order_id
+            │   └── Target (children 1)
+            │       └── ColumnIdentifier order_amount
+            └── TableList (children 1)
+                └── TableIdentifier orders_placed
+
+statement ok
+drop table  orders_placed


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix `explain ast  insert first/all`.

before this PR, explain ast of multiple table insert stmt panics, with this PR:

~~~
query T
EXPLAIN AST
INSERT FIRST
WHEN order_amount > 1000 THEN INTO cat.db1.t1(order_id, update_note) VALUES (order_id, 'PriorityHandling')
WHEN order_amount > 500 THEN INTO cat2.db2.t2 VALUES (order_id, 'ExpressHandling')
WHEN order_amount > 100 THEN
   INTO cat3.db3.t3 VALUES (order_id, 'StandardHandling')
   INTO cat3.db3.t4 VALUES (order_id, 'StandardHandling')
ELSE INTO processing_updates VALUES (order_id, 'ReviewNeeded')
SELECT order_id, order_amount FROM orders_placed;
----
INSERT FIRST (children 5)
├── WHEN (children 2)
│   ├── Function > (children 2)
│   │   ├── ColumnIdentifier order_amount
│   │   └── Literal UInt64(1000)
│   └── INTO (children 2)
│       ├── TableIdentifier cat.db1.t1
│       └── Columns (children 2)
│           ├── Identifier order_id
│           └── Identifier update_note
├── WHEN (children 2)
│   ├── Function > (children 2)
│   │   ├── ColumnIdentifier order_amount
│   │   └── Literal UInt64(500)
│   └── INTO (children 1)
│       └── TableIdentifier cat2.db2.t2
├── WHEN (children 3)
│   ├── Function > (children 2)
│   │   ├── ColumnIdentifier order_amount
│   │   └── Literal UInt64(100)
│   ├── INTO (children 1)
│   │   └── TableIdentifier cat3.db3.t3
│   └── INTO (children 1)
│       └── TableIdentifier cat3.db3.t4
├── ELSE (children 1)
│   └── INTO (children 1)
│       └── TableIdentifier processing_updates
└── Query (children 1)
    └── QueryBody (children 1)
        └── SelectQuery (children 2)
            ├── SelectList (children 2)
            │   ├── Target (children 1)
            │   │   └── ColumnIdentifier order_id
            │   └── Target (children 1)
            │       └── ColumnIdentifier order_amount
            └── TableList (children 1)
                └── TableIdentifier orders_placed

~~~

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15527)
<!-- Reviewable:end -->
