### PR TITLE
feat(metrics): add process collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,6 +2806,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "pprof",
+ "procfs 0.16.0",
  "prometheus-client",
  "prometheus-parse",
  "rand 0.8.5",
@@ -11111,6 +11112,32 @@ dependencies = [
  "hex",
  "lazy_static",
  "rustix 0.36.17",
+]
+
+[[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.4.2",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.31",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.4.2",
+ "chrono",
+ "hex",
 ]
 
 [[package]]

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -58,6 +58,9 @@ tikv-jemalloc-sys = "0.5.2"
 tokio = { workspace = true }
 uuid = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = { version = "^0.16" }
+
 [dev-dependencies]
 anyerror = { workspace = true }
 anyhow = { workspace = true }

--- a/src/common/base/src/runtime/metrics/mod.rs
+++ b/src/common/base/src/runtime/metrics/mod.rs
@@ -26,6 +26,7 @@ pub use gauge::Gauge;
 pub use histogram::Histogram;
 pub use histogram::BUCKET_MILLISECONDS;
 pub use histogram::BUCKET_SECONDS;
+pub use process_collector::dump_process_stat;
 pub use registry::register_counter;
 pub use registry::register_counter_family;
 pub use registry::register_gauge;

--- a/src/common/base/src/runtime/metrics/mod.rs
+++ b/src/common/base/src/runtime/metrics/mod.rs
@@ -17,6 +17,7 @@ mod family;
 mod family_metrics;
 mod gauge;
 mod histogram;
+mod process_collector;
 mod registry;
 mod sample;
 

--- a/src/common/base/src/runtime/metrics/process_collector.rs
+++ b/src/common/base/src/runtime/metrics/process_collector.rs
@@ -22,14 +22,14 @@ impl Collector for ProcessCollector {
             None => return Ok(()),
         };
 
-        let cpu_total = ConstCounter::new(stat.cpu_total);
-        let cpu_total_encoder = encoder.encode_descriptor(
+        let cpu_secs = ConstCounter::new(stat.cpu_secs);
+        let cpu_secs_encoder = encoder.encode_descriptor(
             "process_cpu_seconds_total",
             "Total user and system CPU time spent in seconds.",
             None,
-            cpu_total.metric_type(),
+            cpu_secs.metric_type(),
         )?;
-        cpu_total.encode(cpu_total_encoder)?;
+        cpu_secs.encode(cpu_secs_encoder)?;
 
         let open_fds = ConstGauge::new(stat.open_fds as f64);
         let open_fds_encoder = encoder.encode_descriptor(
@@ -91,7 +91,7 @@ impl Collector for ProcessCollector {
 
 #[derive(Clone, Default)]
 pub struct ProcessStat {
-    pub cpu_total: u64,
+    pub cpu_secs: u64,
     pub open_fds: u64,
     pub max_fds: u64,
     pub vsize: u64,
@@ -147,7 +147,7 @@ fn dump_linux_process_stat() -> Option<ProcessStat> {
     let rss = stat.rss * (page_size as u64);
 
     // cpu time
-    let cpu_total = (stat.utime + stat.stime) / clk_tck as u64;
+    let cpu_secs = (stat.utime + stat.stime) / clk_tck as u64;
 
     // start time
     let start_time = stat.starttime as i64 * clk_tck;
@@ -160,7 +160,7 @@ fn dump_linux_process_stat() -> Option<ProcessStat> {
         max_fds,
         vsize,
         rss,
-        cpu_total,
+        cpu_secs,
         start_time,
         threads_num,
     })

--- a/src/common/base/src/runtime/metrics/process_collector.rs
+++ b/src/common/base/src/runtime/metrics/process_collector.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use prometheus_client::collector::Collector;
 use prometheus_client::encoding::EncodeMetric;
 use prometheus_client::metrics::counter::ConstCounter;

--- a/src/common/base/src/runtime/metrics/process_collector.rs
+++ b/src/common/base/src/runtime/metrics/process_collector.rs
@@ -7,8 +7,8 @@ use prometheus_client::metrics::gauge::ConstGauge;
 pub struct ProcessCollector {}
 
 impl ProcessCollector {
-    pub fn new() -> Self {
-        ProcessCollector {}
+    pub fn new() -> Box<Self> {
+        Box::new(ProcessCollector {})
     }
 }
 

--- a/src/common/base/src/runtime/metrics/process_collector.rs
+++ b/src/common/base/src/runtime/metrics/process_collector.rs
@@ -1,0 +1,76 @@
+use std::time;
+
+use prometheus_client::collector::Collector;
+
+struct ProcessCollector {}
+
+impl Collector for ProcessCollector {
+    fn encode(
+        &self,
+        encoder: prometheus_client::encoding::DescriptorEncoder,
+    ) -> Result<(), std::fmt::Error> {
+        todo!()
+    }
+}
+
+#[derive(Clone, Default)]
+struct ProcessStat {
+    cpu_total: u64,
+    open_fds: u64,
+    max_fds: u64,
+    vsize: u64,
+    rss: u64,
+    start_time: i64,
+    threads_num: usize,
+}
+
+static CLK_TCK: LazyLock<i64> =
+    LazyLock::new(|| unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.into());
+
+static PAGESIZE: LazyLock<i64> =
+    LazyLock::new(|| unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.into());
+
+fn dump_process_stat() -> Option<ProcessStat> {
+    let p = match procfs::process::Process::myself() {
+        Ok(p) => p,
+        Err(_) => {
+            return None;
+        }
+    };
+    let stat = match proc.stat() {
+        Ok(stat) => stat,
+        Err(_) => {
+            return None;
+        }
+    };
+
+    // fds
+    let open_fds = proc.fd_count().unwrap_or(0) as u64;
+    let max_fds = match p.limits().unwrap_or_default().max_open_files.soft_limit {
+        procfs::process::LimitValue::Value(v) => v,
+        procfs::process::LimitValue::Unlimited => 0,
+    };
+
+    // memory
+    let vsize = stat.vsize;
+    let rss = stat.rss * *PAGESIZE;
+
+    // cpu time
+    let cpu_total = (stat.utime + stat.stime) / *CLK_TCK as u64;
+
+    // start time
+    let start_time = stat.starttime as i64 * *CLK_TCK;
+
+    // threads
+    let threads_num = stat.num_threads;
+
+    Self {
+        open_fds,
+        max_fds,
+        vsize,
+        rss,
+        cpu_total,
+        start_time,
+        threads_num,
+    }
+}

--- a/src/common/base/src/runtime/metrics/process_collector.rs
+++ b/src/common/base/src/runtime/metrics/process_collector.rs
@@ -1,12 +1,16 @@
-use std::sync::LazyLock;
-
 use prometheus_client::collector::Collector;
 use prometheus_client::encoding::EncodeMetric;
 use prometheus_client::metrics::counter::ConstCounter;
 use prometheus_client::metrics::gauge::ConstGauge;
 
 #[derive(Debug)]
-struct ProcessCollector {}
+pub struct ProcessCollector {}
+
+impl ProcessCollector {
+    pub fn new() -> Self {
+        ProcessCollector {}
+    }
+}
 
 impl Collector for ProcessCollector {
     fn encode(
@@ -86,17 +90,17 @@ impl Collector for ProcessCollector {
 }
 
 #[derive(Clone, Default)]
-struct ProcessStat {
-    cpu_total: u64,
-    open_fds: u64,
-    max_fds: u64,
-    vsize: u64,
-    rss: u64,
-    start_time: i64,
-    threads_num: usize,
+pub struct ProcessStat {
+    pub cpu_total: u64,
+    pub open_fds: u64,
+    pub max_fds: u64,
+    pub vsize: u64,
+    pub rss: u64,
+    pub start_time: i64,
+    pub threads_num: usize,
 }
 
-fn dump_process_stat() -> Option<ProcessStat> {
+pub fn dump_process_stat() -> Option<ProcessStat> {
     #[cfg(target_os = "linux")]
     {
         return dump_linux_process_stat();

--- a/src/common/base/src/runtime/metrics/process_collector.rs
+++ b/src/common/base/src/runtime/metrics/process_collector.rs
@@ -103,7 +103,7 @@ pub struct ProcessStat {
 pub fn dump_process_stat() -> Option<ProcessStat> {
     #[cfg(target_os = "linux")]
     {
-        return dump_linux_process_stat();
+        dump_linux_process_stat()
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -128,8 +128,8 @@ fn dump_linux_process_stat() -> Option<ProcessStat> {
     };
 
     // constants
-    let clk_tck: i64 = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.into();
-    let page_size: i64 = unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.into();
+    let clk_tck: i64 = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    let page_size: i64 = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
 
     // fds
     let open_fds = proc.fd_count().unwrap_or(0) as u64;

--- a/src/common/base/src/runtime/metrics/process_collector.rs
+++ b/src/common/base/src/runtime/metrics/process_collector.rs
@@ -1,15 +1,87 @@
-use std::time;
+use std::sync::LazyLock;
 
 use prometheus_client::collector::Collector;
+use prometheus_client::encoding::EncodeMetric;
+use prometheus_client::metrics::counter::ConstCounter;
+use prometheus_client::metrics::gauge::ConstGauge;
 
+#[derive(Debug)]
 struct ProcessCollector {}
 
 impl Collector for ProcessCollector {
     fn encode(
         &self,
-        encoder: prometheus_client::encoding::DescriptorEncoder,
+        mut encoder: prometheus_client::encoding::DescriptorEncoder,
     ) -> Result<(), std::fmt::Error> {
-        todo!()
+        let stat = match dump_process_stat() {
+            Some(stat) => stat,
+            None => return Ok(()),
+        };
+
+        let cpu_total = ConstCounter::new(stat.cpu_total);
+        let cpu_total_encoder = encoder.encode_descriptor(
+            "process_cpu_seconds_total",
+            "Total user and system CPU time spent in seconds.",
+            None,
+            cpu_total.metric_type(),
+        )?;
+        cpu_total.encode(cpu_total_encoder)?;
+
+        let open_fds = ConstGauge::new(stat.open_fds as f64);
+        let open_fds_encoder = encoder.encode_descriptor(
+            "process_open_fds",
+            "Number of open file descriptors.",
+            None,
+            open_fds.metric_type(),
+        )?;
+        open_fds.encode(open_fds_encoder)?;
+
+        let max_fds = ConstGauge::new(stat.max_fds as f64);
+        let max_fds_encoder = encoder.encode_descriptor(
+            "process_max_fds",
+            "Maximum number of open file descriptors.",
+            None,
+            max_fds.metric_type(),
+        )?;
+        max_fds.encode(max_fds_encoder)?;
+
+        let vsize = ConstGauge::new(stat.vsize as f64);
+        let vsize_encoder = encoder.encode_descriptor(
+            "process_virtual_memory_bytes",
+            "Virtual memory size in bytes.",
+            None,
+            vsize.metric_type(),
+        )?;
+        vsize.encode(vsize_encoder)?;
+
+        let rss = ConstGauge::new(stat.rss as f64);
+        let rss_encoder = encoder.encode_descriptor(
+            "process_resident_memory_bytes",
+            "Resident memory size in bytes.",
+            None,
+            rss.metric_type(),
+        )?;
+        rss.encode(rss_encoder)?;
+
+        let start_time = ConstGauge::new(stat.start_time as f64);
+        let start_time_encoder = encoder.encode_descriptor(
+            "process_start_time_seconds",
+            "Start time of the process since unix epoch in seconds.",
+            None,
+            start_time.metric_type(),
+        )?;
+        start_time.encode(start_time_encoder)?;
+
+        let threads_num = ConstGauge::new(stat.threads_num as f64);
+        let threads_num_encoder = encoder.encode_descriptor(
+            "process_threads",
+            "Number of OS threads in the process.",
+            None,
+            threads_num.metric_type(),
+        )?;
+        threads_num.encode(threads_num_encoder)?;
+
+        Ok(())
     }
 }
 
@@ -24,14 +96,21 @@ struct ProcessStat {
     threads_num: usize,
 }
 
-static CLK_TCK: LazyLock<i64> =
-    LazyLock::new(|| unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.into());
-
-static PAGESIZE: LazyLock<i64> =
-    LazyLock::new(|| unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.into());
-
 fn dump_process_stat() -> Option<ProcessStat> {
-    let p = match procfs::process::Process::myself() {
+    #[cfg(target_os = "linux")]
+    {
+        return dump_linux_process_stat();
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn dump_linux_process_stat() -> Option<ProcessStat> {
+    let proc = match procfs::process::Process::myself() {
         Ok(p) => p,
         Err(_) => {
             return None;
@@ -44,27 +123,35 @@ fn dump_process_stat() -> Option<ProcessStat> {
         }
     };
 
+    // constants
+    let clk_tck: i64 = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.into();
+    let page_size: i64 = unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.into();
+
     // fds
     let open_fds = proc.fd_count().unwrap_or(0) as u64;
-    let max_fds = match p.limits().unwrap_or_default().max_open_files.soft_limit {
-        procfs::process::LimitValue::Value(v) => v,
-        procfs::process::LimitValue::Unlimited => 0,
+    let max_fds = if let Ok(limits) = proc.limits() {
+        match limits.max_open_files.soft_limit {
+            procfs::process::LimitValue::Value(v) => v,
+            procfs::process::LimitValue::Unlimited => 0,
+        }
+    } else {
+        0
     };
 
     // memory
     let vsize = stat.vsize;
-    let rss = stat.rss * *PAGESIZE;
+    let rss = stat.rss * (page_size as u64);
 
     // cpu time
-    let cpu_total = (stat.utime + stat.stime) / *CLK_TCK as u64;
+    let cpu_total = (stat.utime + stat.stime) / clk_tck as u64;
 
     // start time
-    let start_time = stat.starttime as i64 * *CLK_TCK;
+    let start_time = stat.starttime as i64 * clk_tck;
 
     // threads
-    let threads_num = stat.num_threads;
+    let threads_num = stat.num_threads as usize;
 
-    Self {
+    Some(ProcessStat {
         open_fds,
         max_fds,
         vsize,
@@ -72,5 +159,5 @@ fn dump_process_stat() -> Option<ProcessStat> {
         cpu_total,
         start_time,
         threads_num,
-    }
+    })
 }

--- a/src/common/base/src/runtime/metrics/registry.rs
+++ b/src/common/base/src/runtime/metrics/registry.rs
@@ -26,6 +26,7 @@ use parking_lot::RwLock;
 use prometheus_client::registry::Metric as PMetrics;
 use prometheus_client::registry::Registry;
 
+use super::process_collector::ProcessCollector;
 use crate::runtime::metrics::counter::Counter;
 use crate::runtime::metrics::family::Family;
 use crate::runtime::metrics::family::FamilyCounterCreator as InnerFamilyCounterCreator;
@@ -85,10 +86,12 @@ unsafe impl Sync for GlobalRegistry {}
 
 impl GlobalRegistry {
     pub fn create() -> GlobalRegistry {
+        let registry = Registry::with_prefix("databend");
+        registry.register_collector(ProcessCollector::new());
         GlobalRegistry {
             inner: Mutex::new(GlobalRegistryInner {
                 metrics: vec![],
-                registry: Registry::with_prefix("databend"),
+                registry,
             }),
         }
     }

--- a/src/common/base/src/runtime/metrics/registry.rs
+++ b/src/common/base/src/runtime/metrics/registry.rs
@@ -26,7 +26,6 @@ use parking_lot::RwLock;
 use prometheus_client::registry::Metric as PMetrics;
 use prometheus_client::registry::Registry;
 
-use super::process_collector::ProcessCollector;
 use crate::runtime::metrics::counter::Counter;
 use crate::runtime::metrics::family::Family;
 use crate::runtime::metrics::family::FamilyCounterCreator as InnerFamilyCounterCreator;
@@ -40,6 +39,7 @@ use crate::runtime::metrics::gauge::Gauge;
 use crate::runtime::metrics::histogram::Histogram;
 use crate::runtime::metrics::histogram::BUCKET_MILLISECONDS;
 use crate::runtime::metrics::histogram::BUCKET_SECONDS;
+use crate::runtime::metrics::process_collector::ProcessCollector;
 use crate::runtime::metrics::sample::MetricSample;
 use crate::runtime::ThreadTracker;
 

--- a/src/common/base/src/runtime/metrics/registry.rs
+++ b/src/common/base/src/runtime/metrics/registry.rs
@@ -86,7 +86,7 @@ unsafe impl Sync for GlobalRegistry {}
 
 impl GlobalRegistry {
     pub fn create() -> GlobalRegistry {
-        let registry = Registry::with_prefix("databend");
+        let mut registry = Registry::with_prefix("databend");
         registry.register_collector(ProcessCollector::new());
         GlobalRegistry {
             inner: Mutex::new(GlobalRegistryInner {

--- a/src/query/service/tests/it/metrics.rs
+++ b/src/query/service/tests/it/metrics.rs
@@ -57,4 +57,5 @@ fn test_process_collector() {
     assert!(stat.max_fds > 0);
     assert!(stat.vsize > 0);
     assert!(stat.rss > 0);
+    assert!(stat.threads_num > 0);
 }

--- a/src/query/service/tests/it/metrics.rs
+++ b/src/query/service/tests/it/metrics.rs
@@ -54,7 +54,6 @@ async fn test_metric_server() -> databend_common_exception::Result<()> {
 fn test_process_collector() {
     let stat = dump_process_stat().unwrap();
 
-    assert!(stat.cpu_secs > 0.0);
     assert!(stat.max_fds > 0);
     assert!(stat.vsize > 0);
     assert!(stat.rss > 0);

--- a/src/query/service/tests/it/metrics.rs
+++ b/src/query/service/tests/it/metrics.rs
@@ -54,6 +54,7 @@ async fn test_metric_server() -> databend_common_exception::Result<()> {
 fn test_process_collector() {
     let stat = dump_process_stat().unwrap();
 
+    assert!(stat.cpu_secs > 0.0);
     assert!(stat.max_fds > 0);
     assert!(stat.vsize > 0);
     assert!(stat.rss > 0);

--- a/src/query/service/tests/it/metrics.rs
+++ b/src/query/service/tests/it/metrics.rs
@@ -15,6 +15,7 @@
 use std::net::SocketAddr;
 
 use databend_common_base::base::tokio;
+use databend_common_base::runtime::metrics::dump_process_stat;
 use databend_common_base::runtime::metrics::register_counter;
 use databend_query::servers::metrics::MetricService;
 use databend_query::servers::Server;
@@ -46,4 +47,14 @@ async fn test_metric_server() -> databend_common_exception::Result<()> {
     assert!(output.contains("unit_test_counter_total 1"));
 
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_process_collector() {
+    let stat = dump_process_stat().unwrap();
+
+    assert!(stat.max_fds > 0);
+    assert!(stat.vsize > 0);
+    assert!(stat.rss > 0);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fixes #15538

this PR adds the following process metrics, they're considered as the standard process metrics:

```
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 138100.24
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 26
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 3.7982208e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.70893894953e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.346695168e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
```

as `prometheus/rust-client` still has not builtin support for process collector, this PR adds a vanilla implementation which only works in linux. we can switch to the builtin implementation after https://github.com/prometheus/client_rust/issues/29 got resolved.

## Tests

- [x] Unit Test


## Type of change

- [x] Other (please describe): metrics improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15591)
<!-- Reviewable:end -->
