### PR TITLE
chore: Upgrade minitrace related crates to 0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9639,8 +9639,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minitrace"
-version = "0.6.4"
-source = "git+https://github.com/tikv/minitrace-rust?rev=b987f64#b987f647b0eb5860a2dd2851865f7a211b2831da"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "768c9114d3a27035d5763ac97cd06fab60991b1d5b812f8b10ee811b51cd90ec"
 dependencies = [
  "minitrace-macro",
  "minstant",
@@ -9653,8 +9654,9 @@ dependencies = [
 
 [[package]]
 name = "minitrace-macro"
-version = "0.6.4"
-source = "git+https://github.com/tikv/minitrace-rust?rev=b987f64#b987f647b0eb5860a2dd2851865f7a211b2831da"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c77e679c93b96c3d651bb076015dd5c2e66bf802131ad7dc39cb0b71dbd833"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -9664,8 +9666,9 @@ dependencies = [
 
 [[package]]
 name = "minitrace-opentelemetry"
-version = "0.6.4"
-source = "git+https://github.com/tikv/minitrace-rust?rev=b987f64#b987f647b0eb5860a2dd2851865f7a211b2831da"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4686438a165a3da65bbdc51bd24729e6200938456e3f6551770f095bed46da8"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,8 +241,8 @@ tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"] }
 # Observability
 log = { version = "0.4.21", features = ["serde", "kv_unstable_std"] }
 logcall = "0.1.5"
-minitrace = { version = "0.6", features = ["enable"] }
-minitrace-opentelemetry = "0.6"
+minitrace = { version = "0.6.5", features = ["enable"] }
+minitrace-opentelemetry = "0.6.5"
 opentelemetry = { version = "0.22", features = ["trace", "logs"] }
 opentelemetry-otlp = { version = "0.15", features = ["trace", "logs", "grpc-tonic"] }
 opentelemetry_sdk = { version = "0.22", features = ["trace", "logs", "rt-tokio"] }
@@ -301,7 +301,4 @@ async-backtrace = { git = "https://github.com/zhang2014/async-backtrace.git", re
 z3 = { git = "https://github.com/prove-rs/z3.rs", rev = "247d308" }
 z3-sys = { git = "https://github.com/prove-rs/z3.rs", rev = "247d308" }
 geozero = { git = "https://github.com/georust/geozero", rev = "1d78b36" }
-# Wait for upstream to release new version.
-minitrace = { package = "minitrace", git = "https://github.com/tikv/minitrace-rust", rev = "b987f64" }
-minitrace-opentelemetry = { package = "minitrace-opentelemetry", git = "https://github.com/tikv/minitrace-rust", rev = "b987f64" }
 # proj = { git = "https://github.com/ariesdevil/proj", rev = "51e1c60" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

Updates the `minitrace` and `minitrace-opentelemetry` crate versions to `0.6.5` and removes the patch section for these crates in `Cargo.toml`.

- Updates the `minitrace` crate version to `0.6.5` and includes the `enable` feature.
- Updates the `minitrace-opentelemetry` crate version to `0.6.5`.
- Removes the previously specified git patch for both `minitrace` and `minitrace-opentelemetry` from the `[patch.crates-io]` section, aligning with the task to use the crates.io versions directly.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): deps

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/datafuselabs/databend?shareId=879dc329-34ca-402e-add8-9d8310d6bc0b).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15530)
<!-- Reviewable:end -->
