### PR TITLE
fix: analyze table error

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/table_analyze.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/table_analyze.rs
@@ -234,18 +234,18 @@ async fn test_table_analyze_without_prev_table_seq() -> Result<()> {
 
     // check statistics.
     let table = table.refresh(ctx.as_ref()).await?;
-    let expected = HashMap::from([(0, 3 as u64)]);
+    let expected = HashMap::from([(0, 3_u64)]);
     check_column_ndv_statistics(ctx.clone(), table.clone(), expected.clone()).await?;
 
-    let qry = format!("insert into t values(4)");
-    execute_command(ctx.clone(), &qry).await?;
+    let qry = "insert into t values(4)";
+    execute_command(ctx.clone(), qry).await?;
 
     ctx.evict_table_from_cache("default", "default", "t")?;
     let statistics_sql = "analyze table default.t";
     fixture.execute_command(statistics_sql).await?;
 
     let table = table.refresh(ctx.as_ref()).await?;
-    let expected = HashMap::from([(0, 4 as u64)]);
+    let expected = HashMap::from([(0, 4_u64)]);
     check_column_ndv_statistics(ctx.clone(), table.clone(), expected.clone()).await?;
     Ok(())
 }

--- a/src/query/service/tests/it/storages/fuse/operations/table_analyze.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/table_analyze.rs
@@ -17,10 +17,14 @@ use std::sync::Arc;
 
 use databend_common_base::base::tokio;
 use databend_common_catalog::table::Table;
+use databend_common_catalog::table::TableExt;
 use databend_common_exception::Result;
 use databend_common_expression::types::number::NumberScalar;
+use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
+use databend_common_io::prelude::borsh_deserialize_from_slice;
 use databend_common_storages_fuse::io::MetaReaders;
+use databend_common_storages_fuse::io::MetaWriter;
 use databend_common_storages_fuse::statistics::reducers::merge_statistics_mut;
 use databend_common_storages_fuse::FuseTable;
 use databend_query::sessions::QueryContext;
@@ -29,8 +33,12 @@ use databend_query::sql::plans::Plan;
 use databend_query::sql::Planner;
 use databend_query::test_kits::*;
 use databend_storages_common_cache::LoadParams;
+use databend_storages_common_table_meta::meta::MetaHLL;
 use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::Statistics;
+use databend_storages_common_table_meta::meta::TableSnapshot;
+use databend_storages_common_table_meta::meta::TableSnapshotStatistics;
+use databend_storages_common_table_meta::meta::Versioned;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_table_modify_column_ndv_statistics() -> Result<()> {
@@ -176,6 +184,69 @@ async fn check_column_ndv_statistics(
         assert_eq!(stat.unwrap().ndv.unwrap(), *num);
     }
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_table_analyze_without_prev_table_seq() -> Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+
+    // setup
+    let create_tbl_command = "create table t(c int)";
+    fixture.execute_command(create_tbl_command).await?;
+
+    append_rows(ctx.clone(), 3).await?;
+    let catalog = ctx.get_catalog("default").await?;
+    let table = catalog.get_table(&ctx.get_tenant(), "default", "t").await?;
+    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+    let location_gen = fuse_table.meta_location_generator();
+    let operator = fuse_table.get_operator();
+
+    // genenrate snapshot without prev_table_seq
+    let snapshot_0 = fuse_table.read_table_snapshot().await?.unwrap();
+    let snapshot_1 = TableSnapshot::from_previous(&snapshot_0, None);
+    let snapshot_loc_1 = location_gen
+        .snapshot_location_from_uuid(&snapshot_1.snapshot_id, TableSnapshot::VERSION)?;
+    snapshot_1.write_meta(&operator, &snapshot_loc_1).await?;
+
+    // generate table statistics.
+    let col: Vec<u8> = vec![1, 3, 0, 0, 0, 118, 5, 1, 21, 6, 3, 229, 13, 3];
+    let hll: HashMap<ColumnId, MetaHLL> = HashMap::from([(0, borsh_deserialize_from_slice(&col)?)]);
+    let table_statistics = TableSnapshotStatistics::new(hll, snapshot_1.snapshot_id);
+    let table_statistics_location = location_gen.snapshot_statistics_location_from_uuid(
+        &table_statistics.snapshot_id,
+        table_statistics.format_version(),
+    )?;
+    // genenrate snapshot without prev_table_seq
+    let mut snapshot_2 = TableSnapshot::from_previous(&snapshot_1, None);
+    snapshot_2.table_statistics_location = Some(table_statistics_location);
+    FuseTable::commit_to_meta_server(
+        fixture.new_query_ctx().await?.as_ref(),
+        fuse_table.get_table_info(),
+        location_gen,
+        snapshot_2,
+        Some(table_statistics),
+        &None,
+        &operator,
+    )
+    .await?;
+
+    // check statistics.
+    let table = table.refresh(ctx.as_ref()).await?;
+    let expected = HashMap::from([(0, 3 as u64)]);
+    check_column_ndv_statistics(ctx.clone(), table.clone(), expected.clone()).await?;
+
+    let qry = format!("insert into t values(4)");
+    execute_command(ctx.clone(), &qry).await?;
+
+    ctx.evict_table_from_cache("default", "default", "t")?;
+    let statistics_sql = "analyze table default.t";
+    fixture.execute_command(statistics_sql).await?;
+
+    let table = table.refresh(ctx.as_ref()).await?;
+    let expected = HashMap::from([(0, 4 as u64)]);
+    check_column_ndv_statistics(ctx.clone(), table.clone(), expected.clone()).await?;
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The old snapshot does not have a `prev_table_seq`. During the execution of `ANALYZE TABLE`, it may result in the error: "The stream navigation at point has no table version".

To avoid this error, the program will check if `prev_table_seq` exists. If it does not, it will use a full analyze.


- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15614)
<!-- Reviewable:end -->
