### PR TITLE
refactor: remove redundant lifetime on fmt::Formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,6 @@ name = "databend-common-ast"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "databend-common-base",
  "databend-common-exception",
  "databend-common-io",
  "derive-visitor",

--- a/src/common/arrow/src/arrow/array/binary/fmt.rs
+++ b/src/common/arrow/src/arrow/array/binary/fmt.rs
@@ -30,7 +30,7 @@ pub fn write_value<O: Offset, W: Write>(array: &BinaryArray<O>, index: usize, f:
 }
 
 impl<O: Offset> Debug for BinaryArray<O> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, f);
 
         let head = if O::IS_LARGE {

--- a/src/common/arrow/src/arrow/array/binview/fmt.rs
+++ b/src/common/arrow/src/arrow/array/binview/fmt.rs
@@ -40,7 +40,7 @@ where
 }
 
 impl Debug for BinaryViewArray {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, f);
         write!(f, "BinaryViewArray")?;
         write_vec(f, writer, self.validity(), self.len(), "None", false)
@@ -48,7 +48,7 @@ impl Debug for BinaryViewArray {
 }
 
 impl Debug for Utf8ViewArray {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write!(f, "{}", self.value(index));
         write!(f, "Utf8ViewArray")?;
         write_vec(f, writer, self.validity(), self.len(), "None", false)

--- a/src/common/arrow/src/arrow/array/binview/mutable.rs
+++ b/src/common/arrow/src/arrow/array/binview/mutable.rs
@@ -61,7 +61,7 @@ impl<T: ViewType + ?Sized> Clone for MutableBinaryViewArray<T> {
 }
 
 impl<T: ViewType + ?Sized> Debug for MutableBinaryViewArray<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "mutable-binview{:?}", T::DATA_TYPE)
     }
 }

--- a/src/common/arrow/src/arrow/array/binview/view.rs
+++ b/src/common/arrow/src/arrow/array/binview/view.rs
@@ -46,7 +46,7 @@ impl View {
 }
 
 impl Display for View {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
 }

--- a/src/common/arrow/src/arrow/array/dictionary/fmt.rs
+++ b/src/common/arrow/src/arrow/array/dictionary/fmt.rs
@@ -42,7 +42,7 @@ pub fn write_value<K: DictionaryKey, W: Write>(
 }
 
 impl<K: DictionaryKey> Debug for DictionaryArray<K> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, "None", f);
 
         write!(f, "DictionaryArray")?;

--- a/src/common/arrow/src/arrow/array/dictionary/value_map.rs
+++ b/src/common/arrow/src/arrow/array/dictionary/value_map.rs
@@ -186,7 +186,7 @@ impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
 }
 
 impl<K: DictionaryKey, M: MutableArray> Debug for ValueMap<K, M> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.values.fmt(f)
     }
 }

--- a/src/common/arrow/src/arrow/array/fixed_size_binary/fmt.rs
+++ b/src/common/arrow/src/arrow/array/fixed_size_binary/fmt.rs
@@ -29,7 +29,7 @@ pub fn write_value<W: Write>(array: &FixedSizeBinaryArray, index: usize, f: &mut
 }
 
 impl Debug for FixedSizeBinaryArray {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, f);
 
         write!(f, "{:?}", self.data_type)?;

--- a/src/common/arrow/src/arrow/array/fixed_size_list/fmt.rs
+++ b/src/common/arrow/src/arrow/array/fixed_size_list/fmt.rs
@@ -34,7 +34,7 @@ pub fn write_value<W: Write>(
 }
 
 impl Debug for FixedSizeListArray {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, "None", f);
 
         write!(f, "FixedSizeListArray")?;

--- a/src/common/arrow/src/arrow/array/list/fmt.rs
+++ b/src/common/arrow/src/arrow/array/list/fmt.rs
@@ -35,7 +35,7 @@ pub fn write_value<O: Offset, W: Write>(
 }
 
 impl<O: Offset> Debug for ListArray<O> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, "None", f);
 
         let head = if O::IS_LARGE {

--- a/src/common/arrow/src/arrow/array/map/fmt.rs
+++ b/src/common/arrow/src/arrow/array/map/fmt.rs
@@ -34,7 +34,7 @@ pub fn write_value<W: Write>(
 }
 
 impl Debug for MapArray {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, "None", f);
 
         write!(f, "MapArray")?;

--- a/src/common/arrow/src/arrow/array/mod.rs
+++ b/src/common/arrow/src/arrow/array/mod.rs
@@ -328,7 +328,7 @@ macro_rules! with_match_primitive_type {(
 })}
 
 impl std::fmt::Debug for dyn Array + '_ {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use crate::arrow::datatypes::PhysicalType::*;
         match self.data_type().to_physical_type() {
             Null => fmt_dyn!(self, NullArray, f),

--- a/src/common/arrow/src/arrow/array/null.rs
+++ b/src/common/arrow/src/arrow/array/null.rs
@@ -170,7 +170,7 @@ impl MutableArray for MutableNullArray {
 }
 
 impl std::fmt::Debug for NullArray {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "NullArray({})", self.len())
     }
 }

--- a/src/common/arrow/src/arrow/array/primitive/fmt.rs
+++ b/src/common/arrow/src/arrow/array/primitive/fmt.rs
@@ -162,7 +162,7 @@ pub fn get_write_value<'a, T: NativeType, F: Write>(
 }
 
 impl<T: NativeType> Debug for PrimitiveArray<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = get_write_value(self);
 
         write!(f, "{:?}", self.data_type())?;

--- a/src/common/arrow/src/arrow/array/struct_/fmt.rs
+++ b/src/common/arrow/src/arrow/array/struct_/fmt.rs
@@ -45,7 +45,7 @@ pub fn write_value<W: Write>(
 }
 
 impl Debug for StructArray {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, "None", f);
 
         write!(f, "StructArray")?;

--- a/src/common/arrow/src/arrow/array/union/fmt.rs
+++ b/src/common/arrow/src/arrow/array/union/fmt.rs
@@ -34,7 +34,7 @@ pub fn write_value<W: Write>(
 }
 
 impl Debug for UnionArray {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, "None", f);
 
         write!(f, "UnionArray")?;

--- a/src/common/arrow/src/arrow/array/utf8/fmt.rs
+++ b/src/common/arrow/src/arrow/array/utf8/fmt.rs
@@ -27,7 +27,7 @@ pub fn write_value<O: Offset, W: Write>(array: &Utf8Array<O>, index: usize, f: &
 }
 
 impl<O: Offset> Debug for Utf8Array<O> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, f);
 
         let head = if O::IS_LARGE {

--- a/src/common/arrow/src/arrow/bitmap/immutable.rs
+++ b/src/common/arrow/src/arrow/bitmap/immutable.rs
@@ -82,7 +82,7 @@ pub struct Bitmap {
 }
 
 impl std::fmt::Debug for Bitmap {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let (bytes, offset, len) = self.as_slice();
         fmt(bytes, offset, len, f)
     }

--- a/src/common/arrow/src/arrow/bitmap/mutable.rs
+++ b/src/common/arrow/src/arrow/bitmap/mutable.rs
@@ -74,7 +74,7 @@ pub struct MutableBitmap {
 }
 
 impl std::fmt::Debug for MutableBitmap {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         fmt(&self.buffer, 0, self.len(), f)
     }
 }

--- a/src/common/arrow/src/arrow/bitmap/utils/fmt.rs
+++ b/src/common/arrow/src/arrow/bitmap/utils/fmt.rs
@@ -22,7 +22,7 @@ pub fn fmt(
     bytes: &[u8],
     offset: usize,
     length: usize,
-    f: &mut std::fmt::Formatter<'_>,
+    f: &mut std::fmt::Formatter,
 ) -> std::fmt::Result {
     assert!(offset < 8);
 

--- a/src/common/arrow/src/arrow/buffer/immutable.rs
+++ b/src/common/arrow/src/arrow/buffer/immutable.rs
@@ -75,7 +75,7 @@ impl<T: PartialEq> PartialEq for Buffer<T> {
 }
 
 impl<T: std::fmt::Debug> std::fmt::Debug for Buffer<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         std::fmt::Debug::fmt(&**self, f)
     }
 }

--- a/src/common/arrow/src/arrow/error.rs
+++ b/src/common/arrow/src/arrow/error.rs
@@ -88,7 +88,7 @@ impl From<std::collections::TryReserveError> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Error::NotYetImplemented(source) => {
                 write!(f, "Not yet implemented: {}", &source)

--- a/src/common/arrow/src/arrow/scalar/binview.rs
+++ b/src/common/arrow/src/arrow/scalar/binview.rs
@@ -27,7 +27,7 @@ pub struct BinaryViewScalar<T: ViewType + ?Sized> {
 }
 
 impl<T: ViewType + ?Sized> Debug for BinaryViewScalar<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "Scalar({:?})", self.value)
     }
 }

--- a/src/common/arrow/src/arrow/types/native.rs
+++ b/src/common/arrow/src/arrow/types/native.rs
@@ -318,13 +318,13 @@ impl NativeType for months_days_ns {
 }
 
 impl std::fmt::Display for days_ms {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}d {}ms", self.days(), self.milliseconds())
     }
 }
 
 impl std::fmt::Display for months_days_ns {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}m {}d {}ns", self.months(), self.days(), self.ns())
     }
 }
@@ -495,13 +495,13 @@ impl f16 {
 }
 
 impl std::fmt::Debug for f16 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self.to_f32())
     }
 }
 
 impl std::fmt::Display for f16 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.to_f32())
     }
 }
@@ -554,13 +554,13 @@ impl Neg for i256 {
 }
 
 impl std::fmt::Debug for i256 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self.0)
     }
 }
 
 impl std::fmt::Display for i256 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/common/arrow/tests/it/arrow/bitmap/utils/fmt.rs
+++ b/src/common/arrow/tests/it/arrow/bitmap/utils/fmt.rs
@@ -18,7 +18,7 @@ use databend_common_arrow::arrow::bitmap::utils::fmt;
 struct A<'a>(&'a [u8], usize, usize);
 
 impl<'a> std::fmt::Debug for A<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         fmt(self.0, self.1, self.2, f)
     }
 }

--- a/src/common/base/src/base/singleton_instance.rs
+++ b/src/common/base/src/base/singleton_instance.rs
@@ -83,7 +83,7 @@ impl SingletonType {
 }
 
 impl Debug for SingletonType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("Singleton")
             .field("type", &match self {
                 Self::Production => "Production",

--- a/src/common/base/src/runtime/memory/mem_stat.rs
+++ b/src/common/base/src/runtime/memory/mem_stat.rs
@@ -224,7 +224,7 @@ impl<V> OutOfLimit<V> {
 }
 
 impl Debug for OutOfLimit<i64> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "memory usage {}({}) exceeds limit {}({})",

--- a/src/common/base/src/runtime/metrics/family.rs
+++ b/src/common/base/src/runtime/metrics/family.rs
@@ -59,7 +59,7 @@ pub struct Family<S: FamilyLabels, M: FamilyMetric> {
 }
 
 impl<S: FamilyLabels, M: FamilyMetric> Debug for Family<S, M> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("Family")
             .field("metrics", &self.metrics)
             .finish()

--- a/src/common/base/src/runtime/profile/profiles.rs
+++ b/src/common/base/src/runtime/profile/profiles.rs
@@ -57,7 +57,7 @@ pub enum StatisticsUnit {
 }
 
 impl Display for ProfileStatisticsName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
 }

--- a/src/common/base/tests/it/fixed_heap.rs
+++ b/src/common/base/tests/it/fixed_heap.rs
@@ -184,7 +184,7 @@ struct CompareWrapper<T> {
 }
 
 impl<T: Debug> Debug for CompareWrapper<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self.value)
     }
 }

--- a/src/common/base/tests/it/range_merger.rs
+++ b/src/common/base/tests/it/range_merger.rs
@@ -20,7 +20,7 @@ use databend_common_exception::Result;
 
 struct Array(Vec<std::ops::Range<u64>>);
 impl fmt::Display for Array {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         for range in &self.0 {
             write!(f, "[{},{}] ", range.start, range.end)?;
         }

--- a/src/common/cache/src/cache/lru.rs
+++ b/src/common/cache/src/cache/lru.rs
@@ -503,7 +503,7 @@ impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> Extend<(K, V)>
 impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, M: CountableMeter<K, V>> fmt::Debug
     for LruCache<K, V, S, M>
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map().entries(self.iter().rev()).finish()
     }
 }

--- a/src/common/cloud_control/src/task_utils.rs
+++ b/src/common/cloud_control/src/task_utils.rs
@@ -32,7 +32,7 @@ pub enum Status {
 }
 
 impl Display for Status {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
             Status::Suspended => write!(f, "Suspended"),
             Status::Started => write!(f, "Started"),
@@ -50,7 +50,7 @@ pub enum State {
 }
 
 impl Display for State {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
             State::SCHEDULED => write!(f, "SCHEDULED"),
             State::EXECUTING => write!(f, "EXECUTING"),

--- a/src/common/exception/src/exception.rs
+++ b/src/common/exception/src/exception.rs
@@ -219,7 +219,7 @@ impl ErrorCode {
 pub type Result<T, E = ErrorCode> = std::result::Result<T, E>;
 
 impl Debug for ErrorCode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "{}. Code: {}, Text = {}.",
@@ -253,7 +253,7 @@ impl Debug for ErrorCode {
 }
 
 impl Display for ErrorCode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "{}. Code: {}, Text = {}.",

--- a/src/common/exception/src/exception_into.rs
+++ b/src/common/exception/src/exception_into.rs
@@ -31,7 +31,7 @@ enum OtherErrors {
 }
 
 impl Display for OtherErrors {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             OtherErrors::AnyHow { error } => write!(f, "{}", error),
         }
@@ -39,7 +39,7 @@ impl Display for OtherErrors {
 }
 
 impl Debug for OtherErrors {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             OtherErrors::AnyHow { error } => write!(f, "{:?}", error),
         }
@@ -276,7 +276,7 @@ pub struct SerializedError {
 }
 
 impl Display for SerializedError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         write!(f, "Code: {}, Text = {}.", self.code, self.message,)
     }
 }

--- a/src/common/exception/src/span.rs
+++ b/src/common/exception/src/span.rs
@@ -35,13 +35,13 @@ impl Range {
 }
 
 impl Debug for Range {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}..{}", self.start, self.end)
     }
 }
 
 impl Display for Range {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}..{}", self.start, self.end)
     }
 }

--- a/src/common/io/src/geometry.rs
+++ b/src/common/io/src/geometry.rs
@@ -62,7 +62,7 @@ impl FromStr for GeometryDataType {
 }
 
 impl Display for GeometryDataType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let str = match self {
             GeometryDataType::WKB => "WKB".to_string(),
             GeometryDataType::WKT => "WKT".to_string(),

--- a/src/common/license/src/license.rs
+++ b/src/common/license/src/license.rs
@@ -72,7 +72,7 @@ pub enum Feature {
 }
 
 impl Display for Feature {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Feature::LicenseInfo => write!(f, "license_info"),
             Feature::Vacuum => write!(f, "vacuum"),

--- a/src/common/openai/src/openai.rs
+++ b/src/common/openai/src/openai.rs
@@ -24,7 +24,7 @@ pub struct OpenAI {
 }
 
 impl Debug for OpenAI {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let mut ds = f.debug_struct("OpenAI");
         ds.field("api_version", &self.api_version);
         ds.field("api_base", &self.api_base);

--- a/src/common/storage/src/metrics_layer.rs
+++ b/src/common/storage/src/metrics_layer.rs
@@ -147,7 +147,7 @@ pub struct MetricsLayerAccessor<A: Access> {
 }
 
 impl<A: Access> Debug for MetricsLayerAccessor<A> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("MetricsAccessor")
             .field("inner", &self.inner)
             .finish_non_exhaustive()

--- a/src/common/storage/src/runtime_layer.rs
+++ b/src/common/storage/src/runtime_layer.rs
@@ -53,7 +53,7 @@ pub struct RuntimeLayer {
 }
 
 impl Debug for RuntimeLayer {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{:?}", &self.runtime.inner())
     }
 }
@@ -82,7 +82,7 @@ pub struct RuntimeAccessor<A> {
 }
 
 impl<A> Debug for RuntimeAccessor<A> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self.runtime.inner())
     }
 }

