### PR TITLE
fix(query): fix filter with nested `not` expr return wrong result

### DIFF
--- a/src/query/expression/src/filter/select_expr.rs
+++ b/src/query/expression/src/filter/select_expr.rs
@@ -134,7 +134,7 @@ impl SelectExprBuilder {
                             if result.can_push_down_not {
                                 result
                             } else {
-                                SelectExprBuildResult::new(SelectExpr::Others(expr.clone()))
+                                self.other_select_expr(expr, not)
                             }
                         }
                         "like" => {

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_01_bloom_in_pruning.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_01_bloom_in_pruning.test
@@ -84,12 +84,40 @@ query I
 SELECT a FROM t2 where a = 3
 ----
 
+statement ok
+CREATE TABLE t3(c0 bool null, c1 int null, c2 varchar null)
+
+statement ok
+INSERT INTO TABLE t3 VALUES(false, 1, 'a'), (true, 5, null)
+
+query BIT
+SELECT * FROM t3 WHERE (NOT c0)
+----
+0 1 a
+
+query BIT
+SELECT * FROM t3 WHERE ((c2) IN ('1') IS NULL)
+----
+1 5 NULL
+
+query BIT
+SELECT * FROM t3 WHERE (c2 = '1' IS NULL)
+----
+1 5 NULL
+
+query BIT
+SELECT * FROM t3 WHERE (c2 = '1' IS NOT NULL)
+----
+0 1 a
 
 statement ok
 DROP TABLE t1
 
 statement ok
 DROP TABLE t2
+
+statement ok
+DROP TABLE t3
 
 statement ok
 DROP DATABASE db_09_0009_01

--- a/tests/sqllogictests/suites/query/filter.test
+++ b/tests/sqllogictests/suites/query/filter.test
@@ -63,6 +63,28 @@ select count(*) from t where a <= b;
 ----
 2
 
+query BB
+select * from t where a
+----
+1 1
+1 0
+
+query BB
+select * from t where not(a)
+----
+0 0
+
+query BB
+select * from t where not(not(a))
+----
+1 1
+1 0
+
+query BB
+select * from t where not(not(not(a)))
+----
+0 0
+
 statement ok
 drop table if exists t;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* fix filter with nested `not` expr return wrong result
* add some tests for bloom filter

- Fixes #15579

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15580)
<!-- Reviewable:end -->
