### PR TITLE
fix(query): fix current date/time functions return constant value in a statement.

### DIFF
--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -19,6 +19,8 @@ use std::ops::BitOr;
 use std::ops::Not;
 use std::sync::Arc;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_arrow::arrow::bitmap::Bitmap;
 use databend_common_arrow::arrow::bitmap::MutableBitmap;
 use databend_common_ast::Span;
@@ -95,6 +97,7 @@ pub enum FunctionEval {
 #[derive(Clone, Default)]
 pub struct FunctionContext {
     pub tz: TzLUT,
+    pub now: DateTime<Utc>,
     pub rounding_mode: bool,
     pub disable_variant_check: bool,
 

--- a/src/query/expression/src/utils/date_helper.rs
+++ b/src/query/expression/src/utils/date_helper.rs
@@ -386,8 +386,8 @@ impl AddTimesImpl {
 }
 
 #[inline]
-pub fn today_date(tz: TzLUT) -> i32 {
-    let now = Utc::now().with_timezone(&tz.tz);
+pub fn today_date(now: DateTime<Utc>, tz: TzLUT) -> i32 {
+    let now = now.with_timezone(&tz.tz);
     NaiveDate::from_ymd_opt(now.year(), now.month(), now.day())
         .unwrap()
         .signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -895,14 +895,7 @@ fn register_real_time_functions(registry: &mut FunctionRegistry) {
     registry.register_0_arg_core::<TimestampType, _, _>(
         "now",
         |_| FunctionDomain::Full,
-        |ctx| {
-            Value::Scalar(
-                ctx.func_ctx
-                    .now
-                    .with_timezone(&ctx.func_ctx.tz.tz)
-                    .timestamp_micros(),
-            )
-        },
+        |ctx| Value::Scalar(ctx.func_ctx.now.timestamp_micros()),
     );
 
     registry.register_0_arg_core::<DateType, _, _>(

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -895,25 +895,32 @@ fn register_real_time_functions(registry: &mut FunctionRegistry) {
     registry.register_0_arg_core::<TimestampType, _, _>(
         "now",
         |_| FunctionDomain::Full,
-        |_| Value::Scalar(Utc::now().timestamp_micros()),
+        |ctx| {
+            Value::Scalar(
+                ctx.func_ctx
+                    .now
+                    .with_timezone(&ctx.func_ctx.tz.tz)
+                    .timestamp_micros(),
+            )
+        },
     );
 
     registry.register_0_arg_core::<DateType, _, _>(
         "today",
         |_| FunctionDomain::Full,
-        |ctx| Value::Scalar(today_date(ctx.func_ctx.tz)),
+        |ctx| Value::Scalar(today_date(ctx.func_ctx.now, ctx.func_ctx.tz)),
     );
 
     registry.register_0_arg_core::<DateType, _, _>(
         "yesterday",
         |_| FunctionDomain::Full,
-        |ctx| Value::Scalar(today_date(ctx.func_ctx.tz) - 1),
+        |ctx| Value::Scalar(today_date(ctx.func_ctx.now, ctx.func_ctx.tz) - 1),
     );
 
     registry.register_0_arg_core::<DateType, _, _>(
         "tomorrow",
         |_| FunctionDomain::Full,
-        |ctx| Value::Scalar(today_date(ctx.func_ctx.tz) + 1),
+        |ctx| Value::Scalar(today_date(ctx.func_ctx.now, ctx.func_ctx.tz) + 1),
     );
 }
 

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -28,6 +28,7 @@ use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use chrono::Utc;
 use chrono_tz::Tz;
 use dashmap::mapref::multiple::RefMulti;
 use dashmap::DashMap;
@@ -657,6 +658,7 @@ impl TableContext for QueryContext {
 
         let tz = settings.get_timezone()?;
         let tz = TzFactory::instance().get_by_name(&tz)?;
+        let now = Utc::now();
         let numeric_cast_option = settings.get_numeric_cast_option()?;
         let rounding_mode = numeric_cast_option.as_str() == "rounding";
         let disable_variant_check = settings.get_disable_variant_check()?;
@@ -666,6 +668,7 @@ impl TableContext for QueryContext {
 
         Ok(FunctionContext {
             tz,
+            now,
             rounding_mode,
             disable_variant_check,
 

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -43,6 +43,10 @@ SELECT to_unix_timestamp(now()) >= 1680753801;
 ----
 1
 
+query B
+SELECT now() = now()
+----
+1
 
 query TB
 select to_datetime(1630833797), to_int64(to_datetime(1630833797)) = 1630833797000000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`now()`, `today()`, `yesterday()` and `tomorrow()` functions return constant value in a statement.

```sql
mysql> set timezone='UTC';
Query OK, 0 rows affected (0.02 sec)

mysql> select now(), now();
+----------------------------+----------------------------+
| now()                      | now()                      |
+----------------------------+----------------------------+
| 2024-05-28 09:22:57.995818 | 2024-05-28 09:22:57.995818 |
+----------------------------+----------------------------+
1 row in set (0.04 sec)
Read 1 rows, 1.00 B in 0.017 sec., 58.44 rows/sec., 58.44 B/sec.

mysql> set timezone='Asia/Shanghai';
Query OK, 0 rows affected (0.03 sec)

mysql> select now(), now();
+----------------------------+----------------------------+
| now()                      | now()                      |
+----------------------------+----------------------------+
| 2024-05-28 17:23:01.717210 | 2024-05-28 17:23:01.717210 |
+----------------------------+----------------------------+
1 row in set (0.04 sec)
Read 1 rows, 1.00 B in 0.009 sec., 114.58 rows/sec., 114.58 B/sec.
```

- Fixes #15638

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15659)
<!-- Reviewable:end -->
