### PR TITLE
chore(executor): set plain_statistics to false for spill time profiling statistics

### DIFF
--- a/src/common/base/src/runtime/profile/profiles.rs
+++ b/src/common/base/src/runtime/profile/profiles.rs
@@ -206,7 +206,7 @@ pub fn get_statistics_desc() -> Arc<BTreeMap<ProfileStatisticsName, ProfileDesc>
                 desc: "The time spent to write spill in millisecond",
                 index: ProfileStatisticsName::SpillWriteTime as usize,
                 unit: StatisticsUnit::MillisSeconds,
-                plain_statistics: true,
+                plain_statistics: false,
             }),
             (ProfileStatisticsName::SpillReadCount, ProfileDesc {
                 display_name: "numbers spilled by read",
@@ -227,7 +227,7 @@ pub fn get_statistics_desc() -> Arc<BTreeMap<ProfileStatisticsName, ProfileDesc>
                 desc: "The time spent to read spill in millisecond",
                 index: ProfileStatisticsName::SpillReadTime as usize,
                 unit: StatisticsUnit::MillisSeconds,
-                plain_statistics: true,
+                plain_statistics: false,
             }),
             (ProfileStatisticsName::RuntimeFilterPruneParts, ProfileDesc {
                 display_name: "parts pruned by runtime filter",


### PR DESCRIPTION
…statistics

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(executor): set plain_statistics to false for spill time profiling statistics

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - chore update

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): chore update
