### PR TITLE
chore: change the short_sql from 64bytes to 10KB

### DIFF
--- a/src/query/service/tests/it/sessions/query_ctx.rs
+++ b/src/query/service/tests/it/sessions/query_ctx.rs
@@ -17,6 +17,7 @@ use databend_common_exception::Result;
 use databend_common_meta_app::storage::StorageFsConfig;
 use databend_common_meta_app::storage::StorageParams;
 use databend_common_meta_app::storage::StorageS3Config;
+use databend_query::sessions::short_sql;
 use databend_query::sessions::TableContext;
 use databend_query::test_kits::ConfigBuilder;
 use databend_query::test_kits::TestFixture;
@@ -64,4 +65,30 @@ async fn test_get_storage_accessor_fs() -> Result<()> {
     let _ = ctx.get_data_operator()?;
 
     Ok(())
+}
+
+#[test]
+fn test_short_sql() {
+    // Test case 1: SQL query shorter than 10KB
+    let sql1 = "SELECT * FROM users WHERE id = 1;".to_string();
+    assert_eq!(short_sql(sql1.clone()), sql1);
+
+    // Test case 2: SQL query longer than 10KB and starts with "INSERT"
+    let long_sql = "INSERT INTO users (id, name, email) VALUES ".to_string()
+        + &"(1, 'John Doe', 'john@example.com'), ".repeat(1000);
+    let expected_result = long_sql.as_bytes()[..10240].to_vec();
+    let expected_result = String::from_utf8(expected_result).unwrap() + "...";
+    assert_eq!(short_sql(long_sql), expected_result);
+
+    // Test case 3: SQL query longer than 10KB but does not start with "INSERT"
+    let long_sql = "SELECT * FROM users WHERE ".to_string() + &"id = 1 OR ".repeat(1000);
+    assert_eq!(short_sql(long_sql.clone()), long_sql);
+
+    // Test case 4: Empty SQL query
+    let empty_sql = "".to_string();
+    assert_eq!(short_sql(empty_sql.clone()), empty_sql);
+
+    // Test case 5: SQL query with leading whitespace
+    let sql_with_whitespace = "   SELECT * FROM users;".to_string();
+    assert_eq!(short_sql(sql_with_whitespace.clone()), sql_with_whitespace);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* Increase the maximum size of short_sql from 64 bytes to 10 kb. Some INSERT MERGE INTO queries can reach several kb in size. 

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15554)
<!-- Reviewable:end -->