--- a/src/common/storage/src/statistics.rs
+++ b/src/common/storage/src/statistics.rs
@@ -101,7 +101,7 @@ impl Datum {
 }
 
 impl Display for Datum {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Datum::Bool(v) => write!(f, "{}", v),
             Datum::Int(v) => write!(f, "{}", v),

--- a/src/common/tracing/src/config.rs
+++ b/src/common/tracing/src/config.rs
@@ -61,7 +61,7 @@ pub struct FileConfig {
 }
 
 impl Display for FileConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "enabled={}, level={}, dir={}, format={}",
@@ -91,7 +91,7 @@ pub struct StderrConfig {
 }
 
 impl Display for StderrConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "enabled={}{}, level={}, format={}",
@@ -126,7 +126,7 @@ pub struct OTLPConfig {
 }
 
 impl Display for OTLPConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let labels = self
             .labels
             .iter()
@@ -161,7 +161,7 @@ pub struct QueryLogConfig {
 }
 
 impl Display for QueryLogConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let labels = self
             .labels
             .iter()
@@ -196,7 +196,7 @@ pub struct ProfileLogConfig {
 }
 
 impl Display for ProfileLogConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let labels = self
             .labels
             .iter()
@@ -229,7 +229,7 @@ pub struct StructLogConfig {
 }
 
 impl Display for StructLogConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "enabled={}, dir={}", self.on, self.dir)
     }
 }
@@ -251,7 +251,7 @@ pub struct TracingConfig {
 }
 
 impl Display for TracingConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "enabled={}, capture_log_level={}, otlp_endpoint={}",

--- a/src/common/tracing/src/loggers.rs
+++ b/src/common/tracing/src/loggers.rs
@@ -271,7 +271,7 @@ impl<'kvs> KvDisplay<'kvs> {
 }
 
 impl fmt::Display for KvDisplay<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut visitor = KvWriter { writer: f };
         self.kv.visit(&mut visitor).ok();
         Ok(())

--- a/src/meta/app/src/background/background_job.rs
+++ b/src/meta/app/src/background/background_job.rs
@@ -37,7 +37,7 @@ pub enum BackgroundJobState {
 }
 
 impl Display for BackgroundJobState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
@@ -51,7 +51,7 @@ pub enum BackgroundJobType {
 }
 
 impl Display for BackgroundJobType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
@@ -127,7 +127,7 @@ impl BackgroundJobParams {
 }
 
 impl Display for BackgroundJobParams {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self.job_type {
             BackgroundJobType::ONESHOT => write!(f, "ONESHOT"),
             BackgroundJobType::INTERVAL => {
@@ -155,7 +155,7 @@ pub struct BackgroundJobStatus {
 }
 
 impl Display for BackgroundJobStatus {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "job_state: {}, last_task_id: {}, last_task_run_at: {}, next_scheduled_time: {}",
@@ -223,7 +223,7 @@ pub struct CreateBackgroundJobReq {
 }
 
 impl Display for CreateBackgroundJobReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "create_background_job({}, {}, {:?}, {:?}, {}, {:?})",
@@ -248,7 +248,7 @@ pub struct GetBackgroundJobReq {
 }
 
 impl Display for GetBackgroundJobReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "get_background_job({})", self.name.name())
     }
 }
@@ -272,7 +272,7 @@ pub struct UpdateBackgroundJobStatusReq {
 }
 
 impl Display for UpdateBackgroundJobStatusReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "update_background_job_status({}, {})",
@@ -289,7 +289,7 @@ pub struct UpdateBackgroundJobParamsReq {
 }
 
 impl Display for UpdateBackgroundJobParamsReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "update_background_job_params({}, {})",
@@ -307,7 +307,7 @@ pub struct UpdateBackgroundJobReq {
 }
 
 impl Display for UpdateBackgroundJobReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "update_background_job({}, {}, {:?}, {:?}, {}, {:?})",
@@ -338,7 +338,7 @@ pub struct DeleteBackgroundJobReq {
 }
 
 impl Display for DeleteBackgroundJobReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "delete_background_job({})", self.name.name())
     }
 }
@@ -360,7 +360,7 @@ impl ListBackgroundJobsReq {
 }
 
 impl Display for ListBackgroundJobsReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "list_background_job({})", self.tenant.tenant_name())
     }
 }

--- a/src/meta/app/src/background/background_task.rs
+++ b/src/meta/app/src/background/background_task.rs
@@ -46,7 +46,7 @@ pub enum BackgroundTaskState {
 }
 
 impl Display for BackgroundTaskState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
@@ -69,7 +69,7 @@ pub enum BackgroundTaskType {
 }
 
 impl Display for BackgroundTaskType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
@@ -84,7 +84,7 @@ pub struct CompactionStats {
 }
 
 impl Display for CompactionStats {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "db_id: {}, table_id: {}, before_compaction_stats: {:?}, after_compaction_stats: {:?}, total_compaction_time: {:?}",
@@ -102,7 +102,7 @@ impl Display for CompactionStats {
 pub struct VacuumStats {}
 
 impl Display for VacuumStats {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "vacuum stats")
     }
 }
@@ -160,7 +160,7 @@ pub struct UpdateBackgroundTaskReq {
 }
 
 impl Display for UpdateBackgroundTaskReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "update_background_task({:?}, {}, {}, {}, {:?})",
@@ -185,7 +185,7 @@ pub struct GetBackgroundTaskReq {
 }
 
 impl Display for GetBackgroundTaskReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "get_background_task({:?})", self.name)
     }
 }
@@ -201,7 +201,7 @@ pub struct ListBackgroundTasksReq {
 }
 
 impl Display for ListBackgroundTasksReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "list_background_tasks({})", self.tenant.tenant_name())
     }
 }

--- a/src/meta/app/src/background/task_creator.rs
+++ b/src/meta/app/src/background/task_creator.rs
@@ -37,7 +37,7 @@ impl BackgroundTaskCreator {
 }
 
 impl fmt::Display for BackgroundTaskCreator {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:{}", self.tenant, self.name)
     }
 }

--- a/src/meta/app/src/principal/file_format.rs
+++ b/src/meta/app/src/principal/file_format.rs
@@ -512,7 +512,7 @@ impl FromStr for EmptyFieldAs {
 }
 
 impl Display for EmptyFieldAs {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Self::FieldDefault => write!(f, "FILED_DEFAULT"),
             Self::Null => write!(f, "NULL"),
@@ -547,7 +547,7 @@ impl FromStr for NullAs {
 }
 
 impl Display for NullAs {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             NullAs::Error => write!(f, "ERROR"),
             NullAs::Null => write!(f, "NULL"),
@@ -578,7 +578,7 @@ impl FromStr for BinaryFormat {
 }
 
 impl Display for BinaryFormat {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Self::Hex => write!(f, "hex"),
             Self::Base64 => write!(f, "base64"),
@@ -672,7 +672,7 @@ impl ParquetFileFormatParams {
 }
 
 impl Display for FileFormatParams {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             FileFormatParams::Csv(params) => {
                 write!(

--- a/src/meta/app/src/principal/ownership_info.rs
+++ b/src/meta/app/src/principal/ownership_info.rs
@@ -33,7 +33,7 @@ pub struct OwnershipInfoSerdeError {
 }
 
 impl Display for OwnershipInfoSerdeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         write!(f, "{} cause: {}", self.message, self.source)
     }
 }

--- a/src/meta/app/src/principal/role_info.rs
+++ b/src/meta/app/src/principal/role_info.rs
@@ -65,7 +65,7 @@ impl TryFrom<Vec<u8>> for RoleInfo {
 }
 
 impl Display for RoleInfoSerdeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{} cause: {}", self.message, self.source)
     }
 }

--- a/src/meta/app/src/principal/user_info.rs
+++ b/src/meta/app/src/principal/user_info.rs
@@ -297,7 +297,7 @@ pub enum UserOptionFlag {
 }
 
 impl std::fmt::Display for UserOptionFlag {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             UserOptionFlag::TenantSetting => write!(f, "TENANTSETTING"),
         }

--- a/src/meta/app/src/principal/user_quota.rs
+++ b/src/meta/app/src/principal/user_quota.rs
@@ -39,7 +39,7 @@ impl UserQuota {
 }
 
 impl std::fmt::Debug for UserQuota {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "UserQuota<cpu:{},mem:{},store:{}>",

--- a/src/meta/app/src/principal/user_setting.rs
+++ b/src/meta/app/src/principal/user_setting.rs
@@ -79,7 +79,7 @@ impl fmt::Display for UserSettingValue {
 }
 
 impl fmt::Debug for UserSettingValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             UserSettingValue::UInt64(v) => write!(f, "{}", v),
             UserSettingValue::String(_) => write!(f, "{}", self),

--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -80,7 +80,7 @@ pub enum StageType {
 }
 
 impl fmt::Display for StageType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match self {
             // LegacyInternal will print the same name as Internal, this is by design.
             StageType::LegacyInternal => "Internal",
@@ -346,7 +346,7 @@ impl FileFormatOptions {
 }
 
 impl Display for FileFormatOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "TYPE = {}", self.format.to_string().to_uppercase())?;
         match self.format {
             StageFileFormatType::Csv => {
@@ -448,7 +448,7 @@ impl FromStr for OnErrorMode {
 }
 
 impl Display for OnErrorMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             OnErrorMode::Continue => {
                 write!(f, "continue")
@@ -570,7 +570,7 @@ impl CopyOptions {
 }
 
 impl Display for CopyOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "OnErrorMode {}", self.on_error)?;
         write!(f, "SizeLimit {}", self.size_limit)?;
         write!(f, "MaxFiles {}", self.max_files)?;

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -96,7 +96,7 @@ impl From<CatalogNameIdent> for CatalogName {
 }
 
 impl Display for CatalogName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "'{}'/'{}'", self.tenant, self.catalog_name)
     }
 }
@@ -182,7 +182,7 @@ impl CreateCatalogReq {
 }
 
 impl Display for CreateCatalogReq {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "create_catalog(if_not_exists={}):{}/{}={:?}",
@@ -206,7 +206,7 @@ pub struct DropCatalogReq {
 }
 
 impl Display for DropCatalogReq {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "drop_catalog(if_exists={}):{}/{}",

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -61,7 +61,7 @@ impl From<u64> for DatabaseId {
 }
 
 impl Display for DatabaseId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.db_id)
     }
 }
@@ -72,7 +72,7 @@ pub struct DatabaseIdToName {
 }
 
 impl Display for DatabaseIdToName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.db_id)
     }
 }
@@ -116,7 +116,7 @@ impl Default for DatabaseMeta {
 }
 
 impl Display for DatabaseMeta {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "Engine: {}={:?}, Options: {:?}, CreatedOn: {:?}",
@@ -168,7 +168,7 @@ impl DbIdList {
 }
 
 impl Display for DbIdList {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "DB id list: {:?}", self.id_list)
     }
 }
@@ -181,7 +181,7 @@ pub struct CreateDatabaseReq {
 }
 
 impl Display for CreateDatabaseReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self.create_option {
             CreateOption::Create => write!(
                 f,
@@ -223,7 +223,7 @@ pub struct RenameDatabaseReq {
 }
 
 impl Display for RenameDatabaseReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "rename_database:{}/{}=>{}",
@@ -244,7 +244,7 @@ pub struct DropDatabaseReq {
 }
 
 impl Display for DropDatabaseReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "drop_db(if_exists={}):{}/{}",
@@ -266,7 +266,7 @@ pub struct UndropDatabaseReq {
 }
 
 impl Display for UndropDatabaseReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "undrop_db:{}/{}",

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -32,7 +32,7 @@ pub struct IndexIdToName {
 }
 
 impl Display for IndexIdToName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.index_id)
     }
 }
@@ -49,7 +49,7 @@ impl IndexId {
 }
 
 impl Display for IndexId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.index_id)
     }
 }
@@ -71,7 +71,7 @@ pub enum IndexType {
 }
 
 impl Display for IndexType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             IndexType::AGGREGATING => write!(f, "AGGREGATING"),
             IndexType::JOIN => write!(f, "JOIN"),
@@ -118,7 +118,7 @@ pub struct CreateIndexReq {
 }
 
 impl Display for CreateIndexReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self.create_option {
             CreateOption::Create => {
                 write!(
@@ -156,7 +156,7 @@ pub struct DropIndexReq {
 }
 
 impl Display for DropIndexReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "drop_index(if_exists={}):{}/{}",
@@ -176,7 +176,7 @@ pub struct GetIndexReq {
 }
 
 impl Display for GetIndexReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "get_index:{}/{}",

--- a/src/meta/app/src/schema/lock.rs
+++ b/src/meta/app/src/schema/lock.rs
@@ -70,7 +70,7 @@ impl LockType {
 }
 
 impl Display for LockType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             LockType::TABLE => write!(f, "TABLE"),
         }

--- a/src/meta/app/src/schema/ownership.rs
+++ b/src/meta/app/src/schema/ownership.rs
@@ -43,7 +43,7 @@ impl Default for Ownership {
 }
 
 impl Display for Ownership {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "OwnerRoleName: {}, UpdatedOn: {:?}",

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -64,7 +64,7 @@ impl TableIdent {
 }
 
 impl Display for TableIdent {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "table_id:{}, ver:{}", self.table_id, self.seq)
     }
 }
@@ -103,7 +103,7 @@ impl TableNameIdent {
 }
 
 impl Display for TableNameIdent {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "'{}'.'{}'.'{}'",
@@ -121,7 +121,7 @@ pub struct DBIdTableName {
 }
 
 impl Display for DBIdTableName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}.'{}'", self.db_id, self.table_name)
     }
 }
@@ -138,7 +138,7 @@ impl TableId {
 }
 
 impl Display for TableId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "TableId{{{}}}", self.table_id)
     }
 }
@@ -151,7 +151,7 @@ pub struct TableIdHistoryIdent {
 }
 
 impl Display for TableIdHistoryIdent {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}.'{}'", self.database_id, self.table_name)
     }
 }
