### PR TITLE
refactor: Remove `install_snapshot` v0 meta-service API

### DIFF
--- a/src/meta/README.md
+++ b/src/meta/README.md
@@ -96,10 +96,13 @@ History versions that are not included in the above chart:
 
 ## Compatibility between databend-meta
 
-| Meta version      | Backward compatible with |
-|:------------------|:-------------------------|
-| [0.9.41, 1.2.212) | [0.9.41, 1.2.212)        |
-| [1.2.212, +∞)     | [0.9.41, +∞)             |
+| Meta version         | Backward compatible with |
+|:---------------------|:-------------------------|
+| [0.9.41,   1.2.212)  | [0.9.41,  1.2.212)       |
+| [1.2.212,  1.2.476?) | [0.9.41,  1.2.476?)      |
+| [1.2.476?, +∞)       | [1.2.212, +∞)            |
+
+TODO: fix the above version when merged
 
 
 - `1.2.53` Incompatible, rolling upgrade is allowed without snapshot transmitting.
@@ -113,6 +116,9 @@ History versions that are not included in the above chart:
   In this version, databend-meta raft-server introduced a new API `install_snapshot_v1()`.
   The raft-client will try to use either this new API or the original `install_snapshot()`.
 
+- `1.2.476?` Remove: `install_snapshot()`(v0) from client and server.
+  The `install_snapshot_v1()` is the only API to install snapshot, and becomes **REQUIRED** for the client.
+    
 
 ## Compatibility of databend-meta on-disk data
 

--- a/src/meta/service/src/version.rs
+++ b/src/meta/service/src/version.rs
@@ -99,6 +99,7 @@ pub static MIN_META_SEMVER: Version = Version::new(0, 9, 41);
 pub(crate) mod raft {
     pub(crate) mod server {
         use feature_set::add_provide;
+        use feature_set::del_provide;
         use feature_set::Action;
         use feature_set::Provide;
 
@@ -113,6 +114,8 @@ pub(crate) mod raft {
             add_provide(("install_snapshot", 0), "2023-02-16", (0,  9,  41)),
             add_provide(("install_snapshot", 1), "2023-11-16", (1,  2, 212)),
             add_provide(("install_snapshot", 2), "2024-05-06", (1,  2, 453)),
+            // TODO: fix date and version when merged.
+            del_provide(("install_snapshot", 0), "2024-05-20", (1,  2, 476)),
         ];
 
         /// The client features that raft server depends on.
@@ -125,6 +128,7 @@ pub(crate) mod raft {
     pub(crate) mod client {
         use feature_set::add_optional;
         use feature_set::add_require;
+        use feature_set::del_require;
         use feature_set::Action;
         use feature_set::Require;
 
@@ -138,6 +142,9 @@ pub(crate) mod raft {
             add_require( ("append",           0), "2023-02-16", (0,  9,  41)),
             add_require( ("install_snapshot", 0), "2023-02-16", (0,  9,  41)),
             add_optional(("install_snapshot", 1), "2023-11-16", (1,  2, 212)),
+            // TODO: fix date and version when merged.
+            add_require( ("install_snapshot", 1), "2023-05-20", (1,  2, 476)),
+            del_require( ("install_snapshot", 0), "2024-05-20", (1,  2, 476)),
         ];
 
         /// Feature set provided by raft client.

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -243,7 +243,6 @@ service RaftService {
   // raft RPC
 
   rpc AppendEntries(RaftRequest) returns (RaftReply);
-  rpc InstallSnapshot(RaftRequest) returns (RaftReply);
   rpc InstallSnapshotV1(SnapshotChunkRequest) returns (RaftReply);
   rpc InstallSnapshotV2(stream SnapshotChunkRequestV2) returns (RaftReply);
   rpc Vote(RaftRequest) returns (RaftReply);

--- a/src/meta/types/src/grpc_helper.rs
+++ b/src/meta/types/src/grpc_helper.rs
@@ -124,7 +124,7 @@ impl GrpcHelper {
     ) -> Result<Result<T, RaftError<E>>, serde_json::Error>
     where
         T: serde::de::DeserializeOwned,
-        E: serde::Serialize + serde::de::DeserializeOwned,
+        E: serde::de::DeserializeOwned,
     {
         let raft_reply = reply.into_inner();
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Remove `install_snapshot` v0 meta-service API

**Compatibility Changes:**

This commit introduces changes to inter-meta-service compatibility,
although compatibility between databend-query and meta-service
remains unaffected.

**Details:**

- The initial snapshot transmission API, `install_snapshot` (v0), has
  been removed from both the meta server and meta client sides.

- For clients, the use of `install_snapshot_v1()` transitions from
  **OPTIONAL** to **REQUIRED**.

**Version Requirements:**

- Post this commit, the meta-server requires clients to be at least
  version `1.2.212`, starting from which the clients began using
  `install_snapshot_v1()`.

- Similarly, clients require the server to be at least version
  `1.2.212`, which is the version where `install_snapshot_v1()` becomes
  available.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15590)
<!-- Reviewable:end -->
