### PR TITLE
chore: spill out short_sql to common/base/src/string.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,6 +2817,7 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tikv-jemalloc-sys",
  "tokio",
+ "unicode-segmentation",
  "uuid",
 ]
 
@@ -4753,7 +4754,6 @@ dependencies = [
  "tonic",
  "tower",
  "typetag",
- "unicode-segmentation",
  "url",
  "uuid",
  "walkdir",

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -56,6 +56,7 @@ state = "0.5"
 tikv-jemalloc-ctl = { workspace = true }
 tikv-jemalloc-sys = "0.5.2"
 tokio = { workspace = true }
+unicode-segmentation = "1.10.1"
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -47,6 +47,7 @@ pub use string::escape_for_key;
 pub use string::format_byte_size;
 pub use string::mask_connection_info;
 pub use string::mask_string;
+pub use string::short_sql;
 pub use string::unescape_for_key;
 pub use string::unescape_string;
 pub use take_mut::take_mut;

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -174,7 +174,6 @@ tokio-stream = { workspace = true, features = ["net"] }
 toml = { version = "0.8", default-features = false }
 tonic = { workspace = true }
 typetag = { workspace = true }
-unicode-segmentation = "1.10.1"
 uuid = { workspace = true }
 walkdir = { workspace = true }
 xorf = { version = "0.11.0", default-features = false, features = ["binary-fuse"] }

--- a/src/query/service/src/interpreters/interpreter.rs
+++ b/src/query/service/src/interpreters/interpreter.rs
@@ -18,6 +18,7 @@ use std::time::SystemTime;
 
 use databend_common_ast::ast::Literal;
 use databend_common_ast::ast::Statement;
+use databend_common_base::base::short_sql;
 use databend_common_base::runtime::profile::get_statistics_desc;
 use databend_common_base::runtime::profile::ProfileDesc;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
@@ -46,7 +47,6 @@ use crate::pipelines::executor::ExecutorSettings;
 use crate::pipelines::executor::PipelineCompleteExecutor;
 use crate::pipelines::executor::PipelinePullingExecutor;
 use crate::pipelines::PipelineBuildResult;
-use crate::sessions::short_sql;
 use crate::sessions::QueryContext;
 use crate::sessions::SessionManager;
 use crate::stream::DataBlockStream;

--- a/src/query/service/src/servers/http/clickhouse_handler.rs
+++ b/src/query/service/src/servers/http/clickhouse_handler.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_stream::stream;
+use databend_common_base::base::short_sql;
 use databend_common_base::base::tokio;
 use databend_common_base::base::tokio::sync::mpsc::Sender;
 use databend_common_base::base::tokio::task::JoinHandle;
@@ -64,7 +65,6 @@ use crate::interpreters::InterpreterFactory;
 use crate::interpreters::InterpreterPtr;
 use crate::servers::http::middleware::sanitize_request_headers;
 use crate::servers::http::v1::HttpQueryContext;
-use crate::sessions::short_sql;
 use crate::sessions::QueriesQueueManager;
 use crate::sessions::QueryContext;
 use crate::sessions::QueryEntry;

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use databend_common_base::base::short_sql;
 use databend_common_base::base::tokio;
 use databend_common_base::base::tokio::sync::Mutex as TokioMutex;
 use databend_common_base::base::tokio::sync::RwLock;
@@ -60,7 +61,6 @@ use crate::servers::http::v1::HttpQueryManager;
 use crate::servers::http::v1::QueryError;
 use crate::servers::http::v1::QueryResponse;
 use crate::servers::http::v1::QueryStats;
-use crate::sessions::short_sql;
 use crate::sessions::QueryAffect;
 use crate::sessions::Session;
 use crate::sessions::SessionType;

--- a/src/query/service/src/sessions/mod.rs
+++ b/src/query/service/src/sessions/mod.rs
@@ -29,7 +29,6 @@ pub use databend_common_catalog::table_context::TableContext;
 pub use query_affect::QueryAffect;
 pub use query_ctx::convert_query_log_timestamp;
 pub use query_ctx::QueryContext;
-pub use query_ctx_shared::short_sql;
 pub use query_ctx_shared::QueryContextShared;
 pub use queue_mgr::AcquireQueueGuard;
 pub use queue_mgr::QueriesQueueManager;

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use dashmap::DashMap;
+use databend_common_base::base::short_sql;
 use databend_common_base::base::Progress;
 use databend_common_base::runtime::drop_guard;
 use databend_common_base::runtime::Runtime;
@@ -577,30 +578,5 @@ impl Drop for QueryContextShared {
                 .session_ctx
                 .update_query_ids_results(self.init_query_id.read().clone(), None)
         })
