### PR TITLE
fix: update derive-vistor to unblock rustc upgrage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5147,8 +5147,7 @@ dependencies = [
 [[package]]
 name = "derive-visitor"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21045832f19977a1bec46f3d826609794661c0d23370f3ee35b8ef6537861cd6"
+source = "git+https://github.com/andylokandy/derive-visitor.git?rev=c07c6b6#c07c6b6095f2f137223cbe4b25ff4c19ecde4234"
 dependencies = [
  "derive-visitor-macros",
 ]
@@ -5156,8 +5155,7 @@ dependencies = [
 [[package]]
 name = "derive-visitor-macros"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c6a42ab7b480fb19a029c5e54cb8cdf912c7798cf0192441d2d92eb4af8012"
+source = "git+https://github.com/andylokandy/derive-visitor.git?rev=c07c6b6#c07c6b6095f2f137223cbe4b25ff4c19ecde4234"
 dependencies = [
  "convert_case 0.4.0",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,6 @@ debug-assertions = true
 overflow-checks = true
 rpath = false
 
-# If there are dependencies that need patching, they can be listed below.
 [patch.crates-io]
 arrow-format = { git = "https://github.com/Xuanwo/arrow-format", rev = "be633a0" }
 icelake = { git = "https://github.com/icelake-io/icelake", rev = "be8b2c2" }
@@ -303,3 +302,4 @@ async-backtrace = { git = "https://github.com/zhang2014/async-backtrace.git", re
 z3 = { git = "https://github.com/prove-rs/z3.rs", rev = "247d308" }
 z3-sys = { git = "https://github.com/prove-rs/z3.rs", rev = "247d308" }
 # proj = { git = "https://github.com/ariesdevil/proj", rev = "51e1c60" }
+derive-visitor = { git = 'https://github.com/andylokandy/derive-visitor.git', rev = "c07c6b6" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This is a fix for https://github.com/nikis05/derive-visitor/issues/16. The solution pr is pending for review: https://github.com/nikis05/derive-visitor/pull/17.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15625)
<!-- Reviewable:end -->
