### PR TITLE
chore: fix error capture of mulit statement transaction in mysql session

### DIFF
--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -226,6 +226,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for InteractiveWorke
             let mut write_result = writer.write(query_result, &format).await;
 
             if let Err(cause) = write_result {
+                self.base.session.txn_mgr().lock().set_fail();
                 let suffix = format!("(while in query {})", query);
                 write_result = Err(cause.add_message_back(suffix));
             }

--- a/src/query/service/src/servers/mysql/writers/query_result_writer.rs
+++ b/src/query/service/src/servers/mysql/writers/query_result_writer.rs
@@ -132,6 +132,7 @@ impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
             while let Some(block) = blocks.next().await {
                 if let Err(e) = block {
                     error!("dataset write failed: {:?}", e);
+                    self.session.txn_mgr().lock().set_fail();
                     dataset_writer
                         .error(
                             ErrorKind::ER_UNKNOWN_ERROR,
@@ -220,6 +221,7 @@ impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
                     let block = match block {
                         Err(e) => {
                             error!("result row write failed: {:?}", e);
+                            self.session.txn_mgr().lock().set_fail();
                             row_writer
                                 .finish_error(
                                     ErrorKind::ER_UNKNOWN_ERROR,

--- a/tests/sqllogictests/suites/base/14_transaction/14_0004_rollback.test
+++ b/tests/sqllogictests/suites/base/14_transaction/14_0004_rollback.test
@@ -16,3 +16,43 @@ commit;
 query I
 select * from t_1;
 ----
+
+
+statement ok
+create or replace table t_1 (str varchar);
+
+statement ok
+begin;
+
+statement ok
+insert into t_1 (str) values ('a'), ('b');
+
+statement error
+1;
+
+statement ok
+commit;
+
+query I
+select * from t_1;
+----
+
+
+statement ok
+create or replace table t_1 (str varchar);
+
+statement ok
+begin;
+
+statement ok
+insert into t_1 (str) values ('a'), ('b');
+
+statement error
+select nonexistent from t_1;
+
+statement ok
+commit;
+
+query I
+select * from t_1;
+----

--- a/tests/sqllogictests/suites/base/14_transaction/14_0004_rollback.test
+++ b/tests/sqllogictests/suites/base/14_transaction/14_0004_rollback.test
@@ -1,0 +1,18 @@
+statement ok
+create or replace table t_1 (str varchar);
+
+statement ok
+begin;
+
+statement ok
+insert into t_1 (str) values ('a'), ('b');
+
+statement error
+select 1/0;
+
+statement ok
+commit;
+
+query I
+select * from t_1;
+----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
MySQL implementation did not capture all errors, resulting in transactions not being rolled back when errors occurred.

- Fixes #15584

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15583)
<!-- Reviewable:end -->
