### PR TITLE
chore: short_sql from 10KB to 30KB

### DIFF
--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -582,14 +582,17 @@ impl Drop for QueryContextShared {
 
 pub fn short_sql(sql: String) -> String {
     use unicode_segmentation::UnicodeSegmentation;
+    const MAX_LENGTH: usize = 30 * 1024; // 30KB
+
     let query = sql.trim_start();
-    if query.as_bytes().len() > 10240 && query.as_bytes()[..6].eq_ignore_ascii_case(b"INSERT") {
-        // keep first 10KB (10,240 bytes)
+    if query.as_bytes().len() > MAX_LENGTH && query.as_bytes()[..6].eq_ignore_ascii_case(b"INSERT")
+    {
+        // keep first 30KB
         let mut result = Vec::new();
         let mut bytes_taken = 0;
         for grapheme in query.graphemes(true) {
             let grapheme_bytes = grapheme.as_bytes();
-            if bytes_taken + grapheme_bytes.len() <= 10240 {
+            if bytes_taken + grapheme_bytes.len() <= MAX_LENGTH {
                 result.extend_from_slice(grapheme_bytes);
                 bytes_taken += grapheme_bytes.len();
             } else {

--- a/src/query/service/tests/it/sessions/query_ctx.rs
+++ b/src/query/service/tests/it/sessions/query_ctx.rs
@@ -69,19 +69,19 @@ async fn test_get_storage_accessor_fs() -> Result<()> {
 
 #[test]
 fn test_short_sql() {
-    // Test case 1: SQL query shorter than 10KB
+    // Test case 1: SQL query shorter than 30KB
     let sql1 = "SELECT * FROM users WHERE id = 1;".to_string();
     assert_eq!(short_sql(sql1.clone()), sql1);
 
-    // Test case 2: SQL query longer than 10KB and starts with "INSERT"
+    // Test case 2: SQL query longer than 30KB and starts with "INSERT"
     let long_sql = "INSERT INTO users (id, name, email) VALUES ".to_string()
-        + &"(1, 'John Doe', 'john@example.com'), ".repeat(1000);
-    let expected_result = long_sql.as_bytes()[..10240].to_vec();
+        + &"(1, 'John Doe', 'john@example.com'), ".repeat(1500); // Adjusted for 30KB
+    let expected_result = long_sql.as_bytes()[..30 * 1024].to_vec();
     let expected_result = String::from_utf8(expected_result).unwrap() + "...";
     assert_eq!(short_sql(long_sql), expected_result);
 
-    // Test case 3: SQL query longer than 10KB but does not start with "INSERT"
-    let long_sql = "SELECT * FROM users WHERE ".to_string() + &"id = 1 OR ".repeat(1000);
+    // Test case 3: SQL query longer than 30KB but does not start with "INSERT"
+    let long_sql = "SELECT * FROM users WHERE ".to_string() + &"id = 1 OR ".repeat(1500); // Adjusted for 30KB
     assert_eq!(short_sql(long_sql.clone()), long_sql);
 
     // Test case 4: Empty SQL query


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* If a insert with many columns, short_sql doesn't have room enough, enlarger it from 10KB to 30 KB

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15575)
<!-- Reviewable:end -->