@@ -165,7 +165,7 @@ pub enum DatabaseType {
 }
 
 impl Display for DatabaseType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             DatabaseType::NormalDB => {
                 write!(f, "normal database")
@@ -404,7 +404,7 @@ impl TableMeta {
 }
 
 impl Display for TableMeta {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "Engine: {}={:?}, Schema: {:?}, Options: {:?}, FieldComments: {:?} Indexes: {:?} CreatedOn: {:?} DropOn: {:?}",
@@ -421,7 +421,7 @@ impl Display for TableMeta {
 }
 
 impl Display for TableInfo {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "DB.Table: {}, Table: {}-{}, Engine: {}",
@@ -467,7 +467,7 @@ impl TableIdList {
 }
 
 impl Display for TableIdList {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "DB.Table id list: {:?}", self.id_list)
     }
 }
@@ -500,7 +500,7 @@ impl CreateTableReq {
 }
 
 impl Display for CreateTableReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self.create_option {
             CreateOption::Create => write!(
                 f,
@@ -563,7 +563,7 @@ impl DropTableByIdReq {
 }
 
 impl Display for DropTableByIdReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "drop_table_by_id(if_exists={}):{}",
@@ -606,7 +606,7 @@ impl UndropTableReq {
 }
 
 impl Display for UndropTableReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "undrop_table:{}/{}-{}",
@@ -641,7 +641,7 @@ impl RenameTableReq {
 }
 
 impl Display for RenameTableReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "rename_table:{}/{}-{}=>{}-{}",
@@ -710,7 +710,7 @@ impl UpsertTableOptionReq {
 }
 
 impl Display for UpsertTableOptionReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "upsert-table-options: table-id:{}({:?}) = {:?}",
@@ -762,7 +762,7 @@ pub struct CreateTableIndexReq {
 }
 
 impl Display for CreateTableIndexReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self.create_option {
             CreateOption::Create => {
                 write!(
@@ -800,7 +800,7 @@ pub struct DropTableIndexReq {
 }
 
 impl Display for DropTableIndexReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "drop_table_index(if_exists={}):{}/{}",
@@ -913,7 +913,7 @@ pub struct TableIdToName {
 }
 
 impl Display for TableIdToName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "TableIdToName{{{}}}", self.table_id)
     }
 }

--- a/src/meta/app/src/schema/virtual_column.rs
+++ b/src/meta/app/src/schema/virtual_column.rs
@@ -42,7 +42,7 @@ pub struct CreateVirtualColumnReq {
 }
 
 impl Display for CreateVirtualColumnReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "create_virtual_column ({:?}) for {}",
@@ -63,7 +63,7 @@ pub struct UpdateVirtualColumnReq {
 }
 
 impl Display for UpdateVirtualColumnReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "update_virtual_column ({:?}) for {}",
@@ -83,7 +83,7 @@ pub struct DropVirtualColumnReq {
 }
 
 impl Display for DropVirtualColumnReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "drop_virtual_column for {}", self.name_ident.display())
     }
 }

--- a/src/meta/app/src/share/share.rs
+++ b/src/meta/app/src/share/share.rs
@@ -128,7 +128,7 @@ pub enum ShareGrantObjectName {
 }
 
 impl Display for ShareGrantObjectName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ShareGrantObjectName::Database(db) => {
                 write!(f, "DATABASE {}", db)
@@ -379,7 +379,7 @@ pub struct ShareIdToName {
 }
 
 impl Display for ShareIdToName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.share_id)
     }
 }
@@ -401,7 +401,7 @@ pub struct ShareEndpointIdToName {
 }
 
 impl Display for ShareEndpointIdToName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.share_endpoint_id)
     }
 }
@@ -426,7 +426,7 @@ impl ShareGrantObject {
 }
 
 impl Display for ShareGrantObject {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ShareGrantObject::Database(db_id) => {
                 write!(f, "db/{}", *db_id)
@@ -560,7 +560,7 @@ impl ShareGrantEntry {
 }
 
 impl Display for ShareGrantEntry {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.object)
     }
 }

