### PR TITLE
chore: disk cache load refine and reduce the info flood logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4876,6 +4876,7 @@ dependencies = [
  "crossbeam-channel",
  "databend-common-base",
  "databend-common-cache",
+ "databend-common-config",
  "databend-common-exception",
  "databend-common-metrics",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4878,6 +4878,7 @@ dependencies = [
  "databend-common-cache",
  "databend-common-exception",
  "databend-common-metrics",
+ "env_logger",
  "hex",
  "log",
  "parking_lot 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4879,7 +4879,6 @@ dependencies = [
  "databend-common-config",
  "databend-common-exception",
  "databend-common-metrics",
- "env_logger",
  "hex",
  "log",
  "parking_lot 0.12.1",

--- a/scripts/distribution/configs/databend-query.toml
+++ b/scripts/distribution/configs/databend-query.toml
@@ -129,6 +129,15 @@ data_path = "/var/lib/databend/data"
 # use "disk" to enabled disk cache
 data_cache_storage = "none"
 
+# Policy of data cache key reloading
+#
+# Available options: [reset|fuzzy]
+# "reset":  remove previous data cache during restart  (default value)
+# "fuzzy":  reload cache keys from cache dir, retaining the cache data
+#           that existed before the restart
+
+# data_cache_key_reload_policy = "fuzzy"
+
 [cache.disk]
 # cache path
 path = "/var/lib/databend/cache"

--- a/src/binaries/query/entry.rs
+++ b/src/binaries/query/entry.rs
@@ -215,8 +215,10 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
 
     // Print information to users.
     println!("Databend Query");
+
     println!();
     println!("Version: {}", *DATABEND_COMMIT_VERSION);
+
     println!();
     println!("Logging:");
     println!("    file: {}", conf.log.file);
@@ -224,6 +226,8 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
     println!("    otlp: {}", conf.log.otlp);
     println!("    query: {}", conf.log.query);
     println!("    tracing: {}", conf.log.tracing);
+
+    println!();
     println!(
         "Meta: {}",
         if conf.meta.is_embedded_meta()? {
@@ -232,6 +236,8 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
             format!("connected to endpoints {:#?}", conf.meta.endpoints)
         }
     );
+
+    println!();
     println!("Memory:");
     println!("    limit: {}", {
         if conf.query.max_memory_limit_enabled {
@@ -246,6 +252,7 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
     println!("    allocator: {}", GlobalAllocator::name());
     println!("    config: {}", GlobalAllocator::conf());
 
+    println!();
     println!("Cluster: {}", {
         let cluster = ClusterDiscovery::instance().discover(conf).await?;
         let nodes = cluster.nodes.len();
@@ -255,8 +262,18 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
             "standalone".to_string()
         }
     });
+
+    println!();
     println!("Storage: {}", conf.storage.params);
-    println!("Cache: {}", conf.cache.data_cache_storage.to_string());
+    println!("Disk cache:");
+    println!("    storage: {}", conf.cache.data_cache_storage.to_string());
+    println!("    path: {:?}", conf.cache.disk_cache_config);
+    println!(
+        "    reload policy: {}",
+        conf.cache.data_cache_key_reload_policy.to_string()
+    );
+
+    println!();
     println!(
         "Builtin users: {}",
         conf.query
@@ -267,6 +284,7 @@ pub async fn start_services(conf: &InnerConfig) -> Result<()> {
             .collect::<Vec<_>>()
             .join(", ")
     );
+
     println!();
     println!("Admin");
     println!("    listened at {}", conf.query.admin_api_address);

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -15,6 +15,7 @@ test = true
 bytes = { workspace = true }
 databend-common-base = { path = "../../../../common/base" }
 databend-common-cache = { path = "../../../../common/cache" }
+databend-common-config = { path = "../../../config" }
 databend-common-exception = { path = "../../../../common/exception" }
 databend-common-metrics = { path = "../../../../common/metrics" }
 

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -22,6 +22,7 @@ async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 crc32fast = "1.3.2"
 crossbeam-channel = "0.5.6"
+env_logger = "0.10.2"
 hex = "0.4.3"
 log = { workspace = true }
 parking_lot = { workspace = true }

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -23,7 +23,6 @@ async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 crc32fast = "1.3.2"
 crossbeam-channel = "0.5.6"
-env_logger = "0.10.2"
 hex = "0.4.3"
 log = { workspace = true }
 parking_lot = { workspace = true }

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache.rs
@@ -58,7 +58,7 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
         path: T,
         size: u64,
         disk_cache_key_reload_policy: DiskCacheKeyReloadPolicy,
-    ) -> self::result::Result<Self>
+    ) -> self::io_result::Result<Self>
     where
         PathBuf: From<T>,
     {
@@ -138,7 +138,7 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
     }
 
     /// Remove all files in the cache.
-    fn reset_restart(cache_root: &PathBuf) -> result::Result<()> {
+    fn reset_restart(cache_root: &PathBuf) -> io_result::Result<()> {
         let counter = AtomicUsize::new(0);
         Self::parallel_scan(
             cache_root,
@@ -164,7 +164,7 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
     }
 
     /// Reload cache keys from the cache directory.
-    fn fuzzy_restart(root: &PathBuf, me: CacheHolder<C>) -> result::Result<CacheHolder<C>> {
+    fn fuzzy_restart(root: &PathBuf, me: CacheHolder<C>) -> io_result::Result<CacheHolder<C>> {
         let counter = AtomicUsize::new(0);
         Self::parallel_scan(
             root,
@@ -207,7 +207,7 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
     fn init(
         self,
         disk_cache_key_reload_policy: DiskCacheKeyReloadPolicy,
-    ) -> self::result::Result<Self> {
+    ) -> self::io_result::Result<Self> {
         let begin = Instant::now();
         let parallelism = match std::thread::available_parallelism() {
             Ok(degree) => degree.get(),
@@ -272,7 +272,7 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
         self.rel_to_abs_path(path)
     }
 
-    pub fn insert_bytes(&mut self, key: &str, bytes: &[&[u8]]) -> self::result::Result<()> {
+    pub fn insert_bytes(&mut self, key: &str, bytes: &[&[u8]]) -> self::io_result::Result<()> {
         let bytes_len = bytes.iter().map(|x| x.len() as u64).sum::<u64>();
         // check if this chunk of bytes itself is too large
         if !self.can_store(bytes_len) {
@@ -355,7 +355,7 @@ fn recovery_cache_key_from_path(relative_path: &Path) -> String {
     key_string
 }
 
-pub mod result {
+pub mod io_result {
     use std::error::Error as StdError;
     use std::fmt;
     use std::io;
@@ -405,4 +405,4 @@ pub mod result {
     pub type Result<T> = std::result::Result<T, Error>;
 }
 
-use result::*;
+use io_result::*;

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Display;
 use std::fs;
 use std::fs::File;
-use std::hash::Hasher;
 use std::io::IoSlice;
 use std::io::Read;
 use std::io::Write;
@@ -41,46 +39,13 @@ use log::warn;
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
-use siphasher::sip128;
-use siphasher::sip128::Hasher128;
 
 use crate::CacheAccessor;
+use crate::DiskCacheKey;
 
 pub struct DiskCache<C> {
     cache: C,
     root: PathBuf,
-}
-
-#[derive(Debug)]
-pub struct DiskCacheKey(String);
-
-impl<S> From<S> for DiskCacheKey
-where S: AsRef<str>
-{
-    // convert key string into hex string of SipHash 2-4 128 bit
-    fn from(key: S) -> Self {
-        let mut sip = sip128::SipHasher24::new();
-        let key = key.as_ref();
-        sip.write(key.as_bytes());
-        let hash = sip.finish128();
-        let hex_hash = hex::encode(hash.as_bytes());
-        DiskCacheKey(hex_hash)
-    }
-}
-
-impl From<&DiskCacheKey> for PathBuf {
-    fn from(cache_key: &DiskCacheKey) -> Self {
-        let prefix = &cache_key.0[0..3];
-        let mut path_buf = PathBuf::from(prefix);
-        path_buf.push(Path::new(&cache_key.0));
-        path_buf
-    }
-}
-
-impl Display for DiskCacheKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0.clone())
-    }
 }
 
 impl<C> DiskCache<C>

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_key.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_key.rs
@@ -1,0 +1,53 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Display;
+use std::hash::Hasher;
+use std::path::Path;
+use std::path::PathBuf;
+
+use siphasher::sip128;
+use siphasher::sip128::Hasher128;
+
+#[derive(Debug)]
+pub struct DiskCacheKey(pub String);
+
+impl<S> From<S> for DiskCacheKey
+where S: AsRef<str>
+{
+    // convert key string into hex string of SipHash 2-4 128 bit
+    fn from(key: S) -> Self {
+        let mut sip = sip128::SipHasher24::new();
+        let key = key.as_ref();
+        sip.write(key.as_bytes());
+        let hash = sip.finish128();
+        let hex_hash = hex::encode(hash.as_bytes());
+        DiskCacheKey(hex_hash)
+    }
+}
+
+impl From<&DiskCacheKey> for PathBuf {
+    fn from(cache_key: &DiskCacheKey) -> Self {
+        let prefix = &cache_key.0[0..3];
+        let mut path_buf = PathBuf::from(prefix);
+        path_buf.push(Path::new(&cache_key.0));
+        path_buf
+    }
+}
+
+impl Display for DiskCacheKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.clone())
+    }
+}

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
@@ -22,6 +22,7 @@ use databend_common_cache::Count;
 use databend_common_cache::DefaultHashBuilder;
 use databend_common_cache::FileSize;
 use databend_common_cache::LruCache;
+use databend_common_config::DiskCacheKeyReloadPolicy;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use log::error;
@@ -150,11 +151,10 @@ impl LruDiskCacheBuilder {
     pub fn new_disk_cache(
         path: &PathBuf,
         disk_cache_bytes_size: u64,
-        fuzzy_reload_cache_keys: bool,
+        disk_cache_reload_policy: DiskCacheKeyReloadPolicy,
     ) -> Result<LruDiskCacheHolder> {
-        let external_cache =
-            DiskCache::new(path, disk_cache_bytes_size, fuzzy_reload_cache_keys)
-                .map_err(|e| ErrorCode::StorageOther(format!("create disk cache failed, {e}")))?;
+        let external_cache = DiskCache::new(path, disk_cache_bytes_size, disk_cache_reload_policy)
+            .map_err(|e| ErrorCode::StorageOther(format!("create disk cache failed, {e}")))?;
         Ok(Arc::new(RwLock::new(external_cache)))
     }
 }

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
@@ -1,0 +1,160 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use databend_common_cache::Count;
+use databend_common_cache::DefaultHashBuilder;
+use databend_common_cache::FileSize;
+use databend_common_cache::LruCache;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use log::error;
+use log::warn;
+use parking_lot::RwLock;
+
+use crate::providers::disk_cache::DiskCache;
+use crate::CacheAccessor;
+
+impl CacheAccessor<String, Bytes, databend_common_cache::DefaultHashBuilder, Count>
+    for LruDiskCacheHolder
+{
+    fn get<Q: AsRef<str>>(&self, k: Q) -> Option<Arc<Bytes>> {
+        let k = k.as_ref();
+        {
+            let mut cache = self.write();
+            cache.get_cache_path(k)
+        }
+        .and_then(|cache_file_path| {
+            // check disk cache
+            let get_cache_content = || {
+                let mut v = vec![];
+                let mut file = File::open(cache_file_path)?;
+                file.read_to_end(&mut v)?;
+                Ok::<_, Box<dyn std::error::Error>>(v)
+            };
+
+            match get_cache_content() {
+                Ok(mut bytes) => {
+                    if let Err(e) = validate_checksum(bytes.as_slice()) {
+                        error!("disk cache, of key {k},  crc validation failure: {e}");
+                        {
+                            // remove the invalid cache, error of removal ignored
+                            let r = {
+                                let mut cache = self.write();
+                                cache.remove(k)
+                            };
+                            if let Err(e) = r {
+                                warn!("failed to remove invalid cache item, key {k}. {e}");
+                            }
+                        }
+                        None
+                    } else {
+                        // trim the checksum bytes and return
+                        let total_len = bytes.len();
+                        let body_len = total_len - 4;
+                        bytes.truncate(body_len);
+                        let item = Arc::new(bytes.into());
+                        Some(item)
+                    }
+                }
+                Err(e) => {
+                    error!("get disk cache item failed, cache_key {k}. {e}");
+                    None
+                }
+            }
+        })
+    }
+
+    fn put(&self, key: String, value: Arc<Bytes>) {
+        let crc = crc32fast::hash(value.as_ref());
+        let crc_bytes = crc.to_le_bytes();
+        let mut cache = self.write();
+        if let Err(e) = cache.insert_bytes(&key, &[value.as_ref(), &crc_bytes]) {
+            error!("put disk cache item failed {}", e);
+        }
+    }
+
+    fn evict(&self, k: &str) -> bool {
+        if let Err(e) = {
+            let mut cache = self.write();
+            cache.remove(k)
+        } {
+            error!("evict disk cache item failed {}", e);
+            false
+        } else {
+            true
+        }
+    }
+
+    fn contains_key(&self, k: &str) -> bool {
+        let cache = self.read();
+        cache.contains_key(k)
+    }
+
+    fn size(&self) -> u64 {
+        let cache = self.read();
+        cache.size()
+    }
+
+    fn len(&self) -> usize {
+        let cache = self.read();
+        cache.len()
+    }
+}
+
+/// The crc32 checksum is stored at the end of `bytes` and encoded as le u32.
+// Although parquet page has built-in crc, but it is optional (and not generated in parquet2)
+fn validate_checksum(bytes: &[u8]) -> Result<()> {
+    let total_len = bytes.len();
+    if total_len <= 4 {
+        Err(ErrorCode::StorageOther(format!(
+            "crc checksum validation failure: invalid file length {total_len}"
+        )))
+    } else {
+        // total_len > 4 is ensured
+        let crc_bytes: [u8; 4] = bytes[total_len - 4..].try_into().unwrap();
+        let crc_provided = u32::from_le_bytes(crc_bytes);
+        let crc_calculated = crc32fast::hash(&bytes[0..total_len - 4]);
+        if crc_provided == crc_calculated {
+            Ok(())
+        } else {
+            Err(ErrorCode::StorageOther(format!(
+                "crc checksum validation failure, key : crc checksum not match, crc provided {crc_provided}, crc calculated {crc_calculated}"
+            )))
+        }
+    }
+}
+
+pub type LruDiskCache = DiskCache<LruCache<String, u64, DefaultHashBuilder, FileSize>>;
+pub type LruDiskCacheHolder = Arc<RwLock<LruDiskCache>>;
+
+pub struct LruDiskCacheBuilder;
+
+impl LruDiskCacheBuilder {
+    pub fn new_disk_cache(
+        path: &PathBuf,
+        disk_cache_bytes_size: u64,
+        fuzzy_reload_cache_keys: bool,
+    ) -> Result<LruDiskCacheHolder> {
+        let external_cache =
+            DiskCache::new(path, disk_cache_bytes_size, fuzzy_reload_cache_keys)
+                .map_err(|e| ErrorCode::StorageOther(format!("create disk cache failed, {e}")))?;
+        Ok(Arc::new(RwLock::new(external_cache)))
+    }
+}

--- a/src/query/storages/common/cache/src/providers/disk_cache/mod.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/mod.rs
@@ -15,6 +15,8 @@
 #[allow(clippy::module_inception)]
 mod disk_cache;
 mod disk_cache_key;
+mod disk_cache_lru;
 
 pub use disk_cache::*;
 pub use disk_cache_key::DiskCacheKey;
+pub use disk_cache_lru::*;

--- a/src/query/storages/common/cache/src/providers/disk_cache/mod.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[allow(clippy::module_inception)]
+mod disk_cache;
+mod disk_cache_key;
+
+pub use disk_cache::*;
+pub use disk_cache_key::DiskCacheKey;

--- a/src/query/storages/common/cache/src/providers/mod.rs
+++ b/src/query/storages/common/cache/src/providers/mod.rs
@@ -15,6 +15,7 @@
 mod disk_cache;
 mod memory_cache;
 mod table_data_cache;
+
 pub use disk_cache::result::Error as DiskCacheError;
 pub use disk_cache::result::Result as DiskCacheResult;
 pub use disk_cache::DiskCacheKey;

--- a/src/query/storages/common/cache/src/providers/mod.rs
+++ b/src/query/storages/common/cache/src/providers/mod.rs
@@ -16,8 +16,8 @@ mod disk_cache;
 mod memory_cache;
 mod table_data_cache;
 
-pub use disk_cache::result::Error as DiskCacheError;
-pub use disk_cache::result::Result as DiskCacheResult;
+pub use disk_cache::io_result::Error as DiskCacheError;
+pub use disk_cache::io_result::Result as DiskCacheResult;
 pub use disk_cache::DiskCacheKey;
 pub use disk_cache::LruDiskCache;
 pub use disk_cache::LruDiskCacheBuilder;

--- a/src/query/storages/common/cache/src/providers/table_data_cache.rs
+++ b/src/query/storages/common/cache/src/providers/table_data_cache.rs
@@ -22,6 +22,7 @@ use databend_common_base::runtime::profile::Profile;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_cache::Count;
 use databend_common_cache::DefaultHashBuilder;
+use databend_common_config::DiskCacheKeyReloadPolicy;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_metrics::cache::*;
@@ -72,17 +73,18 @@ pub struct TableDataCache<T = LruDiskCacheHolder> {
 const TABLE_DATA_CACHE_NAME: &str = "table_data";
 
 pub struct TableDataCacheBuilder;
+
 impl TableDataCacheBuilder {
     pub fn new_table_data_disk_cache(
         path: &PathBuf,
         population_queue_size: u32,
         disk_cache_bytes_size: u64,
-        fuzzy_reload_cache_keys: bool,
+        disk_cache_reload_policy: DiskCacheKeyReloadPolicy,
     ) -> Result<TableDataCache<LruDiskCacheHolder>> {
         let disk_cache = LruDiskCacheBuilder::new_disk_cache(
             path,
             disk_cache_bytes_size,
-            fuzzy_reload_cache_keys,
+            disk_cache_reload_policy,
         )?;
         let (tx, rx) = crossbeam_channel::bounded(population_queue_size as usize);
         let num_population_thread = 1;

--- a/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
@@ -164,8 +164,6 @@ fn test_evict_until_enough_space() {
 
 #[test]
 fn test_fuzzy_restart_parallelism() {
-    let _ = env_logger::builder().is_test(true).try_init();
-
     let f = TestFixture::new();
     let cache_root = f.tmp();
 
@@ -202,8 +200,6 @@ fn test_fuzzy_restart_parallelism() {
 
 #[test]
 fn test_reset_restart_parallelism() {
-    let _ = env_logger::builder().is_test(true).try_init();
-
     let f = TestFixture::new();
     let cache_root = f.tmp();
 
@@ -223,7 +219,7 @@ fn test_reset_restart_parallelism() {
         file.write_all(content.as_bytes()).unwrap();
     }
 
-    // Check that all files within prefix directories are removed
+    // Check that all files within prefix directories are properly created
     let prefix_dirs = fs::read_dir(cache_root).unwrap();
     let remaining_files = prefix_dirs
         .map(|entry| {

--- a/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::Read;
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -22,6 +24,7 @@ use databend_storages_common_cache::DiskCacheError;
 use databend_storages_common_cache::DiskCacheKey;
 use databend_storages_common_cache::DiskCacheResult;
 use databend_storages_common_cache::LruDiskCache as DiskCache;
+use log::info;
 use tempfile::TempDir;
 
 struct TestFixture {
@@ -73,6 +76,98 @@ fn test_missing_root() {
     let f = TestFixture::new();
     let fuzzy_reload_cache_keys = false;
     DiskCache::new(f.tmp().join("not-here"), 1024, fuzzy_reload_cache_keys).unwrap();
+}
+
+#[test]
+fn test_fuzzy_restart_parallelism() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let f = TestFixture::new();
+    let cache_root = f.tmp();
+
+    // Create some cache entries
+    let entry_count = 10;
+    for i in 0..entry_count {
+        let sub_dir = format!("dir{}", i % 10);
+        let file_name = DiskCacheKey::from(format!("file{}.txt", i)).to_string();
+        info!("Creating file {}", file_name);
+        let file_path = cache_root.join(&sub_dir).join(&file_name);
+
+        // Create parent directories recursively
+        fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+
+        // Create a non-empty file
+        let mut file = fs::File::create(file_path).unwrap();
+        let content = format!("Content of file {}", i);
+        file.write_all(content.as_bytes()).unwrap();
+    }
+
+    let cache = DiskCache::new(&cache_root.to_path_buf(), 1024 * 1024, true).unwrap();
+
+    // Check if the keys are reloaded correctly
+    for i in 0..entry_count {
+        let file_name = format!("file{}.txt", i);
+        assert!(cache.contains_key(&file_name));
+    }
+}
+
+#[test]
+fn test_reset_restart_parallelism() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let f = TestFixture::new();
+    let cache_root = f.tmp();
+
+    // Create some cache entries
+    let entry_count = 100;
+    for i in 0..entry_count {
+        let sub_dir = format!("dir{}", i % 10);
+        let file_name = DiskCacheKey::from(format!("file{}.txt", i)).to_string();
+        let file_path = cache_root.join(&sub_dir).join(&file_name);
+
+        // Create parent directories recursively
+        fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+
+        // Create a non-empty file
+        let mut file = fs::File::create(file_path).unwrap();
+        let content = format!("Content of file {}", i);
+        file.write_all(content.as_bytes()).unwrap();
+    }
+
+    // Check that all files within prefix directories are removed
+    let prefix_dirs = fs::read_dir(cache_root).unwrap();
+    let remaining_files = prefix_dirs
+        .map(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                fs::read_dir(path).unwrap().count()
+            } else {
+                0
+            }
+        })
+        .sum::<usize>();
+    assert_eq!(remaining_files, entry_count);
+
+    let _cache = DiskCache::new(cache_root, 1024, false).unwrap();
+
+    // Check that all files within prefix directories are removed
+    let prefix_dirs = fs::read_dir(cache_root).unwrap();
+    let remaining_files = prefix_dirs
+        .map(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                fs::read_dir(path).unwrap().count()
+            } else {
+                0
+            }
+        })
+        .sum::<usize>();
+    assert_eq!(
+        remaining_files, 0,
+        "Files within prefix directories are not completely removed"
+    );
 }
 
 #[test]

--- a/src/query/storages/common/cache_manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache_manager/src/cache_manager.rs
@@ -272,19 +272,14 @@ impl CacheManager {
         path: &PathBuf,
         population_queue_size: u32,
         disk_cache_bytes_size: u64,
-        restart_policy: DiskCacheKeyReloadPolicy,
+        disk_cache_key_reload_policy: DiskCacheKeyReloadPolicy,
     ) -> Result<Option<TableDataCache>> {
-        let fuzzy_reload_cache_keys = match restart_policy {
-            DiskCacheKeyReloadPolicy::Reset => false,
-            DiskCacheKeyReloadPolicy::Fuzzy => true,
-        };
-
         if disk_cache_bytes_size > 0 {
             let cache_holder = TableDataCacheBuilder::new_table_data_disk_cache(
                 path,
                 population_queue_size,
                 disk_cache_bytes_size,
-                fuzzy_reload_cache_keys,
+                disk_cache_key_reload_policy,
             )?;
             Ok(Some(cache_holder))
         } else {

--- a/src/query/storages/delta/Cargo.toml
+++ b/src/query/storages/delta/Cargo.toml
@@ -21,7 +21,7 @@ databend-storages-common-table-meta = { path = "../common/table_meta" }
 
 arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
-async-trait = { version = "0.1.77", package = "async-trait-fn" }
+async-trait = { workspace = true }
 bytes = { workspace = true }
 deltalake = { git = "https://github.com/delta-io/delta-rs", package = "deltalake-core", rev = "81593e9" }
 flagset = "0.4"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* Add more unit test for cache restart load
* Refactory the cache reload logic, make the `parallel_scan` both for reset&fuzzy
* Spill `disk_cache.rs` into `disk_cache` dir
* Add `data_cache_key_reload_policy` config description to query.toml

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15576)
<!-- Reviewable:end -->
