### PR TITLE
fix(udf): use Debug to display transport error on UDF server

### DIFF
--- a/src/query/expression/src/utils/udf_client.rs
+++ b/src/query/expression/src/utils/udf_client.rs
@@ -66,7 +66,8 @@ impl UDFFlightClient {
             .await
             .map_err(|err| {
                 ErrorCode::UDFServerConnectError(format!(
-                    "Cannot connect to UDF Server {addr}: {err}"
+                    "Cannot connect to UDF Server {}: {:?}",
+                    addr, err
                 ))
             })?
             .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

currently on connectivity issues, all what we get is "transport error."

there must be some more infomation about the root cause behind it.

## Tests

- [x] No Test  - log enhancement

## Type of change

- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15646)
<!-- Reviewable:end -->
