### PR TITLE
fix: allow http client retry when lost response with next_uri=/final.

### DIFF
--- a/src/query/service/src/servers/http/v1/json_block.rs
+++ b/src/query/service/src/servers/http/v1/json_block.rs
@@ -21,7 +21,7 @@ use databend_common_formats::field_encoder::FieldEncoderValues;
 use databend_common_io::prelude::FormatSettings;
 use serde_json::Value as JsonValue;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct JsonBlock {
     pub(crate) data: Vec<Vec<JsonValue>>,
 }

--- a/src/query/service/src/servers/http/v1/query/page_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/page_manager.rs
@@ -106,10 +106,13 @@ impl PageManager {
                 Ok(page)
             } else {
                 // when end is set to true, client should recv a response with next_url = final_url
-                Err(ErrorCode::Internal(format!(
-                    "expect /final from client, got /page/{}.",
-                    page_no
-                )))
+                // but the response may be lost and client will retry,
+                // we simply return an empty page.
+                let page = Page {
+                    data: JsonBlock::default(),
+                    total_rows: self.total_rows,
+                };
+                Ok(page)
             }
         } else if page_no + 1 == next_no {
             // later, there may be other ways to ack and drop the last page except collect_new_page.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


- Fixe   error "expect /final from client, got /page/0"

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15624)
<!-- Reviewable:end -->
