### PR TITLE
chore(query): all queryies should generate hash

### DIFF
--- a/src/query/service/src/interpreters/interpreter.rs
+++ b/src/query/service/src/interpreters/interpreter.rs
@@ -271,7 +271,7 @@ fn attach_query_hash(ctx: &Arc<QueryContext>, stmt: &mut Option<Statement>, sql:
 
         (query_hash, format!("{:x}", Md5::digest(stmt.to_string())))
     } else {
-        let hash = format!("{:x}", Md5::digest(sql.to_string()));
+        let hash = format!("{:x}", Md5::digest(sql));
         (hash.to_string(), hash)
     };
 

--- a/src/query/service/src/interpreters/interpreter.rs
+++ b/src/query/service/src/interpreters/interpreter.rs
@@ -234,22 +234,24 @@ fn log_query_finished(ctx: &QueryContext, error: Option<ErrorCode>, has_profiles
 pub async fn interpreter_plan_sql(ctx: Arc<QueryContext>, sql: &str) -> Result<(Plan, PlanExtras)> {
     let mut planner = Planner::new(ctx.clone());
     let result = planner.plan_sql(sql).await;
-
-    if let Ok((_, extras)) = &result {
-        let mut stmt = extras.statement.clone();
-        attach_query_hash(&ctx, &mut stmt);
+    let short_sql = short_sql(sql.to_string());
+    let mut stmt = if let Ok((_, extras)) = &result {
+        Some(extras.statement.clone())
     } else {
         // Only log if there's an error
-        ctx.attach_query_str(QueryKind::Unknown, short_sql(sql.to_string()));
+        ctx.attach_query_str(QueryKind::Unknown, short_sql.to_string());
         log_query_start(&ctx);
         log_query_finished(&ctx, result.as_ref().err().cloned(), false);
-    }
+        None
+    };
+
+    attach_query_hash(&ctx, &mut stmt, &short_sql);
 
     result
 }
 
-fn attach_query_hash(ctx: &Arc<QueryContext>, stmt: &mut Statement) {
-    if let Statement::Query(_) = stmt {
+fn attach_query_hash(ctx: &Arc<QueryContext>, stmt: &mut Option<Statement>, sql: &str) {
+    let (query_hash, query_parameterized_hash) = if let Some(stmt) = stmt {
         let query_hash = format!("{:x}", Md5::digest(stmt.to_string()));
         // Use Literal::Null replace literal. Ignore Literal.
         // SELECT * FROM t1 WHERE name = 'data' => SELECT * FROM t1 WHERE name = NULL
@@ -267,7 +269,11 @@ fn attach_query_hash(ctx: &Arc<QueryContext>, stmt: &mut Statement) {
         let mut visitor = AstVisitor {};
         stmt.drive_mut(&mut visitor);
 
-        let query_parameterized_hash = format!("{:x}", Md5::digest(stmt.to_string()));
-        ctx.attach_query_hash(query_hash, query_parameterized_hash);
-    }
+        (query_hash, format!("{:x}", Md5::digest(stmt.to_string())))
+    } else {
+        let hash = format!("{:x}", Md5::digest(sql.to_string()));
+        (hash.to_string(), hash)
+    };
+
+    ctx.attach_query_hash(query_hash, query_parameterized_hash);
 }

--- a/tests/sqllogictests/suites/base/01_system/01_0002_system_query_log.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0002_system_query_log.test
@@ -18,6 +18,17 @@ statement ok
 create table tbl_01_0002(a int)
 
 statement ok
+insert into  tbl_01_0002 values    (1)
+
+statement error
+insert into  tbl_01_0002 values    (?,?,?)
+
+query TTT
+select query_text, query_hash, query_parameterized_hash from system.query_log where query_text='INSERT INTO tbl_01_0002 VALUES (?,?,?)' limit 1;
+----
+INSERT INTO tbl_01_0002 VALUES (?,?,?) 56531330ce650af109dc38ae2fe2a6a3 56531330ce650af109dc38ae2fe2a6a3
+
+statement ok
 insert into  tbl_01_0002 values(1)
 
 # TODO sometimes get empty result
@@ -53,6 +64,16 @@ select * from tbl_01_0002 where a=200;
 
 query T
 select count(query_text)>1 from system.query_log where query_text like 'SELECT * FROM tbl_01_0002 WHERE a = 1' and log_type_name='Finish' group by query_hash;
+----
+1
+
+query TTT
+select query_text, query_hash, query_parameterized_hash from system.query_log where query_hash='932d5555e275c38b46574f4adfa5e01b' limit 1;
+----
+INSERT INTO tbl_01_0002 VALUES (1) 932d5555e275c38b46574f4adfa5e01b 932d5555e275c38b46574f4adfa5e01b
+
+query B
+select count(query_text)>1 from system.query_log where query_text like 'INSERT INTO tbl_01_0002%' group by query_parameterized_hash having query_parameterized_hash='932d5555e275c38b46574f4adfa5e01b';
 ----
 1
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

all success plan should generate hash

https://github.com/datafuselabs/databend/pull/15531/files#diff-5abf95c43975a311470a7a6e3e9aa84d35190852ee611e7923a41eda94ca0902R252-R254

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15560)
<!-- Reviewable:end -->
