### PR TITLE
chore: Remove tokio-console since we don't need it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,9 +4492,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tonic",
- "tracing",
  "tracing-appender",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -14572,18 +14570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
- "valuable",
- "valuable-serde",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14593,17 +14579,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -14908,16 +14889,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "valuable-serde"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285cfff30cdabe26626736a54d989687dd9cab84f51f4048b61d6d0ae8b0907"
-dependencies = [
- "serde",
- "valuable",
-]
 
 [[package]]
 name = "value-bag"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-types",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -548,7 +548,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-derive 0.12.3",
  "serde",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -2263,43 +2263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console-api"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
-dependencies = [
- "futures-core",
- "prost 0.12.3",
- "prost-types",
- "tonic 0.10.2",
- "tracing-core",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
-dependencies = [
- "console-api",
- "crossbeam-channel",
- "crossbeam-utils",
- "futures-task",
- "hdrhistogram",
- "humantime",
- "prost-types",
- "serde",
- "serde_json",
- "thread_local",
- "tokio",
- "tokio-stream",
- "tonic 0.10.2",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,7 +3092,7 @@ dependencies = [
  "prost-build",
  "semver",
  "serde",
- "tonic 0.11.0",
+ "tonic",
  "tonic-build",
  "tower",
 ]
@@ -3215,7 +3178,7 @@ dependencies = [
  "serde_json",
  "tantivy",
  "thiserror",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -3270,7 +3233,7 @@ dependencies = [
  "simdutf8",
  "strength_reduce",
  "terminal_size 0.2.6",
- "tonic 0.11.0",
+ "tonic",
  "typetag",
  "unicode-segmentation",
 ]
@@ -3380,7 +3343,7 @@ dependencies = [
  "log",
  "serde",
  "thiserror",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -3508,7 +3471,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -3573,7 +3536,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -3742,7 +3705,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
  "tonic-build",
 ]
 
@@ -3906,7 +3869,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-build",
  "semver",
- "tonic 0.11.0",
+ "tonic",
  "tonic-build",
 ]
 
@@ -4515,7 +4478,6 @@ dependencies = [
 name = "databend-common-tracing"
 version = "0.1.0"
 dependencies = [
- "console-subscriber",
  "databend-common-base",
  "defer",
  "fern",
@@ -4529,7 +4491,7 @@ dependencies = [
  "opentelemetry_sdk",
  "serde",
  "serde_json",
- "tonic 0.11.0",
+ "tonic",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -4824,7 +4786,7 @@ dependencies = [
  "tempfile",
  "test-harness",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic",
  "tonic-reflection",
 ]
 
@@ -4978,7 +4940,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.7.8",
- "tonic 0.11.0",
+ "tonic",
  "tower",
  "typetag",
  "unicode-segmentation",
@@ -8010,19 +7972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "base64 0.21.7",
- "byteorder",
- "flate2",
- "nom",
- "num-traits",
-]
-
-[[package]]
 name = "hdrs"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10414,7 +10363,7 @@ dependencies = [
  "prost 0.12.3",
  "thiserror",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -10426,7 +10375,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.12.3",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -14459,33 +14408,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.26",
- "http 0.2.11",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.12.3",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
@@ -14538,7 +14460,7 @@ dependencies = [
  "prost-types",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,6 @@ opentelemetry-otlp = { version = "0.15", features = ["trace", "logs", "grpc-toni
 opentelemetry_sdk = { version = "0.22", features = ["trace", "logs", "rt-tokio"] }
 tracing = "0.1.40"
 tracing-appender = "0.2.3"
-console-subscriber = { version = "0.2.0" }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json", "valuable"] }
 
 [profile.release]

--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -17,12 +17,6 @@ memory-profiling = [
 simd = ["databend-meta/simd", "databend-query/simd"]
 z3-prove = ["databend-query/z3-prove"]
 jemalloc = ["databend-common-base/jemalloc"]
-tokio-console = [
-    "databend-meta/tokio-console",
-    "databend-query/io-uring",
-    "databend-common-base/tracing",
-    "databend-common-tracing/console",
-]
 io-uring = [
     "databend-meta/io-uring",
     "databend-query/io-uring",

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -10,15 +10,11 @@ edition = { workspace = true }
 doctest = false
 test = true
 
-[features]
-console = ["console-subscriber", "tracing", "tracing-subscriber"]
-
 [dependencies] # In alphabetical order
 # Workspace dependencies
 databend-common-base = { path = "../base" }
 
 # Crates.io dependencies
-console-subscriber = { workspace = true, optional = true }
 defer = "0.2"
 fern = "0.6.2"
 humantime = "2.1.0"

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -28,6 +28,4 @@ opentelemetry_sdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tonic = { workspace = true }
-tracing = { workspace = true, optional = true }
 tracing-appender = { workspace = true }
-tracing-subscriber = { workspace = true, optional = true }

--- a/src/common/tracing/src/init.rs
+++ b/src/common/tracing/src/init.rs
@@ -294,17 +294,5 @@ pub fn init_logging(
         return Vec::new();
     }
 
-    #[cfg(feature = "console")]
-    init_tokio_console();
-
     guards
-}
-
-#[cfg(feature = "console")]
-fn init_tokio_console() {
-    use tracing_subscriber::prelude::*;
-
-    let subscriber = tracing_subscriber::registry::Registry::default();
-    let subscriber = subscriber.with(console_subscriber::spawn());
-    tracing::subscriber::set_global_default(subscriber).ok();
 }

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -15,7 +15,6 @@ test = true
 default = ["simd"]
 memory-profiling = ["databend-common-base/memory-profiling", "databend-common-http/memory-profiling"]
 simd = ["databend-common-arrow/simd"]
-tokio-console = ["databend-common-tracing/console", "databend-common-base/tracing"]
 io-uring = [
     "sled/io_uring",
     "databend-common-meta-sled-store/io-uring",

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -18,7 +18,6 @@ simd = ["databend-common-arrow/simd"]
 z3-prove = ["databend-common-sql/z3-prove"]
 disable_initial_exec_tls = ["databend-common-base/disable_initial_exec_tls"]
 
-tokio-console = ["databend-common-tracing/console", "databend-common-base/tracing"]
 memory-profiling = ["databend-common-base/memory-profiling", "databend-common-http/memory-profiling"]
 storage-hdfs = ["opendal/services-hdfs", "databend-common-storage/storage-hdfs"]
 io-uring = [


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore: Remove tokio-console since we don't need it

This PR to git rid of different tonic versions.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15546)
<!-- Reviewable:end -->
