### PR TITLE
fix: consume stream inside explicit txn

### DIFF
--- a/src/query/service/src/interpreters/common/mod.rs
+++ b/src/query/service/src/interpreters/common/mod.rs
@@ -26,6 +26,7 @@ pub use notification::get_notification_client_config;
 pub use query_log::InterpreterQueryLog;
 pub use stream::dml_build_update_stream_req;
 pub use stream::query_build_update_stream_req;
+pub use stream::StreamTableUpdates;
 pub use table::check_referenced_computed_columns;
 pub use task::get_task_client_config;
 pub use task::make_schedule_options;

--- a/src/query/service/src/interpreters/interpreter_select.rs
+++ b/src/query/service/src/interpreters/interpreter_select.rs
@@ -25,6 +25,7 @@ use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::TableSchemaRef;
+use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
 use databend_common_meta_store::MetaStore;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
@@ -45,6 +46,7 @@ use log::error;
 use log::info;
 
 use crate::interpreters::common::query_build_update_stream_req;
+use crate::interpreters::common::StreamTableUpdates;
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
 use crate::schedulers::build_query_pipeline;
@@ -138,13 +140,16 @@ impl SelectInterpreter {
         .await?;
 
         // consume stream
-        if let Some(req) = query_build_update_stream_req(&self.ctx, &self.metadata).await? {
-            assert!(!req.update_table_metas.is_empty());
+        if let Some(StreamTableUpdates {
+            update_table_metas,
+            table_infos,
+        }) = query_build_update_stream_req(&self.ctx, &self.metadata).await?
+        {
+            assert!(!update_table_metas.is_empty());
 
             // defensively checks that all catalog names are identical
             {
-                let mut iter = req
-                    .update_table_metas
+                let mut iter = update_table_metas
                     .iter()
                     .map(|item| item.new_table_meta.catalog.as_str());
                 let first = iter.next().unwrap();
@@ -158,9 +163,10 @@ impl SelectInterpreter {
                 }
             }
 
-            let catalog_name = req.update_table_metas[0].new_table_meta.catalog.as_str();
+            let catalog_name = update_table_metas[0].new_table_meta.catalog.as_str();
             let catalog = self.ctx.get_catalog(catalog_name).await?;
             let query_id = self.ctx.get_id();
+            let auto_commit = !self.ctx.txn_mgr().lock().is_active();
             build_res.main_pipeline.set_on_finished(
                 move |(_profiles, may_error)| match may_error {
                     Ok(_) => GlobalIORuntime::instance().block_on(async move {
@@ -168,7 +174,26 @@ impl SelectInterpreter {
                             "Updating the stream meta to consume data, query_id: {}",
                             query_id
                         );
-                        catalog.update_multi_table_meta(req).await.map(|_| ())
+
+                        if auto_commit {
+                            info!("(auto) committing stream consumptions");
+                            // commit to meta server directly
+                            let r = UpdateMultiTableMetaReq {
+                                update_table_metas,
+                                copied_files: vec![],
+                                update_stream_metas: vec![],
+                                deduplicated_labels: vec![],
+                            };
+                            catalog.update_multi_table_meta(r).await.map(|_| ())
+                        } else {
+                            info!("(non-auto) committing stream consumptions");
+                            for (req, info) in
+                                update_table_metas.into_iter().zip(table_infos.into_iter())
+                            {
+                                catalog.update_table_meta(&info, req).await?;
+                            }
+                            Ok(())
+                        }
                     }),
                     Err(error_code) => Err(error_code.clone()),
                 },

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -39,6 +39,7 @@ use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::StageFileFormatType;
 use indexmap::IndexMap;
 use log::warn;
+use databend_common_catalog::query_kind::QueryKind;
 
 use super::Finder;
 use crate::binder::util::illegal_ident_name;
@@ -663,6 +664,22 @@ impl<'a> Binder {
                 self.bind_set_priority(priority, object_id).await?
             },
         };
+
+        match plan.kind() {
+            QueryKind::Query { .. } | QueryKind::Explain { .. } => {}
+            _ => {
+                let meta_data_guard = self.metadata.read();
+                let tables = meta_data_guard.tables();
+                for t in tables {
+                    if t.is_consume() {
+                        return Err(ErrorCode::SyntaxException(
+                            "WITH CONSUME only allowed in query",
+                        ));
+                    }
+                }
+            }
+        }
+
         Ok(plan)
     }
 

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -27,6 +27,7 @@ use databend_common_ast::parser::parse_sql;
 use databend_common_ast::parser::tokenize_sql;
 use databend_common_ast::parser::Dialect;
 use databend_common_catalog::catalog::CatalogManager;
+use databend_common_catalog::query_kind::QueryKind;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -39,7 +40,6 @@ use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::StageFileFormatType;
 use indexmap::IndexMap;
 use log::warn;
-use databend_common_catalog::query_kind::QueryKind;
 
 use super::Finder;
 use crate::binder::util::illegal_ident_name;

--- a/src/query/sql/src/planner/binder/insert.rs
+++ b/src/query/sql/src/planner/binder/insert.rs
@@ -37,6 +37,7 @@ use crate::plans::Insert;
 use crate::plans::InsertInputSource;
 use crate::plans::Plan;
 use crate::BindContext;
+
 impl Binder {
     pub fn schema_project(
         &self,

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
@@ -289,8 +289,10 @@ SELECT c FROM s2;
 ----
 
 
+#######################################
+# consume inside explicit transaction #
+#######################################
 
-# consume inside explicit transaction
 
 statement ok
 create or replace table t_1 (
@@ -304,7 +306,7 @@ statement ok
 insert into t_1 (str) values ('a'), ('b');
 
 
-# rollback if txn failed
+# case 1: with consume should rollback-able (implicitly)
 
 onlyif http
 statement ok
@@ -332,8 +334,9 @@ select str from s_1 order by str;
 a
 b
 
+# case 2: with consume should rollback-able (explicitly)
+
 onlyif http
-# explicitly rollback
 statement ok
 begin;
 
@@ -362,11 +365,20 @@ b
 
 
 
+# case 3:  mixed with DMLs
+
 onlyif http
-# repeatable read of stream works
+statement ok
+create table tmp_sink like t_1;
+
+onlyif http
 statement ok
 begin;
 
+# normal dml (without consume, changes should not consumes)
+onlyif http
+statement ok
+insert into tmp_sink select str from s_1;
 
 onlyif http
 query I
@@ -375,21 +387,7 @@ select str from s_1 order by str;
 a
 b
 
-# after the first normal select, changes are still there
-onlyif http
-query I
-select str from s_1 order by str;
-----
-a
-b
-
-onlyif http
-query I
-select str from s_1 with consume order by str;
-----
-a
-b
-
+# and also rollback-able
 onlyif http
 statement ok
 rollback;
@@ -400,6 +398,37 @@ select str from s_1 order by str;
 ----
 a
 b
+
+
+# case 4:  disallows WITH CONSUME inside dml
+
+statement error 1005
+insert into tmp_sink select str from s_1 with consume;
+
+statement error 1005
+copy into tmp_sink select str from s_1 with consume;
+
+# allows explain
+
+# using statement to ignore the result (which may not be deterministic)
+
+statement ok
+explain select str from s_1 with consume;
+
+statement ok
+explain select str from s_1;
+
+# explain should not consume the stream
+onlyif http
+query I
+select str from s_1 order by str;
+----
+a
+b
+
+
+
+
 
 statement ok
 drop database test_txn_stream;

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
@@ -367,7 +367,6 @@ b
 
 # case 3:  mixed with DMLs
 
-onlyif http
 statement ok
 create table tmp_sink like t_1;
 
@@ -425,10 +424,6 @@ select str from s_1 order by str;
 ----
 a
 b
-
-
-
-
 
 statement ok
 drop database test_txn_stream;

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
@@ -288,6 +288,119 @@ query I
 SELECT c FROM s2;
 ----
 
+
+
+# consume inside explicit transaction
+
+statement ok
+create or replace table t_1 (
+  str varchar
+);
+
+statement ok
+create or replace stream s_1 on table t_1 append_only = true;
+
+statement ok
+insert into t_1 (str) values ('a'), ('b');
+
+
+# rollback if txn failed
+
+onlyif http
+statement ok
+begin;
+
+onlyif http
+query I
+select str from s_1 with consume order by str;
+----
+a
+b
+
+onlyif http
+statement error 1006
+select 1/0;
+
+onlyif http
+statement ok
+commit;
+
+onlyif http
+query I
+select str from s_1 order by str;
+----
+a
+b
+
+onlyif http
+# explicitly rollback
+statement ok
+begin;
+
+onlyif http
+query I
+select str from s_1 with consume order by str;
+----
+a
+b
+
+# inside txn, s_1 is consumed, expects empty result set
+onlyif http
+query I
+select str from s_1;
+
+onlyif http
+statement ok
+rollback;
+
+onlyif http
+query I
+select str from s_1 order by str;
+----
+a
+b
+
+
+
+onlyif http
+# repeatable read of stream works
+statement ok
+begin;
+
+
+onlyif http
+query I
+select str from s_1 order by str;
+----
+a
+b
+
+# after the first normal select, changes are still there
+onlyif http
+query I
+select str from s_1 order by str;
+----
+a
+b
+
+onlyif http
+query I
+select str from s_1 with consume order by str;
+----
+a
+b
+
+onlyif http
+statement ok
+rollback;
+
+onlyif http
+query I
+select str from s_1 order by str;
+----
+a
+b
+
 statement ok
 drop database test_txn_stream;
 

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
@@ -453,6 +453,54 @@ select str from s_1 order by str;
 a
 b
 
+onlyif http
+statement ok
+create or replace table target_1 (
+  str varchar
+);
+
+onlyif http
+statement ok
+create or replace table target_2 (
+  str varchar
+);
+
+onlyif http
+statement ok
+begin;
+
+onlyif http
+statement ok
+insert into target_1 select str from s_1;
+
+onlyif http
+query I
+select str from s_1 with consume order by str;
+----
+a
+b
+
+onlyif http
+statement ok
+insert into target_2 select str from s_1;
+
+onlyif http
+statement ok
+commit;
+
+onlyif http
+query I
+select str from target_1 order by str;
+----
+a
+b
+
+onlyif http
+query I
+select str from target_2 order by str;
+----
+
+
 statement ok
 drop database test_txn_stream;
 

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
@@ -374,32 +374,60 @@ onlyif http
 statement ok
 begin;
 
-# normal dml (without consume, changes should not consumes)
+# normal dml
+onlyif http
+statement ok
+insert into tmp_sink select str from s_1;
+
+# changes should not be consumed
+onlyif http
+query I
+select str from s_1 order by str;
+----
+a
+b
+
+# but changes should be captured by insert stmt
+onlyif http
+query I
+select count() from tmp_sink
+----
+2
+
+# dml and stream consume
+
+onlyif http
+statement ok
+select str from s_1 with consume;
+
+onlyif http
+statement ok
+truncate table tmp_sink;
+
 onlyif http
 statement ok
 insert into tmp_sink select str from s_1;
 
 onlyif http
 query I
-select str from s_1 order by str;
+select count() from tmp_sink
 ----
-a
-b
+0
 
-# and also rollback-able
 onlyif http
 statement ok
-rollback;
+commit;
 
 onlyif http
 query I
 select str from s_1 order by str;
 ----
-a
-b
 
 
 # case 4:  disallows WITH CONSUME inside dml
+
+statement ok
+insert into t_1 (str) values ('a'), ('b');
 
 statement error 1005
 insert into tmp_sink select str from s_1 with consume;

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0002_stream_txn_consume.test
@@ -308,26 +308,21 @@ insert into t_1 (str) values ('a'), ('b');
 
 # case 1: with consume should rollback-able (implicitly)
 
-onlyif http
 statement ok
 begin;
 
-onlyif http
 query I
 select str from s_1 with consume order by str;
 ----
 a
 b
 
-onlyif http
 statement error 1006
 select 1/0;
 
-onlyif http
 statement ok
 commit;
 
-onlyif http
 query I
 select str from s_1 order by str;
 ----
@@ -336,11 +331,9 @@ b
 
 # case 2: with consume should rollback-able (explicitly)
 
-onlyif http
 statement ok
 begin;
 
-onlyif http
 query I
 select str from s_1 with consume order by str;
 ----
@@ -348,15 +341,12 @@ a
 b
 
 # inside txn, s_1 is consumed, expects empty result set
-onlyif http
 query I
 select str from s_1;
 
-onlyif http
 statement ok
 rollback;
 
-onlyif http
 query I
 select str from s_1 order by str;
 ----
@@ -370,17 +360,14 @@ b
 statement ok
 create table tmp_sink like t_1;
 
-onlyif http
 statement ok
 begin;
 
 # normal dml
-onlyif http
 statement ok
 insert into tmp_sink select str from s_1;
 
 # changes should not be consumed
-onlyif http
 query I
 select str from s_1 order by str;
 ----
@@ -388,7 +375,6 @@ a
 b
 
 # but changes should be captured by insert stmt
-onlyif http
 query I
 select count() from tmp_sink
 ----
@@ -396,29 +382,23 @@ select count() from tmp_sink
 
 # dml and stream consume
 
-onlyif http
 statement ok
 select str from s_1 with consume;
 
-onlyif http
 statement ok
 truncate table tmp_sink;
 
-onlyif http
 statement ok
 insert into tmp_sink select str from s_1;
 
-onlyif http
 query I
 select count() from tmp_sink
 ----
 0
 
-onlyif http
 statement ok
 commit;
 
-onlyif http
 query I
 select str from s_1 order by str;
 ----
@@ -446,56 +426,46 @@ statement ok
 explain select str from s_1;
 
 # explain should not consume the stream
-onlyif http
 query I
 select str from s_1 order by str;
 ----
 a
 b
 
-onlyif http
 statement ok
 create or replace table target_1 (
   str varchar
 );
 
-onlyif http
 statement ok
 create or replace table target_2 (
   str varchar
 );
 
-onlyif http
 statement ok
 begin;
 
-onlyif http
 statement ok
 insert into target_1 select str from s_1;
 
-onlyif http
 query I
 select str from s_1 with consume order by str;
 ----
 a
 b
 
-onlyif http
 statement ok
 insert into target_2 select str from s_1;
 
-onlyif http
 statement ok
 commit;
 
-onlyif http
 query I
 select str from target_1 order by str;
 ----
 a
 b
 
-onlyif http
 query I
 select str from target_2 order by str;
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- The consuming (`with consume`) of stream should respect the semantics of transactions: if  transaction is aborted, the stream should roll back to its original state.

- Only the usage of `WITH CONSUME` in queries is allowed. Statements like `INSERT INTO t SELECT * FROM s WITH CONSUME` will fail with errors.


- Fixes #15581

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15582)
<!-- Reviewable:end -->
