### PR TITLE
fix: Avoid duplicate temp file name for install-snapshot requests

### DIFF
--- a/src/meta/raft-store/src/sm_v002/snapshot_store.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_store.rs
@@ -103,6 +103,8 @@ pub struct SnapshotStoreV002 {
 }
 
 impl SnapshotStoreV002 {
+    const TEMP_PREFIX: &'static str = "0.snap";
+
     pub fn new(data_version: DataVersion, config: RaftConfig) -> Self {
         SnapshotStoreV002 {
             data_version,
@@ -130,12 +132,15 @@ impl SnapshotStoreV002 {
     }
 
     pub fn snapshot_temp_path(&self) -> String {
+        // Sleep to avoid timestamp collision when this function is called twice in a short time.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis();
 
-        format!("{}/0.snap-{}", self.snapshot_dir(), ts)
+        format!("{}/{}-{}", self.snapshot_dir(), Self::TEMP_PREFIX, ts)
     }
 
     /// Return a list of valid snapshot ids found in the snapshot directory.
@@ -164,7 +169,19 @@ impl SnapshotStoreV002 {
 
         info!("cleaning old snapshots in {}", dir);
 
-        let (snapshot_ids, invalid_files) = self.load_snapshot_ids().await?;
+        let (snapshot_ids, mut invalid_files) = self.load_snapshot_ids().await?;
+
+        // The last several temp files may be in use by snapshot transmitting.
+        // And do not delete them at once.
+        {
+            let l = invalid_files.len();
+            if l > 2 {
+                invalid_files = invalid_files.into_iter().take(l - 2).collect();
+            } else {
+                invalid_files = vec![];
+            }
+        }
+
         for invalid_file in invalid_files {
             let path = format!("{}/{}", dir, invalid_file);
 
@@ -240,7 +257,10 @@ impl SnapshotStoreV002 {
         }
 
         snapshot_ids.sort();
+        invalid_files.sort();
+
         info!("dir: {}; loaded snapshots: {:?}", dir, snapshot_ids);
+        info!("dir: {}; invalid files: {:?}", dir, invalid_files);
 
         Ok((snapshot_ids, invalid_files))
     }
@@ -327,5 +347,32 @@ impl SnapshotStoreV002 {
         let s = context.to_string();
         error!("{} while context: {}", e, s);
         SnapshotStoreError::read(e).with_context(context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::RaftConfig;
+    use crate::ondisk::DATA_VERSION;
+
+    #[test]
+    fn test_temp_path_no_dup() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let p = temp.path();
+        let raft_config = RaftConfig {
+            raft_dir: p.to_str().unwrap().to_string(),
+            ..Default::default()
+        };
+
+        let store = super::SnapshotStoreV002::new(DATA_VERSION, raft_config);
+
+        let mut prev = None;
+        for _i in 0..10 {
+            let path = store.snapshot_temp_path();
+            assert_ne!(prev, Some(path.clone()), "dup: {}", path);
+            prev = Some(path);
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: Avoid duplicate temp file name for install-snapshot requests

This commit resolves an issue where duplicate temporary file names were
generated when two install-snapshot requests were received in close
temporal proximity. This could potentially lead to conflicts and
erroneous behavior during snapshot installation.

Changes:

- Added logic to generate unique temporary file names for each
  install-snapshot request to prevent naming conflicts.

- Additionally, this commit enhances error handling by including context
  information in the `io::Error` returned from `SnapshotStoreV002`. This
  improvement aids in better understanding the source and nature of
  errors when they occur.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15565)
<!-- Reviewable:end -->