--- a/src/meta/app/src/storage/storage_params.rs
+++ b/src/meta/app/src/storage/storage_params.rs
@@ -165,7 +165,7 @@ impl StorageParams {
 
 /// StorageParams will be displayed by `{protocol}://{key1=value1},{key2=value2}`
 impl Display for StorageParams {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             StorageParams::Azblob(v) => write!(
                 f,
@@ -242,7 +242,7 @@ pub struct StorageAzblobConfig {
 }
 
 impl Debug for StorageAzblobConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("StorageAzblobConfig")
             .field("endpoint_url", &self.endpoint_url)
             .field("container", &self.container)
@@ -289,7 +289,7 @@ impl Default for StorageFtpConfig {
 }
 
 impl Debug for StorageFtpConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("StorageFtpConfig")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)
@@ -322,7 +322,7 @@ impl Default for StorageGcsConfig {
 }
 
 impl Debug for StorageGcsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("StorageGcsConfig")
             .field("endpoint", &self.endpoint_url)
             .field("bucket", &self.bucket)
@@ -398,7 +398,7 @@ impl Default for StorageS3Config {
 }
 
 impl Debug for StorageS3Config {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("StorageS3Config")
             .field("endpoint_url", &self.endpoint_url)
             .field("region", &self.region)
@@ -445,7 +445,7 @@ pub struct StorageObsConfig {
 }
 
 impl Debug for StorageObsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("StorageObsConfig")
             .field("endpoint_url", &self.endpoint_url)
             .field("bucket", &self.bucket)
@@ -479,7 +479,7 @@ pub struct StorageOssConfig {
 }
 
 impl Debug for StorageOssConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("StorageOssConfig")
             .field("endpoint_url", &self.endpoint_url)
             .field("presign_endpoint_url", &self.presign_endpoint_url)
@@ -533,7 +533,7 @@ pub struct StorageWebhdfsConfig {
 }
 
 impl Debug for StorageWebhdfsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let mut ds = f.debug_struct("StorageWebhdfsConfig");
 
         ds.field("endpoint_url", &self.endpoint_url)
@@ -555,7 +555,7 @@ pub struct StorageCosConfig {
 }
 
 impl Debug for StorageCosConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let mut ds = f.debug_struct("StorageCosConfig");
 
         ds.field("bucket", &self.bucket);
@@ -590,7 +590,7 @@ pub struct StorageHuggingfaceConfig {
 }
 
 impl Debug for StorageHuggingfaceConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let mut ds = f.debug_struct("StorageHuggingFaceConfig");
 
         ds.field("repo_id", &self.repo_id);

--- a/src/meta/app/src/tenant_key/errors.rs
+++ b/src/meta/app/src/tenant_key/errors.rs
@@ -46,7 +46,7 @@ impl<R> ExistError<R> {
 impl<R> fmt::Debug for ExistError<R>
 where R: TenantResource
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let typ = type_name::<R>();
 
         f.debug_struct("ExistError")
@@ -60,7 +60,7 @@ where R: TenantResource
 impl<R> fmt::Display for ExistError<R>
 where R: TenantResource
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let typ = type_name::<R>();
         write!(f, "{typ} '{}' already exists: {}", self.name, self.ctx)
     }
@@ -95,7 +95,7 @@ impl<R> UnknownError<R> {
 impl<R> fmt::Debug for UnknownError<R>
 where R: TenantResource
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let typ = type_name::<R>();
 
         f.debug_struct("UnknownError")
@@ -109,7 +109,7 @@ where R: TenantResource
 impl<R> fmt::Display for UnknownError<R>
 where R: TenantResource
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let typ = type_name::<R>();
         write!(f, "Unknown {typ} '{}': {}", self.name, self.ctx)
     }

--- a/src/meta/app/src/tenant_key/ident.rs
+++ b/src/meta/app/src/tenant_key/ident.rs
@@ -36,7 +36,7 @@ where
     R: TenantResource,
     N: Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         // If there is a specified type name for this alias, use it.
         // Otherwise use the default name
         let type_name = if R::TYPE.is_empty() {

--- a/src/meta/app/src/tenant_key/raw.rs
+++ b/src/meta/app/src/tenant_key/raw.rs
@@ -49,7 +49,7 @@ where
     R: TenantResource,
     N: Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         // If there is a specified type name for this alias, use it.
         // Otherwise use the default name
         let type_name = if R::TYPE.is_empty() {

--- a/src/meta/client/src/endpoints.rs
+++ b/src/meta/client/src/endpoints.rs
@@ -120,7 +120,7 @@ impl Endpoints {
 }
 
 impl fmt::Display for Endpoints {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let keys = self.nodes.keys().map(|x| x.as_str()).join(", ");
         write!(f, "current:{:?}, all:[{}]", self.current, keys)
     }

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -368,7 +368,7 @@ pub struct MetaGrpcClient {
 }
 
 impl Debug for MetaGrpcClient {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let mut de = f.debug_struct("MetaGrpcClient");
         de.field("endpoints", &*self.endpoints.lock());
         de.field("auto_sync_interval", &self.auto_sync_interval);

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -50,7 +50,7 @@ pub struct ClientWorkerRequest {
 }
 
 impl fmt::Debug for ClientWorkerRequest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("ClientWorkerRequest")
             .field("request_id", &self.request_id)
             .field("req", &self.req)
@@ -135,7 +135,7 @@ pub enum Response {
 }
 
 impl fmt::Debug for Response {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Response::StreamMGet(x) => {
                 write!(f, "StreamMGet({:?})", x.as_ref().map(|_s| "<stream>"))

--- a/src/meta/kvapi/src/kvapi/message.rs
+++ b/src/meta/kvapi/src/kvapi/message.rs
@@ -49,7 +49,7 @@ impl MGetKVReq {
 }
 
 impl fmt::Display for MGetKVReq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", VecDisplay::new_at_most(&self.keys, 5))
     }
 }

--- a/src/meta/raft-store/src/ondisk/data_version.rs
+++ b/src/meta/raft-store/src/ondisk/data_version.rs
@@ -37,7 +37,7 @@ pub enum DataVersion {
 }
 
 impl fmt::Debug for DataVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::V0 => write!(
                 f,
@@ -53,7 +53,7 @@ impl fmt::Debug for DataVersion {
 }
 
 impl fmt::Display for DataVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::V0 => write!(f, "V0"),
             Self::V001 => write!(f, "V001"),

--- a/src/meta/raft-store/src/ondisk/header.rs
+++ b/src/meta/raft-store/src/ondisk/header.rs
@@ -35,7 +35,7 @@ pub struct Header {
 }
 
 impl fmt::Display for Header {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "version: {}, upgrading: {}",

--- a/src/meta/raft-store/src/ondisk/mod.rs
+++ b/src/meta/raft-store/src/ondisk/mod.rs
@@ -64,7 +64,7 @@ pub struct OnDisk {
 }
 
 impl fmt::Display for OnDisk {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "header: {:?}, data-dir: {}",

--- a/src/meta/raft-store/src/ondisk/version_info.rs
+++ b/src/meta/raft-store/src/ondisk/version_info.rs
@@ -37,7 +37,7 @@ pub struct VersionInfo {
 }
 
 impl fmt::Display for VersionInfo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}: {}", self.build, self.desc)
     }
 }

--- a/src/meta/raft-store/src/state/raft_state_kv.rs
+++ b/src/meta/raft-store/src/state/raft_state_kv.rs
@@ -59,7 +59,7 @@ pub enum RaftStateValue {
 }
 
 impl fmt::Display for RaftStateKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }

--- a/src/meta/raft-store/src/state_machine/expire.rs
+++ b/src/meta/raft-store/src/state_machine/expire.rs
@@ -116,7 +116,7 @@ impl SledOrderedSerde for ExpireKey {
 }
 
 impl Display for ExpireKey {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let t = UNIX_EPOCH + Duration::from_millis(self.time_ms);
         let datetime: DateTime<Utc> = t.into();
         write!(f, "{}={}", datetime.format("%Y-%m-%d-%H-%M-%S"), self.seq)

--- a/src/meta/raft-store/src/state_machine/log_meta.rs
+++ b/src/meta/raft-store/src/state_machine/log_meta.rs
@@ -39,7 +39,7 @@ pub enum LogMetaValue {
 }
 
 impl fmt::Display for LogMetaKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             LogMetaKey::LastPurged => {
                 write!(f, "last-purged")

--- a/src/meta/raft-store/src/state_machine/state_machine_meta.rs
+++ b/src/meta/raft-store/src/state_machine/state_machine_meta.rs
@@ -46,7 +46,7 @@ pub enum StateMachineMetaValue {
 }
 
 impl fmt::Display for StateMachineMetaKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             StateMachineMetaKey::LastApplied => {
                 write!(f, "last-applied")

--- a/src/meta/sled-store/tests/it/testing/fake_state_machine_meta.rs
+++ b/src/meta/sled-store/tests/it/testing/fake_state_machine_meta.rs
@@ -43,7 +43,7 @@ pub enum StateMachineMetaValue {
 }
 
 impl fmt::Display for StateMachineMetaKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             StateMachineMetaKey::LastApplied => {
                 write!(f, "last-applied")

--- a/src/meta/types/src/applied_state.rs
+++ b/src/meta/types/src/applied_state.rs
@@ -47,7 +47,7 @@ pub enum AppliedState {
 }
 
 impl fmt::Display for AppliedState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "AppliedState: ")?;
         match self {
             AppliedState::Node { prev, result } => {

--- a/src/meta/types/src/change.rs
+++ b/src/meta/types/src/change.rs
@@ -139,7 +139,7 @@ where
     T: Debug + Clone + PartialEq,
     ID: Debug + Clone + PartialEq,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "id: {:?}", self.ident)?;
         write!(f, "prev: {:?}", self.prev)?;
         write!(f, "result: {:?}", self.result)

--- a/src/meta/types/src/cluster.rs
+++ b/src/meta/types/src/cluster.rs
@@ -56,7 +56,7 @@ impl Node {
 }
 
 impl fmt::Display for Node {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let grpc_addr_display = if let Some(grpc_addr) = &self.grpc_api_advertise_address {
             grpc_addr.to_string()
         } else {

--- a/src/meta/types/src/cmd/mod.rs
+++ b/src/meta/types/src/cmd/mod.rs
@@ -73,7 +73,7 @@ pub struct UpsertKV {
 }
 
 impl fmt::Display for Cmd {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Cmd::AddNode {
                 node_id,
@@ -100,7 +100,7 @@ impl fmt::Display for Cmd {
 }
 
 impl fmt::Display for UpsertKV {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{}({:?}) = {:?} ({:?})",

--- a/src/meta/types/src/endpoint.rs
+++ b/src/meta/types/src/endpoint.rs
@@ -57,7 +57,7 @@ impl Endpoint {
 }
 
 impl fmt::Display for Endpoint {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:{}", self.addr, self.port)
     }
 }

--- a/src/meta/types/src/log_entry.rs
+++ b/src/meta/types/src/log_entry.rs
@@ -44,7 +44,7 @@ pub struct LogEntry {
 }
 
 impl Display for LogEntry {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if let Some(txid) = &self.txid {
             write!(f, "txid: {:?}", txid)?;
         }

--- a/src/meta/types/src/match_seq.rs
+++ b/src/meta/types/src/match_seq.rs
@@ -41,7 +41,7 @@ pub enum MatchSeq {
 }
 
 impl Display for MatchSeq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             MatchSeq::Any => {
                 write!(f, "is any value")

--- a/src/meta/types/src/non_empty.rs
+++ b/src/meta/types/src/non_empty.rs
@@ -35,7 +35,7 @@ impl<'a> NonEmptyStr<'a> {
 }
 
 impl<'a> Display for NonEmptyStr<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.non_empty)
     }
 }
@@ -65,7 +65,7 @@ impl NonEmptyString {
 }
 
 impl Display for NonEmptyString {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.non_empty)
     }
 }

--- a/src/meta/types/src/operation.rs
+++ b/src/meta/types/src/operation.rs
@@ -28,7 +28,7 @@ pub enum Operation<T> {
 }
 
 impl<T> Debug for Operation<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Operation::Update(_) => f.debug_tuple("Update").field(&"[binary]").finish(),
             Operation::Delete => f.debug_tuple("Delete").finish(),

--- a/src/meta/types/src/proto_display.rs
+++ b/src/meta/types/src/proto_display.rs
@@ -43,7 +43,7 @@ struct OptionDisplay<'a, T: Display> {
 }
 
 impl<'a, T: Display> Display for OptionDisplay<'a, T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match &self.t {
             None => {
                 write!(f, "None")
@@ -74,7 +74,7 @@ where T: Display
 }
 
 impl<'a, T: Display> Display for VecDisplay<'a, T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "[")?;
 
         for (i, t) in self.vec.iter().enumerate() {
@@ -97,7 +97,7 @@ impl<'a, T: Display> Display for VecDisplay<'a, T> {
 }
 
 impl Display for TxnRequest {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "TxnRequest{{ if:{} then:{} else:{} }}",
@@ -109,7 +109,7 @@ impl Display for TxnRequest {
 }
 
 impl Display for TxnCondition {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let expect: ConditionResult = FromPrimitive::from_i32(self.expected).unwrap();
 
         write!(f, "{} {} {}", self.key, expect, OptionDisplay {
@@ -119,7 +119,7 @@ impl Display for TxnCondition {
 }
 
 impl Display for ConditionResult {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let x = match self {
             ConditionResult::Eq => "==",
             ConditionResult::Gt => ">",
@@ -133,13 +133,13 @@ impl Display for ConditionResult {
 }
 
 impl Display for TxnOp {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", OptionDisplay { t: &self.request })
     }
 }
 
 impl Display for txn_op::Request {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Request::Get(r) => {
                 write!(f, "Get({})", r)
@@ -158,13 +158,13 @@ impl Display for txn_op::Request {
 }
 
 impl Display for TxnGetRequest {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "Get key={}", self.key)
     }
 }
 
 impl Display for TxnPutRequest {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "Put key={}", self.key)?;
         if let Some(expire_at) = self.expire_at {
             let t = SystemTime::UNIX_EPOCH + Duration::from_millis(expire_at);
@@ -178,19 +178,19 @@ impl Display for TxnPutRequest {
 }
 
 impl Display for TxnDeleteRequest {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "Delete key={}", self.key)
     }
 }
 
 impl Display for TxnDeleteByPrefixRequest {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "TxnDeleteByPrefixRequest prefix={}", self.prefix)
     }
 }
 
 impl Display for Target {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Target::Value(_) => {
                 write!(f, "value(...)",)
@@ -203,7 +203,7 @@ impl Display for Target {
 }
 
 impl Display for TxnReply {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "TxnReply{{ success: {}, responses: {}, error: {}}}",
@@ -215,13 +215,13 @@ impl Display for TxnReply {
 }
 
 impl Display for TxnOpResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "TxnOpResponse: {}", OptionDisplay { t: &self.response })
     }
 }
 
 impl Display for Response {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Response::Get(r) => {
                 write!(f, "Get: {}", r)
@@ -240,7 +240,7 @@ impl Display for Response {
 }
 
 impl Display for TxnGetResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "Get-resp: key={}, prev_seq={:?}",
@@ -250,7 +250,7 @@ impl Display for TxnGetResponse {
     }
 }
 impl Display for TxnPutResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "Put-resp: key={}, prev_seq={:?}",
@@ -260,7 +260,7 @@ impl Display for TxnPutResponse {
     }
 }
 impl Display for TxnDeleteResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "Delete-resp: success: {}, key={}, prev_seq={:?}",
@@ -272,7 +272,7 @@ impl Display for TxnDeleteResponse {
 }
 
 impl Display for TxnDeleteByPrefixResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "TxnDeleteByPrefixResponse prefix={},count={}",

--- a/src/meta/types/src/raft_txid.rs
+++ b/src/meta/types/src/raft_txid.rs
@@ -40,7 +40,7 @@ impl RaftTxId {
 }
 
 impl Display for RaftTxId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "txid-{}-{}", &self.client, self.serial)
     }
 }

--- a/src/meta/types/src/seq_num.rs
+++ b/src/meta/types/src/seq_num.rs
@@ -30,7 +30,7 @@ impl std::ops::Add<u64> for SeqNum {
 }
 
 impl fmt::Display for SeqNum {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/meta/types/src/seq_value.rs
+++ b/src/meta/types/src/seq_value.rs
@@ -119,7 +119,7 @@ impl<V> SeqValue<V> for Option<SeqV<V>> {
 }
 
 impl<T: std::fmt::Debug> std::fmt::Debug for SeqV<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let mut de = f.debug_struct("SeqV");
         de.field("seq", &self.seq);
         de.field("meta", &self.meta);

--- a/src/query/ast/Cargo.toml
+++ b/src/query/ast/Cargo.toml
@@ -43,7 +43,6 @@ url = "2.3.1"
 
 [dev-dependencies]
 criterion = "0.4"
-databend-common-base = { path = "../../common/base" }
 goldenfile = "1.4"
 pretty_assertions = "1.3.0"
 regex = { workspace = true }

--- a/src/query/ast/src/ast/common.rs
+++ b/src/query/ast/src/ast/common.rs
@@ -59,7 +59,7 @@ impl Identifier {
 }
 
 impl Display for Identifier {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if self.is_hole {
             write!(f, "IDENTIFIER(:{})", self.name)
         } else if let Some(c) = self.quote {
@@ -95,7 +95,7 @@ impl ColumnPosition {
 }
 
 impl Display for ColumnPosition {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "${}", self.pos)
     }
 }
@@ -116,7 +116,7 @@ impl ColumnID {
 }
 
 impl Display for ColumnID {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ColumnID::Name(id) => write!(f, "{}", id),
             ColumnID::Position(id) => write!(f, "{}", id),
@@ -131,7 +131,7 @@ pub struct DatabaseRef {
 }
 
 impl Display for DatabaseRef {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if let Some(catalog) = &self.catalog {
             write!(f, "{}.", catalog)?;
         }
@@ -148,7 +148,7 @@ pub struct TableRef {
 }
 
 impl Display for TableRef {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         assert!(self.catalog.is_none() || (self.catalog.is_some() && self.database.is_some()));
         if let Some(catalog) = &self.catalog {
             write!(f, "{}.", catalog)?;
@@ -169,7 +169,7 @@ pub struct ColumnRef {
 }
 
 impl Display for ColumnRef {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         assert!(self.database.is_none() || (self.database.is_some() && self.table.is_some()));
 
         if f.alternate() {
@@ -189,7 +189,7 @@ impl Display for ColumnRef {
 }
 
 pub(crate) fn write_dot_separated_list(
-    f: &mut Formatter<'_>,
+    f: &mut Formatter,
     items: impl IntoIterator<Item = impl Display>,
 ) -> std::fmt::Result {
     for (i, item) in items.into_iter().enumerate() {
@@ -203,7 +203,7 @@ pub(crate) fn write_dot_separated_list(
 
 /// Write input items into `a, b, c`
 pub(crate) fn write_comma_separated_list(
-    f: &mut Formatter<'_>,
+    f: &mut Formatter,
     items: impl IntoIterator<Item = impl Display>,
 ) -> std::fmt::Result {
     for (i, item) in items.into_iter().enumerate() {
@@ -217,7 +217,7 @@ pub(crate) fn write_comma_separated_list(
 
 /// Write input items into `'a', 'b', 'c'`
 pub(crate) fn write_comma_separated_string_list(
-    f: &mut Formatter<'_>,
+    f: &mut Formatter,
     items: impl IntoIterator<Item = impl Display>,
 ) -> std::fmt::Result {
     for (i, item) in items.into_iter().enumerate() {
@@ -231,7 +231,7 @@ pub(crate) fn write_comma_separated_string_list(
 
 /// Write input map items into `field_a=x, field_b=y`
 pub(crate) fn write_comma_separated_map(
-    f: &mut Formatter<'_>,
+    f: &mut Formatter,
     items: impl IntoIterator<Item = (impl Display, impl Display)>,
 ) -> std::fmt::Result {
     for (i, (k, v)) in items.into_iter().enumerate() {
@@ -245,7 +245,7 @@ pub(crate) fn write_comma_separated_map(
 
 /// Write input map items into `field_a='x', field_b='y'`
 pub(crate) fn write_comma_separated_string_map(
-    f: &mut Formatter<'_>,
+    f: &mut Formatter,
     items: impl IntoIterator<Item = (impl Display, impl Display)>,
 ) -> std::fmt::Result {
     for (i, (k, v)) in items.into_iter().enumerate() {
@@ -259,7 +259,7 @@ pub(crate) fn write_comma_separated_string_map(
 
 /// Write input map items into `field_a='x' field_b='y'`
 pub(crate) fn write_space_separated_string_map(
-    f: &mut Formatter<'_>,
+    f: &mut Formatter,
     items: impl IntoIterator<Item = (impl Display, impl Display)>,
 ) -> std::fmt::Result {
     for (i, (k, v)) in items.into_iter().enumerate() {

--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -465,11 +465,11 @@ impl Expr {
 }
 
 impl Display for Expr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         fn write_expr(
             expr: &Expr,
             min_precedence: Precedence,
-            f: &mut Formatter<'_>,
+            f: &mut Formatter,
         ) -> std::fmt::Result {
             let precedence = expr.precedence();
             let need_parentheses = precedence.map(|p| p < min_precedence).unwrap_or(false);
@@ -779,7 +779,7 @@ pub enum SubqueryModifier {
 }
 
 impl Display for SubqueryModifier {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             SubqueryModifier::Any => write!(f, "ANY"),
             SubqueryModifier::All => write!(f, "ALL"),
@@ -807,7 +807,7 @@ pub enum Literal {
 }
 
 impl Display for Literal {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Literal::UInt64(val) => {
                 write!(f, "{val}")
@@ -848,7 +848,7 @@ pub struct FunctionCall {
 }
 
 impl Display for FunctionCall {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let FunctionCall {
             distinct,
             name,
@@ -956,7 +956,7 @@ impl TypeName {
 }
 
 impl Display for TypeName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             TypeName::Boolean => {
                 write!(f, "BOOLEAN")?;
@@ -1084,7 +1084,7 @@ pub enum Window {
 }
 
 impl Display for Window {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
             Window::WindowReference(ref window_ref) => write!(f, "{}", window_ref),
             Window::WindowSpec(ref window_spec) => write!(f, "{}", window_spec),
@@ -1099,7 +1099,7 @@ pub struct WindowDefinition {
 }
 
 impl Display for WindowDefinition {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{} AS {}", self.name, self.spec)
     }
 }
@@ -1110,7 +1110,7 @@ pub struct WindowRef {
 }
 
 impl Display for WindowRef {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.window_name)
     }
 }
@@ -1124,7 +1124,7 @@ pub struct WindowSpec {
 }
 
 impl Display for WindowSpec {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "(")?;
         if let Some(existing_window_name) = &self.existing_window_name {
             write!(f, " {existing_window_name}")?;
@@ -1203,7 +1203,7 @@ pub struct Lambda {
 }
 
 impl Display for Lambda {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if self.params.len() == 1 {
             write!(f, "{}", self.params[0])?;
         } else {
@@ -1290,7 +1290,7 @@ impl BinaryOperator {
 }
 
 impl Display for BinaryOperator {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             BinaryOperator::Plus => {
                 write!(f, "+")
@@ -1437,7 +1437,7 @@ impl JsonOperator {
 }
 
 impl Display for JsonOperator {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             JsonOperator::Arrow => {
                 write!(f, "->")
@@ -1492,7 +1492,7 @@ pub enum UnaryOperator {
 }
 
 impl Display for UnaryOperator {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             UnaryOperator::Plus => {
                 write!(f, "+")

--- a/src/query/ast/src/ast/format/ast_format.rs
+++ b/src/query/ast/src/ast/format/ast_format.rs
@@ -63,7 +63,7 @@ impl AstFormatContext {
 }
 
 impl Display for AstFormatContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match &self.alias {
             Some(alias) => {
                 if self.children_num > 0 {

--- a/src/query/ast/src/ast/query.rs
+++ b/src/query/ast/src/ast/query.rs
@@ -53,7 +53,7 @@ pub struct Query {
 }
 
 impl Display for Query {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         // CTE, with clause
         if let Some(with) = &self.with {
             write!(f, "WITH {with} ")?;
@@ -93,7 +93,7 @@ pub struct With {
 }
 
 impl Display for With {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if self.recursive {
             write!(f, "RECURSIVE ")?;
         }
@@ -114,7 +114,7 @@ pub struct CTE {
 }
 
 impl Display for CTE {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{} AS ", self.alias)?;
         if self.materialized {
             write!(f, "MATERIALIZED ")?;
@@ -164,7 +164,7 @@ pub struct SelectStmt {
 }
 
 impl Display for SelectStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         // SELECT clause
         write!(f, "SELECT ")?;
         if let Some(hints) = &self.hints {
@@ -272,7 +272,7 @@ pub enum SetExpr {
 }
 
 impl Display for SetExpr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             SetExpr::Select(select_stmt) => {
                 write!(f, "{select_stmt}")?;
@@ -334,7 +334,7 @@ pub struct OrderByExpr {
 }
 
 impl Display for OrderByExpr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.expr)?;
         if let Some(asc) = self.asc {
             if asc {
@@ -416,7 +416,7 @@ impl SelectTarget {
 }
 
 impl Display for SelectTarget {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             SelectTarget::AliasedExpr { expr, alias } => {
                 write!(f, "{expr}")?;
@@ -483,7 +483,7 @@ pub enum Indirection {
 }
 
 impl Display for Indirection {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Indirection::Identifier(ident) => {
                 write!(f, "{ident}")?;
@@ -510,7 +510,7 @@ pub enum TimeTravelPoint {
 }
 
 impl Display for TimeTravelPoint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             TimeTravelPoint::Snapshot(sid) => {
                 write!(f, "(SNAPSHOT => '{sid}')")?;
@@ -547,7 +547,7 @@ pub struct Pivot {
 }
 
 impl Display for Pivot {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "PIVOT({} FOR {} IN (", self.aggregate, self.value_column)?;
         write_comma_separated_list(f, &self.values)?;
         write!(f, "))")?;
@@ -563,7 +563,7 @@ pub struct Unpivot {
 }
 
 impl Display for Unpivot {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "UNPIVOT({} FOR {} IN (",
@@ -584,7 +584,7 @@ pub struct ChangesInterval {
 }
 
 impl Display for ChangesInterval {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CHANGES (INFORMATION => ")?;
         if self.append_only {
             write!(f, "APPEND_ONLY")?;
@@ -606,7 +606,7 @@ pub enum TemporalClause {
 }
 
 impl Display for TemporalClause {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             TemporalClause::TimeTravel(point) => {
                 write!(f, "AT {}", point)?;
@@ -694,7 +694,7 @@ impl TableReference {
 }
 
 impl Display for TableReference {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             TableReference::Table {
                 span: _,
@@ -840,7 +840,7 @@ pub struct TableAlias {
 }
 
 impl Display for TableAlias {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", &self.name)?;
         if !self.columns.is_empty() {
             write!(f, "(")?;

--- a/src/query/ast/src/ast/statements/call.rs
+++ b/src/query/ast/src/ast/statements/call.rs
@@ -29,7 +29,7 @@ pub struct CallStmt {
 }
 
 impl Display for CallStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CALL {}(", self.name)?;
         write_comma_separated_string_list(f, self.args.clone())?;
         write!(f, ")")?;

--- a/src/query/ast/src/ast/statements/catalog.rs
+++ b/src/query/ast/src/ast/statements/catalog.rs
@@ -30,7 +30,7 @@ pub struct ShowCatalogsStmt {
 }
 
 impl Display for ShowCatalogsStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "SHOW CATALOGS")?;
         if let Some(limit) = &self.limit {
             write!(f, " {}", limit)?
@@ -46,7 +46,7 @@ pub struct ShowCreateCatalogStmt {
 }
 
 impl Display for ShowCreateCatalogStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "SHOW CREATE CATALOG {}", &self.catalog)
     }
 }
@@ -64,7 +64,7 @@ pub struct CreateCatalogStmt {
 }
 
 impl Display for CreateCatalogStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE CATALOG")?;
         if self.if_not_exists {
             write!(f, " IF NOT EXISTS")?;
@@ -85,7 +85,7 @@ pub struct DropCatalogStmt {
 }
 
 impl Display for DropCatalogStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP CATALOG ")?;
         if self.if_exists {
             write!(f, "IF EXISTS ")?;

--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -102,7 +102,7 @@ impl CopyIntoTableStmt {
 }
 
 impl Display for CopyIntoTableStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if let Some(cte) = &self.with {
             write!(f, "WITH {} ", cte)?;
         }
@@ -173,7 +173,7 @@ pub struct CopyIntoLocationStmt {
 }
 
 impl Display for CopyIntoLocationStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if let Some(cte) = &self.with {
             write!(f, "WITH {} ", cte)?;
         }
@@ -215,7 +215,7 @@ pub enum CopyIntoTableSource {
 }
 
 impl Display for CopyIntoTableSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             CopyIntoTableSource::Location(location) => write!(f, "{location}"),
             CopyIntoTableSource::Query(query) => {
@@ -233,7 +233,7 @@ pub enum CopyIntoLocationSource {
 }
 
 impl Display for CopyIntoLocationSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             CopyIntoLocationSource::Query(query) => {
                 write!(f, "({query})")
@@ -303,7 +303,7 @@ impl Connection {
 }
 
 impl Display for Connection {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if !self.conns.is_empty() {
             write!(f, " CONNECTION = ( ")?;
             write_comma_separated_string_map(f, &self.conns)?;
@@ -420,7 +420,7 @@ impl UriLocation {
 }
 
 impl Display for UriLocation {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "'{}://{}{}'", self.protocol, self.name, self.path)?;
         write!(f, "{}", self.connection)?;
         if !self.part_prefix.is_empty() {
@@ -447,7 +447,7 @@ pub enum FileLocation {
 }
 
 impl Display for FileLocation {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             FileLocation::Uri(loc) => {
                 write!(f, "{}", loc)
@@ -494,7 +494,7 @@ impl FileFormatOptions {
 }
 
 impl Display for FileFormatOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write_comma_separated_map(f, &self.options)
     }
 }
@@ -521,7 +521,7 @@ impl FileFormatValue {
 }
 
 impl Display for FileFormatValue {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             FileFormatValue::Keyword(v) => write!(f, "{v}"),
             FileFormatValue::Bool(v) => write!(f, "{v}"),

--- a/src/query/ast/src/ast/statements/database.rs
+++ b/src/query/ast/src/ast/statements/database.rs
@@ -34,7 +34,7 @@ pub struct ShowDatabasesStmt {
 }
 
 impl Display for ShowDatabasesStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "SHOW ")?;
         if self.full {
             write!(f, "FULL ")?;
@@ -58,7 +58,7 @@ pub struct ShowCreateDatabaseStmt {
 }
 
 impl Display for ShowCreateDatabaseStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "SHOW CREATE DATABASE ")?;
         write_dot_separated_list(f, self.catalog.iter().chain(Some(&self.database)))?;
 
@@ -76,7 +76,7 @@ pub struct CreateDatabaseStmt {
 }
 
 impl Display for CreateDatabaseStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE ")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, "OR REPLACE ")?;
@@ -109,7 +109,7 @@ pub struct DropDatabaseStmt {
 }
 
 impl Display for DropDatabaseStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP DATABASE ")?;
         if self.if_exists {
             write!(f, "IF EXISTS ")?;
@@ -127,7 +127,7 @@ pub struct UndropDatabaseStmt {
 }
 
 impl Display for UndropDatabaseStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "UNDROP DATABASE ")?;
         write_dot_separated_list(f, self.catalog.iter().chain(Some(&self.database)))?;
         Ok(())
@@ -144,7 +144,7 @@ pub struct AlterDatabaseStmt {
 }
 
 impl Display for AlterDatabaseStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ALTER DATABASE ")?;
         if self.if_exists {
             write!(f, "IF EXISTS ")?;
@@ -172,7 +172,7 @@ pub enum DatabaseEngine {
 }
 
 impl Display for DatabaseEngine {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             DatabaseEngine::Default => write!(f, "DEFAULT"),
             DatabaseEngine::Share => write!(f, "SHARE"),

--- a/src/query/ast/src/ast/statements/dynamic_table.rs
+++ b/src/query/ast/src/ast/statements/dynamic_table.rs
@@ -36,7 +36,7 @@ pub enum TargetLag {
 }
 
 impl Display for TargetLag {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             TargetLag::IntervalSecs(secs) => {
                 write!(f, "{} SECOND", secs)
@@ -56,7 +56,7 @@ pub enum RefreshMode {
 }
 
 impl Display for RefreshMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             RefreshMode::Auto => {
                 write!(f, "AUTO")
@@ -78,7 +78,7 @@ pub enum InitializeMode {
 }
 
 impl Display for InitializeMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             InitializeMode::OnCreate => {
                 write!(f, "ON_CREATE")
@@ -112,7 +112,7 @@ pub struct CreateDynamicTableStmt {
 }
 
 impl Display for CreateDynamicTableStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE ")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, "OR REPLACE ")?;

--- a/src/query/ast/src/ast/statements/hint.rs
+++ b/src/query/ast/src/ast/statements/hint.rs
@@ -33,7 +33,7 @@ pub struct HintItem {
 }
 
 impl Display for Hint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "/*+ ")?;
         for hint in &self.hints_list {
             write!(f, "SET_VAR(")?;

--- a/src/query/ast/src/ast/statements/index.rs
+++ b/src/query/ast/src/ast/statements/index.rs
@@ -46,7 +46,7 @@ pub enum TableIndexType {
 }
 
 impl Display for TableIndexType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             TableIndexType::Aggregating => {
                 write!(f, "AGGREGATING")
@@ -59,7 +59,7 @@ impl Display for TableIndexType {
 }
 
 impl Display for CreateIndexStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE ")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, "OR REPLACE ")?;
@@ -85,7 +85,7 @@ pub struct DropIndexStmt {
 }
 
 impl Display for DropIndexStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP AGGREGATING INDEX")?;
         if self.if_exists {
             write!(f, " IF EXISTS")?;
@@ -104,7 +104,7 @@ pub struct RefreshIndexStmt {
 }
 
 impl Display for RefreshIndexStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "REFRESH AGGREGATING INDEX {index}", index = self.index)?;
         if let Some(limit) = self.limit {
             write!(f, " LIMIT {limit}")?;
@@ -131,7 +131,7 @@ pub struct CreateInvertedIndexStmt {
 }
 
 impl Display for CreateInvertedIndexStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE ")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, "OR REPLACE ")?;
@@ -177,7 +177,7 @@ pub struct DropInvertedIndexStmt {
 }
 
 impl Display for DropInvertedIndexStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP INVERTED INDEX")?;
         if self.if_exists {
             write!(f, " IF EXISTS")?;
@@ -207,7 +207,7 @@ pub struct RefreshInvertedIndexStmt {
 }
 
 impl Display for RefreshInvertedIndexStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "REFRESH INVERTED INDEX")?;
         write!(f, " {}", self.index_name)?;
         write!(f, " ON ")?;

--- a/src/query/ast/src/ast/statements/kill.rs
+++ b/src/query/ast/src/ast/statements/kill.rs
@@ -24,7 +24,7 @@ pub enum KillTarget {
 }
 
 impl Display for KillTarget {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             KillTarget::Query => write!(f, "QUERY"),
             KillTarget::Connection => write!(f, "CONNECTION"),

--- a/src/query/ast/src/ast/statements/lock.rs
+++ b/src/query/ast/src/ast/statements/lock.rs
@@ -28,7 +28,7 @@ pub struct ShowLocksStmt {
 }
 
 impl Display for ShowLocksStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "SHOW LOCKS")?;
         if self.in_account {
             write!(f, " IN ACCOUNT")?;

--- a/src/query/ast/src/ast/statements/merge_into.rs
+++ b/src/query/ast/src/ast/statements/merge_into.rs
@@ -284,7 +284,7 @@ impl MergeSource {
 }
 
 impl Display for MergeSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             MergeSource::StreamingV2 {
                 settings,

--- a/src/query/ast/src/ast/statements/notification.rs
+++ b/src/query/ast/src/ast/statements/notification.rs
@@ -34,7 +34,7 @@ pub struct CreateNotificationStmt {
 }
 
 impl Display for CreateNotificationStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE NOTIFICATION INTEGRATION")?;
         if self.if_not_exists {
             write!(f, " IF NOT EXISTS")?;
@@ -63,7 +63,7 @@ pub struct NotificationWebhookOptions {
 }
 
 impl Display for NotificationWebhookOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let NotificationWebhookOptions {
             url,
             method,
@@ -117,7 +117,7 @@ pub struct DropNotificationStmt {
 }
 
 impl Display for DropNotificationStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP NOTIFICATION INTEGRATION")?;
         if self.if_exists {
             write!(f, " IF EXISTS")?;
@@ -176,7 +176,7 @@ impl AlterNotificationSetOptions {
 }
 
 impl Display for AlterNotificationStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ALTER NOTIFICATION INTEGRATION {}", self.name)?;
         match &self.options {
             AlterNotificationOptions::Set(set_opts) => {
@@ -204,7 +204,7 @@ pub struct DescribeNotificationStmt {
 }
 
 impl Display for DescribeNotificationStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DESCRIBE NOTIFICATION INTEGRATION {}", self.name)
     }
 }

--- a/src/query/ast/src/ast/statements/pipe.rs
+++ b/src/query/ast/src/ast/statements/pipe.rs
@@ -34,7 +34,7 @@ pub struct CreatePipeStmt {
 }
 
 impl Display for CreatePipeStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE PIPE")?;
         if self.if_not_exists {
             write!(f, " IF NOT EXISTS")?;
@@ -63,7 +63,7 @@ pub struct DropPipeStmt {
 }
 
 impl Display for DropPipeStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP PIPE")?;
         if self.if_exists {
             write!(f, " IF EXISTS")?;
@@ -79,7 +79,7 @@ pub struct DescribePipeStmt {
 }
 
 impl Display for DescribePipeStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DESCRIBE PIPE {}", self.name)
     }
 }
@@ -110,7 +110,7 @@ pub enum AlterPipeOptions {
 }
 
 impl Display for AlterPipeOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             AlterPipeOptions::Set {
                 execution_paused,
@@ -142,7 +142,7 @@ impl Display for AlterPipeOptions {
 }
 
 impl Display for AlterPipeStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ALTER PIPE")?;
         if self.if_exists {
             write!(f, " IF EXISTS")?;

--- a/src/query/ast/src/ast/statements/presign.rs
+++ b/src/query/ast/src/ast/statements/presign.rs
@@ -34,7 +34,7 @@ impl Default for PresignAction {
 }
 
 impl Display for PresignAction {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             PresignAction::Download => write!(f, "DOWNLOAD"),
             PresignAction::Upload => write!(f, "UPLOAD"),
@@ -49,7 +49,7 @@ pub enum PresignLocation {
 }
 
 impl Display for PresignLocation {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             PresignLocation::StageLocation(v) => write!(f, "@{}", escape_at_string(v)),
         }
@@ -67,7 +67,7 @@ pub struct PresignStmt {
 }
 
 impl Display for PresignStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "PRESIGN {} {} EXPIRE = {}",

--- a/src/query/ast/src/ast/statements/principal.rs
+++ b/src/query/ast/src/ast/statements/principal.rs
@@ -87,7 +87,7 @@ pub enum AuthType {
 }
 
 impl Display for AuthType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", match self {
             AuthType::NoPassword => "no_password",
             AuthType::Sha256Password => "sha256_password",
@@ -105,7 +105,7 @@ pub enum CatalogType {
 }
 
 impl Display for CatalogType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             CatalogType::Default => write!(f, "DEFAULT"),
             CatalogType::Hive => write!(f, "HIVE"),
@@ -161,7 +161,7 @@ pub enum UserPrivilegeType {
 }
 
 impl Display for UserPrivilegeType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", match self {
             UserPrivilegeType::Usage => "USAGE",
             UserPrivilegeType::Create => "CREATE",
@@ -197,7 +197,7 @@ pub enum ShareGrantObjectName {
 }
 
 impl Display for ShareGrantObjectName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ShareGrantObjectName::Database(db) => {
                 write!(f, "DATABASE {db}")
@@ -220,7 +220,7 @@ pub enum ShareGrantObjectPrivilege {
 }
 
 impl Display for ShareGrantObjectPrivilege {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
             ShareGrantObjectPrivilege::Usage => write!(f, "USAGE"),
             ShareGrantObjectPrivilege::ReferenceUsage => write!(f, "REFERENCE_USAGE"),
@@ -253,7 +253,7 @@ pub struct CopyOptions {
 }
 
 impl Display for CopyOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "OnErrorMode {}", self.on_error)?;
         write!(f, "SizeLimit {}", self.size_limit)?;
         write!(f, "MaxFiles {}", self.max_files)?;
@@ -275,7 +275,7 @@ pub enum OnErrorMode {
 }
 
 impl Display for OnErrorMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             OnErrorMode::Continue => {
                 write!(f, "continue")

--- a/src/query/ast/src/ast/statements/priority.rs
+++ b/src/query/ast/src/ast/statements/priority.rs
@@ -25,7 +25,7 @@ pub enum Priority {
 }
 
 impl Display for Priority {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Priority::HIGH => write!(f, "HIGH"),
             Priority::MEDIUM => write!(f, "MEDIUM"),

--- a/src/query/ast/src/ast/statements/procedure.rs
+++ b/src/query/ast/src/ast/statements/procedure.rs
@@ -25,7 +25,7 @@ pub struct ExecuteImmediateStmt {
 }
 
 impl Display for ExecuteImmediateStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "EXECUTE IMMEDIATE $$\n{}\n$$", self.script)?;
         Ok(())
     }

--- a/src/query/ast/src/ast/statements/script.rs
+++ b/src/query/ast/src/ast/statements/script.rs
@@ -31,7 +31,7 @@ pub struct ScriptBlock {
 }
 
 impl Display for ScriptBlock {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         writeln!(f, "DECLARE")?;
         for declare in &self.declares {
             writeln!(
@@ -60,7 +60,7 @@ pub enum DeclareItem {
 }
 
 impl Display for DeclareItem {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             DeclareItem::Var(declare) => write!(f, "{declare}"),
             DeclareItem::Set(declare) => write!(f, "{declare}"),
@@ -76,7 +76,7 @@ pub struct DeclareVar {
 }
 
 impl Display for DeclareVar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let DeclareVar { name, default, .. } = self;
         write!(f, "{name} := {default}")?;
         Ok(())
@@ -91,7 +91,7 @@ pub struct DeclareSet {
 }
 
 impl Display for DeclareSet {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let DeclareSet { name, stmt, .. } = self;
         write!(f, "{name} RESULTSET := {stmt}")
     }
@@ -105,7 +105,7 @@ pub enum ReturnItem {
 }
 
 impl Display for ReturnItem {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ReturnItem::Var(expr) => write!(f, "{expr}"),
             ReturnItem::Set(name) => write!(f, "TABLE({name})"),
@@ -199,7 +199,7 @@ pub enum ScriptStatement {
 }
 
 impl Display for ScriptStatement {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ScriptStatement::LetVar { declare, .. } => write!(f, "LET {declare}"),
             ScriptStatement::LetStatement { declare, .. } => write!(f, "LET {declare}"),

--- a/src/query/ast/src/ast/statements/sequence.rs
+++ b/src/query/ast/src/ast/statements/sequence.rs
@@ -30,7 +30,7 @@ pub struct CreateSequenceStmt {
 }
 
 impl Display for CreateSequenceStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE ")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, "OR REPLACE ")?;
@@ -55,7 +55,7 @@ pub struct DropSequenceStmt {
 }
 
 impl Display for DropSequenceStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP SEQUENCE ")?;
         if self.if_exists {
             write!(f, "IF EXISTS ")?;

--- a/src/query/ast/src/ast/statements/show.rs
+++ b/src/query/ast/src/ast/statements/show.rs
@@ -32,7 +32,7 @@ pub enum ShowLimit {
 }
 
 impl Display for ShowLimit {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ShowLimit::Like { pattern } => write!(f, "LIKE '{pattern}'"),
             ShowLimit::Where { selection } => write!(f, "WHERE {selection}"),
@@ -48,7 +48,7 @@ pub struct ShowOptions {
 }
 
 impl Display for ShowOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if let Some(limit_option) = self.show_limit.clone() {
             write!(f, "{}", limit_option)?;
         }

--- a/src/query/ast/src/ast/statements/stage.rs
+++ b/src/query/ast/src/ast/statements/stage.rs
@@ -46,7 +46,7 @@ pub struct CreateStageStmt {
 }
 
 impl Display for CreateStageStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, " OR REPLACE")?;
@@ -145,7 +145,7 @@ impl SelectStageOptions {
 // [ ENABLE_VIRTUAL_HOST_STYLE => true|false ]
 // )]
 impl Display for SelectStageOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, " (")?;
 
         if let Some(files) = self.files.as_ref() {

--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -383,7 +383,7 @@ impl Statement {
 }
 
 impl Display for Statement {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Statement::Explain {
                 options,

--- a/src/query/ast/src/ast/statements/stream.rs
+++ b/src/query/ast/src/ast/statements/stream.rs
@@ -40,7 +40,7 @@ pub struct CreateStreamStmt {
 }
 
 impl Display for CreateStreamStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE ")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, "OR REPLACE ")?;
@@ -81,7 +81,7 @@ pub struct DropStreamStmt {
 }
 
 impl Display for DropStreamStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP STREAM ")?;
         if self.if_exists {
             write!(f, "IF EXISTS ")?;
@@ -106,7 +106,7 @@ pub struct ShowStreamsStmt {
 }
 
 impl Display for ShowStreamsStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "SHOW ")?;
         if self.full {
             write!(f, "FULL ")?;

--- a/src/query/ast/src/ast/statements/task.rs
+++ b/src/query/ast/src/ast/statements/task.rs
@@ -31,7 +31,7 @@ pub enum TaskSql {
 }
 
 impl Display for TaskSql {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             TaskSql::SingleStatement(stmt) => write!(f, "{}", stmt),
             TaskSql::ScriptBlock(stmts) => {
@@ -72,7 +72,7 @@ pub struct CreateTaskStmt {
 }
 
 impl Display for CreateTaskStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE TASK")?;
         if self.if_not_exists {
             write!(f, " IF NOT EXISTS")?;
@@ -126,7 +126,7 @@ pub struct WarehouseOptions {
 }
 
 impl Display for WarehouseOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if let Some(wh) = &self.warehouse {
             write!(f, "WAREHOUSE = '{}'", wh)?;
         }
@@ -141,7 +141,7 @@ pub enum ScheduleOptions {
 }
 
 impl Display for ScheduleOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ScheduleOptions::IntervalSecs(secs) => {
                 write!(f, "{} SECOND", secs)
@@ -167,7 +167,7 @@ pub struct AlterTaskStmt {
 }
 
 impl Display for AlterTaskStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ALTER TASK")?;
         if self.if_exists {
             write!(f, " IF EXISTS")?;
@@ -207,7 +207,7 @@ pub enum AlterTaskOptions {
 }
 
 impl Display for AlterTaskOptions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             AlterTaskOptions::Resume => write!(f, "RESUME"),
             AlterTaskOptions::Suspend => write!(f, "SUSPEND"),
@@ -270,7 +270,7 @@ pub struct DropTaskStmt {
 }
 
 impl Display for DropTaskStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP TASK")?;
         if self.if_exists {
             write!(f, " IF EXISTS")?;
@@ -285,7 +285,7 @@ pub struct ShowTasksStmt {
 }
 
 impl Display for ShowTasksStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "SHOW ")?;
         write!(f, "TASKS")?;
         if let Some(limit) = &self.limit {
@@ -303,7 +303,7 @@ pub struct ExecuteTaskStmt {
 }
 
 impl Display for ExecuteTaskStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "EXECUTE TASK {}", self.name)
     }
 }
@@ -315,7 +315,7 @@ pub struct DescribeTaskStmt {
 }
 
 impl Display for DescribeTaskStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DESCRIBE TASK {}", self.name)
     }
 }

--- a/src/query/ast/src/ast/statements/user.rs
+++ b/src/query/ast/src/ast/statements/user.rs
@@ -34,7 +34,7 @@ pub struct CreateUserStmt {
 }
 
 impl Display for CreateUserStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, " OR REPLACE")?;
@@ -62,7 +62,7 @@ pub struct AuthOption {
 }
 
 impl Display for AuthOption {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         if let Some(auth_type) = &self.auth_type {
             write!(f, "WITH {auth_type} ")?;
         }
@@ -84,7 +84,7 @@ pub struct AlterUserStmt {
 }
 
 impl Display for AlterUserStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ALTER USER")?;
         if let Some(user) = &self.user {
             write!(f, " {}", user)?;
@@ -110,7 +110,7 @@ pub struct GrantStmt {
 }
 
 impl Display for GrantStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "GRANT")?;
         write!(f, "{}", self.source)?;
 
@@ -126,7 +126,7 @@ pub struct RevokeStmt {
 }
 
 impl Display for RevokeStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "REVOKE")?;
         write!(f, "{}", self.source)?;
 
@@ -151,7 +151,7 @@ pub enum AccountMgrSource {
 }
 
 impl Display for AccountMgrSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             AccountMgrSource::Role { role } => write!(f, " ROLE '{role}'")?,
             AccountMgrSource::Privs { privileges, level } => {

--- a/src/query/ast/src/ast/statements/virtual_column.rs
+++ b/src/query/ast/src/ast/statements/virtual_column.rs
@@ -36,7 +36,7 @@ pub struct CreateVirtualColumnStmt {
 }
 
 impl Display for CreateVirtualColumnStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CREATE ")?;
         if let CreateOption::CreateOrReplace = self.create_option {
             write!(f, "OR REPLACE ")?;
@@ -71,7 +71,7 @@ pub struct AlterVirtualColumnStmt {
 }
 
 impl Display for AlterVirtualColumnStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ALTER VIRTUAL COLUMN ")?;
         if self.if_exists {
             write!(f, "IF EXISTS ")?;
@@ -100,7 +100,7 @@ pub struct DropVirtualColumnStmt {
 }
 
 impl Display for DropVirtualColumnStmt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DROP VIRTUAL COLUMN ")?;
         if self.if_exists {
             write!(f, "IF EXISTS ")?;

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -1324,11 +1324,11 @@ pub fn unary_op(i: Input) -> IResult<UnaryOperator> {
     // Plus and Minus are parsed as binary op at first.
     alt((
         value(UnaryOperator::Not, rule! { NOT }),
-        value(UnaryOperator::Factorial, rule! { Factorial}),
-        value(UnaryOperator::SquareRoot, rule! { SquareRoot}),
-        value(UnaryOperator::BitwiseNot, rule! {BitWiseNot}),
-        value(UnaryOperator::CubeRoot, rule! { CubeRoot}),
-        value(UnaryOperator::Abs, rule! { Abs}),
+        value(UnaryOperator::Factorial, rule! { Factorial }),
+        value(UnaryOperator::SquareRoot, rule! { SquareRoot }),
+        value(UnaryOperator::BitwiseNot, rule! { BitWiseNot }),
+        value(UnaryOperator::CubeRoot, rule! { CubeRoot }),
+        value(UnaryOperator::Abs, rule! { Abs }),
     ))(i)
 }
 

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -44,7 +44,7 @@ impl<'a> Token<'a> {
 }
 
 impl<'a> std::fmt::Debug for Token<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}({:?})", self.kind, self.span)
     }
 }

--- a/src/query/catalog/src/plan/datasource/datasource_info/stage.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_info/stage.rs
@@ -80,14 +80,14 @@ pub async fn list_stage_files(
 
 impl Debug for StageTableInfo {
     // Ignore the schema.
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self.stage_info)
     }
 }
 
 impl Display for StageTableInfo {
     // Ignore the schema.
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "StageName {}", self.stage_info.stage_name)?;
         write!(f, "StageType {}", self.stage_info.stage_type)?;
         write!(f, "StageParam {}", self.stage_info.stage_params.storage)?;

--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -58,7 +58,7 @@ pub trait PartInfo: Send + Sync {
 }
 
 impl Debug for Box<dyn PartInfo> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match serde_json::to_string(self) {
             Ok(str) => write!(f, "{}", str),
             Err(_cause) => Err(std::fmt::Error {}),

--- a/src/query/catalog/src/query_kind.rs
+++ b/src/query/catalog/src/query_kind.rs
@@ -31,7 +31,7 @@ pub enum QueryKind {
 }
 
 impl Display for QueryKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
 }

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -96,7 +96,7 @@ pub enum ProcessInfoState {
 }
 
 impl Display for ProcessInfoState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             ProcessInfoState::Query => write!(f, "Query"),
             ProcessInfoState::Aborting => write!(f, "Aborting"),

--- a/src/query/config/src/background_config.rs
+++ b/src/query/config/src/background_config.rs
@@ -244,7 +244,7 @@ impl Default for BackgroundCompactionConfig {
 }
 
 impl Debug for BackgroundCompactionConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("BackgroundCompactionConfig")
             .field("mode", &self.compact_mode)
             .field("segment_limit", &self.segment_limit)
@@ -265,7 +265,7 @@ impl Default for BackgroundScheduledConfig {
 }
 
 impl Debug for BackgroundScheduledConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("BackgroundCompactionFixedConfig")
             .field("duration_secs", &self.duration_secs)
             .finish()
@@ -288,7 +288,7 @@ impl Default for InnerBackgroundConfig {
 }
 
 impl Debug for InnerBackgroundConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("InnerBackgroundConfig")
             .field("compaction", &self.compaction)
             .finish()
@@ -296,7 +296,7 @@ impl Debug for InnerBackgroundConfig {
 }
 
 impl Debug for InnerBackgroundCompactionConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("InnerBackgroundCompactionConfig")
             .field("segment_limit", &self.segment_limit)
             .field("block_limit", &self.block_limit)

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -621,7 +621,7 @@ impl Default for GcsStorageConfig {
 }
 
 impl Debug for GcsStorageConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("GcsStorageConfig")
             .field("endpoint_url", &self.gcs_endpoint_url)
             .field("root", &self.gcs_root)
@@ -970,7 +970,7 @@ impl Default for ObsStorageConfig {
 }
 
 impl Debug for ObsStorageConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("ObsStorageConfig")
             .field("endpoint_url", &self.obs_endpoint_url)
             .field("bucket", &self.obs_bucket)

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -130,7 +130,7 @@ impl InnerConfig {
 }
 
 impl Debug for InnerConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("InnerConfig")
             .field("subcommand", &self.subcommand)
             .field("config_file", &self.config_file)
@@ -469,7 +469,7 @@ impl FromStr for ThriftProtocol {
 }
 
 impl Display for ThriftProtocol {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Self::Binary => write!(f, "binary"),
         }

--- a/src/query/datavalues/src/data_field.rs
+++ b/src/query/datavalues/src/data_field.rs
@@ -93,7 +93,7 @@ impl DataField {
 }
 
 impl std::fmt::Debug for DataField {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataField");
         let remove_nullable = remove_nullable(self.data_type());
         debug_struct

--- a/src/query/datavalues/src/types/type_array.rs
+++ b/src/query/datavalues/src/types/type_array.rs
@@ -48,7 +48,7 @@ impl DataType for ArrayType {
 }
 
 impl std::fmt::Debug for ArrayType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_boolean.rs
+++ b/src/query/datavalues/src/types/type_boolean.rs
@@ -34,7 +34,7 @@ impl DataType for BooleanType {
 }
 
 impl std::fmt::Debug for BooleanType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_date.rs
+++ b/src/query/datavalues/src/types/type_date.rs
@@ -42,7 +42,7 @@ impl DataType for DateType {
 }
 
 impl std::fmt::Debug for DateType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_id.rs
+++ b/src/query/datavalues/src/types/type_id.rs
@@ -63,7 +63,7 @@ impl TypeID {
 }
 
 impl std::fmt::Display for TypeID {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             TypeID::VariantArray => write!(f, "Array"),
             TypeID::VariantObject => write!(f, "Object"),

--- a/src/query/datavalues/src/types/type_interval.rs
+++ b/src/query/datavalues/src/types/type_interval.rs
@@ -94,7 +94,7 @@ impl DataType for IntervalType {
 }
 
 impl std::fmt::Debug for IntervalType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}({:?})", self.name(), self.kind)
     }
 }

--- a/src/query/datavalues/src/types/type_null.rs
+++ b/src/query/datavalues/src/types/type_null.rs
@@ -39,7 +39,7 @@ impl DataType for NullType {
 }
 
 impl std::fmt::Debug for NullType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_nullable.rs
+++ b/src/query/datavalues/src/types/type_nullable.rs
@@ -61,7 +61,7 @@ impl DataType for NullableType {
 }
 
 impl std::fmt::Debug for NullableType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_primitive.rs
+++ b/src/query/datavalues/src/types/type_primitive.rs
@@ -48,7 +48,7 @@ macro_rules! impl_numeric {
         }
 
         impl std::fmt::Debug for PrimitiveDataType<$ty> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 write!(f, "{}", self.name())
             }
         }

--- a/src/query/datavalues/src/types/type_string.rs
+++ b/src/query/datavalues/src/types/type_string.rs
@@ -36,7 +36,7 @@ impl DataType for StringType {
 }
 
 impl std::fmt::Debug for StringType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_struct.rs
+++ b/src/query/datavalues/src/types/type_struct.rs
@@ -85,7 +85,7 @@ impl DataType for StructType {
 }
 
 impl std::fmt::Debug for StructType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_timestamp.rs
+++ b/src/query/datavalues/src/types/type_timestamp.rs
@@ -50,7 +50,7 @@ impl DataType for TimestampType {
 }
 
 impl std::fmt::Debug for TimestampType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "Timestamp")
     }
 }

--- a/src/query/datavalues/src/types/type_variant.rs
+++ b/src/query/datavalues/src/types/type_variant.rs
@@ -36,7 +36,7 @@ impl DataType for VariantType {
 }
 
 impl std::fmt::Debug for VariantType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_variant_array.rs
+++ b/src/query/datavalues/src/types/type_variant_array.rs
@@ -36,7 +36,7 @@ impl DataType for VariantArrayType {
 }
 
 impl std::fmt::Debug for VariantArrayType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/datavalues/src/types/type_variant_object.rs
+++ b/src/query/datavalues/src/types/type_variant_object.rs
@@ -36,7 +36,7 @@ impl DataType for VariantObjectType {
 }
 
 impl std::fmt::Debug for VariantObjectType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/src/query/ee/tests/it/aggregating_index/index_scan.rs
+++ b/src/query/ee/tests/it/aggregating_index/index_scan.rs
@@ -613,7 +613,7 @@ struct FuzzParams {
 }
 
 impl Display for FuzzParams {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "Query: {}\nIndex: {}\nIsIndexScan: {}\nNumBlocks: {}\nNumRowsPerBlock: {}\nIndexBlockRatio: {}\n",

--- a/src/query/expression/src/utils/display.rs
+++ b/src/query/expression/src/utils/display.rs
@@ -72,7 +72,7 @@ use crate::TableDataType;
 const FLOAT_NUM_FRAC_DIGITS: u32 = 10;
 
 impl Debug for DataBlock {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let mut table = Table::new();
         table.load_preset("||--+-++|    ++++++");
 
@@ -91,7 +91,7 @@ impl Debug for DataBlock {
 }
 
 impl Display for DataBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut table = Table::new();
         table.load_preset("||--+-++|    ++++++");
 
@@ -111,7 +111,7 @@ impl Display for DataBlock {
 }
 
 impl<'a> Debug for ScalarRef<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ScalarRef::Null => write!(f, "NULL"),
             ScalarRef::EmptyArray => write!(f, "[] :: Array(Nothing)"),
@@ -177,7 +177,7 @@ impl<'a> Debug for ScalarRef<'a> {
 }
 
 impl Debug for Column {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Column::Null { len } => f.debug_struct("Null").field("len", len).finish(),
             Column::EmptyArray { len } => f.debug_struct("EmptyArray").field("len", len).finish(),
@@ -201,7 +201,7 @@ impl Debug for Column {
 }
 
 impl<'a> Display for ScalarRef<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ScalarRef::Null => write!(f, "NULL"),
             ScalarRef::EmptyArray => write!(f, "[]"),
@@ -268,13 +268,13 @@ impl<'a> Display for ScalarRef<'a> {
 }
 
 impl Display for Scalar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.as_ref())
     }
 }
 
 impl Debug for NumberScalar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             NumberScalar::UInt8(val) => write!(f, "{val}_u8"),
             NumberScalar::UInt16(val) => write!(f, "{val}_u16"),
@@ -291,7 +291,7 @@ impl Debug for NumberScalar {
 }
 
 impl Display for NumberScalar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             NumberScalar::UInt8(val) => write!(f, "{val}"),
             NumberScalar::UInt16(val) => write!(f, "{val}"),
@@ -308,7 +308,7 @@ impl Display for NumberScalar {
 }
 
 impl Debug for DecimalScalar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             DecimalScalar::Decimal128(val, size) => {
                 write!(
@@ -333,7 +333,7 @@ impl Debug for DecimalScalar {
 }
 
 impl Display for DecimalScalar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             DecimalScalar::Decimal128(val, size) => {
                 write!(f, "{}", display_decimal_128(*val, size.scale))
@@ -346,7 +346,7 @@ impl Display for DecimalScalar {
 }
 
 impl Debug for NumberColumn {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             NumberColumn::UInt8(val) => f.debug_tuple("UInt8").field(val).finish(),
             NumberColumn::UInt16(val) => f.debug_tuple("UInt16").field(val).finish(),
@@ -375,7 +375,7 @@ impl Debug for NumberColumn {
 }
 
 impl Debug for DecimalColumn {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             DecimalColumn::Decimal128(val, size) => f
                 .debug_tuple("Decimal128")
@@ -400,7 +400,7 @@ impl Debug for DecimalColumn {
 }
 
 impl Debug for BinaryColumn {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("BinaryColumn")
             .field(
                 "data",
@@ -412,7 +412,7 @@ impl Debug for BinaryColumn {
 }
 
 impl Debug for StringColumn {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("StringColumn")
             .field(
                 "data",
@@ -424,7 +424,7 @@ impl Debug for StringColumn {
 }
 
 impl<Index: ColumnIndex> Display for RawExpr<Index> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             RawExpr::Constant { scalar, .. } => write!(f, "{scalar}"),
             RawExpr::ColumnRef {
@@ -630,7 +630,7 @@ impl Display for NumberClass {
 }
 
 impl<Index: ColumnIndex> Display for Expr<Index> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Expr::Constant { scalar, .. } => write!(f, "{:?}", scalar.as_ref()),
             Expr::ColumnRef { display_name, .. } => write!(f, "{display_name}"),
@@ -890,13 +890,13 @@ impl<'a, T: ValueType> Display for ValueRef<'a, T> {
 }
 
 impl Debug for Function {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self.signature)
     }
 }
 
 impl Debug for FunctionEval {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             FunctionEval::Scalar { .. } => write!(f, "FunctionEval::Scalar"),
             FunctionEval::SRF { .. } => write!(f, "FunctionEval::SRF"),
@@ -905,7 +905,7 @@ impl Debug for FunctionEval {
 }
 
 impl Display for FunctionSignature {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "{}({}) :: {}",
@@ -917,7 +917,7 @@ impl Display for FunctionSignature {
 }
 
 impl Display for FunctionProperty {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut properties = Vec::new();
         if self.non_deterministic {
             properties.push("non_deterministic");

--- a/src/query/functions/src/aggregates/aggregate_bitmap.rs
+++ b/src/query/functions/src/aggregates/aggregate_bitmap.rs
@@ -503,7 +503,7 @@ where
     T: ValueType + Send + Sync,
     <T as ValueType>::Scalar: Send + Sync,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.display_name)
     }
 }

--- a/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
@@ -288,7 +288,7 @@ pub struct AggregateQuantileTDigestFunction<T> {
 impl<T> Display for AggregateQuantileTDigestFunction<T>
 where T: Number + AsPrimitive<f64>
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.display_name)
     }
 }

--- a/src/query/functions/src/aggregates/aggregate_quantile_tdigest_weighted.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_tdigest_weighted.rs
@@ -61,7 +61,7 @@ where
     T0: Number + AsPrimitive<f64>,
     T1: Number + AsPrimitive<u64>,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.display_name)
     }
 }

--- a/src/query/functions/src/aggregates/aggregate_unary.rs
+++ b/src/query/functions/src/aggregates/aggregate_unary.rs
@@ -78,7 +78,7 @@ where
     T: ValueType,
     R: ValueType,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.display_name)
     }
 }

--- a/src/query/pipeline/core/src/pipe.rs
+++ b/src/query/pipeline/core/src/pipe.rs
@@ -43,7 +43,7 @@ impl PipeItem {
 }
 
 impl Debug for PipeItem {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("PipeItem")
             .field("name", &unsafe { self.processor.name() })
             .field("inputs", &self.inputs_port.len())
@@ -61,7 +61,7 @@ pub struct Pipe {
 }
 
 impl Debug for Pipe {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{:?}", &self.items)
     }
 }

--- a/src/query/pipeline/core/src/pipeline.rs
+++ b/src/query/pipeline/core/src/pipeline.rs
@@ -69,7 +69,7 @@ pub struct Pipeline {
 }
 
 impl Debug for Pipeline {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{:?}", &self.pipes)
     }
 }

--- a/src/query/pipeline/core/src/pipeline_display.rs
+++ b/src/query/pipeline/core/src/pipeline_display.rs
@@ -35,7 +35,7 @@ impl<'a> PipelineIndentDisplayWrapper<'a> {
 }
 
 impl<'a> Display for PipelineIndentDisplayWrapper<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let pipes = &self.pipeline.pipes;
         for (index, pipe) in pipes.iter().rev().enumerate() {
             if index > 0 {

--- a/src/query/pipeline/sources/src/input_formats/impls/input_format_parquet.rs
+++ b/src/query/pipeline/sources/src/input_formats/impls/input_format_parquet.rs
@@ -134,7 +134,7 @@ pub struct SplitMeta {
 }
 
 impl Debug for SplitMeta {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "parquet split meta")
     }
 }
@@ -294,7 +294,7 @@ impl RowGroupInMemory {
 }
 
 impl Debug for RowGroupInMemory {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "RowGroupInMemory")
     }
 }

--- a/src/query/pipeline/sources/src/input_formats/input_context.rs
+++ b/src/query/pipeline/sources/src/input_formats/input_context.rs
@@ -139,7 +139,7 @@ pub struct InputContext {
 impl InputContext {}
 
 impl Debug for InputContext {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("InputContext")
             .field("plan", &self.plan)
             .field("block_compact_thresholds", &self.block_compact_thresholds)

--- a/src/query/pipeline/sources/src/input_formats/input_split.rs
+++ b/src/query/pipeline/sources/src/input_formats/input_split.rs
@@ -84,7 +84,7 @@ impl PartInfo for SplitInfo {
 }
 
 impl Debug for SplitInfo {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("SplitInfo")
             .field("seq_in_file", &self.seq_in_file)
             .field("offset", &self.offset)
@@ -94,7 +94,7 @@ impl Debug for SplitInfo {
 }
 
 impl Display for SplitInfo {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let n = self.file.num_splits;
         if n > 1 {
             write!(

--- a/src/query/script/src/compiler.rs
+++ b/src/query/script/src/compiler.rs
@@ -1068,7 +1068,7 @@ struct Scope {
 struct RefName(String);
 
 impl Display for RefName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/query/script/src/ir.rs
+++ b/src/query/script/src/ir.rs
@@ -53,7 +53,7 @@ impl<const REFKIND: usize> Hash for Ref<REFKIND> {
 }
 
 impl<const REFKIND: usize> Display for Ref<REFKIND> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}({})", self.display_name, self.index)
     }
 }
@@ -95,7 +95,7 @@ pub enum ScriptIR {
 }
 
 impl Display for ScriptIR {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ScriptIR::Query {
                 stmt: query,
@@ -134,7 +134,7 @@ pub enum ColumnAccess {
 }
 
 impl Display for ColumnAccess {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ColumnAccess::Position(index) => write!(f, "${}", index),
             ColumnAccess::Name(name) => write!(f, "\"{}\"", name),
@@ -143,7 +143,7 @@ impl Display for ColumnAccess {
 }
 
 impl Display for StatementTemplate {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.stmt)
     }
 }

--- a/src/query/script/tests/it/main.rs
+++ b/src/query/script/tests/it/main.rs
@@ -731,7 +731,7 @@ impl MockSet {
 }
 
 impl Display for MockSet {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "(")?;
         for (i, name) in self.column_names.iter().enumerate() {
             if i > 0 {

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -125,7 +125,7 @@ pub struct DatabaseCatalog {
 }
 
 impl Debug for DatabaseCatalog {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("DefaultCatalog").finish_non_exhaustive()
     }
 }

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -112,7 +112,7 @@ pub struct ImmutableCatalog {
 }
 
 impl Debug for ImmutableCatalog {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("ImmutableCatalog").finish_non_exhaustive()
     }
 }

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -133,7 +133,7 @@ pub struct MutableCatalog {
 }
 
 impl Debug for MutableCatalog {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("MutableCatalog").finish_non_exhaustive()
     }
 }

--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -840,7 +840,7 @@ impl RunningGraph {
         }
 
         impl Debug for NodeDisplay {
-            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
                 match &self.details_status {
                     None => f
                         .debug_struct("Node")
@@ -939,13 +939,13 @@ impl RunningGraph {
 }
 
 impl Debug for Node {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         unsafe { write!(f, "{}", self.processor.name()) }
     }
 }
 
 impl Debug for ExecutingGraph {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         write!(
             f,
             "{:?}",
@@ -955,14 +955,14 @@ impl Debug for ExecutingGraph {
 }
 
 impl Debug for RunningGraph {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         // let graph = self.0.read();
         write!(f, "{:?}", self.0)
     }
 }
 
 impl Debug for ScheduleQueue {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         #[derive(Debug)]
         #[allow(dead_code)]
         struct QueueItem {

--- a/src/query/service/src/pipelines/executor/executor_worker_context.rs
+++ b/src/query/service/src/pipelines/executor/executor_worker_context.rs
@@ -213,7 +213,7 @@ impl ExecutorWorkerContext {
 }
 
 impl Debug for ExecutorTask {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         unsafe {
             match self {
                 ExecutorTask::None => write!(f, "ExecutorTask::None"),

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
@@ -223,7 +223,7 @@ impl<'de, Method: HashMethodBounds, V: Send + Sync + 'static> serde::Deserialize
 }
 
 impl<Method: HashMethodBounds, V: Send + Sync + 'static> Debug for AggregateMeta<Method, V> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             AggregateMeta::HashTable(_) => f.debug_struct("AggregateMeta::HashTable").finish(),
             AggregateMeta::Partitioned { .. } => {

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_group_by_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_group_by_serializer.rs
@@ -140,7 +140,7 @@ impl FlightSerializedMeta {
 }
 
 impl Debug for FlightSerializedMeta {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("FlightSerializedMeta").finish()
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_state.rs
@@ -60,7 +60,7 @@ impl ArenaHolder {
 }
 
 impl Debug for ArenaHolder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("ArenaHolder").finish()
     }
 }

--- a/src/query/service/src/schedulers/fragments/query_fragment_actions.rs
+++ b/src/query/service/src/schedulers/fragments/query_fragment_actions.rs
@@ -377,7 +377,7 @@ impl QueryFragmentsActions {
 }
 
 impl Debug for QueryFragmentsActions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("QueryFragmentsActions")
             .field("actions", &self.fragments_actions)
             .finish()

--- a/src/query/service/src/schedulers/fragments/query_fragment_actions_display.rs
+++ b/src/query/service/src/schedulers/fragments/query_fragment_actions_display.rs
@@ -36,7 +36,7 @@ struct QueryFragmentsActionsWrap<'a> {
 }
 
 impl<'a> Display for QueryFragmentsActionsWrap<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         for (index, fragment_actions) in self.inner.fragments_actions.iter().enumerate() {
             if index != 0 {
                 writeln!(f)?;
@@ -64,7 +64,7 @@ struct QueryFragmentActionsWrap<'a> {
 }
 
 impl<'a> Display for QueryFragmentActionsWrap<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         writeln!(f, "Fragment {}:", self.inner.fragment_id)?;
 
         if let Some(data_exchange) = &self.inner.data_exchange {

--- a/src/query/service/src/servers/flight/v1/exchange/exchange_transform_shuffle.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_transform_shuffle.rs
@@ -53,7 +53,7 @@ impl ExchangeShuffleMeta {
 }
 
 impl Debug for ExchangeShuffleMeta {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("ExchangeShuffleMeta").finish()
     }
 }

--- a/src/query/service/src/servers/flight/v1/exchange/serde/exchange_deserializer.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/serde/exchange_deserializer.rs
@@ -143,7 +143,7 @@ impl ExchangeDeserializeMeta {
 }
 
 impl Debug for ExchangeDeserializeMeta {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("ExchangeSourceMeta").finish()
     }
 }

--- a/src/query/service/src/servers/flight/v1/exchange/serde/exchange_serializer.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/serde/exchange_serializer.rs
@@ -65,7 +65,7 @@ impl ExchangeSerializeMeta {
 }
 
 impl Debug for ExchangeSerializeMeta {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("ExchangeSerializeMeta").finish()
     }
 }

--- a/src/query/service/src/servers/flight/v1/packets/packet_data.rs
+++ b/src/query/service/src/servers/flight/v1/packets/packet_data.rs
@@ -46,7 +46,7 @@ impl FragmentData {
 }
 
 impl Debug for FragmentData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("FragmentData").finish()
     }
 }

--- a/src/query/service/src/servers/flight/v1/packets/packet_fragment.rs
+++ b/src/query/service/src/servers/flight/v1/packets/packet_fragment.rs
@@ -40,7 +40,7 @@ impl FragmentPlanPacket {
 }
 
 impl Debug for FragmentPlanPacket {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("FragmentPacket")
             .field("physical_plan", &self.physical_plan)
             .field("fragment_id", &self.fragment_id)

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -118,7 +118,7 @@ impl HttpQueryRequest {
 }
 
 impl Debug for HttpQueryRequest {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("HttpQueryRequest")
             .field("session_id", &self.session_id)
             .field("session", &self.session)

--- a/src/query/service/src/servers/http/v1/query/http_query_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_manager.rs
@@ -49,7 +49,7 @@ pub(crate) enum RemoveReason {
 }
 
 impl Display for RemoveReason {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", format!("{self:?}").to_lowercase())
     }
 }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -1120,7 +1120,7 @@ impl TrySpawn for QueryContext {
 }
 
 impl std::fmt::Debug for QueryContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self.get_current_user())
     }
 }

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -46,7 +46,7 @@ pub enum SpillerType {
 }
 
 impl Display for SpillerType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             SpillerType::HashJoinBuild => write!(f, "HashJoinBuild"),
             SpillerType::HashJoinProbe => write!(f, "HashJoinProbe"),

--- a/src/query/settings/src/settings.rs
+++ b/src/query/settings/src/settings.rs
@@ -38,7 +38,7 @@ pub enum ScopeLevel {
 }
 
 impl Debug for ScopeLevel {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         match self {
             ScopeLevel::Default => {
                 write!(f, "DEFAULT")

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -52,7 +52,7 @@ pub enum SettingRange {
 }
 
 impl Display for SettingRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             SettingRange::Numeric(range) => write!(f, "[{}, {}]", range.start(), range.end()),
             SettingRange::String(values) => write!(f, "{:?}", values),

--- a/src/query/sharing/src/signer.rs
+++ b/src/query/sharing/src/signer.rs
@@ -50,7 +50,7 @@ pub struct SharedSigner {
 }
 
 impl Debug for SharedSigner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("SharedSigner")
             .field("endpoint", &self.endpoint)
             .finish_non_exhaustive()

--- a/src/query/sql/src/executor/physical_plan_display.rs
+++ b/src/query/sql/src/executor/physical_plan_display.rs
@@ -70,7 +70,7 @@ pub struct PhysicalPlanIndentFormatDisplay<'a> {
 }
 
 impl<'a> Display for PhysicalPlanIndentFormatDisplay<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", "  ".repeat(self.indent))?;
 
         match self.node {
@@ -136,25 +136,25 @@ impl<'a> Display for PhysicalPlanIndentFormatDisplay<'a> {
 }
 
 impl Display for TableScan {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "TableScan: [{}]", self.source.source_info.desc())
     }
 }
 
 impl Display for CteScan {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CteScan: [{}]", self.cte_idx.0)
     }
 }
 
 impl Display for MaterializedCte {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "MaterializedCte")
     }
 }
 
 impl Display for ConstantTableScan {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let columns = self
             .values
             .iter()
@@ -170,7 +170,7 @@ impl Display for ConstantTableScan {
 }
 
 impl Display for Filter {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let predicates = self
             .predicates
             .iter()
@@ -182,7 +182,7 @@ impl Display for Filter {
 }
 
 impl Display for Sort {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let scalars = self
             .order_by
             .iter()
@@ -200,7 +200,7 @@ impl Display for Sort {
 }
 
 impl Display for EvalScalar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let scalars = self
             .exprs
             .iter()
@@ -212,7 +212,7 @@ impl Display for EvalScalar {
 }
 
 impl Display for AggregateExpand {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let sets = self
             .grouping_sets
             .sets
@@ -231,7 +231,7 @@ impl Display for AggregateExpand {
 }
 
 impl Display for AggregateFinal {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let group_items = self
             .group_by
             .iter()
@@ -264,7 +264,7 @@ impl Display for AggregateFinal {
 }
 
 impl Display for AggregatePartial {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let group_items = self
             .group_by
             .iter()
@@ -297,27 +297,27 @@ impl Display for AggregatePartial {
 }
 
 impl Display for Window {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let window_id = self.plan_id;
         write!(f, "Window: [{}]", window_id)
     }
 }
 
 impl Display for Limit {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let limit = self.limit.as_ref().cloned().unwrap_or(0);
         write!(f, "Limit: [{}], Offset: [{}]", limit, self.offset)
     }
 }
 
 impl Display for RowFetch {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "RowFetch: [{:?}]", self.cols_to_fetch)
     }
 }
 
 impl Display for HashJoin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self.join_type {
             JoinType::Cross => {
                 write!(f, "CrossJoin")
@@ -355,13 +355,13 @@ impl Display for HashJoin {
 }
 
 impl Display for RangeJoin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "IEJoin: {}", &self.join_type)
     }
 }
 
 impl Display for Exchange {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let keys = self
             .keys
             .iter()
@@ -373,7 +373,7 @@ impl Display for Exchange {
 }
 
 impl Display for ExchangeSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "Exchange Source: fragment id: [{:?}]",
@@ -383,7 +383,7 @@ impl Display for ExchangeSource {
 }
 
 impl Display for ExchangeSink {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "Exchange Sink: fragment id: [{:?}]",
@@ -393,48 +393,48 @@ impl Display for ExchangeSink {
 }
 
 impl Display for UnionAll {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "UnionAll")
     }
 }
 
 impl Display for DistributedInsertSelect {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DistributedInsertSelect")
     }
 }
 
 impl Display for CompactSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CompactSource")
     }
 }
 
 impl Display for DeleteSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "DeleteSource")
     }
 }
 
 impl Display for CommitSink {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CommitSink")
     }
 }
 impl Display for CopyIntoTable {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CopyIntoTable")
     }
 }
 
 impl Display for CopyIntoLocation {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CopyIntoLocation")
     }
 }
 
 impl Display for ProjectSet {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let scalars = self
             .srf_exprs
             .iter()
@@ -450,61 +450,61 @@ impl Display for ProjectSet {
 }
 
 impl Display for ReplaceAsyncSourcer {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "AsyncSourcer")
     }
 }
 
 impl Display for ReplaceDeduplicate {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "Deduplicate")
     }
 }
 
 impl Display for ReplaceInto {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "Replace")
     }
 }
 
 impl Display for MergeInto {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "MergeInto")
     }
 }
 
 impl Display for MergeIntoAddRowNumber {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "MergeIntoAddRowNumber")
     }
 }
 
 impl Display for MergeIntoAppendNotMatched {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "MergeIntoAppendNotMatched")
     }
 }
 
 impl Display for ReclusterSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ReclusterSource")
     }
 }
 
 impl Display for ReclusterSink {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ReclusterSink")
     }
 }
 
 impl Display for UpdateSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "UpdateSource")
     }
 }
 
 impl Display for Udf {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let scalars = self
             .udf_funcs
             .iter()
@@ -518,7 +518,7 @@ impl Display for Udf {
 }
 
 impl Display for AsyncFunction {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "AsyncFunction: {}", self.display_name)
     }
 }

--- a/src/query/sql/src/executor/physical_plans/common.rs
+++ b/src/query/sql/src/executor/physical_plans/common.rs
@@ -83,7 +83,7 @@ pub enum MutationKind {
 }
 
 impl Display for MutationKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             MutationKind::Delete => write!(f, "Delete"),
             MutationKind::Insert => write!(f, "Insert"),

--- a/src/query/sql/src/executor/physical_plans/physical_refresh_index.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_refresh_index.rs
@@ -44,7 +44,7 @@ impl RefreshIndex {
 }
 
 impl Display for RefreshIndex {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "RefreshIndex")
     }
 }

--- a/src/query/sql/src/executor/physical_plans/physical_window.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_window.rs
@@ -102,7 +102,7 @@ impl WindowFunction {
 }
 
 impl Display for WindowFunction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             WindowFunction::Aggregate(agg) => write!(f, "{}", agg.sig.name),
             WindowFunction::RowNumber => write!(f, "row_number"),

--- a/src/query/sql/src/planner/metadata.rs
+++ b/src/query/sql/src/planner/metadata.rs
@@ -428,7 +428,7 @@ pub struct TableEntry {
 }
 
 impl Debug for TableEntry {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("TableEntry")
             .field("catalog", &self.catalog)
             .field("database", &self.database)

--- a/src/query/sql/src/planner/optimizer/cost/cost.rs
+++ b/src/query/sql/src/planner/optimizer/cost/cost.rs
@@ -36,7 +36,7 @@ where T: Into<f64>
 }
 
 impl Display for Cost {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:.3}", self.0)
     }
 }

--- a/src/query/sql/src/planner/optimizer/property/histogram.rs
+++ b/src/query/sql/src/planner/optimizer/property/histogram.rs
@@ -291,7 +291,7 @@ pub struct InterleavedBucket {
 }
 
 impl fmt::Display for Histogram {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for bucket in &self.buckets {
             writeln!(
                 f,

--- a/src/query/sql/src/planner/optimizer/property/property.rs
+++ b/src/query/sql/src/planner/optimizer/property/property.rs
@@ -36,7 +36,7 @@ impl RequiredProperty {
 }
 
 impl Display for RequiredProperty {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{{ dist: {} }}", self.distribution)
     }
 }
@@ -120,7 +120,7 @@ impl Distribution {
 }
 
 impl Display for Distribution {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Distribution::Any => write!(f, "Any"),
             Distribution::Random => write!(f, "Random"),

--- a/src/query/sql/src/planner/optimizer/rule/rule.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rule.rs
@@ -110,7 +110,7 @@ pub enum RuleID {
 }
 
 impl Display for RuleID {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             RuleID::PushDownFilterUnion => write!(f, "PushDownFilterUnion"),
             RuleID::PushDownFilterEvalScalar => write!(f, "PushDownFilterEvalScalar"),

--- a/src/query/sql/src/planner/plans/copy_into_location.rs
+++ b/src/query/sql/src/planner/plans/copy_into_location.rs
@@ -50,7 +50,7 @@ impl CopyIntoLocationPlan {
 }
 
 impl Debug for CopyIntoLocationPlan {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "Copy into {:?}/{} from {:?}",

--- a/src/query/sql/src/planner/plans/copy_into_table.rs
+++ b/src/query/sql/src/planner/plans/copy_into_table.rs
@@ -49,7 +49,7 @@ pub enum ValidationMode {
 }
 
 impl Display for ValidationMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ValidationMode::None => write!(f, ""),
             ValidationMode::ReturnNRows(v) => write!(f, "RETURN_ROWS={v}"),
@@ -88,7 +88,7 @@ pub enum CopyIntoTableMode {
 }
 
 impl Display for CopyIntoTableMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             CopyIntoTableMode::Insert { overwrite } => {
                 if *overwrite {
@@ -252,7 +252,7 @@ impl CopyIntoTablePlan {
 }
 
 impl Debug for CopyIntoTablePlan {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let CopyIntoTablePlan {
             catalog_info,
             database_name,

--- a/src/query/sql/src/planner/plans/insert.rs
+++ b/src/query/sql/src/planner/plans/insert.rs
@@ -236,7 +236,7 @@ impl Insert {
 }
 
 impl std::fmt::Debug for Insert {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("Insert")
             .field("catalog", &self.catalog)
             .field("database", &self.database)

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -97,7 +97,7 @@ impl JoinType {
 }
 
 impl Display for JoinType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             JoinType::Inner => {
                 write!(f, "INNER")

--- a/src/query/sql/src/planner/plans/merge_into.rs
+++ b/src/query/sql/src/planner/plans/merge_into.rs
@@ -79,7 +79,7 @@ pub struct MergeInto {
 }
 
 impl std::fmt::Debug for MergeInto {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("Merge Into")
             .field("catalog", &self.catalog)
             .field("database", &self.database)

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -424,7 +424,7 @@ impl Plan {
 }
 
 impl Display for Plan {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}", self.kind())
     }
 }

--- a/src/query/sql/src/planner/plans/replace.rs
+++ b/src/query/sql/src/planner/plans/replace.rs
@@ -55,7 +55,7 @@ impl Replace {
 }
 
 impl std::fmt::Debug for Replace {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("Replace")
             .field("catalog", &self.catalog)
             .field("database", &self.database)

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -220,7 +220,7 @@ pub struct WindowFuncFrame {
 }
 
 impl Display for WindowFuncFrame {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
             "{:?}: {:?} ~ {:?}",

--- a/src/query/storages/common/cache/src/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache.rs
@@ -229,7 +229,7 @@ pub mod result {
     }
 
     impl fmt::Display for Error {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {
                 Error::FileTooLarge => write!(f, "File too large"),
                 Error::MalformedPath => write!(f, "Malformed catch file path"),

--- a/src/query/storages/common/table_meta/src/table/stream_keys.rs
+++ b/src/query/storages/common/table_meta/src/table/stream_keys.rs
@@ -51,7 +51,7 @@ impl std::str::FromStr for StreamMode {
 }
 
 impl std::fmt::Display for StreamMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", match self {
             StreamMode::AppendOnly => MODE_APPEND_ONLY.to_string(),
             StreamMode::Standard => MODE_STANDARD.to_string(),

--- a/src/query/storages/delta/src/dal.rs
+++ b/src/query/storages/delta/src/dal.rs
@@ -68,7 +68,7 @@ impl OpendalStore {
 }
 
 impl std::fmt::Display for OpendalStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "OpenDAL({:?})", self.inner)
     }
 }

--- a/src/query/storages/fuse/src/operations/read/data_source_with_meta.rs
+++ b/src/query/storages/fuse/src/operations/read/data_source_with_meta.rs
@@ -47,7 +47,7 @@ where DataSourceWithMeta<T>: BlockMetaInfo
 }
 
 impl<T> Debug for DataSourceWithMeta<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("DataSourceWithMeta")
             .field("meta", &self.meta)
             .finish()

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -149,7 +149,7 @@ pub struct HiveCatalog {
 }
 
 impl Debug for HiveCatalog {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("HiveCatalog")
             .field("info", &self.info)
             .field("sp", &self.sp)

--- a/src/query/storages/system/src/query_log_table.rs
+++ b/src/query/storages/system/src/query_log_table.rs
@@ -60,7 +60,7 @@ impl LogType {
 }
 
 impl std::fmt::Debug for LogType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.as_string())
     }
 }

--- a/tests/sqllogictests/src/error.rs
+++ b/tests/sqllogictests/src/error.rs
@@ -38,7 +38,7 @@ pub struct TextError {
 }
 
 impl Display for TextError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             ". Code: {}, Text = {}.",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15528)
<!-- Reviewable:end -->
