### PR TITLE
chore: Refine state machine v002

### DIFF
--- a/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/leveled_map_test.rs
@@ -51,9 +51,9 @@ async fn test_freeze() -> anyhow::Result<()> {
     ]);
 
     // Listing from the base level sees the old value.
-    let frozen = l.frozen_ref();
+    let immutables = l.immutable_levels_ref();
 
-    let got = frozen
+    let got = immutables
         .str_map()
         .range(s("")..)
         .await?
@@ -193,9 +193,9 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     // Check base level
 
-    let frozen = l.frozen_ref();
+    let immutables = l.immutable_levels_ref();
 
-    let strm = frozen.str_map().range(s("")..).await?;
+    let strm = immutables.str_map().range(s("")..).await?;
     let got = strm.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //

--- a/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/map_api.rs
@@ -223,9 +223,9 @@ where
 /// There could be tombstone entries: [`Marked::TombStone`].
 ///
 /// The `TOP` is the type of the top level.
-/// The `L` is the type of frozen levels.
+/// The `L` is the type of immutable levels.
 ///
-/// Because the top level is very likely to be a different type from the frozen levels, i.e., it is writable.
+/// Because the top level is very likely to be a different type from the immutable levels, i.e., it is writable.
 pub(in crate::sm_v002) async fn compacted_range<'d, K, R, L, TOP>(
     range: R,
     top: Option<&'d TOP>,
@@ -257,10 +257,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use futures_util::TryStreamExt;
 
+    use crate::sm_v002::leveled_store::immutable::Immutable;
     use crate::sm_v002::leveled_store::level::Level;
     use crate::sm_v002::leveled_store::map_api::compacted_get;
     use crate::sm_v002::leveled_store::map_api::compacted_range;
