### PR TITLE
feat(metasrv): add metrics for snapshot key numbers

### DIFF
--- a/src/meta/service/src/metrics/meta_metrics.rs
+++ b/src/meta/service/src/metrics/meta_metrics.rs
@@ -51,6 +51,7 @@ pub mod server_metrics {
         node_is_health: Gauge,
         leader_changes: Counter,
         applying_snapshot: Gauge,
+        snapshot_key_num: Gauge,
         last_log_index: Gauge,
         last_seq: Gauge,
         current_term: Gauge,
@@ -70,6 +71,7 @@ pub mod server_metrics {
                 node_is_health: Gauge::default(),
                 leader_changes: Counter::default(),
                 applying_snapshot: Gauge::default(),
+                snapshot_key_num: Gauge::default(),
                 last_log_index: Gauge::default(),
                 last_seq: Gauge::default(),
                 current_term: Gauge::default(),
@@ -102,6 +104,11 @@ pub mod server_metrics {
                 key!("applying_snapshot"),
                 "if this node is applying snapshot",
                 metrics.applying_snapshot.clone(),
+            );
+            registry.register(
+                key!("snapshot_key_num"),
+                "snapshot key numbers",
+                metrics.snapshot_key_num.clone(),
             );
             registry.register(
                 key!("proposals_applied"),
@@ -161,6 +168,10 @@ pub mod server_metrics {
     /// Whether or not state-machine is applying snapshot.
     pub fn incr_applying_snapshot(cnt: i64) {
         SERVER_METRICS.applying_snapshot.inc_by(cnt);
+    }
+
+    pub fn set_snapshot_key_num(snapshot_key_num: usize) {
+        SERVER_METRICS.snapshot_key_num.set(snapshot_key_num as i64);
     }
 
     pub fn set_proposals_applied(proposals_applied: u64) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

add new metrics
* metasrv_server_snapshot_key_num

```
❯ curl localhost:28002/v1/metrics
# HELP metasrv_server_snapshot_key_num snapshot key numbers.
# TYPE metasrv_server_snapshot_key_num gauge
metasrv_server_snapshot_key_num 2873
```


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15545)
<!-- Reviewable:end -->
