### PR TITLE
fix(query): useridentity hostname only support char %

### DIFF
--- a/src/common/storage/src/stage.rs
+++ b/src/common/storage/src/stage.rs
@@ -23,7 +23,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::principal::StageType;
-use databend_common_meta_app::principal::UserIdentity;
 use futures::stream;
 use futures::Stream;
 use futures::StreamExt;
@@ -51,7 +50,6 @@ pub struct StageFileInfo {
     pub last_modified: DateTime<Utc>,
     pub etag: Option<String>,
     pub status: StageFileStatus,
-    pub creator: Option<UserIdentity>,
 }
 
 impl StageFileInfo {
@@ -63,7 +61,6 @@ impl StageFileInfo {
             last_modified: meta.last_modified().unwrap_or_default(),
             etag: meta.etag().map(str::to_string),
             status: StageFileStatus::NeedCopy,
-            creator: None,
         }
     }
 
@@ -420,6 +417,5 @@ fn stdin_stage_info() -> StageFileInfo {
         last_modified: Utc::now(),
         etag: None,
         status: StageFileStatus::NeedCopy,
-        creator: None,
     }
 }

--- a/src/meta/app/src/principal/principal_identity.rs
+++ b/src/meta/app/src/principal/principal_identity.rs
@@ -21,8 +21,8 @@ pub enum PrincipalIdentity {
 }
 
 impl PrincipalIdentity {
-    pub fn user(name: String, host: String) -> Self {
-        PrincipalIdentity::User(UserIdentity::new(name, host))
+    pub fn user(name: String) -> Self {
+        PrincipalIdentity::User(UserIdentity::new(name))
     }
 
     pub fn role(name: String) -> Self {

--- a/src/meta/app/src/principal/tenant_user_ident.rs
+++ b/src/meta/app/src/principal/tenant_user_ident.rs
@@ -29,8 +29,8 @@ impl TenantUserIdent {
         Self::new_generic(tenant, user)
     }
 
-    pub fn new_user_host(tenant: impl ToTenant, user: impl ToString, host: impl ToString) -> Self {
-        Self::new(tenant, UserIdentity::new(user, host))
+    pub fn new_user_host(tenant: impl ToTenant, user: impl ToString) -> Self {
+        Self::new(tenant, UserIdentity::new(user))
     }
 }
 
@@ -70,7 +70,7 @@ mod tests {
 
     fn test_format_parse(user: &str, host: &str, expect: &str) {
         let tenant = Tenant::new_literal("test_tenant");
-        let user_ident = UserIdentity::new(user, host);
+        let user_ident = UserIdentity::new(user);
         let tenant_user_ident = TenantUserIdent::new(tenant, user_ident);
 
         let key = tenant_user_ident.to_string_key();

--- a/src/meta/app/src/principal/tenant_user_ident.rs
+++ b/src/meta/app/src/principal/tenant_user_ident.rs
@@ -70,7 +70,11 @@ mod tests {
 
     fn test_format_parse(user: &str, host: &str, expect: &str) {
         let tenant = Tenant::new_literal("test_tenant");
-        let user_ident = UserIdentity::new(user);
+        let user_ident = UserIdentity {
+            username: user.to_string(),
+            hostname: host.to_string(),
+        };
+
         let tenant_user_ident = TenantUserIdent::new(tenant, user_ident);
 
         let key = tenant_user_ident.to_string_key();

--- a/src/meta/app/src/principal/user_identity.rs
+++ b/src/meta/app/src/principal/user_identity.rs
@@ -30,10 +30,10 @@ pub struct UserIdentity {
 impl UserIdentity {
     const ESCAPE_CHARS: [u8; 2] = [b'\'', b'@'];
 
-    pub fn new(name: impl ToString, host: impl ToString) -> Self {
+    pub fn new(name: impl ToString) -> Self {
         Self {
             username: name.to_string(),
-            hostname: host.to_string(),
+            hostname: "%".to_string(),
         }
     }
 
@@ -72,6 +72,11 @@ impl UserIdentity {
             kvapi::KeyBuilder::escape_specified(&self.hostname, &Self::ESCAPE_CHARS),
         )
     }
+
+    /// Identity is human readable, used to record log or err message.
+    pub fn identity(&self) -> impl fmt::Display {
+        format!("'{}'@'{}'", &self.username, &self.hostname)
+    }
 }
 
 impl KeyCodec for UserIdentity {
@@ -88,6 +93,6 @@ impl KeyCodec for UserIdentity {
 
 impl From<databend_common_ast::ast::UserIdentity> for UserIdentity {
     fn from(user: databend_common_ast::ast::UserIdentity) -> Self {
-        UserIdentity::new(user.username, user.hostname)
+        UserIdentity::new(user.username)
     }
 }

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -419,7 +419,10 @@ pub(crate) fn test_stage_file() -> mt::principal::StageFile {
         NaiveDate::from_ymd_opt(2022, 9, 16).unwrap(),
         NaiveTime::from_hms_opt(0, 1, 2).unwrap(),
     );
-    let user_id = mt::principal::UserIdentity::new("datafuselabs", "datafuselabs.rs");
+    let user_id = mt::principal::UserIdentity {
+        username: "datafuselabs".to_string(),
+        hostname: "datafuselabs.rs".to_string(),
+    };
     mt::principal::StageFile {
         path: "/path/to/stage".to_string(),
         size: 233,
@@ -806,7 +809,10 @@ fn test_old_stage_file() -> anyhow::Result<()> {
             NaiveDate::from_ymd_opt(2022, 9, 16).unwrap(),
             NaiveTime::from_hms_opt(0, 1, 2).unwrap(),
         );
-        let user_id = mt::principal::UserIdentity::new("datafuselabs", "datafuselabs.rs");
+        let user_id = mt::principal::UserIdentity {
+            username: "datafuselabs".to_string(),
+            hostname: "datafuselabs.rs".to_string(),
+        };
         let want = mt::principal::StageFile {
             path: "/path/to/stage".to_string(),
             size: 233,

--- a/src/meta/proto-conv/tests/it/v066_stage_create_on.rs
+++ b/src/meta/proto-conv/tests/it/v066_stage_create_on.rs
@@ -72,10 +72,7 @@ fn test_decode_v66_stage() -> anyhow::Result<()> {
         },
         comment: "ccc".to_string(),
         number_of_files: 100,
-        creator: Some(UserIdentity {
-            username: "databend".to_string(),
-            hostname: "%".to_string(),
-        }),
+        creator: Some(UserIdentity::new("databend")),
         created_on: DateTime::<Utc>::from_timestamp(1702603569, 0).unwrap(),
     };
     common::test_pb_from_to(func_name!(), want())?;

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -90,7 +90,7 @@ mod add {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_add_user() -> databend_common_exception::Result<()> {
         let test_user_name = "test_user";
-        let test_hostname = "localhost";
+        let test_hostname = "%";
         let user_info = UserInfo::new(test_user_name, test_hostname, default_test_auth_info());
 
         let v = serialize_struct(&user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
@@ -168,7 +168,7 @@ mod get {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_get_user_seq_match() -> databend_common_exception::Result<()> {
         let test_user_name = "test";
-        let test_hostname = "localhost";
+        let test_hostname = "%";
         let test_key = format!(
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
@@ -194,7 +194,7 @@ mod get {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_get_user_do_not_care_seq() -> databend_common_exception::Result<()> {
         let test_user_name = "test";
-        let test_hostname = "localhost";
+        let test_hostname = "%";
         let test_key = format!(
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
@@ -471,7 +471,7 @@ mod update {
 
     async fn test_update_user_normal(full: bool) -> databend_common_exception::Result<()> {
         let test_user_name = "name";
-        let test_hostname = "localhost";
+        let test_hostname = "%";
 
         let test_key = format!(
             "__fd_users/tenant1/{}",
@@ -551,7 +551,7 @@ mod update {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_update_user_with_complete() -> databend_common_exception::Result<()> {
         let test_user_name = "name";
-        let test_hostname = "localhost";
+        let test_hostname = "%";
         let test_key = format!(
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?
@@ -600,7 +600,7 @@ mod set_user_privileges {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_grant_user_privileges() -> databend_common_exception::Result<()> {
         let test_user_name = "name";
-        let test_hostname = "localhost";
+        let test_hostname = "%";
         let test_key = format!(
             "__fd_users/tenant1/{}",
             escape_for_key(&format_user_key(test_user_name, test_hostname))?

--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -90,7 +90,7 @@ impl AuthMgr {
                 };
 
                 let tenant = session.get_current_tenant();
-                let identity = UserIdentity::new(&user_name, "%");
+                let identity = UserIdentity::new(&user_name);
 
                 // create a new user for this identity if not exists
                 let user = match user_api
@@ -135,7 +135,7 @@ impl AuthMgr {
                 client_ip,
             } => {
                 let tenant = session.get_current_tenant();
-                let identity = UserIdentity::new(n, "%");
+                let identity = UserIdentity::new(n);
                 let user = user_api
                     .get_user_with_client_ip(&tenant, identity.clone(), client_ip.as_deref())
                     .await?;

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -197,7 +197,7 @@ impl PrivilegeAccess {
                                 privileges,
                                 catalog_name,
                                 db_name,
-                                &current_user.identity().display(),
+                                &current_user.identity().identity(),
                                 roles_name,
                             )));
                         }
@@ -295,7 +295,7 @@ impl PrivilegeAccess {
                                         catalog_name,
                                         db_name,
                                         table_name,
-                                        &current_user.identity().display(),
+                                        &current_user.identity().identity(),
                                         roles_name,
                                     )));
                                 }
@@ -399,7 +399,7 @@ impl PrivilegeAccess {
                         "Permission denied: privilege [{:?}] is required on {} for user {} with roles [{}]",
                         privilege,
                         grant_object,
-                        &current_user.identity().display(),
+                        &current_user.identity().identity(),
                         roles_name,
                     ))),
                 }
@@ -477,7 +477,7 @@ impl AccessChecker for PrivilegeAccess {
     #[async_backtrace::framed]
     async fn check(&self, ctx: &Arc<QueryContext>, plan: &Plan) -> Result<()> {
         let user = self.ctx.get_current_user()?;
-        let (identity, grant_set) = (user.identity().display().to_string(), user.grants);
+        let (identity, grant_set) = (user.identity().identity().to_string(), user.grants);
 
         let enable_experimental_rbac_check = self
             .ctx

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/session.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/session.rs
@@ -99,7 +99,7 @@ impl FlightSqlServiceImpl {
 
         let tenant = session.get_current_tenant();
 
-        let identity = UserIdentity::new(&user, "%");
+        let identity = UserIdentity::new(&user);
         let user = UserApiProvider::instance()
             .get_user_with_client_ip(&tenant, identity.clone(), client_ip)
             .await

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -267,7 +267,7 @@ impl InteractiveWorkerBase {
     #[async_backtrace::framed]
     async fn authenticate(&self, salt: &[u8], info: CertifiedInfo) -> Result<bool> {
         let ctx = self.session.create_query_context().await?;
-        let identity = UserIdentity::new(&info.user_name, "%");
+        let identity = UserIdentity::new(&info.user_name);
         let client_ip = info.user_client_address.split(':').collect::<Vec<_>>()[0];
         let user_info = UserApiProvider::instance()
             .get_user_with_client_ip(&ctx.get_tenant(), identity.clone(), Some(client_ip))

--- a/src/query/service/src/table_functions/infer_schema/parquet.rs
+++ b/src/query/service/src/table_functions/infer_schema/parquet.rs
@@ -112,7 +112,7 @@ impl AsyncSource for ParquetInferSchemaSource {
                 return Err(ErrorCode::PermissionDenied(format!(
                     "Permission denied: privilege READ is required on stage {} for user {}",
                     stage_info.stage_name.clone(),
-                    &self.ctx.get_current_user()?.identity().display(),
+                    &self.ctx.get_current_user()?.identity().identity(),
                 )));
             }
         }

--- a/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
+++ b/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
@@ -220,7 +220,7 @@ impl AsyncSource for InspectParquetSource {
                 return Err(ErrorCode::PermissionDenied(format!(
                     "Permission denied: privilege READ is required on stage {} for user {}",
                     stage_info.stage_name.clone(),
-                    &self.ctx.get_current_user()?.identity().display(),
+                    &self.ctx.get_current_user()?.identity().identity(),
                 )));
             }
         }

--- a/src/query/service/src/table_functions/list_stage/list_stage_table.rs
+++ b/src/query/service/src/table_functions/list_stage/list_stage_table.rs
@@ -193,7 +193,7 @@ impl ListStagesSource {
                 return Err(ErrorCode::PermissionDenied(format!(
                     "Permission denied: privilege READ is required on stage {} for user {}",
                     stage_info.stage_name.clone(),
-                    &self.ctx.get_current_user()?.identity().display(),
+                    &self.ctx.get_current_user()?.identity().identity(),
                 )));
             }
         }
@@ -226,10 +226,7 @@ fn make_block(files: &[StageFileInfo]) -> DataBlock {
                 .to_string()
         })
         .collect();
-    let creators: Vec<Option<String>> = files
-        .iter()
-        .map(|file| file.creator.as_ref().map(|c| c.display().to_string()))
-        .collect();
+    let creators: Vec<Option<String>> = vec![None; files.len()];
 
     DataBlock::new_from_columns(vec![
         StringType::from_data(names),

--- a/src/query/service/src/table_functions/show_grants/show_grants_table.rs
+++ b/src/query/service/src/table_functions/show_grants/show_grants_table.rs
@@ -274,7 +274,7 @@ async fn show_account_grants(
     let (grant_to, name, identity, grant_set) = match grant_type {
         "user" => {
             let user = UserApiProvider::instance()
-                .get_user(&tenant, UserIdentity::new(name, "%"))
+                .get_user(&tenant, UserIdentity::new(name))
                 .await?;
             if current_user.identity().username != name && !has_grant_priv {
                 let mut roles = current_user.grants.roles();
@@ -282,14 +282,14 @@ async fn show_account_grants(
 
                 return Err(ErrorCode::PermissionDenied(format!(
                     "Permission denied: privilege [Grant] is required on *.* for user {} with roles [{}]",
-                    &current_user.identity().display(),
+                    &current_user.identity().identity(),
                     roles.join(",")
                 )));
             }
             (
                 "USER".to_string(),
                 user.name.to_string(),
-                user.identity().display().to_string(),
+                user.identity().identity().to_string(),
                 user.grants,
             )
         }
@@ -299,7 +299,7 @@ async fn show_account_grants(
                 roles.sort();
                 return Err(ErrorCode::PermissionDenied(format!(
                     "Permission denied: privilege [Grant] is required on *.* for user {} with roles [{}]",
-                    &current_user.identity().display(),
+                    &current_user.identity().identity(),
                     roles.join(",")
                 )));
             }

--- a/src/query/service/tests/it/servers/admin/v1/status.rs
+++ b/src/query/service/tests/it/servers/admin/v1/status.rs
@@ -58,7 +58,7 @@ async fn get_status(ep: &Route) -> InstanceStatus {
 async fn run_query(query_ctx: &Arc<QueryContext>) -> Result<Arc<dyn Interpreter>> {
     let sql = "select sleep(3) from numbers(1)";
     let user = UserApiProvider::instance()
-        .get_user(&Tenant::new_literal("test"), UserIdentity::new("root", "%"))
+        .get_user(&Tenant::new_literal("test"), UserIdentity::new("root"))
         .await?;
     query_ctx
         .get_current_session()

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -2900,7 +2900,7 @@ impl<'a> TypeChecker<'a> {
                 Ok(user) => Some(
                     self.resolve(&Expr::Literal {
                         span,
-                        value: Literal::String(user.identity().display().to_string()),
+                        value: Literal::String(user.identity().identity().to_string()),
                     })
                     .await,
                 ),

--- a/src/query/storages/system/src/background_jobs_table.rs
+++ b/src/query/storages/system/src/background_jobs_table.rs
@@ -131,7 +131,7 @@ impl AsyncSystemTable for BackgroundJobTable {
             );
             message.push(job.message);
             last_updated.push(job.last_updated.map(|t| t.timestamp_micros()));
-            creator.push(job.creator.map(|x| x.display().to_string()));
+            creator.push(job.creator.map(|x| x.identity().to_string()));
             create_time.push(job.created_at.timestamp_micros());
         }
 

--- a/src/query/storages/system/src/stages_table.rs
+++ b/src/query/storages/system/src/stages_table.rs
@@ -108,7 +108,7 @@ impl AsyncSystemTable for StagesTable {
                     number_of_files.push(None);
                 }
             };
-            creator.push(stage.creator.map(|c| c.display().to_string()));
+            creator.push(stage.creator.map(|c| c.identity().to_string()));
             created_on.push(stage.created_on.timestamp_micros());
             comment.push(stage.comment.clone());
         }

--- a/src/query/users/tests/it/network_policy.rs
+++ b/src/query/users/tests/it/network_policy.rs
@@ -68,7 +68,7 @@ async fn test_network_policy() -> Result<()> {
         .add_user(&tenant, user_info, &CreateOption::Create)
         .await?;
 
-    let user = UserIdentity::new(username, hostname);
+    let user = UserIdentity::new(username);
 
     // check get user with client ip
     let res = user_mgr

--- a/src/query/users/tests/it/password_policy.rs
+++ b/src/query/users/tests/it/password_policy.rs
@@ -299,7 +299,7 @@ async fn test_password_policy() -> Result<()> {
     assert!(res.is_ok());
 
     // check login password success
-    let identity = UserIdentity::new(username, hostname);
+    let identity = UserIdentity::new(username);
     let res = user_mgr
         .check_login_password(&tenant, identity.clone(), &user_info)
         .await;

--- a/src/query/users/tests/it/user_mgr.rs
+++ b/src/query/users/tests/it/user_mgr.rs
@@ -81,7 +81,7 @@ async fn test_user_manager() -> Result<()> {
     // get user hostname.
     {
         let user_info = user_mgr
-            .get_user(&tenant, UserIdentity::new(username, hostname))
+            .get_user(&tenant, UserIdentity::new(username))
             .await?;
         assert_eq!(hostname, user_info.hostname);
         assert_eq!(pwd.as_bytes(), user_info.auth_info.get_password().unwrap());
@@ -90,7 +90,7 @@ async fn test_user_manager() -> Result<()> {
     // drop.
     {
         user_mgr
-            .drop_user(&tenant, UserIdentity::new(username, hostname), false)
+            .drop_user(&tenant, UserIdentity::new(username), false)
             .await?;
         let users = user_mgr.get_users(&tenant).await?;
         assert_eq!(0, users.len());
@@ -99,7 +99,7 @@ async fn test_user_manager() -> Result<()> {
     // repeat drop same user not with if exist.
     {
         let res = user_mgr
-            .drop_user(&tenant, UserIdentity::new(username, hostname), false)
+            .drop_user(&tenant, UserIdentity::new(username), false)
             .await;
         assert!(res.is_err());
     }
@@ -107,7 +107,7 @@ async fn test_user_manager() -> Result<()> {
     // repeat drop same user with if exist.
     {
         let res = user_mgr
-            .drop_user(&tenant, UserIdentity::new(username, hostname), true)
+            .drop_user(&tenant, UserIdentity::new(username), true)
             .await;
         assert!(res.is_ok());
     }
@@ -228,7 +228,7 @@ async fn test_user_manager() -> Result<()> {
         let not_exist = user_mgr
             .update_user(
                 &tenant,
-                UserIdentity::new("user", hostname),
+                UserIdentity::new("user"),
                 Some(auth_info.clone()),
                 None,
             )

--- a/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.result
+++ b/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.result
@@ -80,5 +80,5 @@ UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_sch
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
-Error: APIError: ResponseError with 2201: User 'role3%40test'@'%' does not exist.
+Error: APIError: ResponseError with 2201: User 'role3@test'@'%' does not exist.
 === clean up ===


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. username containing @ should not encode when record log or err msg

2. We disabled arbitrary hostnames when creating users last year pr https://github.com/datafuselabs/databend/pull/11818 so the user meta key can only be generated by username, and % is a default value in UserIdentity.

3. delete StageFileInfo::creator

Note:

Also, do not support localhost as hostname.

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15652)
<!-- Reviewable:end -->
