### PR TITLE
feat: compact and recluster add table lock

### DIFF
--- a/src/query/catalog/src/lock.rs
+++ b/src/query/catalog/src/lock.rs
@@ -31,4 +31,6 @@ pub trait Lock: Sync + Send {
     fn tenant_name(&self) -> &str;
 
     async fn try_lock(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>>;
+
+    async fn try_lock_no_retry(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>>;
 }

--- a/src/query/catalog/src/lock.rs
+++ b/src/query/catalog/src/lock.rs
@@ -30,7 +30,9 @@ pub trait Lock: Sync + Send {
 
     fn tenant_name(&self) -> &str;
 
-    async fn try_lock(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>>;
-
-    async fn try_lock_no_retry(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>>;
+    async fn try_lock(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        should_retry: bool,
+    ) -> Result<Option<LockGuard>>;
 }

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -41,7 +41,6 @@ use databend_storages_common_table_meta::meta::SnapshotId;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::table::ChangeType;
 
-use crate::lock::Lock;
 use crate::plan::DataSourceInfo;
 use crate::plan::DataSourcePlan;
 use crate::plan::PartStatistics;
@@ -339,10 +338,9 @@ pub trait Table: Sync + Send {
     async fn compact_segments(
         &self,
         ctx: Arc<dyn TableContext>,
-        lock: Arc<dyn Lock>,
         limit: Option<usize>,
     ) -> Result<()> {
-        let (_, _, _) = (ctx, lock, limit);
+        let (_, _) = (ctx, limit);
 
         Err(ErrorCode::Unimplemented(format!(
             "The operation 'compact_segments' is not supported for the table '{}', which is using the '{}' engine.",

--- a/src/query/ee/tests/it/inverted_index/index_refresh.rs
+++ b/src/query/ee/tests/it/inverted_index/index_refresh.rs
@@ -20,6 +20,7 @@ use databend_common_catalog::table::TableExt;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableIndexReq;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::RefreshTableIndexPlan;
 use databend_common_storages_fuse::io::read::InvertedIndexReader;
 use databend_common_storages_fuse::io::MetaReaders;
@@ -86,7 +87,7 @@ async fn test_fuse_do_refresh_inverted_index() -> Result<()> {
         table: fixture.default_table_name(),
         index_name: index_name.clone(),
         segment_locs: None,
-        need_lock: true,
+        lock_opt: LockTableOption::LockWithRetry,
     };
     let interpreter = RefreshTableIndexInterpreter::try_create(ctx.clone(), refresh_index_plan)?;
     let _ = interpreter.execute(ctx.clone()).await?;

--- a/src/query/ee/tests/it/inverted_index/pruning.rs
+++ b/src/query/ee/tests/it/inverted_index/pruning.rs
@@ -36,6 +36,7 @@ use databend_common_expression::TableSchemaRefExt;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableIndexReq;
 use databend_common_sql::plans::CreateTablePlan;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::RefreshTableIndexPlan;
 use databend_common_sql::BloomIndexColumns;
 use databend_common_storages_fuse::pruning::create_segment_location_vector;
@@ -525,7 +526,7 @@ async fn test_block_pruner() -> Result<()> {
         table: test_tbl_name.to_string(),
         index_name: index_name.clone(),
         segment_locs: None,
-        need_lock: true,
+        lock_opt: LockTableOption::LockWithRetry,
     };
     let interpreter = RefreshTableIndexInterpreter::try_create(ctx.clone(), refresh_index_plan)?;
     let _ = interpreter.execute(ctx.clone()).await?;

--- a/src/query/service/src/interpreters/hook/hook.rs
+++ b/src/query/service/src/interpreters/hook/hook.rs
@@ -18,6 +18,7 @@ use std::time::Instant;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_pipeline_core::Pipeline;
 use databend_common_sql::executor::physical_plans::MutationKind;
+use databend_common_sql::plans::LockTableOption;
 use log::info;
 use log::warn;
 
@@ -35,7 +36,7 @@ pub struct HookOperator {
     database: String,
     table: String,
     mutation_kind: MutationKind,
-    need_lock: bool,
+    lock_opt: LockTableOption,
 }
 
 impl HookOperator {
@@ -45,7 +46,7 @@ impl HookOperator {
         database: String,
         table: String,
         mutation_kind: MutationKind,
-        need_lock: bool,
+        lock_opt: LockTableOption,
     ) -> Self {
         Self {
             ctx,
@@ -53,7 +54,7 @@ impl HookOperator {
             database,
             table,
             mutation_kind,
-            need_lock,
+            lock_opt,
         }
     }
 
@@ -105,7 +106,7 @@ impl HookOperator {
             pipeline,
             compact_target,
             trace_ctx,
-            self.need_lock,
+            self.lock_opt.clone(),
         )
         .await;
     }
@@ -122,6 +123,12 @@ impl HookOperator {
             table: self.table.to_owned(),
         };
 
-        hook_refresh(self.ctx.clone(), pipeline, refresh_desc, self.need_lock).await;
+        hook_refresh(
+            self.ctx.clone(),
+            pipeline,
+            refresh_desc,
+            self.lock_opt.clone(),
+        )
+        .await;
     }
 }

--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -31,6 +31,7 @@ use databend_common_sql::executor::physical_plans::MutationKind;
 use databend_common_sql::executor::physical_plans::TableScan;
 use databend_common_sql::executor::table_read_plan::ToReadDataSourcePlan;
 use databend_common_sql::executor::PhysicalPlan;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_storage::StageFileInfo;
 use databend_common_storages_stage::StageTable;
 use log::debug;
@@ -392,7 +393,7 @@ impl Interpreter for CopyIntoTableInterpreter {
                 self.plan.database_name.to_string(),
                 self.plan.table_name.to_string(),
                 MutationKind::Insert,
-                true,
+                LockTableOption::LockNoRetry,
             );
             hook_operator.execute(&mut build_res.main_pipeline).await;
         }

--- a/src/query/service/src/interpreters/interpreter_delete.rs
+++ b/src/query/service/src/interpreters/interpreter_delete.rs
@@ -48,6 +48,7 @@ use databend_common_sql::plans::BoundColumnRef;
 use databend_common_sql::plans::ConstantExpr;
 use databend_common_sql::plans::EvalScalar;
 use databend_common_sql::plans::FunctionCall;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::RelOperator;
 use databend_common_sql::plans::ScalarItem;
 use databend_common_sql::plans::SubqueryDesc;
@@ -301,7 +302,7 @@ impl Interpreter for DeleteInterpreter {
                 tbl_name.to_string(),
                 MutationKind::Delete,
                 // table lock has been added, no need to check.
-                false,
+                LockTableOption::NoLock,
             );
             hook_operator
                 .execute_refresh(&mut build_res.main_pipeline)

--- a/src/query/service/src/interpreters/interpreter_delete.rs
+++ b/src/query/service/src/interpreters/interpreter_delete.rs
@@ -117,7 +117,12 @@ impl Interpreter for DeleteInterpreter {
         let lock_guard = self
             .ctx
             .clone()
-            .acquire_table_lock(catalog_name, db_name, tbl_name)
+            .acquire_table_lock(
+                catalog_name,
+                db_name,
+                tbl_name,
+                &LockTableOption::LockWithRetry,
+            )
             .await?;
 
         let catalog = self.ctx.get_catalog(catalog_name).await?;

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -29,6 +29,7 @@ use databend_common_sql::executor::PhysicalPlanBuilder;
 use databend_common_sql::plans::insert::InsertValue;
 use databend_common_sql::plans::Insert;
 use databend_common_sql::plans::InsertInputSource;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::Plan;
 use databend_common_sql::NameResolutionContext;
 
@@ -276,7 +277,7 @@ impl Interpreter for InsertInterpreter {
                         self.plan.database.clone(),
                         self.plan.table.clone(),
                         MutationKind::Insert,
-                        true,
+                        LockTableOption::LockNoRetry,
                     );
                     hook_operator.execute(&mut build_res.main_pipeline).await;
                 }
@@ -311,7 +312,7 @@ impl Interpreter for InsertInterpreter {
                 self.plan.database.clone(),
                 self.plan.table.clone(),
                 MutationKind::Insert,
-                true,
+                LockTableOption::LockNoRetry,
             );
             hook_operator.execute(&mut build_res.main_pipeline).await;
         }

--- a/src/query/service/src/interpreters/interpreter_merge_into.rs
+++ b/src/query/service/src/interpreters/interpreter_merge_into.rs
@@ -149,7 +149,12 @@ impl MergeIntoInterpreter {
         let lock_guard = self
             .ctx
             .clone()
-            .acquire_table_lock(catalog, database, table_name)
+            .acquire_table_lock(
+                catalog,
+                database,
+                table_name,
+                &LockTableOption::LockWithRetry,
+            )
             .await?;
 
         let table = self.ctx.get_table(catalog, database, table_name).await?;

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -35,6 +35,7 @@ use databend_common_sql::executor::physical_plans::ReplaceSelectCtx;
 use databend_common_sql::executor::PhysicalPlan;
 use databend_common_sql::plans::insert::InsertValue;
 use databend_common_sql::plans::InsertInputSource;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::Plan;
 use databend_common_sql::plans::Replace;
 use databend_common_sql::BindContext;
@@ -112,7 +113,7 @@ impl Interpreter for ReplaceInterpreter {
                 self.plan.database.clone(),
                 self.plan.table.clone(),
                 MutationKind::Replace,
-                true,
+                LockTableOption::LockNoRetry,
             );
             hook_operator.execute(&mut pipeline.main_pipeline).await;
         }

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -335,7 +335,6 @@ impl ReplaceInterpreter {
             mutation_kind: MutationKind::Replace,
             update_stream_meta: update_stream_meta.clone(),
             merge_meta: false,
-            need_lock: false,
             deduplicated_label: unsafe { self.ctx.get_settings().get_deduplicate_label()? },
             plan_id: u32::MAX,
         })));

--- a/src/query/service/src/interpreters/interpreter_table_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_table_index_refresh.rs
@@ -20,13 +20,11 @@ use databend_common_exception::Result;
 use databend_common_expression::TableSchemaRefExt;
 use databend_common_license::license::Feature;
 use databend_common_license::license_manager::get_license_manager;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::RefreshTableIndexPlan;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::TableContext;
 
 use crate::interpreters::Interpreter;
-use crate::locks::LockManager;
 use crate::pipelines::PipelineBuildResult;
 use crate::sessions::QueryContext;
 
@@ -58,10 +56,24 @@ impl Interpreter for RefreshTableIndexInterpreter {
             .manager
             .check_enterprise_enabled(self.ctx.get_license_key(), Feature::InvertedIndex)?;
 
+        // Add table lock.
+        let lock_guard = self
+            .ctx
+            .clone()
+            .acquire_table_lock_with_opt(
+                &self.plan.catalog,
+                &self.plan.database,
+                &self.plan.table,
+                &self.plan.lock_opt,
+            )
+            .await?;
+
         let table = self
             .ctx
             .get_table(&self.plan.catalog, &self.plan.database, &self.plan.table)
             .await?;
+        // check mutability
+        table.check_mutable()?;
 
         let index_name = self.plan.index_name.clone();
         let segment_locs = self.plan.segment_locs.clone();
@@ -89,19 +101,6 @@ impl Interpreter for RefreshTableIndexInterpreter {
         }
         let index_version = index.version.clone();
         let index_schema = TableSchemaRefExt::create(index_fields);
-
-        // Add table lock if need.
-        let table_lock = LockManager::create_table_lock(table.get_table_info().clone())?;
-        let lock_guard = match self.plan.lock_opt {
-            LockTableOption::LockNoRetry => table_lock.try_lock_no_retry(self.ctx.clone()).await?,
-            LockTableOption::LockWithRetry => table_lock.try_lock(self.ctx.clone()).await?,
-            LockTableOption::NoLock => None,
-        };
-
-        // refresh table.
-        let table = table.refresh(self.ctx.as_ref()).await?;
-        // check mutability
-        table.check_mutable()?;
 
         let mut build_res = PipelineBuildResult::create();
         build_res.main_pipeline.add_lock_guard(lock_guard);

--- a/src/query/service/src/interpreters/interpreter_table_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_table_index_refresh.rs
@@ -60,7 +60,7 @@ impl Interpreter for RefreshTableIndexInterpreter {
         let lock_guard = self
             .ctx
             .clone()
-            .acquire_table_lock_with_opt(
+            .acquire_table_lock(
                 &self.plan.catalog,
                 &self.plan.database,
                 &self.plan.table,

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -51,9 +51,8 @@ use databend_enterprise_data_mask_feature::get_datamask_handler;
 use databend_storages_common_index::BloomIndex;
 use databend_storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 
-use super::common::check_referenced_computed_columns;
+use crate::interpreters::common::check_referenced_computed_columns;
 use crate::interpreters::Interpreter;
-use crate::locks::LockManager;
 use crate::pipelines::PipelineBuildResult;
 use crate::schedulers::build_query_pipeline_without_render_result_set;
 use crate::sessions::QueryContext;
@@ -73,7 +72,7 @@ impl ModifyTableColumnInterpreter {
     async fn do_set_data_mask_policy(
         &self,
         catalog: Arc<dyn Catalog>,
-        table: &Arc<dyn Table>,
+        table: Arc<dyn Table>,
         column: String,
         mask_name: String,
     ) -> Result<PipelineBuildResult> {
@@ -140,15 +139,9 @@ impl ModifyTableColumnInterpreter {
     // Set data column type.
     async fn do_set_data_type(
         &self,
-        table: &Arc<dyn Table>,
+        table: Arc<dyn Table>,
         field_and_comments: &[(TableField, String)],
     ) -> Result<PipelineBuildResult> {
-        // Add table lock.
-        let table_lock = LockManager::create_table_lock(table.get_table_info().clone())?;
-        let lock_guard = table_lock.try_lock(self.ctx.clone()).await?;
-        // refresh table.
-        let table = table.refresh(self.ctx.as_ref()).await?;
-
         let schema = table.schema().as_ref().clone();
         let table_info = table.get_table_info();
         let mut new_schema = schema.clone();
@@ -420,7 +413,6 @@ impl ModifyTableColumnInterpreter {
             None,
         )?;
 
-        build_res.main_pipeline.add_lock_guard(lock_guard);
         Ok(build_res)
     }
 
@@ -428,7 +420,7 @@ impl ModifyTableColumnInterpreter {
     async fn do_unset_data_mask_policy(
         &self,
         catalog: Arc<dyn Catalog>,
-        table: &Arc<dyn Table>,
+        table: Arc<dyn Table>,
         column: String,
     ) -> Result<PipelineBuildResult> {
         let license_manager = get_license_manager();
@@ -474,7 +466,7 @@ impl ModifyTableColumnInterpreter {
     async fn do_convert_stored_computed_column(
         &self,
         catalog: Arc<dyn Catalog>,
-        table: &Arc<dyn Table>,
+        table: Arc<dyn Table>,
         table_meta: TableMeta,
         column: String,
     ) -> Result<PipelineBuildResult> {
@@ -553,53 +545,50 @@ impl Interpreter for ModifyTableColumnInterpreter {
         let db_name = self.plan.database.as_str();
         let tbl_name = self.plan.table.as_str();
 
-        let tbl = self
+        // try add lock table.
+        let lock_guard = self
             .ctx
-            .get_catalog(catalog_name)
-            .await?
-            .get_table(&self.ctx.get_tenant(), db_name, tbl_name)
-            .await
-            .ok();
+            .clone()
+            .acquire_table_lock(catalog_name, db_name, tbl_name)
+            .await?;
 
-        let table = if let Some(table) = &tbl {
-            // check mutability
-            table.check_mutable()?;
-            table
-        } else {
-            return Ok(PipelineBuildResult::create());
-        };
+        let catalog = self.ctx.get_catalog(catalog_name).await?;
+        let table = catalog
+            .get_table(&self.ctx.get_tenant(), db_name, tbl_name)
+            .await?;
+
+        table.check_mutable()?;
 
         let table_info = table.get_table_info();
         let engine = table.engine();
         if matches!(engine, VIEW_ENGINE | STREAM_ENGINE) {
             return Err(ErrorCode::TableEngineNotSupported(format!(
                 "{}.{} engine is {} that doesn't support alter",
-                &self.plan.database, &self.plan.table, engine
+                db_name, tbl_name, engine
             )));
         }
         if table_info.db_type != DatabaseType::NormalDB {
             return Err(ErrorCode::TableEngineNotSupported(format!(
                 "{}.{} doesn't support alter",
-                &self.plan.database, &self.plan.table
+                db_name, tbl_name
             )));
         }
 
-        let catalog = self.ctx.get_catalog(catalog_name).await?;
         let table_meta = table.get_table_info().meta.clone();
 
         // NOTICE: if we support modify column data type,
         // need to check whether this column is referenced by other computed columns.
-        match &self.plan.action {
+        let mut build_res = match &self.plan.action {
             ModifyColumnAction::SetMaskingPolicy(column, mask_name) => {
                 self.do_set_data_mask_policy(catalog, table, column.to_string(), mask_name.clone())
-                    .await
+                    .await?
             }
             ModifyColumnAction::UnsetMaskingPolicy(column) => {
                 self.do_unset_data_mask_policy(catalog, table, column.to_string())
-                    .await
+                    .await?
             }
             ModifyColumnAction::SetDataType(field_and_comment) => {
-                self.do_set_data_type(table, field_and_comment).await
+                self.do_set_data_type(table, field_and_comment).await?
             }
             ModifyColumnAction::ConvertStoredComputedColumn(column) => {
                 self.do_convert_stored_computed_column(
@@ -608,8 +597,11 @@ impl Interpreter for ModifyTableColumnInterpreter {
                     table_meta,
                     column.to_string(),
                 )
-                .await
+                .await?
             }
-        }
+        };
+
+        build_res.main_pipeline.add_lock_guard(lock_guard);
+        Ok(build_res)
     }
 }

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -37,6 +37,7 @@ use databend_common_sql::executor::physical_plans::DistributedInsertSelect;
 use databend_common_sql::executor::PhysicalPlan;
 use databend_common_sql::executor::PhysicalPlanBuilder;
 use databend_common_sql::field_default_value;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::ModifyColumnAction;
 use databend_common_sql::plans::ModifyTableColumnPlan;
 use databend_common_sql::plans::Plan;
@@ -549,7 +550,12 @@ impl Interpreter for ModifyTableColumnInterpreter {
         let lock_guard = self
             .ctx
             .clone()
-            .acquire_table_lock(catalog_name, db_name, tbl_name)
+            .acquire_table_lock(
+                catalog_name,
+                db_name,
+                tbl_name,
+                &LockTableOption::LockWithRetry,
+            )
             .await?;
 
         let catalog = self.ctx.get_catalog(catalog_name).await?;

--- a/src/query/service/src/interpreters/interpreter_table_optimize.rs
+++ b/src/query/service/src/interpreters/interpreter_table_optimize.rs
@@ -148,7 +148,7 @@ impl OptimizeTableInterpreter {
         let lock_guard = self
             .ctx
             .clone()
-            .acquire_table_lock_with_opt(
+            .acquire_table_lock(
                 &self.plan.catalog,
                 &self.plan.database,
                 &self.plan.table,

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -30,6 +30,7 @@ use databend_common_sql::executor::physical_plans::ReclusterSink;
 use databend_common_sql::executor::physical_plans::ReclusterSource;
 use databend_common_sql::executor::physical_plans::ReclusterTask;
 use databend_common_sql::executor::PhysicalPlan;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_storages_fuse::FuseTable;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::Statistics;
@@ -122,7 +123,12 @@ impl Interpreter for ReclusterTableInterpreter {
             let lock_guard = self
                 .ctx
                 .clone()
-                .acquire_table_lock(&self.plan.catalog, &self.plan.database, &self.plan.table)
+                .acquire_table_lock(
+                    &self.plan.catalog,
+                    &self.plan.database,
+                    &self.plan.table,
+                    &LockTableOption::LockWithRetry,
+                )
                 .await?;
 
             let table = catalog

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -19,7 +19,6 @@ use std::time::SystemTime;
 use databend_common_catalog::plan::Filters;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::table::TableExt;
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::type_check::check_function;
 use databend_common_functions::BUILTIN_FUNCTIONS;
@@ -40,8 +39,6 @@ use log::warn;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterClusteringHistory;
-use crate::locks::LockExt;
-use crate::locks::LockManager;
 use crate::pipelines::executor::ExecutorSettings;
 use crate::pipelines::executor::PipelineCompleteExecutor;
 use crate::pipelines::PipelineBuildResult;
@@ -107,12 +104,6 @@ impl Interpreter for ReclusterTableInterpreter {
 
         let catalog = self.ctx.get_catalog(&self.plan.catalog).await?;
         let tenant = self.ctx.get_tenant();
-        let mut table = catalog
-            .get_table(&tenant, &self.plan.database, &self.plan.table)
-            .await?;
-
-        // check mutability
-        table.check_mutable()?;
 
         let mut times = 0;
         let mut block_count = 0;
@@ -127,16 +118,18 @@ impl Interpreter for ReclusterTableInterpreter {
                 return Err(err);
             }
 
-            let table_info = table.get_table_info().clone();
+            // try add lock table.
+            let lock_guard = self
+                .ctx
+                .clone()
+                .acquire_table_lock(&self.plan.catalog, &self.plan.database, &self.plan.table)
+                .await?;
 
-            // check if the table is locked.
-            let table_lock = LockManager::create_table_lock(table_info.clone())?;
-            if !table_lock.wait_lock_expired(catalog.clone()).await? {
-                return Err(ErrorCode::TableAlreadyLocked(format!(
-                    "table '{}' is locked, please retry recluster later",
-                    self.plan.table
-                )));
-            }
+            let table = catalog
+                .get_table(&tenant, &self.plan.database, &self.plan.table)
+                .await?;
+            // check mutability
+            table.check_mutable()?;
 
             let fuse_table = FuseTable::try_from_table(table.as_ref())?;
             let mutator = fuse_table
@@ -153,17 +146,17 @@ impl Interpreter for ReclusterTableInterpreter {
             block_count += mutator.recluster_blocks_count;
             let physical_plan = build_recluster_physical_plan(
                 mutator.tasks,
-                table_info,
+                table.get_table_info().clone(),
                 catalog.info(),
                 mutator.snapshot,
                 mutator.remained_blocks,
                 mutator.removed_segment_indexes,
                 mutator.removed_segment_summary,
-                true,
             )?;
 
             let mut build_res =
                 build_query_pipeline_without_render_result_set(&self.ctx, &physical_plan).await?;
+            build_res.main_pipeline.add_lock_guard(lock_guard);
             assert!(build_res.main_pipeline.is_complete_pipeline()?);
             build_res.set_max_threads(max_threads);
 
@@ -201,11 +194,6 @@ impl Interpreter for ReclusterTableInterpreter {
                 );
                 break;
             }
-
-            // refresh table.
-            table = catalog
-                .get_table(&tenant, &self.plan.database, &self.plan.table)
-                .await?;
         }
 
         if block_count != 0 {
@@ -231,7 +219,6 @@ pub fn build_recluster_physical_plan(
     remained_blocks: Vec<Arc<BlockMeta>>,
     removed_segment_indexes: Vec<usize>,
     removed_segment_summary: Statistics,
-    need_lock: bool,
 ) -> Result<PhysicalPlan> {
     let is_distributed = tasks.len() > 1;
     let mut root = PhysicalPlan::ReclusterSource(Box::new(ReclusterSource {
@@ -260,7 +247,6 @@ pub fn build_recluster_physical_plan(
         removed_segment_indexes,
         removed_segment_summary,
         plan_id: u32::MAX,
-        need_lock,
     }));
     plan.adjust_plan_id(&mut 0);
     Ok(plan)

--- a/src/query/service/src/interpreters/interpreter_table_truncate.rs
+++ b/src/query/service/src/interpreters/interpreter_table_truncate.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use databend_common_catalog::table::TableExt;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::TruncateTablePlan;
 
 use crate::interpreters::Interpreter;
@@ -74,7 +75,12 @@ impl Interpreter for TruncateTableInterpreter {
         let lock_guard = self
             .ctx
             .clone()
-            .acquire_table_lock(&self.catalog_name, &self.database_name, &self.table_name)
+            .acquire_table_lock(
+                &self.catalog_name,
+                &self.database_name,
+                &self.table_name,
+                &LockTableOption::LockWithRetry,
+            )
             .await?;
 
         let table = self

--- a/src/query/service/src/interpreters/interpreter_table_truncate.rs
+++ b/src/query/service/src/interpreters/interpreter_table_truncate.rs
@@ -18,10 +18,8 @@ use databend_common_catalog::table::TableExt;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
 use databend_common_sql::plans::TruncateTablePlan;
-use databend_common_storages_fuse::FuseTable;
 
 use crate::interpreters::Interpreter;
-use crate::locks::LockManager;
 use crate::pipelines::PipelineBuildResult;
 use crate::servers::flight::v1::packets::Packet;
 use crate::servers::flight::v1::packets::TruncateTablePacket;
@@ -72,22 +70,19 @@ impl Interpreter for TruncateTableInterpreter {
     #[async_backtrace::framed]
     #[minitrace::trace]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
+        // try add lock table.
+        let lock_guard = self
+            .ctx
+            .clone()
+            .acquire_table_lock(&self.catalog_name, &self.database_name, &self.table_name)
+            .await?;
+
         let table = self
             .ctx
             .get_table(&self.catalog_name, &self.database_name, &self.table_name)
             .await?;
-
         // check mutability
         table.check_mutable()?;
-
-        // Add table lock.
-        let maybe_fuse_table = FuseTable::try_from_table(table.as_ref()).is_ok();
-        let lock_guard = if maybe_fuse_table {
-            let table_lock = LockManager::create_table_lock(table.get_table_info().clone())?;
-            table_lock.try_lock(self.ctx.clone()).await?
-        } else {
-            None
-        };
 
         if self.proxy_to_cluster && table.broadcast_truncate_to_cluster() {
             let settings = self.ctx.get_settings();

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -41,6 +41,7 @@ use databend_common_sql::executor::physical_plans::FragmentKind;
 use databend_common_sql::executor::physical_plans::MutationKind;
 use databend_common_sql::executor::physical_plans::UpdateSource;
 use databend_common_sql::executor::PhysicalPlan;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::Visibility;
 use databend_common_storages_factory::Table;
 use databend_common_storages_fuse::FuseTable;
@@ -122,7 +123,7 @@ impl Interpreter for UpdateInterpreter {
                     tbl_name.to_string(),
                     MutationKind::Update,
                     // table lock has been added, no need to check.
-                    false,
+                    LockTableOption::NoLock,
                 );
                 hook_operator
                     .execute_refresh(&mut build_res.main_pipeline)

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -101,7 +101,12 @@ impl Interpreter for UpdateInterpreter {
         let lock_guard = self
             .ctx
             .clone()
-            .acquire_table_lock(catalog_name, db_name, tbl_name)
+            .acquire_table_lock(
+                catalog_name,
+                db_name,
+                tbl_name,
+                &LockTableOption::LockWithRetry,
+            )
             .await?;
 
         // build physical plan.

--- a/src/query/service/src/locks/lock_manager.rs
+++ b/src/query/service/src/locks/lock_manager.rs
@@ -105,10 +105,10 @@ impl LockManager {
 
         let tenant_name = lock.tenant_name();
         let tenant = Tenant::new_or_err(tenant_name, func_name!())?;
-
+        let table_id = lock.get_table_id();
         let lock_key = LockKey::Table {
             tenant: tenant.clone(),
-            table_id: lock.get_table_id(),
+            table_id,
         };
 
         let req = CreateLockRevReq::new(lock_key.clone(), user, node, query_id, expire_secs);
@@ -117,7 +117,7 @@ impl LockManager {
         let res = catalog.create_lock_revision(req).await?;
         let revision = res.revision;
         // metrics.
-        record_created_lock_nums(lock.lock_type().to_string(), lock.get_table_id(), 1);
+        record_created_lock_nums(lock.lock_type().to_string(), table_id, 1);
 
         let lock_holder = Arc::new(LockHolder::default());
         lock_holder
@@ -147,18 +147,16 @@ impl LockManager {
 
             if position == 0 {
                 // The lock is acquired by current session.
-
                 let extend_table_lock_req =
                     ExtendLockRevReq::new(lock_key.clone(), revision, expire_secs, true);
 
                 catalog.extend_lock_revision(extend_table_lock_req).await?;
                 // metrics.
-                record_acquired_lock_nums(lock.lock_type().to_string(), lock.get_table_id(), 1);
+                record_acquired_lock_nums(lock.lock_type().to_string(), table_id, 1);
                 break;
             }
 
-            let watch_delete_ident =
-                TableLockIdent::new(&tenant, lock.get_table_id(), reply[position - 1].0);
+            let watch_delete_ident = TableLockIdent::new(&tenant, table_id, reply[position - 1].0);
 
             // Get the previous revision, watch the delete event.
             let req = WatchRequest {
@@ -189,6 +187,71 @@ impl LockManager {
                     ))
                 }
             }?;
+        }
+
+        Ok(Some(guard))
+    }
+
+    /// Try request lock without retry.
+    #[async_backtrace::framed]
+    pub async fn try_lock_no_retry<T: Lock + ?Sized>(
+        self: &Arc<Self>,
+        ctx: Arc<dyn TableContext>,
+        lock: &T,
+    ) -> Result<Option<LockGuard>> {
+        let table_id = lock.get_table_id();
+        let lock_key = LockKey::Table {
+            tenant: Tenant::new_or_err(lock.tenant_name(), func_name!())?,
+            table_id,
+        };
+
+        let expire_secs = ctx.get_settings().get_table_lock_expire_secs()?;
+        let req = CreateLockRevReq::new(
+            lock_key.clone(),
+            ctx.get_current_user()?.name,
+            ctx.get_cluster().local_id.clone(),
+            ctx.get_current_session_id(),
+            expire_secs,
+        );
+
+        // get a new table lock revision.
+        let catalog = ctx.get_catalog(lock.get_catalog()).await?;
+        let res = catalog.create_lock_revision(req).await?;
+        let revision = res.revision;
+        // metrics.
+        record_created_lock_nums(lock.lock_type().to_string(), table_id, 1);
+
+        let lock_holder = Arc::new(LockHolder::default());
+        lock_holder
+            .start(ctx.get_id(), catalog.clone(), lock, revision, expire_secs)
+            .await?;
+
+        self.insert_lock(revision, lock_holder);
+        let guard = LockGuard::new(self.clone(), revision);
+
+        // List all revisions and check if the current is the minimum.
+        let reply = catalog
+            .list_lock_revisions(ListLockRevReq::new(lock_key.clone()))
+            .await?;
+        let position = reply.iter().position(|(x, _)| *x == revision).ok_or_else(||
+                // If the current is not found in list,  it means that the current has been expired.
+                ErrorCode::TableLockExpired("the acquired table lock has been expired".to_string()),
+            )?;
+
+        if position == 0 {
+            // The lock is acquired by current session.
+            catalog
+                .extend_lock_revision(ExtendLockRevReq::new(lock_key, revision, expire_secs, true))
+                .await?;
+            // metrics.
+            record_acquired_lock_nums(lock.lock_type().to_string(), table_id, 1);
+        } else {
+            catalog
+                .delete_lock_revision(DeleteLockRevReq::new(lock_key, revision))
+                .await?;
+            return Err(ErrorCode::TableAlreadyLocked(
+                "table is locked by other session, please retry later".to_string(),
+            ));
         }
 
         Ok(Some(guard))

--- a/src/query/service/src/locks/table_lock/mod.rs
+++ b/src/query/service/src/locks/table_lock/mod.rs
@@ -56,20 +56,10 @@ impl Lock for TableLock {
     }
 
     async fn try_lock(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>> {
-        let enabled_table_lock = ctx.get_settings().get_enable_table_lock().unwrap_or(false);
-        if enabled_table_lock {
-            self.lock_mgr.try_lock(ctx, self).await
-        } else {
-            Ok(None)
-        }
+        self.lock_mgr.try_lock(ctx, self).await
     }
 
     async fn try_lock_no_retry(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>> {
-        let enabled_table_lock = ctx.get_settings().get_enable_table_lock().unwrap_or(false);
-        if enabled_table_lock {
-            self.lock_mgr.try_lock_no_retry(ctx, self).await
-        } else {
-            Ok(None)
-        }
+        self.lock_mgr.try_lock_no_retry(ctx, self).await
     }
 }

--- a/src/query/service/src/locks/table_lock/mod.rs
+++ b/src/query/service/src/locks/table_lock/mod.rs
@@ -55,11 +55,11 @@ impl Lock for TableLock {
         &self.table_info.tenant
     }
 
-    async fn try_lock(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>> {
-        self.lock_mgr.try_lock(ctx, self).await
-    }
-
-    async fn try_lock_no_retry(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>> {
-        self.lock_mgr.try_lock_no_retry(ctx, self).await
+    async fn try_lock(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        should_retry: bool,
+    ) -> Result<Option<LockGuard>> {
+        self.lock_mgr.try_lock(ctx, self, should_retry).await
     }
 }

--- a/src/query/service/src/locks/table_lock/mod.rs
+++ b/src/query/service/src/locks/table_lock/mod.rs
@@ -63,4 +63,13 @@ impl Lock for TableLock {
             Ok(None)
         }
     }
+
+    async fn try_lock_no_retry(&self, ctx: Arc<dyn TableContext>) -> Result<Option<LockGuard>> {
+        let enabled_table_lock = ctx.get_settings().get_enable_table_lock().unwrap_or(false);
+        if enabled_table_lock {
+            self.lock_mgr.try_lock_no_retry(ctx, self).await
+        } else {
+            Ok(None)
+        }
+    }
 }

--- a/src/query/service/src/pipelines/builders/builder_commit.rs
+++ b/src/query/service/src/pipelines/builders/builder_commit.rs
@@ -24,7 +24,6 @@ use databend_common_storages_fuse::operations::TableMutationAggregator;
 use databend_common_storages_fuse::operations::TransformMergeCommitMeta;
 use databend_common_storages_fuse::FuseTable;
 
-use crate::locks::LockManager;
 use crate::pipelines::PipelineBuilder;
 
 impl PipelineBuilder {
@@ -66,11 +65,6 @@ impl PipelineBuilder {
         }
 
         let snapshot_gen = MutationGenerator::new(plan.snapshot.clone(), plan.mutation_kind);
-        let lock = if plan.need_lock {
-            Some(LockManager::create_table_lock(plan.table_info.clone())?)
-        } else {
-            None
-        };
         self.main_pipeline.add_sink(|input| {
             CommitSink::try_create(
                 table,
@@ -80,7 +74,6 @@ impl PipelineBuilder {
                 snapshot_gen.clone(),
                 input,
                 None,
-                lock.clone(),
                 None,
                 plan.deduplicated_label.clone(),
             )

--- a/src/query/service/src/pipelines/builders/builder_recluster.rs
+++ b/src/query/service/src/pipelines/builders/builder_recluster.rs
@@ -39,7 +39,6 @@ use databend_common_storages_fuse::operations::TransformSerializeBlock;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::TableContext;
 
-use crate::locks::LockManager;
 use crate::pipelines::builders::SortPipelineBuilder;
 use crate::pipelines::processors::TransformAddStreamColumns;
 use crate::pipelines::PipelineBuilder;
@@ -229,13 +228,6 @@ impl PipelineBuilder {
 
         let snapshot_gen =
             MutationGenerator::new(recluster_sink.snapshot.clone(), MutationKind::Recluster);
-        let lock = if recluster_sink.need_lock {
-            Some(LockManager::create_table_lock(
-                recluster_sink.table_info.clone(),
-            )?)
-        } else {
-            None
-        };
         self.main_pipeline.add_sink(|input| {
             CommitSink::try_create(
                 table,
@@ -245,7 +237,6 @@ impl PipelineBuilder {
                 snapshot_gen.clone(),
                 input,
                 None,
-                lock.clone(),
                 None,
                 None,
             )

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -75,7 +75,9 @@ use databend_common_meta_app::tenant::Tenant;
 use databend_common_metrics::storage::*;
 use databend_common_pipeline_core::processors::PlanProfile;
 use databend_common_pipeline_core::InputError;
+use databend_common_pipeline_core::LockGuard;
 use databend_common_settings::Settings;
+use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::IndexType;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::DataOperator;
@@ -102,6 +104,7 @@ use xorf::BinaryFuse16;
 
 use crate::catalogs::Catalog;
 use crate::clusters::Cluster;
+use crate::locks::LockManager;
 use crate::pipelines::executor::PipelineExecutor;
 use crate::servers::flight::v1::exchange::DataExchangeManager;
 use crate::sessions::query_affect::QueryAffect;
@@ -314,6 +317,59 @@ impl QueryContext {
 
     pub fn clear_tables_cache(&self) {
         self.shared.clear_tables_cache()
+    }
+
+    pub async fn acquire_table_lock(
+        self: Arc<Self>,
+        catalog_name: &str,
+        db_name: &str,
+        tbl_name: &str,
+    ) -> Result<Option<LockGuard>> {
+        let enabled_table_lock = self.get_settings().get_enable_table_lock().unwrap_or(false);
+        if !enabled_table_lock {
+            return Ok(None);
+        }
+
+        let catalog = self.get_catalog(catalog_name).await?;
+        let tbl = catalog
+            .get_table(&self.get_tenant(), db_name, tbl_name)
+            .await?;
+        if tbl.engine() != "FUSE" {
+            return Ok(None);
+        }
+
+        // Add table lock.
+        let table_lock = LockManager::create_table_lock(tbl.get_table_info().clone())?;
+        table_lock.try_lock(self).await
+    }
+
+    pub async fn acquire_table_lock_with_opt(
+        self: Arc<Self>,
+        catalog_name: &str,
+        db_name: &str,
+        tbl_name: &str,
+        lock_opt: &LockTableOption,
+    ) -> Result<Option<LockGuard>> {
+        let enabled_table_lock = self.get_settings().get_enable_table_lock().unwrap_or(false);
+        if !enabled_table_lock {
+            return Ok(None);
+        }
+
+        let catalog = self.get_catalog(catalog_name).await?;
+        let tbl = catalog
+            .get_table(&self.get_tenant(), db_name, tbl_name)
+            .await?;
+        if tbl.engine() != "FUSE" {
+            return Ok(None);
+        }
+
+        // Add table lock.
+        let table_lock = LockManager::create_table_lock(tbl.get_table_info().clone())?;
+        match lock_opt {
+            LockTableOption::LockNoRetry => table_lock.try_lock_no_retry(self).await,
+            LockTableOption::LockWithRetry => table_lock.try_lock(self).await,
+            LockTableOption::NoLock => Ok(None),
+        }
     }
 }
 

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -122,7 +122,6 @@ async fn do_compact(ctx: Arc<QueryContext>, table: Arc<dyn Table>) -> Result<boo
             snapshot,
             catalog_info,
             false,
-            true,
         )?;
 
         let build_res =

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -50,7 +50,6 @@ use databend_common_storages_fuse::statistics::sort_by_cluster_stats;
 use databend_common_storages_fuse::statistics::StatisticsAccumulator;
 use databend_common_storages_fuse::FuseStorageFormat;
 use databend_common_storages_fuse::FuseTable;
-use databend_query::locks::LockManager;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContext;
 use databend_query::test_kits::*;
@@ -262,10 +261,8 @@ async fn build_mutator(
         num_block_limit: None,
     };
 
-    let table_lock = LockManager::create_table_lock(tbl.get_table_info().clone())?;
     let mut segment_mutator = SegmentCompactMutator::try_create(
         ctx.clone(),
-        table_lock,
         compact_params,
         tbl.meta_location_generator().clone(),
         tbl.get_operator(),

--- a/src/query/sql/src/executor/physical_plans/physical_commit_sink.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_commit_sink.rs
@@ -34,6 +34,5 @@ pub struct CommitSink {
     pub mutation_kind: MutationKind,
     pub update_stream_meta: Vec<UpdateStreamMetaReq>,
     pub merge_meta: bool,
-    pub need_lock: bool,
     pub deduplicated_label: Option<String>,
 }

--- a/src/query/sql/src/executor/physical_plans/physical_recluster_sink.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_recluster_sink.rs
@@ -34,5 +34,4 @@ pub struct ReclusterSink {
     pub remained_blocks: Vec<Arc<BlockMeta>>,
     pub removed_segment_indexes: Vec<usize>,
     pub removed_segment_summary: Statistics,
-    pub need_lock: bool,
 }

--- a/src/query/sql/src/planner/binder/ddl/index.rs
+++ b/src/query/sql/src/planner/binder/ddl/index.rs
@@ -52,6 +52,7 @@ use crate::plans::CreateIndexPlan;
 use crate::plans::CreateTableIndexPlan;
 use crate::plans::DropIndexPlan;
 use crate::plans::DropTableIndexPlan;
+use crate::plans::LockTableOption;
 use crate::plans::Plan;
 use crate::plans::RefreshIndexPlan;
 use crate::plans::RefreshTableIndexPlan;
@@ -590,7 +591,7 @@ impl Binder {
             table,
             index_name,
             segment_locs: None,
-            need_lock: true,
+            lock_opt: LockTableOption::LockWithRetry,
         };
         Ok(Plan::RefreshTableIndex(Box::new(plan)))
     }

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -107,6 +107,7 @@ use crate::plans::DropTableClusterKeyPlan;
 use crate::plans::DropTableColumnPlan;
 use crate::plans::DropTablePlan;
 use crate::plans::ExistsTablePlan;
+use crate::plans::LockTableOption;
 use crate::plans::ModifyColumnAction as ModifyColumnActionInPlan;
 use crate::plans::ModifyTableColumnPlan;
 use crate::plans::ModifyTableCommentPlan;
@@ -1115,7 +1116,7 @@ impl Binder {
             table,
             action,
             limit: limit.map(|v| v as usize),
-            need_lock: true,
+            lock_opt: LockTableOption::LockWithRetry,
         })))
     }
 

--- a/src/query/sql/src/planner/plans/ddl/index.rs
+++ b/src/query/sql/src/planner/plans/ddl/index.rs
@@ -22,6 +22,7 @@ use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_types::MetaId;
 use databend_storages_common_table_meta::meta::Location;
 
+use crate::plans::LockTableOption;
 use crate::plans::Plan;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -81,5 +82,5 @@ pub struct RefreshTableIndexPlan {
     pub table: String,
     pub index_name: String,
     pub segment_locs: Option<Vec<Location>>,
-    pub need_lock: bool,
+    pub lock_opt: LockTableOption,
 }

--- a/src/query/sql/src/planner/plans/ddl/table.rs
+++ b/src/query/sql/src/planner/plans/ddl/table.rs
@@ -205,13 +205,20 @@ pub struct OptimizeTablePlan {
     pub table: String,
     pub action: OptimizeTableAction,
     pub limit: Option<usize>,
-    pub need_lock: bool,
+    pub lock_opt: LockTableOption,
 }
 
 impl OptimizeTablePlan {
     pub fn schema(&self) -> DataSchemaRef {
         Arc::new(DataSchema::empty())
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LockTableOption {
+    NoLock,
+    LockWithRetry,
+    LockNoRetry,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -19,7 +19,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use databend_common_catalog::catalog::StorageDescription;
-use databend_common_catalog::lock::Lock;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::PartStatistics;
 use databend_common_catalog::plan::Partitions;
@@ -882,10 +881,9 @@ impl Table for FuseTable {
     async fn compact_segments(
         &self,
         ctx: Arc<dyn TableContext>,
-        lock: Arc<dyn Lock>,
         limit: Option<usize>,
     ) -> Result<()> {
-        self.do_compact_segments(ctx, lock, limit).await
+        self.do_compact_segments(ctx, limit).await
     }
 
     #[async_backtrace::framed]

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -104,7 +104,6 @@ impl FuseTable {
                 snapshot_gen.clone(),
                 input,
                 None,
-                None,
                 prev_snapshot_id,
                 deduplicated_label.clone(),
             )

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -16,7 +16,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use databend_common_base::runtime::Runtime;
-use databend_common_catalog::lock::Lock;
 use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::plan::PartitionsShuffleKind;
@@ -58,7 +57,6 @@ impl FuseTable {
     pub(crate) async fn do_compact_segments(
         &self,
         ctx: Arc<dyn TableContext>,
-        lock: Arc<dyn Lock>,
         num_segment_limit: Option<usize>,
     ) -> Result<()> {
         let compact_options = if let Some(v) = self
@@ -72,7 +70,6 @@ impl FuseTable {
 
         let mut segment_mutator = SegmentCompactMutator::try_create(
             ctx.clone(),
-            lock,
             compact_options,
             self.meta_location_generator().clone(),
             self.operator.clone(),

--- a/src/query/storages/fuse/src/operations/inverted_index.rs
+++ b/src/query/storages/fuse/src/operations/inverted_index.rs
@@ -107,8 +107,11 @@ impl FuseTable {
             MetaReaders::segment_info_reader(self.get_operator(), table_schema.clone());
 
         // If no segment locations are specified, iterates through all segments
-        let segment_locs = if let Some(segment_locs) = &segment_locs {
-            segment_locs.clone()
+        let segment_locs = if let Some(segment_locs) = segment_locs {
+            segment_locs
+                .into_iter()
+                .filter(|s| snapshot.segments.contains(s))
+                .collect()
         } else {
             snapshot.segments.clone()
         };

--- a/src/query/storages/fuse/src/operations/truncate.rs
+++ b/src/query/storages/fuse/src/operations/truncate.rs
@@ -67,7 +67,6 @@ impl FuseTable {
                     snapshot_gen.clone(),
                     input,
                     None,
-                    None,
                     prev_snapshot_id,
                     None,
                 )

--- a/src/query/storages/fuse/src/operations/util.rs
+++ b/src/query/storages/fuse/src/operations/util.rs
@@ -48,7 +48,7 @@ pub fn set_backoff(
     // The initial retry delay in millisecond. By default,  it is 5 ms.
     let init_delay = init_retry_delay.unwrap_or(OCC_DEFAULT_BACKOFF_INIT_DELAY_MS);
 
-    // The maximum  back off delay in millisecond, once the retry interval reaches this value, it stops increasing.
+    // The maximum back off delay in millisecond, once the retry interval reaches this value, it stops increasing.
     // By default, it is 20 seconds.
     let max_delay = max_retry_delay.unwrap_or(OCC_DEFAULT_BACKOFF_MAX_DELAY_MS);
 

--- a/tests/cloud_control_server/simple_server.py
+++ b/tests/cloud_control_server/simple_server.py
@@ -44,9 +44,9 @@ def load_data_from_json():
                 notification_history_data = json.load(f)
                 notification_history = notification_pb2.NotificationHistory()
                 json_format.ParseDict(notification_history_data, notification_history)
-                NOTIFICATION_HISTORY_DB[
-                    notification_history.name
-                ] = notification_history
+                NOTIFICATION_HISTORY_DB[notification_history.name] = (
+                    notification_history
+                )
 
 
 def create_task_request_to_task(id, create_task_request):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR introduces the following enhancements:

1. **Addition of `LockTableOption` Enum**:
   - **NoLock**: No lock will be applied.
   - **LockWithRetry**: Attempts to acquire a lock and retries until a timeout is reached.
   - **LockNoRetry**: Attempts to acquire a lock without retrying on failure.

2. **Global Table Lock for `optimize` and `recluster` Operations**:
   - Implements a global table lock mechanism for `optimize` and `recluster` operations.
   - Currently, only `insert`, `copy`, and `replace` do not apply table locks

3. **Compact Hook with Locking Mechanism**:
   - The compact hook if need lock, it will attempts to acquire a lock using the `LockNoRetry` option. If the lock acquisition fails, the operation returns immediately without retrying.

4. **Fix: Refresh Table After Acquiring Lock**:
   - Added logic to refresh the table after successfully acquiring a lock, ensuring the table state is up-to-date.


Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15632)
<!-- Reviewable:end -->
