### PR TITLE
fix(query): fix bloom fitler using `is_null` and `not` function

### DIFF
--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -590,7 +590,15 @@ fn visit_expr_column_eq_constant(
         Expr::Cast { expr, .. } => {
             visit_expr_column_eq_constant(expr, visitor)?;
         }
-        Expr::FunctionCall { args, .. } => {
+        Expr::FunctionCall { function, args, .. } => {
+            // Ignore the `not`, `is_null` and `is_not_null` functions,
+            // as the return values of these functions may lead to incorrect results.
+            if function.signature.name == "not"
+                || function.signature.name == "is_null"
+                || function.signature.name == "is_not_null"
+            {
+                return Ok(());
+            }
             for arg in args.iter_mut() {
                 visit_expr_column_eq_constant(arg, visitor)?;
             }

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -303,6 +303,9 @@ statement ok
 drop table bloom_test_alter_t2
 
 statement ok
+drop table if exists bloom_test_nullable_t
+
+statement ok
 create table bloom_test_nullable_t(c1 int null, c2 int16 null);
 
 statement ok
@@ -355,5 +358,50 @@ EvalScalar
         ├── push downs: [filters: [is_true(bloom_test_nullable_t.c2 (#1) = 12345)], limit: NONE]
         └── estimated rows: 6.00
 
+# fix https://github.com/datafuselabs/databend/issues/15570
+# fix https://github.com/datafuselabs/databend/issues/15572
+
 statement ok
-drop table bloom_test_nullable_t
+drop table if exists bloom_test_nullable_t2
+
+statement ok
+create table bloom_test_nullable_t2(c0 bool null, c1 int null, c2 varchar null)
+
+statement ok
+insert into bloom_test_nullable_t2 values(false, 1, 'a'), (true, 5, null)
+
+query T
+explain select * from bloom_test_nullable_t2 where ((c2) in ('1') is null);
+----
+Filter
+├── output columns: [bloom_test_nullable_t2.c0 (#0), bloom_test_nullable_t2.c1 (#1), bloom_test_nullable_t2.c2 (#2)]
+├── filters: [NOT is_not_null(bloom_test_nullable_t2.c2 (#2) = '1')]
+├── estimated rows: 1.60
+└── TableScan
+    ├── table: default.default.bloom_test_nullable_t2
+    ├── output columns: [c0 (#0), c1 (#1), c2 (#2)]
+    ├── read rows: 2
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [NOT is_not_null(bloom_test_nullable_t2.c2 (#2) = '1')], limit: NONE]
+    └── estimated rows: 2.00
+
+query T
+explain select * from bloom_test_nullable_t2 where (not (not c0))
+----
+Filter
+├── output columns: [bloom_test_nullable_t2.c0 (#0), bloom_test_nullable_t2.c1 (#1), bloom_test_nullable_t2.c2 (#2)]
+├── filters: [is_true(NOT NOT bloom_test_nullable_t2.c0 (#0))]
+├── estimated rows: 2.00
+└── TableScan
+    ├── table: default.default.bloom_test_nullable_t2
+    ├── output columns: [c0 (#0), c1 (#1), c2 (#2)]
+    ├── read rows: 2
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [is_true(NOT NOT bloom_test_nullable_t2.c0 (#0))], limit: NONE]
+    └── estimated rows: 2.00

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/bloom_filter.test
@@ -121,6 +121,9 @@ statement ok
 drop table bloom_test_t
 
 statement ok
+drop table if exists bloom_test_nullable_t
+
+statement ok
 create table bloom_test_nullable_t(c1 int null, c2 int null);
 
 statement ok
@@ -143,5 +146,42 @@ TableScan
 ├── push downs: [filters: [and_filters(bloom_test_nullable_t.c1 (#0) = 5, bloom_test_nullable_t.c2 (#1) > 1)], limit: NONE]
 └── estimated rows: 1.00
 
+# fix https://github.com/datafuselabs/databend/issues/15570
+# fix https://github.com/datafuselabs/databend/issues/15572
+
 statement ok
-drop table bloom_test_nullable_t
+drop table if exists bloom_test_nullable_t2
+
+statement ok
+create table bloom_test_nullable_t2(c0 bool null, c1 int null, c2 varchar null) storage_format = 'native'
+
+statement ok
+insert into bloom_test_nullable_t2 values(false, 1, 'a'), (true, 5, null)
+
+query T
+explain select * from bloom_test_nullable_t2 where ((c2) in ('1') is null);
+----
+TableScan
+├── table: default.default.bloom_test_nullable_t2
+├── output columns: [c0 (#0), c1 (#1), c2 (#2)]
+├── read rows: 2
+├── read size: < 1 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+├── push downs: [filters: [NOT is_not_null(bloom_test_nullable_t2.c2 (#2) = '1')], limit: NONE]
+└── estimated rows: 1.60
+
+query T
+explain select * from bloom_test_nullable_t2 where (not (not c0))
+----
+TableScan
+├── table: default.default.bloom_test_nullable_t2
+├── output columns: [c0 (#0), c1 (#1), c2 (#2)]
+├── read rows: 2
+├── read size: < 1 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+├── push downs: [filters: [is_true(NOT NOT bloom_test_nullable_t2.c0 (#0))], limit: NONE]
+└── estimated rows: 2.00


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Ignore the `not`, `is_null` and `is_not_null` functions in bloom filter.

- Fixes #15570
- Fixes #15572


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15577)
<!-- Reviewable:end -->
