### PR TITLE
chore: more commit logs

### DIFF
--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -455,6 +455,19 @@ where F: SnapshotGenerator + Send + 'static
                         for segment_loc in std::mem::take(&mut self.new_segment_locs).into_iter() {
                             self.ctx.add_segment_location(segment_loc)?;
                         }
+
+                        let target_descriptions = {
+                            let table_info = self.table.get_table_info();
+                            let tbl = (&table_info.name, table_info.ident, &table_info.meta.engine);
+
+                            let stream_descriptions = self
+                                .update_stream_meta
+                                .iter()
+                                .map(|s| (s.stream_id, s.seq, "stream"))
+                                .collect::<Vec<_>>();
+                            (tbl, stream_descriptions)
+                        };
+                        info!("commit mutation success, targets {:?}", target_descriptions);
                         self.state = State::Finish;
                     }
                     Err(e) if self.is_error_recoverable(&e) => {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

more logs for commit actions, which logs the table/stream id, version, engine when txn is done (succ or failed).

There are duplicated code snippets. Let's address this later by refactoring to unify the updating of tables/streams and various commit paths.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - only adding logs

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): adding some extra logs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15617)
<!-- Reviewable:end -->
