### PR TITLE
chore: leave all un-committed data to purge/vacuum

### DIFF
--- a/src/common/storage/src/parquet_rs.rs
+++ b/src/common/storage/src/parquet_rs.rs
@@ -93,6 +93,7 @@ pub async fn read_metadata_async(
         None => operator.stat(path).await?.content_length(),
         Some(n) => n,
     };
+
     check_footer_size(file_size)?;
 
     // read and cache up to DEFAULT_FOOTER_READ_SIZE bytes from the end and process the footer

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -161,16 +161,11 @@ impl FuseTable {
         .await;
         if need_to_save_statistics {
             let table_statistics_location: String = table_statistics_location.unwrap();
-            match &res {
-                Ok(_) => TableSnapshotStatistics::cache().put(
+            if res.is_ok() {
+                TableSnapshotStatistics::cache().put(
                     table_statistics_location,
                     Arc::new(table_statistics.unwrap()),
-                ),
-                Err(e) => {
-                    if Self::no_side_effects_in_meta_store(e) {
-                        let _ = operator.delete(&table_statistics_location).await;
-                    }
-                }
+                )
             }
         }
         res
@@ -235,30 +230,13 @@ impl FuseTable {
         };
 
         // 3. let's roll
-        let reply = catalog.update_table_meta(table_info, req).await;
-        match reply {
-            Ok(_) => {
-                TableSnapshot::cache().put(snapshot_location.clone(), Arc::new(snapshot));
-                // try keep a hit file of last snapshot
-                Self::write_last_snapshot_hint(operator, location_generator, snapshot_location)
-                    .await;
-                Ok(())
-            }
-            Err(e) => {
-                // commit snapshot to meta server failed.
-                // figure out if the un-committed snapshot is safe to be removed.
-                if Self::no_side_effects_in_meta_store(&e) {
-                    // currently, only in this case (TableVersionMismatched),  we are SURE about
-                    // that the table state insides meta store has NOT been changed.
-                    info!(
-                        "removing uncommitted table snapshot at location {}, of table {}, {}",
-                        snapshot_location, table_info.desc, table_info.ident
-                    );
-                    let _ = operator.delete(&snapshot_location).await;
-                }
-                Err(e)
-            }
-        }
+        catalog.update_table_meta(table_info, req).await?;
+
+        // update_table_meta succeed, populate the snapshot cache item and try keeping a hit file of last snapshot
+        TableSnapshot::cache().put(snapshot_location.clone(), Arc::new(snapshot));
+        Self::write_last_snapshot_hint(operator, location_generator, snapshot_location).await;
+
+        Ok(())
     }
 
     // Left a hint file which indicates the location of the latest snapshot

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -159,15 +159,18 @@ impl FuseTable {
             None,
         )
         .await;
+
         if need_to_save_statistics {
             let table_statistics_location: String = table_statistics_location.unwrap();
-            if res.is_ok() {
-                TableSnapshotStatistics::cache().put(
+            match &res {
+                Ok(_) => TableSnapshotStatistics::cache().put(
                     table_statistics_location,
                     Arc::new(table_statistics.unwrap()),
-                )
+                ),
+                Err(e) => info!("update_table_meta failed. {}", e),
             }
         }
+
         res
     }
 

--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -506,10 +506,7 @@ where F: SnapshotGenerator + Send + 'static
             State::AbortOperation(e) => {
                 let duration = self.start_time.elapsed();
                 metrics_inc_commit_aborts();
-                // todo: use histogram when it ready
                 metrics_inc_commit_milliseconds(duration.as_millis());
-                let op = self.abort_operation.clone();
-                op.abort(self.ctx.clone(), self.dal.clone()).await?;
                 error!(
                     "transaction aborted after {} retries, which took {} ms, cause: {:?}",
                     self.retries,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

instead of purging un-committed data of failed txn, leave them to purge/vacuum

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15535)
<!-- Reviewable:end -->