@@ -301,12 +301,12 @@ mod tests {
         let mut l0 = Level::default();
         l0.set(s("a"), Some((b("a"), None))).await?;
         l0.set(s("b"), Some((b("b"), None))).await?;
-        let l0 = Arc::new(l0);
+        let l0 = Immutable::new_from_level(l0);
 
         let mut l1 = l0.new_level();
         l1.set(s("a"), None).await?;
         l1.set(s("c"), None).await?;
-        let l1 = Arc::new(l1);
+        let l1 = Immutable::new_from_level(l1);
 
         let mut l2 = l1.new_level();
         l2.set(s("b"), Some((b("b2"), None))).await?;

--- a/src/meta/raft-store/src/sm_v002/leveled_store/mod.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/mod.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod arc_level_impl;
+pub mod immutable;
+pub mod immutable_levels;
 pub mod level;
 pub mod leveled_map;
 pub mod map_api;
 pub mod ref_;
 pub mod ref_mut;
-pub mod static_levels;
 pub mod sys_data;
 pub mod sys_data_api;
 pub mod util;

--- a/src/meta/raft-store/src/sm_v002/leveled_store/util.rs
+++ b/src/meta/raft-store/src/sm_v002/leveled_store/util.rs
@@ -15,19 +15,16 @@
 use std::fmt;
 use std::io;
 
-use crate::sm_v002::leveled_store::map_api::MapKV;
 use crate::sm_v002::leveled_store::map_api::MapKey;
 use crate::sm_v002::marked::Marked;
 
+/// Result type of a key-value pair and io Error used in a map.
+type KVResult<K> = Result<(K, Marked<<K as MapKey>::V>), io::Error>;
+
 /// Sort by key and internal_seq.
 /// Return `true` if `a` should be placed before `b`, e.g., `a` is smaller.
-pub(in crate::sm_v002) fn by_key_seq<K>(
-    r1: &Result<MapKV<K>, io::Error>,
-    r2: &Result<MapKV<K>, io::Error>,
-) -> bool
-where
-    K: MapKey + Ord + fmt::Debug,
-{
+pub(in crate::sm_v002) fn by_key_seq<K>(r1: &KVResult<K>, r2: &KVResult<K>) -> bool
+where K: MapKey + Ord + fmt::Debug {
     match (r1, r2) {
         (Ok((k1, v1)), Ok((k2, v2))) => {
             assert_ne!((k1, v1.internal_seq()), (k2, v2.internal_seq()));
@@ -41,9 +38,6 @@ where
         _ => true,
     }
 }
-
-/// Result type of a key-value pair and io Error used in a map.
-type KVResult<K> = Result<MapKV<K>, io::Error>;
 
 /// Return a Ok(combined) to merge two consecutive values,
 /// otherwise return Err((x,y)) to not to merge.

--- a/src/meta/raft-store/src/sm_v002/sm_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/sm_v002.rs
@@ -424,13 +424,13 @@ impl SMV002 {
     pub fn replace_frozen(&mut self, snapshot: &SnapshotViewV002) {
         assert!(
             Arc::ptr_eq(
-                self.levels.frozen_ref().newest().unwrap(),
-                snapshot.original_ref().newest().unwrap()
+                self.levels.immutable_levels_ref().newest().unwrap().inner(),
+                snapshot.original_ref().newest().unwrap().inner()
             ),
             "the frozen must not change"
         );
 
-        self.levels.replace_frozen(snapshot.compacted());
+        self.levels.replace_immutable_levels(snapshot.compacted());
     }
 
     /// It returns 2 entries: the previous one and the new one after upsert.

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002.rs
@@ -14,7 +14,6 @@
 
 use std::future;
 use std::io;
-use std::sync::Arc;
 
 use databend_common_meta_types::SeqNum;
 use databend_common_meta_types::SeqV;
@@ -25,10 +24,11 @@ use futures_util::TryStreamExt;
 use crate::key_spaces::SMEntry;
 use crate::ondisk::Header;
 use crate::ondisk::OnDisk;
+use crate::sm_v002::leveled_store::immutable::Immutable;
+use crate::sm_v002::leveled_store::immutable_levels::ImmutableLevels;
 use crate::sm_v002::leveled_store::map_api::AsMap;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
 use crate::sm_v002::leveled_store::map_api::ResultStream;
-use crate::sm_v002::leveled_store::static_levels::StaticLevels;
 use crate::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use crate::state_machine::ExpireValue;
 use crate::state_machine::MetaSnapshotId;
@@ -38,16 +38,16 @@ use crate::state_machine::StateMachineMetaValue;
 /// A snapshot view of a state machine, which is static and not affected by further writing to the state machine.
 pub struct SnapshotViewV002 {
     /// The compacted snapshot data.
-    compacted: StaticLevels,
+    compacted: ImmutableLevels,
 
     /// Original non compacted snapshot data.
     ///
     /// This is kept just for debug.
-    original: StaticLevels,
+    original: ImmutableLevels,
 }
 
 impl SnapshotViewV002 {
-    pub fn new(top: StaticLevels) -> Self {
+    pub fn new(top: ImmutableLevels) -> Self {
         Self {
             compacted: top.clone(),
             original: top,
@@ -55,12 +55,12 @@ impl SnapshotViewV002 {
     }
 
     /// Return the data level of this snapshot
-    pub fn compacted(&self) -> StaticLevels {
+    pub fn compacted(&self) -> ImmutableLevels {
         self.compacted.clone()
     }
 
     /// The original, non compacted snapshot data.
-    pub fn original_ref(&self) -> &StaticLevels {
+    pub fn original_ref(&self) -> &ImmutableLevels {
         &self.original
     }
 
@@ -110,7 +110,7 @@ impl SnapshotViewV002 {
 
         data.replace_expire(bt);
 
-        self.compacted = StaticLevels::new([Arc::new(data)]);
+        self.compacted = ImmutableLevels::new([Immutable::new_from_level(data)]);
         Ok(())
     }
 

--- a/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_view_v002_test.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use databend_common_meta_types::Endpoint;
 use databend_common_meta_types::KVMeta;
 use databend_common_meta_types::Membership;
@@ -26,11 +24,12 @@ use openraft::testing::log_id;
 use pretty_assertions::assert_eq;
 
 use crate::key_spaces::RaftStoreEntry;
+use crate::sm_v002::leveled_store::immutable::Immutable;
+use crate::sm_v002::leveled_store::immutable_levels::ImmutableLevels;
 use crate::sm_v002::leveled_store::leveled_map::LeveledMap;
 use crate::sm_v002::leveled_store::map_api::AsMap;
 use crate::sm_v002::leveled_store::map_api::MapApi;
 use crate::sm_v002::leveled_store::map_api::MapApiRO;
-use crate::sm_v002::leveled_store::static_levels::StaticLevels;
 use crate::sm_v002::leveled_store::sys_data_api::SysDataApiRO;
 use crate::sm_v002::marked::Marked;
 use crate::sm_v002::sm_v002::SMV002;
@@ -51,7 +50,7 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
 
     let d = top_level.newest().unwrap().as_ref();
 
-    assert_eq!(top_level.iter_arc_levels().count(), 1);
+    assert_eq!(top_level.iter_immutable_levels().count(), 1);
     assert_eq!(
         d.last_membership_ref(),
         &StoredMembership::new(Some(log_id(3, 3, 3)), Membership::new(vec![], ()))
@@ -214,7 +213,7 @@ async fn test_import() -> anyhow::Result<()> {
 
     let d = SMV002::import(data)?;
 
-    let snapshot = SnapshotViewV002::new(StaticLevels::new([Arc::new(d)]));
+    let snapshot = SnapshotViewV002::new(ImmutableLevels::new([Immutable::new_from_level(d)]));
 
     let got = snapshot
         .export()


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: Refine state machine v002

Add `ImmutableLevel` as a wrapper for `Arc<Level>`;

Rename corresponding fields

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15608)
<!-- Reviewable:end -->
