### PR TITLE
fix: Prevent premature snapshot commit on unfinished writes

### DIFF
--- a/src/meta/raft-store/src/sm_v002/mod.rs
+++ b/src/meta/raft-store/src/sm_v002/mod.rs
@@ -32,4 +32,5 @@ pub use sm_v002::SMV002;
 pub use snapshot_store::SnapshotStoreError;
 pub use snapshot_store::SnapshotStoreV002;
 pub use snapshot_view_v002::SnapshotViewV002;
+pub use writer_v002::WriteEntry;
 pub use writer_v002::WriterV002;

--- a/src/meta/raft-store/src/sm_v002/writer_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/writer_v002.rs
@@ -30,6 +30,15 @@ use crate::sm_v002::SnapshotStoreV002;
 use crate::state_machine::MetaSnapshotId;
 use crate::state_machine::StateMachineMetaKey;
 
+/// A write entry sent to snapshot writer.
+///
+/// A `Commit` entry will flush the writer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WriteEntry<T> {
+    Data(T),
+    Commit,
+}
+
 /// Write json lines snapshot data to [`SnapshotStoreV002`].
 pub struct WriterV002<'a> {
     /// The temp path to write to, which will be renamed to the final path.
@@ -137,13 +146,21 @@ impl<'a> WriterV002<'a> {
     /// Returns the count of entries
     pub fn write_entries_sync(
         &mut self,
-        mut entries_rx: tokio::sync::mpsc::Receiver<RaftStoreEntry>,
+        mut entries_rx: tokio::sync::mpsc::Receiver<WriteEntry<RaftStoreEntry>>,
     ) -> Result<usize, io::Error> {
         let mut cnt = 0;
         let data_version = self.snapshot_store.data_version();
 
         while let Some(ent) = entries_rx.blocking_recv() {
             debug!(entry :? =(&ent); "write {} entry", data_version);
+
+            let ent = match ent {
+                WriteEntry::Data(ent) => ent,
+                WriteEntry::Commit => {
+                    info!("received Commit entry, quit and about to commit");
+                    return Ok(cnt);
+                }
+            };
 
             if let RaftStoreEntry::StateMachineMeta {
                 key: StateMachineMetaKey::LastApplied,
@@ -179,7 +196,10 @@ impl<'a> WriterV002<'a> {
             }
         }
 
-        Ok(cnt)
+        Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "input channel is closed",
+        ))
     }
 
     /// Commit the snapshot so that it is visible to the readers.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: Prevent premature snapshot commit on unfinished writes

Prior to this commit, the snapshot writer would attempt to commit the
snapshot upon closure of the input channel, operating under the
assumption that the snapshot was fully written. This assumption is
flawed as the closure of the channel might be due to a process shutdown,
not completion of the snapshot.

To address this issue, this commit introduces a change where items sent
to the snapshot writer are encapsulated within a `WriteEntry`, which can
be either `Data(T)` or `Commit`. The snapshot is only considered
complete and ready for commit when a `Commit` variant is received. This
adjustment ensures that premature snapshot commits are avoided in cases
of early channel closures.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15534)
<!-- Reviewable:end -->
