### PR TITLE
refactor: Decouple Snapshot Write and Commit Operations

### DIFF
--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -31,6 +31,7 @@ use anyhow::anyhow;
 use databend_common_base::base::tokio;
 use databend_common_meta_raft_store::config::RaftConfig;
 use databend_common_meta_raft_store::key_spaces::RaftStoreEntry;
+use databend_common_meta_raft_store::key_spaces::SMEntry;
 use databend_common_meta_raft_store::ondisk::DataVersion;
 use databend_common_meta_raft_store::ondisk::OnDisk;
 use databend_common_meta_raft_store::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
@@ -175,7 +176,11 @@ async fn import_v002(
 
     let snapshot_store = SnapshotStoreV002::new(DataVersion::V002, raft_config);
 
-    let (tx, join_handle) = snapshot_store.spawn_writer_thread("import_v002");
+    let writer = snapshot_store.new_writer()?;
+
+    let (tx, join_handle) = writer.spawn_writer_thread("import_v002");
+
+    let mut last_applied = None;
 
     for line in lines {
         let l = line?;
@@ -183,9 +188,14 @@ async fn import_v002(
 
         if tree_name.starts_with("state_machine/") {
             // Write to snapshot
-            let sm_entry = kv_entry.try_into().map_err(|err_str| {
+            let sm_entry: SMEntry = kv_entry.try_into().map_err(|err_str| {
                 anyhow::anyhow!("Failed to convert RaftStoreEntry to SMEntry: {}", err_str)
             })?;
+
+            if let Some(last) = sm_entry.last_applied() {
+                last_applied = Some(last);
+            }
+
             tx.send(WriteEntry::Data(sm_entry)).await?;
         } else {
             // Write to sled tree
@@ -214,9 +224,21 @@ async fn import_v002(
 
     tx.send(WriteEntry::Finish).await?;
 
-    let (_snapshot_store, snapshot_stat) = join_handle.await??;
+    let (temp_snapshot_data, snapshot_stat) = join_handle.await??;
 
-    eprintln!("Imported {} records, snapshot: {}", n, snapshot_stat,);
+    let (snapshot_id, snapshot_data) = snapshot_store.commit_snapshot_data_gen_id(
+        temp_snapshot_data,
+        last_applied,
+        snapshot_stat.entry_cnt,
+    )?;
+
+    eprintln!(
+        "Imported {} records, snapshot: {}; snapshot_path: {}; snapshot_stat: {}",
+        n,
+        snapshot_id.to_string(),
+        snapshot_data.path(),
+        snapshot_stat,
+    );
     Ok(max_log_id)
 }
 

--- a/src/meta/raft-store/src/key_spaces.rs
+++ b/src/meta/raft-store/src/key_spaces.rs
@@ -21,6 +21,7 @@ use databend_common_meta_sled_store::SledOrderedSerde;
 use databend_common_meta_sled_store::SledSerde;
 use databend_common_meta_stoerr::MetaStorageError;
 use databend_common_meta_types::Entry;
+use databend_common_meta_types::LogId;
 use databend_common_meta_types::LogIndex;
 use databend_common_meta_types::Node;
 use databend_common_meta_types::NodeId;
@@ -208,6 +209,20 @@ impl SMEntry {
         );
 
         unreachable!("unknown prefix: {}", prefix);
+    }
+
+    pub fn last_applied(&self) -> Option<LogId> {
+        match self {
+            Self::StateMachineMeta { key, value } => {
+                if *key == StateMachineMetaKey::LastApplied {
+                    let last: LogId = value.clone().try_into().unwrap();
+                    Some(last)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 }
 

--- a/src/meta/raft-store/src/sm_v002/snapshot_stat.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_stat.rs
@@ -15,13 +15,9 @@
 use std::fmt;
 use std::fmt::Formatter;
 
-use crate::state_machine::MetaSnapshotId;
-
 /// Snapshot stat.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SnapshotStat {
-    pub snapshot_id: MetaSnapshotId,
-
     /// Total number of entries in the snapshot.
     ///
     /// Including meta entries, such as seq, nodes, generic kv, and expire index
@@ -35,10 +31,8 @@ impl fmt::Display for SnapshotStat {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{{ snapshot_id: {}, entry_cnt: {}, size: {} }}",
-            self.snapshot_id.to_string(),
-            self.entry_cnt,
-            self.size
+            "{{ entry_cnt: {}, size: {} }}",
+            self.entry_cnt, self.size
         )
     }
 }

--- a/src/meta/raft-store/src/sm_v002/snapshot_store.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_store.rs
@@ -20,24 +20,21 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use databend_common_meta_types::ErrorSubject;
+use databend_common_meta_types::LogId;
 use databend_common_meta_types::SnapshotData;
 use databend_common_meta_types::SnapshotMeta;
 use databend_common_meta_types::StorageError;
 use databend_common_meta_types::StorageIOError;
+use databend_common_meta_types::TempSnapshotData;
 use log::error;
 use log::info;
 use log::warn;
 use openraft::AnyError;
 use openraft::ErrorVerb;
 use openraft::SnapshotId;
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 
 use crate::config::RaftConfig;
-use crate::key_spaces::SMEntry;
 use crate::ondisk::DataVersion;
-use crate::sm_v002::SnapshotStat;
-use crate::sm_v002::WriteEntry;
 use crate::sm_v002::WriterV002;
 use crate::state_machine::MetaSnapshotId;
 
@@ -270,54 +267,9 @@ impl SnapshotStoreV002 {
         Ok((snapshot_ids, invalid_files))
     }
 
-    /// Spawn a thread to receive snapshot data and write them to a snapshot file.
-    ///
-    /// It returns a sender to send entries and a handle to wait for the thread to finish.
-    /// Internally it calls tokio::spawn_blocking.
-    #[allow(clippy::type_complexity)]
-    pub fn spawn_writer_thread(
-        mut self,
-        context: impl Display + Send + Sync + 'static,
-    ) -> (
-        mpsc::Sender<WriteEntry<SMEntry>>,
-        JoinHandle<Result<(Self, SnapshotStat), io::Error>>,
-    ) {
-        // Add context information to io::Error
-
-        let (tx, rx) = mpsc::channel(64 * 1024);
-
-        // Spawn another thread to write entries to disk.
-        let join_handle = databend_common_base::runtime::spawn_blocking(move || {
-            let with_context =
-                |e: io::Error| io::Error::new(e.kind(), format!("{} while {}", e, context));
-
-            let writer = self.new_writer().map_err(|e| {
-                io::Error::new(e.source.kind(), format!("creating snapshot writer: {}", e))
-            })?;
-
-            info!("snapshot_writer_thread start writing: {}", context);
-            let writer = writer.write_entries_sync(rx).map_err(with_context)?;
-
-            info!("snapshot_writer_thread committing...: {}", context);
-            let cnt = writer.cnt;
-            let last_applied = writer.last_applied;
-            let snapshot_id = MetaSnapshotId::new_with_epoch(last_applied).with_key_num(Some(cnt));
-            let size = writer.commit(snapshot_id.clone()).map_err(with_context)?;
-
-            info!("snapshot_writer_thread commit done: {}", context);
-
-            Ok::<(Self, SnapshotStat), io::Error>((self, SnapshotStat {
-                snapshot_id,
-                size,
-                entry_cnt: cnt,
-            }))
-        });
-
-        (tx, join_handle)
-    }
-
-    pub fn new_writer(&mut self) -> Result<WriterV002, SnapshotStoreError> {
-        self.ensure_snapshot_dir()?;
+    pub fn new_writer(&self) -> Result<WriterV002, SnapshotStoreError> {
+        self.ensure_snapshot_dir()
+            .map_err(|e| e.with_context("creating snapshot writer"))?;
 
         WriterV002::new(self)
             .map_err(|e| SnapshotStoreError::write(e).with_context("creating snapshot writer"))
@@ -328,6 +280,40 @@ impl SnapshotStoreV002 {
         let p = self.snapshot_temp_path();
 
         SnapshotData::new_temp(p).await
+    }
+
+    /// Commit [`TempSnapshotData`] to a snapshot file with a generated snapshot id.
+    pub fn commit_snapshot_data_gen_id(
+        &self,
+        temp: TempSnapshotData,
+        last_applied: Option<LogId>,
+        key_cnt: u64,
+    ) -> Result<(MetaSnapshotId, SnapshotData), io::Error> {
+        let snapshot_id = MetaSnapshotId::new_with_epoch(last_applied).with_key_num(Some(key_cnt));
+        let d = self.commit_snapshot_data(temp, snapshot_id.clone())?;
+        Ok((snapshot_id, d))
+    }
+
+    /// Commit [`TempSnapshotData`] to a snapshot file with the given snapshot id.
+    pub fn commit_snapshot_data(
+        &self,
+        temp: TempSnapshotData,
+        snapshot_id: MetaSnapshotId,
+    ) -> Result<SnapshotData, io::Error> {
+        if snapshot_id.key_num.is_none() {
+            warn!("snapshot_id.key_num is not set: {:?}", snapshot_id);
+        }
+
+        let final_path = self.snapshot_path(&snapshot_id.to_string());
+        let d = temp.commit(final_path.clone())?;
+
+        info!(
+            "snapshot committed: snapshot_id: {}, path: {}",
+            snapshot_id.to_string(),
+            final_path
+        );
+
+        Ok(d)
     }
 
     /// Return a snapshot for async reading

--- a/src/meta/raft-store/src/sm_v002/writer_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/writer_v002.rs
@@ -12,20 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
 use std::fs;
 use std::io;
 use std::io::BufWriter;
 use std::io::Seek;
 use std::io::Write;
 
-use databend_common_meta_types::LogId;
+use databend_common_meta_types::SnapshotData;
+use databend_common_meta_types::TempSnapshotData;
 use log::debug;
 use log::info;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::key_spaces::SMEntry;
+use crate::ondisk::DataVersion;
+use crate::ondisk::DATA_VERSION;
+use crate::sm_v002::SnapshotStat;
 use crate::sm_v002::SnapshotStoreV002;
-use crate::state_machine::MetaSnapshotId;
-use crate::state_machine::StateMachineMetaKey;
 
 /// A write entry sent to snapshot writer.
 ///
@@ -37,7 +42,7 @@ pub enum WriteEntry<T> {
 }
 
 /// Write json lines snapshot data to [`SnapshotStoreV002`].
-pub struct WriterV002<'a> {
+pub struct WriterV002 {
     /// The temp path to write to, which will be renamed to the final path.
     /// So that the readers could only see a complete snapshot.
     temp_path: String,
@@ -53,18 +58,35 @@ pub struct WriterV002<'a> {
     /// The time when the writer starts to write entries.
     start_time: std::time::Instant,
 
-    /// The last_applied entry that has written to the snapshot.
-    ///
-    /// It will be used to create a snapshot id.
-    pub(crate) last_applied: Option<LogId>,
-
-    // Keep a mutable ref so that there could only be one writer at a time.
-    snapshot_store: &'a mut SnapshotStoreV002,
+    /// The version of the on disk data.
+    data_version: DataVersion,
 }
 
-impl<'a> WriterV002<'a> {
+impl WriterV002 {
+    /// Create a writer from a temp snapshot data [`TempSnapshotData`].
+    pub async fn new_from_temp_snapshot_data(
+        temp_snapshot_data: TempSnapshotData,
+    ) -> Result<Self, io::Error> {
+        let ss_data = temp_snapshot_data.into_inner();
+        let path = ss_data.path().to_string();
+        let f = ss_data.into_std().await;
+
+        let buffered_file = BufWriter::with_capacity(16 * 1024 * 1024, f);
+
+        let writer = WriterV002 {
+            temp_path: path,
+            inner: buffered_file,
+            cnt: 0,
+            next_progress_cnt: 1000,
+            start_time: std::time::Instant::now(),
+            data_version: DATA_VERSION,
+        };
+
+        Ok(writer)
+    }
+
     /// Create a singleton writer for the snapshot.
-    pub fn new(snapshot_store: &'a mut SnapshotStoreV002) -> Result<Self, io::Error> {
+    pub fn new(snapshot_store: &SnapshotStoreV002) -> Result<Self, io::Error> {
         let temp_path = snapshot_store.snapshot_temp_path();
 
         let f = fs::OpenOptions::new()
@@ -81,8 +103,7 @@ impl<'a> WriterV002<'a> {
             cnt: 0,
             next_progress_cnt: 1000,
             start_time: std::time::Instant::now(),
-            last_applied: None,
-            snapshot_store,
+            data_version: snapshot_store.data_version(),
         };
 
         Ok(writer)
@@ -131,7 +152,7 @@ impl<'a> WriterV002<'a> {
         mut self,
         mut entries_rx: tokio::sync::mpsc::Receiver<WriteEntry<SMEntry>>,
     ) -> Result<Self, io::Error> {
-        let data_version = self.snapshot_store.data_version();
+        let data_version = self.data_version;
 
         while let Some(ent) = entries_rx.blocking_recv() {
             debug!(entry :? =(&ent); "write {} entry", data_version);
@@ -143,22 +164,6 @@ impl<'a> WriterV002<'a> {
                     return Ok(self);
                 }
             };
-
-            if let SMEntry::StateMachineMeta {
-                key: StateMachineMetaKey::LastApplied,
-                ref value,
-            } = ent
-            {
-                let last: LogId = value.clone().try_into().unwrap();
-                info!(last_applied :? =(last); "write last applied to snapshot");
-
-                assert!(
-                    self.last_applied.is_none(),
-                    "already seen a last_applied: {:?}",
-                    self.last_applied
-                );
-                self.last_applied = Some(last);
-            }
 
             serde_json::to_writer(&mut self.inner, &ent)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -176,25 +181,67 @@ impl<'a> WriterV002<'a> {
         ))
     }
 
-    /// Commit the snapshot so that it is visible to the readers.
+    /// Flush all data to disk.
     ///
-    /// Returns the file size written.
+    /// Returns a **temp** [`SnapshotData`] and the file size written.
     ///
     /// This method consumes the writer, thus the writer will not be used after commit.
-    pub fn commit(mut self, snapshot_id: MetaSnapshotId) -> Result<u64, io::Error> {
+    pub fn flush(mut self) -> Result<(TempSnapshotData, u64), io::Error> {
         self.inner.flush()?;
         let mut f = self.inner.into_inner()?;
         f.sync_all()?;
 
         let file_size = f.seek(io::SeekFrom::End(0))?;
 
-        let id_str = snapshot_id.to_string();
-        let path = self.snapshot_store.snapshot_path(&id_str);
+        let snapshot_data = SnapshotData::new(&self.temp_path, f, true);
+        let t = TempSnapshotData::new(snapshot_data);
+        Ok((t, file_size))
+    }
 
-        fs::rename(&self.temp_path, path)?;
+    /// Spawn a thread to receive snapshot data [`SMEntry`] and write them to a snapshot file.
+    ///
+    /// It returns a sender to send entries and a handle to wait for the thread to finish.
+    /// Internally it calls tokio::spawn_blocking.
+    ///
+    /// When a [`WritenEntry::Finish`] is received, the thread will flush the data to disk and return
+    /// a [`TempSnapshotData`] and a [`SnapshotStat`].
+    ///
+    /// [`TempSnapshotData`] is a temporary snapshot data that will be renamed to the final path by the caller.
+    #[allow(clippy::type_complexity)]
+    pub fn spawn_writer_thread(
+        self,
+        context: impl Display + Send + Sync + 'static,
+    ) -> (
+        mpsc::Sender<WriteEntry<SMEntry>>,
+        JoinHandle<Result<(TempSnapshotData, SnapshotStat), io::Error>>,
+    ) {
+        let (tx, rx) = mpsc::channel(64 * 1024);
 
-        info!(snapshot_id :% = id_str; "snapshot committed: file_size: {}", file_size);
+        // Spawn another thread to write entries to disk.
+        let join_handle = databend_common_base::runtime::spawn_blocking(move || {
+            let with_context =
+                |e: io::Error| io::Error::new(e.kind(), format!("{} while {}", e, context));
 
-        Ok(file_size)
+            info!("snapshot_writer_thread start writing: {}", context);
+            let writer = self.write_entries_sync(rx).map_err(with_context)?;
+
+            info!("snapshot_writer_thread committing...: {}", context);
+            let cnt = writer.cnt;
+            let (temp_snapshot_data, size) = writer.flush().map_err(with_context)?;
+
+            info!(
+                "snapshot writer flushed: path: {}",
+                temp_snapshot_data.path()
+            );
+
+            let snapshot_stat = SnapshotStat {
+                size,
+                entry_cnt: cnt,
+            };
+
+            Ok::<(TempSnapshotData, SnapshotStat), io::Error>((temp_snapshot_data, snapshot_stat))
+        });
+
+        (tx, join_handle)
     }
 }

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -249,7 +249,8 @@ impl StoreInner {
 
         let context = format!("build snapshot: {}", meta.snapshot_id);
         let ss_store = self.snapshot_store();
-        let (tx, th) = ss_store.spawn_writer_thread(context);
+        let writer = ss_store.new_writer()?;
+        let (tx, th) = writer.spawn_writer_thread(context);
 
         // Pipe entries to the writer.
         {
@@ -268,7 +269,7 @@ impl StoreInner {
         }
 
         // Get snapshot write result
-        let (ss_store, snapshot_stat) = th
+        let (temp_snapshot_data, snapshot_stat) = th
             .await
             .map_err(|e| {
                 error!(error :% = e; "snapshot writer thread error");
@@ -279,30 +280,32 @@ impl StoreInner {
                 StorageIOError::write_snapshot(Some(signature.clone()), &e)
             })?;
 
-        info!(snapshot_stat :% = snapshot_stat; "do_build_snapshot complete");
+        let (snapshot_id, snapshot_data) = ss_store
+            .commit_snapshot_data_gen_id(
+                temp_snapshot_data,
+                snapshot_meta.last_log_id,
+                snapshot_stat.entry_cnt,
+            )
+            .map_err(|e| {
+                error!(error :% = e; "commit temp snapshot error");
+                StorageIOError::write_snapshot(Some(signature.clone()), &e)
+            })?;
+
+        info!(
+            snapshot_id :% = snapshot_id.to_string(),
+            snapshot_stat :% = snapshot_stat; "do_build_snapshot complete");
 
         // Clean old snapshot
         ss_store.clean_old_snapshots().await?;
         info!("do_build_snapshot clean_old_snapshots complete");
 
-        let snapshot_id = &snapshot_stat.snapshot_id;
-        assert_eq!(
-            snapshot_id.last_applied, snapshot_meta.last_log_id,
-            "snapshot_id.last_applied: {:?} must equal snapshot_meta.last_log_id: {:?}",
-            snapshot_id.last_applied, snapshot_meta.last_log_id
-        );
         snapshot_meta.snapshot_id = snapshot_id.to_string();
 
         self.set_snapshot(Some(snapshot_meta.clone())).await;
 
-        let r = ss_store
-            .load_snapshot(&snapshot_meta.snapshot_id)
-            .await
-            .map_err(|e| StorageIOError::read_snapshot(Some(signature), &e))?;
-
         Ok(Snapshot {
             meta: snapshot_meta,
-            snapshot: Box::new(r),
+            snapshot: Box::new(snapshot_data),
         })
     }
 

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -121,6 +121,7 @@ pub use crate::grpc_helper::GrpcHelper;
 pub use crate::non_empty::NonEmptyStr;
 pub use crate::non_empty::NonEmptyString;
 pub use crate::raft_snapshot_data::SnapshotData;
+pub use crate::raft_snapshot_data::TempSnapshotData;
 pub use crate::raft_types::new_log_id;
 pub use crate::raft_types::AppendEntriesRequest;
 pub use crate::raft_types::AppendEntriesResponse;

--- a/src/meta/types/src/raft_snapshot_data.rs
+++ b/src/meta/types/src/raft_snapshot_data.rs
@@ -14,6 +14,7 @@
 
 use std::io;
 use std::io::SeekFrom;
+use std::path::Path;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -27,6 +28,51 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::io::ReadBuf;
 
+/// A typed temporary snapshot data.
+pub struct TempSnapshotData {
+    inner: SnapshotData,
+}
+
+impl TempSnapshotData {
+    pub fn new(snapshot_data: SnapshotData) -> Self {
+        assert!(snapshot_data.is_temp());
+        TempSnapshotData {
+            inner: snapshot_data,
+        }
+    }
+
+    /// Commit the temp snapshot to a final snapshot file.
+    ///
+    /// It requires the input snapshot is a temp snapshot.
+    pub fn commit<P: AsRef<Path>>(self, final_path: P) -> Result<SnapshotData, io::Error> {
+        let final_path = final_path.as_ref().to_string_lossy().to_string();
+
+        std::fs::rename(self.inner.path(), &final_path).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "{}: while TempSnapshotData::commit(); temp path: {}; final path: {}",
+                    e,
+                    self.path(),
+                    final_path
+                ),
+            )
+        })?;
+
+        let d = SnapshotData::open(final_path)?;
+
+        Ok(d)
+    }
+
+    pub fn into_inner(self) -> SnapshotData {
+        self.inner
+    }
+
+    pub fn path(&self) -> &str {
+        self.inner.path()
+    }
+}
+
 pub struct SnapshotData {
     /// Whether it is a temp file that may contain partial data.
     is_temp: bool,
@@ -35,6 +81,14 @@ pub struct SnapshotData {
 }
 
 impl SnapshotData {
+    pub fn new(path: impl ToString, f: std::fs::File, is_temp: bool) -> Self {
+        SnapshotData {
+            is_temp,
+            path: path.to_string(),
+            f: fs::File::from_std(f),
+        }
+    }
+
     pub fn open(path: String) -> Result<Self, io::Error> {
         let f = std::fs::OpenOptions::new()
             .create(false)


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Decouple Snapshot Write and Commit Operations

This commit introduces a significant change in the snapshot management
process by separating the snapshot writing and committing phases:

- **Snapshot Writing Update:**
  - The `WriterV002::spawn_writer_thread()` function now solely handles
    the writing of snapshot data and flushing it to disk. The
    responsibility of moving the snapshot from a temporary location to
    the final path has been decoupled from this thread.

- **Enhanced Control Over Snapshot Final Path:**
  - This change gives the caller more control over how to construct the
    final path of the snapshot. For instance:
    - When importing data from a previous version on disk, the final
      path is constructed using the `last-applied-log-id` found in the
      imported data.
    - When building a snapshot from the state machine, the final path is
      constructed using the snapshot meta passed in.

- **Introduction of `TempSnapshotData`:**
  - A new structure, `TempSnapshotData`, has been introduced to clearly
    differentiate between uncommitted temporary snapshot data and
    committed visible snapshot data.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15603)
<!-- Reviewable:end -->