-    }
-}
-
-pub fn short_sql(sql: String) -> String {
-    use unicode_segmentation::UnicodeSegmentation;
-    const MAX_LENGTH: usize = 128;
-
-    let query = sql.trim_start();
-    if query.as_bytes().len() > MAX_LENGTH && query.as_bytes()[..6].eq_ignore_ascii_case(b"INSERT")
-    {
-        let mut result = Vec::new();
-        let mut bytes_taken = 0;
-        for grapheme in query.graphemes(true) {
-            let grapheme_bytes = grapheme.as_bytes();
-            if bytes_taken + grapheme_bytes.len() <= MAX_LENGTH {
-                result.extend_from_slice(grapheme_bytes);
-                bytes_taken += grapheme_bytes.len();
-            } else {
-                break;
-            }
-        }
-        result.extend_from_slice(b"...");
-        String::from_utf8(result).unwrap() // by construction, this cannot panic as we extracted unicode graphemes
-    } else {
-        sql
     }
 }

--- a/src/query/service/tests/it/sessions/query_ctx.rs
+++ b/src/query/service/tests/it/sessions/query_ctx.rs
@@ -17,7 +17,6 @@ use databend_common_exception::Result;
 use databend_common_meta_app::storage::StorageFsConfig;
 use databend_common_meta_app::storage::StorageParams;
 use databend_common_meta_app::storage::StorageS3Config;
-use databend_query::sessions::short_sql;
 use databend_query::sessions::TableContext;
 use databend_query::test_kits::ConfigBuilder;
 use databend_query::test_kits::TestFixture;
@@ -65,30 +64,4 @@ async fn test_get_storage_accessor_fs() -> Result<()> {
     let _ = ctx.get_data_operator()?;
 
     Ok(())
-}
-
-#[test]
-fn test_short_sql() {
-    // Test case 1: SQL query shorter than 128 bytes
-    let sql1 = "SELECT * FROM users WHERE id = 1;".to_string();
-    assert_eq!(short_sql(sql1.clone()), sql1);
-
-    // Test case 2: SQL query longer than 128 bytes and starts with "INSERT"
-    let long_sql = "INSERT INTO users (id, name, email) VALUES ".to_string()
-        + &"(1, 'John Doe', 'john@example.com'), ".repeat(5); // Adjusted for 128 bytes
-    let expected_result = long_sql.as_bytes()[..128].to_vec();
-    let expected_result = String::from_utf8(expected_result).unwrap() + "...";
-    assert_eq!(short_sql(long_sql), expected_result);
-
-    // Test case 3: SQL query longer than 128 bytes but does not start with "INSERT"
-    let long_sql = "SELECT * FROM users WHERE ".to_string() + &"id = 1 OR ".repeat(20); // Adjusted for 128 bytes
-    assert_eq!(short_sql(long_sql.clone()), long_sql);
-
-    // Test case 4: Empty SQL query
-    let empty_sql = "".to_string();
-    assert_eq!(short_sql(empty_sql.clone()), empty_sql);
-
-    // Test case 5: SQL query with leading whitespace
-    let sql_with_whitespace = "   SELECT * FROM users;".to_string();
-    assert_eq!(short_sql(sql_with_whitespace.clone()), sql_with_whitespace);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* spill out `short_sql` to `common/base/src/string.rs`
* Simple short_sql and add more unicode tests

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15633)
<!-- Reviewable:end -->
