### PR TITLE
fix(query): db owner role can access all tables under this db

### DIFF
--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.result
@@ -49,3 +49,12 @@ OWNERSHIP a  ROLE drop_role1 GRANT OWNERSHIP ON 'default'.'a'.* TO ROLE `drop_ro
 OWNERSHIP default.a.t  ROLE drop_role1 GRANT OWNERSHIP ON 'default'.'a'.'t' TO ROLE `drop_role1`
 == test create database privilege and drop object ===
 Error: APIError: ResponseError with 1003: Unknown database 'c'
+=== test db owner can access all table under this db ===
+Error: APIError: ResponseError with 1063: Permission denied: User 'u1'@'%' does not have the required privileges for database 'default'
+t1
+t2
+1
+2
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'db1'.'t1' for user 'u2'@'%' with roles [public,role2]
+2
+OWNERSHIP default.db1.t2  ROLE role2 GRANT OWNERSHIP ON 'default'.'db1'.'t2' TO ROLE `role2`


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

db owner role can access all tables under this db.

If db owner drop the table that under db but not owned this role, the table's ownership also be revoked.

- Fixes #15612

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15634)
<!-- Reviewable:end -->
