### PR TITLE
feat: fuzzy table data disk cache key reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5146,6 +5146,7 @@ dependencies = [
  "hex",
  "log",
  "parking_lot 0.12.1",
+ "rayon",
  "siphasher",
  "tempfile",
 ]

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -71,8 +71,6 @@ use super::inner::QueryConfig as InnerQueryConfig;
 use crate::background_config::BackgroundConfig;
 use crate::DATABEND_COMMIT_VERSION;
 
-// FIXME: too much boilerplate here
-
 const CATALOG_HIVE: &str = "hive";
 
 /// Config for `query`.
@@ -2806,6 +2804,15 @@ pub struct CacheConfig {
     )]
     pub data_cache_storage: CacheStorageTypeConfig,
 
+    /// Policy of disk cache restart
+    #[clap(
+        long = "cache-data-cache-key-reload-policy",
+        value_name = "VALUE",
+        value_enum,
+        default_value_t
+    )]
+    pub data_cache_key_reload_policy: DiskCacheKeyReloadPolicy,
+
     /// Max size of external cache population queue length
     ///
     /// the items being queued reference table column raw data, which are
@@ -2887,6 +2894,22 @@ pub enum CacheStorageTypeConfig {
 impl Default for CacheStorageTypeConfig {
     fn default() -> Self {
         Self::None
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum DiskCacheKeyReloadPolicy {
+    // remove all the disk cache during restart
+    Reset,
+    // recovery the cache keys during restart,
+    // but cache capacity will not be checked
+    Fuzzy,
+}
+
+impl Default for DiskCacheKeyReloadPolicy {
+    fn default() -> Self {
+        Self::Reset
     }
 }
 
@@ -2991,6 +3014,7 @@ mod cache_config_converters {
                 table_data_cache_population_queue_size: value
                     .table_data_cache_population_queue_size,
                 disk_cache_config: value.disk_cache_config.try_into()?,
+                data_cache_key_reload_policy: value.data_cache_key_reload_policy.try_into()?,
                 table_data_deserialized_data_bytes: value.table_data_deserialized_data_bytes,
                 table_data_deserialized_memory_ratio: value.table_data_deserialized_memory_ratio,
             })
@@ -3013,6 +3037,7 @@ mod cache_config_converters {
                 inverted_index_filter_memory_ratio: value.inverted_index_filter_memory_ratio,
                 table_prune_partitions_count: value.table_prune_partitions_count,
                 data_cache_storage: value.data_cache_storage.into(),
+                data_cache_key_reload_policy: value.data_cache_key_reload_policy.into(),
                 table_data_cache_population_queue_size: value
                     .table_data_cache_population_queue_size,
                 disk_cache_config: value.disk_cache_config.into(),
@@ -3057,6 +3082,25 @@ mod cache_config_converters {
             match value {
                 inner::CacheStorageTypeConfig::None => CacheStorageTypeConfig::None,
                 inner::CacheStorageTypeConfig::Disk => CacheStorageTypeConfig::Disk,
+            }
+        }
+    }
+
+    impl TryFrom<DiskCacheKeyReloadPolicy> for inner::DiskCacheKeyReloadPolicy {
+        type Error = ErrorCode;
+        fn try_from(value: DiskCacheKeyReloadPolicy) -> std::result::Result<Self, Self::Error> {
+            Ok(match value {
+                DiskCacheKeyReloadPolicy::Reset => inner::DiskCacheKeyReloadPolicy::Reset,
+                DiskCacheKeyReloadPolicy::Fuzzy => inner::DiskCacheKeyReloadPolicy::Fuzzy,
+            })
+        }
+    }
+
+    impl From<inner::DiskCacheKeyReloadPolicy> for DiskCacheKeyReloadPolicy {
+        fn from(value: inner::DiskCacheKeyReloadPolicy) -> Self {
+            match value {
+                inner::DiskCacheKeyReloadPolicy::Reset => DiskCacheKeyReloadPolicy::Reset,
+                inner::DiskCacheKeyReloadPolicy::Fuzzy => DiskCacheKeyReloadPolicy::Fuzzy,
             }
         }
     }

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -568,6 +568,9 @@ pub struct CacheConfig {
     /// Storage that hold the raw data caches
     pub disk_cache_config: DiskCacheConfig,
 
+    /// Policy of reloading disk cache keys
+    pub data_cache_key_reload_policy: DiskCacheKeyReloadPolicy,
+
     /// Max size of in memory table column object cache. By default it is 0 (disabled)
     ///
     /// CAUTION: The cache items are deserialized table column objects, may take a lot of memory.
@@ -589,7 +592,6 @@ pub struct CacheConfig {
 pub enum CacheStorageTypeConfig {
     None,
     Disk,
-    // Redis,
 }
 
 impl Default for CacheStorageTypeConfig {
@@ -598,11 +600,34 @@ impl Default for CacheStorageTypeConfig {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiskCacheKeyReloadPolicy {
+    // remove all the disk cache during restart
+    Reset,
+    // recovery the cache keys during restart,
+    // but cache capacity will not be checked
+    Fuzzy,
+}
+impl Default for DiskCacheKeyReloadPolicy {
+    fn default() -> Self {
+        Self::Reset
+    }
+}
+
 impl ToString for CacheStorageTypeConfig {
     fn to_string(&self) -> String {
         match self {
             CacheStorageTypeConfig::None => "none".to_string(),
             CacheStorageTypeConfig::Disk => "disk".to_string(),
+        }
+    }
+}
+
+impl ToString for DiskCacheKeyReloadPolicy {
+    fn to_string(&self) -> String {
+        match self {
+            DiskCacheKeyReloadPolicy::Reset => "reset".to_string(),
+            DiskCacheKeyReloadPolicy::Fuzzy => "fuzzy".to_string(),
         }
     }
 }
@@ -643,6 +668,7 @@ impl Default for CacheConfig {
             data_cache_storage: Default::default(),
             table_data_cache_population_queue_size: 0,
             disk_cache_config: Default::default(),
+            data_cache_key_reload_policy: Default::default(),
             table_data_deserialized_data_bytes: 0,
             table_data_deserialized_memory_ratio: 0,
         }

--- a/src/query/config/src/lib.rs
+++ b/src/query/config/src/lib.rs
@@ -46,6 +46,7 @@ pub use inner::CacheConfig;
 pub use inner::CacheStorageTypeConfig as CacheStorageTypeInnerConfig;
 pub use inner::CatalogConfig;
 pub use inner::CatalogHiveConfig;
+pub use inner::DiskCacheKeyReloadPolicy;
 pub use inner::InnerConfig;
 pub use inner::ThriftProtocol;
 pub use version::DATABEND_COMMIT_VERSION;

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -4,6 +4,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 +-----------+--------------------------------------------+----------------------------------------------------------------+----------+
 | Column 0  | Column 1                                   | Column 2                                                       | Column 3 |
 +-----------+--------------------------------------------+----------------------------------------------------------------+----------+
+| 'cache'   | 'data_cache_key_reload_policy'             | 'reset'                                                        | ''       |
 | 'cache'   | 'data_cache_storage'                       | 'none'                                                         | ''       |
 | 'cache'   | 'disk.max_bytes'                           | '21474836480'                                                  | ''       |
 | 'cache'   | 'disk.path'                                | './.databend/_cache'                                           | ''       |

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -25,8 +25,8 @@ crossbeam-channel = "0.5.6"
 hex = "0.4.3"
 log = { workspace = true }
 parking_lot = { workspace = true }
-siphasher = "0.3.10"
 rayon = "1.9.0"
+siphasher = "0.3.10"
 
 [dev-dependencies]
 tempfile = "3.4.0"

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -26,6 +26,7 @@ hex = "0.4.3"
 log = { workspace = true }
 parking_lot = { workspace = true }
 siphasher = "0.3.10"
+rayon = "1.9.0"
 
 [dev-dependencies]
 tempfile = "3.4.0"

--- a/src/query/storages/common/cache/src/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache.rs
@@ -136,9 +136,13 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
     fn fuzzy_restart(self) -> result::Result<Self> {
         fs::create_dir_all(&self.root)?;
 
-        let parallel_degree = std::thread::available_parallelism()
-            .expect("failed to detect number of parallelism")
-            .get();
+let parallel_degree = match std::thread::available_parallelism() {
+    Ok(degree) => degree.get(),
+    Err(e) => {
+        error!("Failed to detect the number of parallelism: {}", e);
+        8
+    }
+};
 
         let root_dir = Path::new(&self.root);
         assert!(root_dir.is_dir());

--- a/src/query/storages/common/cache/src/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache.rs
@@ -136,13 +136,13 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
     fn fuzzy_restart(self) -> result::Result<Self> {
         fs::create_dir_all(&self.root)?;
 
-let parallel_degree = match std::thread::available_parallelism() {
-    Ok(degree) => degree.get(),
-    Err(e) => {
-        error!("Failed to detect the number of parallelism: {}", e);
-        8
-    }
-};
+        let parallel_degree = match std::thread::available_parallelism() {
+            Ok(degree) => degree.get(),
+            Err(e) => {
+                error!("Failed to detect the number of parallelism: {}", e);
+                8
+            }
+        };
 
         let root_dir = Path::new(&self.root);
         assert!(root_dir.is_dir());

--- a/src/query/storages/common/cache/src/providers/table_data_cache.rs
+++ b/src/query/storages/common/cache/src/providers/table_data_cache.rs
@@ -77,8 +77,13 @@ impl TableDataCacheBuilder {
         path: &PathBuf,
         population_queue_size: u32,
         disk_cache_bytes_size: u64,
+        fuzzy_reload_cache_keys: bool,
     ) -> Result<TableDataCache<LruDiskCacheHolder>> {
-        let disk_cache = LruDiskCacheBuilder::new_disk_cache(path, disk_cache_bytes_size)?;
+        let disk_cache = LruDiskCacheBuilder::new_disk_cache(
+            path,
+            disk_cache_bytes_size,
+            fuzzy_reload_cache_keys,
+        )?;
         let (tx, rx) = crossbeam_channel::bounded(population_queue_size as usize);
         let num_population_thread = 1;
         Ok(TableDataCache {

--- a/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
@@ -64,19 +64,22 @@ impl TestFixture {
 #[test]
 fn test_empty_dir() {
     let f = TestFixture::new();
-    DiskCache::new(f.tmp(), 1024).unwrap();
+    let fuzzy_reload_cache_keys = false;
+    DiskCache::new(f.tmp(), 1024, fuzzy_reload_cache_keys).unwrap();
 }
 
 #[test]
 fn test_missing_root() {
     let f = TestFixture::new();
-    DiskCache::new(f.tmp().join("not-here"), 1024).unwrap();
+    let fuzzy_reload_cache_keys = false;
+    DiskCache::new(f.tmp().join("not-here"), 1024, fuzzy_reload_cache_keys).unwrap();
 }
 
 #[test]
 fn test_insert_bytes() {
     let f = TestFixture::new();
-    let mut c = DiskCache::new(f.tmp(), 25).unwrap();
+    let fuzzy_reload_cache_keys = false;
+    let mut c = DiskCache::new(f.tmp(), 25, fuzzy_reload_cache_keys).unwrap();
     c.insert_single_slice("a/b/c", &[0; 10]).unwrap();
     assert!(c.contains_key("a/b/c"));
     c.insert_single_slice("a/b/d", &[0; 10]).unwrap();
@@ -95,7 +98,8 @@ fn test_insert_bytes() {
 fn test_insert_bytes_exact() {
     // Test that files adding up to exactly the size limit works.
     let f = TestFixture::new();
-    let mut c = DiskCache::new(f.tmp(), 20).unwrap();
+    let fuzzy_reload_cache_keys = false;
+    let mut c = DiskCache::new(f.tmp(), 20, fuzzy_reload_cache_keys).unwrap();
     c.insert_single_slice("file1", &[1; 10]).unwrap();
     c.insert_single_slice("file2", &[2; 10]).unwrap();
     assert_eq!(c.size(), 20);
@@ -108,7 +112,8 @@ fn test_insert_bytes_exact() {
 fn test_add_get_lru() {
     let f = TestFixture::new();
     {
-        let mut c = DiskCache::new(f.tmp(), 25).unwrap();
+        let fuzzy_reload_cache_keys = false;
+        let mut c = DiskCache::new(f.tmp(), 25, fuzzy_reload_cache_keys).unwrap();
         c.insert_single_slice("file1", &[1; 10]).unwrap();
         c.insert_single_slice("file2", &[2; 10]).unwrap();
         // Get the file to bump its LRU status.
@@ -127,7 +132,8 @@ fn test_add_get_lru() {
 #[test]
 fn test_insert_bytes_too_large() {
     let f = TestFixture::new();
-    let mut c = DiskCache::new(f.tmp(), 1).unwrap();
+    let fuzzy_reload_cache_keys = false;
+    let mut c = DiskCache::new(f.tmp(), 1, fuzzy_reload_cache_keys).unwrap();
     match c.insert_single_slice("a/b/c", &[0; 2]) {
         Err(DiskCacheError::FileTooLarge) => {}
         x => panic!("Unexpected result: {x:?}"),
@@ -137,7 +143,8 @@ fn test_insert_bytes_too_large() {
 #[test]
 fn test_evict_until_enough_space() {
     let f = TestFixture::new();
-    let mut c = DiskCache::new(f.tmp(), 4).unwrap();
+    let fuzzy_reload_cache_keys = false;
+    let mut c = DiskCache::new(f.tmp(), 4, fuzzy_reload_cache_keys).unwrap();
     c.insert_single_slice("file1", &[1; 1]).unwrap();
     c.insert_single_slice("file2", &[2; 2]).unwrap();
     c.insert_single_slice("file3", &[3; 1]).unwrap();

--- a/src/query/storages/common/cache_manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache_manager/src/cache_manager.rs
@@ -20,6 +20,7 @@ use databend_common_cache::CountableMeter;
 use databend_common_cache::DefaultHashBuilder;
 use databend_common_config::CacheConfig;
 use databend_common_config::CacheStorageTypeInnerConfig;
+use databend_common_config::DiskCacheKeyReloadPolicy;
 use databend_common_exception::Result;
 use databend_storages_common_cache::InMemoryCacheBuilder;
 use databend_storages_common_cache::InMemoryItemCacheHolder;
@@ -97,6 +98,7 @@ impl CacheManager {
                         &real_disk_cache_root,
                         queue_size,
                         config.disk_cache_config.max_bytes,
+                        config.data_cache_key_reload_policy.clone(),
                     )?
                 }
             }
@@ -270,12 +272,19 @@ impl CacheManager {
         path: &PathBuf,
         population_queue_size: u32,
         disk_cache_bytes_size: u64,
+        restart_policy: DiskCacheKeyReloadPolicy,
     ) -> Result<Option<TableDataCache>> {
+        let fuzzy_reload_cache_keys = match restart_policy {
+            DiskCacheKeyReloadPolicy::Reset => false,
+            DiskCacheKeyReloadPolicy::Fuzzy => true,
+        };
+
         if disk_cache_bytes_size > 0 {
             let cache_holder = TableDataCacheBuilder::new_table_data_disk_cache(
                 path,
                 population_queue_size,
                 disk_cache_bytes_size,
+                fuzzy_reload_cache_keys,
             )?;
             Ok(Some(cache_holder))
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

During query node restart, if the config item `data_cache_key_reload_policy` is set to "fuzzy", disk cache keys will be reloaded from the cache directory instead of directly removing previous cache data. This means that the cache data existing before the restart will NOT be deleted.

To accelerate the reloading,  sub directories of cache directory, will be processed in parallel. 

Note that during the reloading of cache keys, cache capacity will NOT be checked. Therefore, if `cache.disk.max_bytes` is decreased between restarts, no cached items on disk will be removed immediately. Instead, items will be removed when the first new item is put into the cache.


If `data_cache_key_reload_policy` is set to "reset", cached data will be remove (in parallel) during restart.


New config item introduced:

~~~
[cache]

# Policy of data cache key reloading
#
# Available options: [reset|fuzzy]
# "reset":  remove previous data cache during restart  (default value)
# "fuzzy":  reload cache keys from cache dir, retaining the cache data
#           that existed before the restart

data_cache_key_reload_policy = "reset"
~~~

please note that if storage type is `fs` (or storage that support blocking io),  disk cache will NOT be populated at all.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test: manually tested 

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15566)
<!-- Reviewable:end -->
