### PR TITLE
feat(metasrv): add metrics for db_size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4917,7 +4917,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-functions",
  "databend-storages-common-table-meta",
- "jsonb 0.3.0 (git+https://github.com/datafuselabs/jsonb?rev=3fe3acd)",
+ "jsonb",
  "log",
  "match-template",
  "minitrace",
@@ -9656,9 +9656,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccdc1fe2bb3ef97e07ba4397327ed45509a1e2e499e2f8265243879cbc7313c"
+checksum = "d1e52cf194ab414202ead9dfda216d2a9ec59cc97ac024ba499ca686d82f040d"
 dependencies = [
  "base64 0.21.7",
  "bigdecimal",

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -507,11 +507,9 @@ impl MetaNode {
                 let mm = metrics_rx.borrow().clone();
 
                 // Report metrics about server state and role.
-
                 server_metrics::set_node_is_health(
                     mm.state == ServerState::Follower || mm.state == ServerState::Leader,
                 );
-
                 if mm.current_leader.is_some() && mm.current_leader != last_leader {
                     server_metrics::incr_leader_change();
                 }
@@ -519,11 +517,14 @@ impl MetaNode {
                 server_metrics::set_is_leader(mm.current_leader == Some(meta_node.sto.id));
 
                 // metrics about raft log and state machine.
-
                 server_metrics::set_current_term(mm.current_term);
                 server_metrics::set_last_log_index(mm.last_log_index.unwrap_or_default());
                 server_metrics::set_proposals_applied(mm.last_applied.unwrap_or_default().index);
                 server_metrics::set_last_seq(meta_node.get_last_seq().await);
+
+                // metrics about server storage
+                server_metrics::set_db_size(meta_node.get_db_size().unwrap_or_default());
+                server_metrics::set_snapshot_key_num(meta_node.get_key_num().await);
 
                 last_leader = mm.current_leader;
             }
@@ -895,6 +896,22 @@ impl MetaNode {
         nodes
     }
 
+    fn get_db_size(&self) -> Result<u64, MetaError> {
+        self.sto.db.size_on_disk().map_err(|e| {
+            let se = MetaStorageError::SledError(AnyError::new(&e).add_context(|| "get db_size"));
+            MetaError::StorageError(se)
+        })
+    }
+
+    async fn get_key_num(&self) -> u64 {
+        let snapshot_info = self.sto.try_get_snapshot_info().await;
+        if let Some((id, _)) = snapshot_info {
+            id.key_num.unwrap_or_default()
+        } else {
+            0
+        }
+    }
+
     pub async fn get_status(&self) -> Result<MetaNodeStatus, MetaError> {
         let voters = self
             .sto
@@ -908,20 +925,8 @@ impl MetaNode {
 
         let endpoint = self.sto.get_node_raft_endpoint(&self.sto.id).await?;
 
-        let db_size = self.sto.db.size_on_disk().map_err(|e| {
-            let se = MetaStorageError::SledError(AnyError::new(&e).add_context(|| "get db_size"));
-            MetaError::StorageError(se)
-        })?;
-
-        let key_num = {
-            let snapshot_info = self.sto.try_get_snapshot_info().await;
-
-            if let Some((id, _)) = snapshot_info {
-                id.key_num.unwrap_or_default()
-            } else {
-                0
-            }
-        };
+        let db_size = self.get_db_size()?;
+        let key_num = self.get_key_num().await;
 
         let metrics = self.raft.metrics().borrow().clone();
 

--- a/src/meta/service/src/metrics/meta_metrics.rs
+++ b/src/meta/service/src/metrics/meta_metrics.rs
@@ -52,6 +52,7 @@ pub mod server_metrics {
         leader_changes: Counter,
         applying_snapshot: Gauge,
         snapshot_key_num: Gauge,
+        db_size: Gauge,
         last_log_index: Gauge,
         last_seq: Gauge,
         current_term: Gauge,
@@ -72,6 +73,7 @@ pub mod server_metrics {
                 leader_changes: Counter::default(),
                 applying_snapshot: Gauge::default(),
                 snapshot_key_num: Gauge::default(),
+                db_size: Gauge::default(),
                 last_log_index: Gauge::default(),
                 last_seq: Gauge::default(),
                 current_term: Gauge::default(),
@@ -110,6 +112,7 @@ pub mod server_metrics {
                 "snapshot key numbers",
                 metrics.snapshot_key_num.clone(),
             );
+            registry.register(key!("db_size"), "db size", metrics.db_size.clone());
             registry.register(
                 key!("proposals_applied"),
                 "proposals applied",
@@ -170,8 +173,12 @@ pub mod server_metrics {
         SERVER_METRICS.applying_snapshot.inc_by(cnt);
     }
 
-    pub fn set_snapshot_key_num(snapshot_key_num: i64) {
-        SERVER_METRICS.snapshot_key_num.set(snapshot_key_num);
+    pub fn set_snapshot_key_num(snapshot_key_num: u64) {
+        SERVER_METRICS.snapshot_key_num.set(snapshot_key_num as i64);
+    }
+
+    pub fn set_db_size(db_size: u64) {
+        SERVER_METRICS.db_size.set(db_size as i64);
     }
 
     pub fn set_proposals_applied(proposals_applied: u64) {

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -64,7 +64,6 @@ use log::info;
 use log::warn;
 
 use crate::export::vec_kv_to_json;
-use crate::metrics;
 use crate::Opened;
 
 /// This is the inner store that provides support utilities for implementing the raft storage API.
@@ -341,22 +340,6 @@ impl StoreInner {
     /// The snapshot is a small object and the snapshot data is store on disk.
     pub(crate) async fn set_snapshot(&self, snapshot_meta: Option<SnapshotMeta>) {
         info!("set_snapshot: {:?}", snapshot_meta);
-
-        // Update snapshot metrics
-        let key_num = if let Some(meta) = &snapshot_meta {
-            match MetaSnapshotId::from_str(&meta.snapshot_id) {
-                Ok(id) => id.key_num.unwrap_or_default() as i64,
-                Err(e) => {
-                    warn!("invalid snapshot id: {:?}, error: {:?}", meta, e);
-                    0
-                }
-            }
-        } else {
-            0
-        };
-
-        metrics::server_metrics::set_snapshot_key_num(key_num);
-
         let mut current_snapshot = self.current_snapshot.write().await;
         *current_snapshot = snapshot_meta;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

add metrics
* metasrv_server_db_size

```
❯ curl localhost:28002/v1/metrics
# HELP metasrv_server_snapshot_key_num snapshot key numbers.
# TYPE metasrv_server_snapshot_key_num gauge
metasrv_server_snapshot_key_num 0
# HELP metasrv_server_db_size db size.
# TYPE metasrv_server_db_size gauge
metasrv_server_db_size 2102662
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15595)
<!-- Reviewable:end -->
