### PR TITLE
fix: failed to select blocks for recluster

### DIFF
--- a/src/query/sql/src/planner/expression_parser.rs
+++ b/src/query/sql/src/planner/expression_parser.rs
@@ -411,6 +411,12 @@ pub fn parse_cluster_keys(
         if let AExpr::Tuple { exprs, .. } = &ast_exprs[0] {
             ast_exprs = exprs.clone();
         }
+    } else {
+        // Defensive check:
+        // `ast_exprs` should always contain one element which can be one of the following:
+        // 1. A tuple of composite cluster keys
+        // 2. A single cluster key
+        unreachable!("invalid cluster key ast expression, {:?}", ast_exprs);
     }
 
     let mut exprs = Vec::with_capacity(ast_exprs.len());

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -32,6 +32,7 @@ use databend_common_catalog::table::TimeNavigation;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::types::DataType;
 use databend_common_expression::AbortChecker;
 use databend_common_expression::BlockThresholds;
 use databend_common_expression::ColumnId;
@@ -50,7 +51,7 @@ use databend_common_meta_app::schema::UpsertTableCopiedFileReq;
 use databend_common_pipeline_core::Pipeline;
 use databend_common_sharing::create_share_table_operator;
 use databend_common_sql::binder::STREAM_COLUMN_FACTORY;
-use databend_common_sql::parse_exprs;
+use databend_common_sql::parse_cluster_keys;
 use databend_common_sql::BloomIndexColumns;
 use databend_common_storage::init_operator;
 use databend_common_storage::DataOperator;
@@ -89,7 +90,6 @@ use crate::io::TableMetaLocationGenerator;
 use crate::io::WriteSettings;
 use crate::operations::ChangesDesc;
 use crate::operations::TruncateMode;
-use crate::table_functions::unwrap_tuple;
 use crate::FuseStorageFormat;
 use crate::NavigationPoint;
 use crate::Table;
@@ -453,6 +453,18 @@ impl FuseTable {
             .get(OPT_KEY_TABLE_ATTACHED_READ_ONLY)
             .is_some()
     }
+
+    pub fn cluster_key_types(&self, ctx: Arc<dyn TableContext>) -> Vec<DataType> {
+        let Some((_, cluster_key_str)) = &self.cluster_key_meta else {
+            return vec![];
+        };
+        let cluster_keys =
+            parse_cluster_keys(ctx, Arc::new(self.clone()), cluster_key_str).unwrap();
+        cluster_keys
+            .into_iter()
+            .map(|v| v.data_type().clone())
+            .collect()
+    }
 }
 
 #[async_trait::async_trait]
@@ -488,12 +500,7 @@ impl Table for FuseTable {
     fn cluster_keys(&self, ctx: Arc<dyn TableContext>) -> Vec<RemoteExpr<String>> {
         let table_meta = Arc::new(self.clone());
         if let Some((_, order)) = &self.cluster_key_meta {
-            let cluster_keys = parse_exprs(ctx, table_meta.clone(), order).unwrap();
-            let cluster_keys = if cluster_keys.len() == 1 {
-                unwrap_tuple(&cluster_keys[0]).unwrap_or(cluster_keys)
-            } else {
-                cluster_keys
-            };
+            let cluster_keys = parse_cluster_keys(ctx, table_meta.clone(), order).unwrap();
             let cluster_keys = cluster_keys
                 .iter()
                 .map(|k| {

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -225,7 +225,7 @@ impl FuseTable {
 
         let input_schema =
             modified_schema.unwrap_or(DataSchema::from(self.schema_with_stream()).into());
-        let mut merged: Vec<DataField> = input_schema.fields().clone();
+        let mut merged = input_schema.fields().clone();
 
         let mut cluster_key_index = Vec::with_capacity(cluster_keys.len());
         let mut extra_key_num = 0;
@@ -233,7 +233,7 @@ impl FuseTable {
         let mut exprs = Vec::with_capacity(cluster_keys.len());
 
         for remote_expr in &cluster_keys {
-            let expr: Expr = remote_expr
+            let expr = remote_expr
                 .as_expr(&BUILTIN_FUNCTIONS)
                 .project_column_ref(|name| input_schema.index_of(name).unwrap());
             let index = match &expr {

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -19,9 +19,12 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use databend_common_base::runtime::execute_futures_in_parallel;
+use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::compare_scalars;
+use databend_common_expression::types::DataType;
 use databend_common_expression::BlockThresholds;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
@@ -33,16 +36,18 @@ use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use indexmap::IndexSet;
-use itertools::Itertools;
-use log::error;
+use log::warn;
 use minitrace::full_name;
 use minitrace::future::FutureExt;
 use minitrace::Span;
 
 use crate::statistics::reducers::merge_statistics_mut;
-use crate::table_functions::cmp_with_null;
 use crate::FuseTable;
 use crate::SegmentLocation;
+use crate::DEFAULT_AVG_DEPTH_THRESHOLD;
+use crate::DEFAULT_BLOCK_PER_SEGMENT;
+use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
+use crate::FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD;
 
 #[derive(Clone)]
 pub struct ReclusterMutator {
@@ -52,6 +57,8 @@ pub struct ReclusterMutator {
     pub(crate) cluster_key_id: u32,
     pub(crate) schema: TableSchemaRef,
     pub(crate) max_tasks: usize,
+    pub(crate) block_per_seg: usize,
+    pub(crate) cluster_key_types: Vec<DataType>,
 
     pub snapshot: Arc<TableSnapshot>,
     pub tasks: Vec<ReclusterTask>,
@@ -63,14 +70,32 @@ pub struct ReclusterMutator {
 
 impl ReclusterMutator {
     pub fn try_create(
+        table: &FuseTable,
         ctx: Arc<dyn TableContext>,
         snapshot: Arc<TableSnapshot>,
-        schema: TableSchemaRef,
-        depth_threshold: f64,
-        block_thresholds: BlockThresholds,
-        cluster_key_id: u32,
-        max_tasks: usize,
     ) -> Result<Self> {
+        let schema = table.schema_with_stream();
+        let cluster_key_id = table.cluster_key_meta.clone().unwrap().0;
+        let block_thresholds = table.get_block_thresholds();
+        let block_per_seg =
+            table.get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT);
+
+        let avg_depth_threshold = table.get_option(
+            FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD,
+            DEFAULT_AVG_DEPTH_THRESHOLD,
+        );
+        let depth_threshold = (snapshot.summary.block_count as f64 * avg_depth_threshold)
+            .max(1.0)
+            .min(64.0);
+
+        let mut max_tasks = 1;
+        let cluster = ctx.get_cluster();
+        if !cluster.is_empty() && ctx.get_settings().get_enable_distributed_recluster()? {
+            max_tasks = cluster.nodes.len();
+        }
+
+        let cluster_key_types = table.cluster_key_types(ctx.clone());
+
         Ok(Self {
             ctx,
             schema,
@@ -78,6 +103,8 @@ impl ReclusterMutator {
             block_thresholds,
             cluster_key_id,
             max_tasks,
+            block_per_seg,
+            cluster_key_types,
             snapshot,
             tasks: Vec::new(),
             remained_blocks: Vec::new(),
@@ -85,6 +112,36 @@ impl ReclusterMutator {
             removed_segment_indexes: Vec::new(),
             removed_segment_summary: Statistics::default(),
         })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        ctx: Arc<dyn TableContext>,
+        snapshot: Arc<TableSnapshot>,
+        schema: TableSchemaRef,
+        cluster_key_types: Vec<DataType>,
+        depth_threshold: f64,
+        block_thresholds: BlockThresholds,
+        cluster_key_id: u32,
+        max_tasks: usize,
+        block_per_seg: usize,
+    ) -> Self {
+        Self {
+            ctx,
+            schema,
+            depth_threshold,
+            block_thresholds,
+            cluster_key_id,
+            max_tasks,
+            block_per_seg,
+            cluster_key_types,
+            snapshot,
+            tasks: Vec::new(),
+            remained_blocks: Vec::new(),
+            recluster_blocks_count: 0,
+            removed_segment_indexes: Vec::new(),
+            removed_segment_summary: Statistics::default(),
+        }
     }
 
     #[async_backtrace::framed]
@@ -166,7 +223,7 @@ impl ReclusterMutator {
             }
 
             let selected_idx =
-                Self::fetch_max_depth(points_map, self.depth_threshold, max_blocks_num)?;
+                self.fetch_max_depth(points_map, self.depth_threshold, max_blocks_num)?;
             if selected_idx.is_empty() {
                 remained_blocks.extend(block_metas.into_iter());
                 continue;
@@ -267,20 +324,15 @@ impl ReclusterMutator {
     }
 
     pub fn select_segments(
+        &mut self,
         compact_segments: &[(SegmentLocation, Arc<CompactSegmentInfo>)],
-        block_per_seg: usize,
         max_len: usize,
-        cluster_key_id: u32,
     ) -> Result<IndexSet<usize>> {
         let mut blocks_num = 0;
         let mut indices = IndexSet::new();
         let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
         for (i, (_, compact_segment)) in compact_segments.iter().enumerate() {
-            if !ReclusterMutator::segment_can_recluster(
-                &compact_segment.summary,
-                block_per_seg,
-                cluster_key_id,
-            ) {
+            if !self.segment_can_recluster(&compact_segment.summary) {
                 continue;
             }
 
@@ -298,21 +350,17 @@ impl ReclusterMutator {
             }
         }
 
-        if indices.len() < 2 || blocks_num < block_per_seg {
+        if indices.len() < 2 || blocks_num < self.block_per_seg {
             return Ok(indices);
         }
 
-        ReclusterMutator::fetch_max_depth(points_map, 1.0, max_len)
+        self.fetch_max_depth(points_map, 1.0, max_len)
     }
 
-    pub fn segment_can_recluster(
-        summary: &Statistics,
-        block_per_seg: usize,
-        cluster_key_id: u32,
-    ) -> bool {
+    pub fn segment_can_recluster(&self, summary: &Statistics) -> bool {
         if let Some(stats) = &summary.cluster_stats {
-            stats.cluster_key_id == cluster_key_id
-                && (stats.level >= 0 || (summary.block_count as usize) < block_per_seg)
+            stats.cluster_key_id == self.cluster_key_id
+                && (stats.level >= 0 || (summary.block_count as usize) < self.block_per_seg)
         } else {
             false
         }
@@ -362,6 +410,7 @@ impl ReclusterMutator {
     }
 
     fn fetch_max_depth(
+        &self,
         points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)>,
         depth_threshold: f64,
         max_len: usize,
@@ -371,12 +420,12 @@ impl ReclusterMutator {
         let mut block_depths = Vec::new();
         let mut point_overlaps: Vec<Vec<usize>> = Vec::new();
         let mut unfinished_parts: HashMap<usize, usize> = HashMap::new();
-        for (i, (_, (start, end))) in points_map
-            .into_iter()
-            .sorted_by(|(a, _), (b, _)| a.iter().cmp_by(b.iter(), cmp_with_null))
-            .enumerate()
-        {
-            let point_depth = if unfinished_parts.len() == 1 && Self::check_point(&start, &end) {
+        let (keys, values): (Vec<_>, Vec<_>) = points_map.into_iter().unzip();
+        let indices = compare_scalars(keys, &self.cluster_key_types)?;
+        for (i, idx) in indices.into_iter().enumerate() {
+            let start = &values[idx as usize].0;
+            let end = &values[idx as usize].1;
+            let point_depth = if unfinished_parts.len() == 1 && Self::check_point(start, end) {
                 1
             } else {
                 unfinished_parts.len() + start.len()
@@ -403,11 +452,13 @@ impl ReclusterMutator {
                 }
             });
         }
+
+        let mut selected_idx = IndexSet::new();
         if !unfinished_parts.is_empty() {
-            error!("Recluster: unfinished_parts is not empty after calculate the blocks overlaps");
-            return Err(ErrorCode::Internal(
-                "failed to select blocks for recluster, please check your data",
-            ));
+            warn!("Recluster: unfinished_parts is not empty after calculate the blocks overlaps");
+            unfinished_parts.keys().for_each(|idx| {
+                selected_idx.insert(*idx);
+            });
         }
 
         let sum_depth: usize = block_depths.iter().sum();
@@ -416,7 +467,6 @@ impl ReclusterMutator {
             (10000.0 * sum_depth as f64 / block_depths.len() as f64).round() / 10000.0;
 
         // find the max point, gather the indices.
-        let mut selected_idx = IndexSet::new();
         if average_depth > depth_threshold {
             point_overlaps[max_point].iter().for_each(|idx| {
                 selected_idx.insert(*idx);

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -209,8 +209,10 @@ impl ReclusterMutator {
                 .block_thresholds
                 .check_for_recluster(total_rows as usize, total_bytes as usize)
             {
-                let block_metas: Vec<_> =
-                    block_metas.into_iter().map(|meta| (None, meta)).collect();
+                let block_metas = block_metas
+                    .into_iter()
+                    .map(|meta| (None, meta))
+                    .collect::<Vec<_>>();
                 self.generate_task(
                     &block_metas,
                     &column_nodes,
@@ -453,12 +455,9 @@ impl ReclusterMutator {
             });
         }
 
-        let mut selected_idx = IndexSet::new();
         if !unfinished_parts.is_empty() {
             warn!("Recluster: unfinished_parts is not empty after calculate the blocks overlaps");
-            unfinished_parts.keys().for_each(|idx| {
-                selected_idx.insert(*idx);
-            });
+            // todo: re-sort the unfinished parts firstly.
         }
 
         let sum_depth: usize = block_depths.iter().sum();
@@ -467,6 +466,7 @@ impl ReclusterMutator {
             (10000.0 * sum_depth as f64 / block_depths.len() as f64).round() / 10000.0;
 
         // find the max point, gather the indices.
+        let mut selected_idx = IndexSet::new();
         if average_depth > depth_threshold {
             point_overlaps[max_point].iter().for_each(|idx| {
                 selected_idx.insert(*idx);

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -35,10 +35,6 @@ use crate::pruning::PruningContext;
 use crate::pruning::SegmentPruner;
 use crate::FuseTable;
 use crate::SegmentLocation;
-use crate::DEFAULT_AVG_DEPTH_THRESHOLD;
-use crate::DEFAULT_BLOCK_PER_SEGMENT;
-use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
-use crate::FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD;
 
 impl FuseTable {
     /// The flow of Pipeline is as follows:
@@ -88,39 +84,12 @@ impl FuseTable {
 
         let start = Instant::now();
 
-        let settings = ctx.get_settings();
-        let mut max_tasks = 1;
-        let cluster = ctx.get_cluster();
-        if !cluster.is_empty() && settings.get_enable_distributed_recluster()? {
-            max_tasks = cluster.nodes.len();
-        }
-
-        let schema = self.schema_with_stream();
-        let default_cluster_key_id = self.cluster_key_meta.clone().unwrap().0;
-        let block_thresholds = self.get_block_thresholds();
-        let block_per_seg =
-            self.get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT);
-        let avg_depth_threshold = self.get_option(
-            FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD,
-            DEFAULT_AVG_DEPTH_THRESHOLD,
-        );
-        let threshold = (snapshot.summary.block_count as f64 * avg_depth_threshold)
-            .max(1.0)
-            .min(64.0);
-        let mut mutator = ReclusterMutator::try_create(
-            ctx.clone(),
-            snapshot.clone(),
-            schema,
-            threshold,
-            block_thresholds,
-            default_cluster_key_id,
-            max_tasks,
-        )?;
+        let mut mutator = ReclusterMutator::try_create(self, ctx.clone(), snapshot.clone())?;
 
         let segment_locations = snapshot.segments.clone();
         let segment_locations = create_segment_location_vector(segment_locations, None);
 
-        let max_threads = settings.get_max_threads()? as usize;
+        let max_threads = ctx.get_settings().get_max_threads()? as usize;
         let limit = limit.unwrap_or(1000);
         // The default limit might be too small, which makes
         // the scanning of recluster candidates slow.
@@ -159,28 +128,19 @@ impl FuseTable {
             }
 
             // select the segments with the highest depth.
-            let selected_segs = ReclusterMutator::select_segments(
-                &compact_segments,
-                block_per_seg,
-                max_seg_num,
-                default_cluster_key_id,
-            )?;
+            let selected_segs = mutator.select_segments(&compact_segments, max_seg_num)?;
             // select the blocks with the highest depth.
             if selected_segs.is_empty() {
                 let mut selected_segs = vec![];
                 let mut block_count = 0;
                 for compact_segment in compact_segments.into_iter() {
-                    if !ReclusterMutator::segment_can_recluster(
-                        &compact_segment.1.summary,
-                        block_per_seg,
-                        default_cluster_key_id,
-                    ) {
+                    if !mutator.segment_can_recluster(&compact_segment.1.summary) {
                         continue;
                     }
 
                     block_count += compact_segment.1.summary.block_count as usize;
                     selected_segs.push(compact_segment);
-                    if block_count >= block_per_seg {
+                    if block_count >= mutator.block_per_seg {
                         let seg_num = selected_segs.len();
                         if mutator
                             .target_select(std::mem::take(&mut selected_segs))

--- a/src/query/storages/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/cluster_statistics.rs
@@ -23,10 +23,7 @@ use databend_common_expression::Scalar;
 use databend_common_sql::evaluator::BlockOperator;
 use databend_storages_common_table_meta::meta::ClusterStatistics;
 
-use crate::statistics::column_statistic::Trim;
 use crate::table_functions::cmp_with_null;
-
-pub const CLUSTER_STATS_STRING_PREFIX_LEN: usize = 8;
 
 #[derive(Clone, Default)]
 pub struct ClusterStatsGenerator {
@@ -136,21 +133,12 @@ impl ClusterStatsGenerator {
             let val = data_block.get_by_offset(*key);
             let val_ref = val.value.as_ref();
             let left = unsafe { val_ref.index_unchecked(0) }.to_owned();
-            min.push(
-                left.clone()
-                    .trim_min(CLUSTER_STATS_STRING_PREFIX_LEN)
-                    .unwrap_or(left),
-            );
+            min.push(left);
 
             // The maximum in cluster statistics neednot larger than the non-trimmed one.
             // So we use trim_min directly.
             let right = unsafe { val_ref.index_unchecked(val_ref.len() - 1) }.to_owned();
-            max.push(
-                right
-                    .clone()
-                    .trim_min(CLUSTER_STATS_STRING_PREFIX_LEN)
-                    .unwrap_or(right),
-            );
+            max.push(right);
         }
 
         let level = if min == max

--- a/src/query/storages/fuse/src/table_functions/clustering_information/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_information/clustering_information.rs
@@ -155,21 +155,24 @@ impl<'a> ClusteringInformation<'a> {
                 *depth = cmp::max(*depth, point_depth);
             });
 
-            start.iter().for_each(|&idx| {
-                unfinished_parts.insert(idx, (point_depth - 1, point_depth));
+            start.iter().for_each(|idx| {
+                if let Some(v) = unfinished_parts.remove(idx) {
+                    stats.push(v);
+                } else {
+                    unfinished_parts.insert(*idx, (point_depth - 1, point_depth));
+                }
             });
 
             end.iter().for_each(|idx| {
                 if let Some(v) = unfinished_parts.remove(idx) {
                     stats.push(v);
+                } else {
+                    warn!("clustering_information: please check your data and perform recluster to re-sort.");
+                    unfinished_parts.insert(*idx, (point_depth - 1, point_depth));
                 }
             });
         }
-        if !unfinished_parts.is_empty() {
-            warn!(
-                "clustering_information: unfinished_parts is not empty after calculate the blocks overlaps"
-            );
-        }
+        assert!(unfinished_parts.is_empty());
 
         let mut sum_overlap = 0;
         let mut sum_depth = 0;

--- a/src/query/storages/fuse/src/table_functions/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/table_args.rs
@@ -16,7 +16,6 @@ use std::cmp::Ordering;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::Expr;
 use databend_common_expression::Scalar;
 
 use crate::table_functions::TableArgs;
@@ -82,13 +81,4 @@ pub fn parse_db_tb_col_args(table_args: &TableArgs, func_name: &str) -> Result<S
     let args = table_args.expect_all_positioned(func_name, Some(1))?;
     let db = string_value(&args[0])?;
     Ok(db)
-}
-
-pub fn unwrap_tuple(expr: &Expr) -> Option<Vec<Expr>> {
-    match expr {
-        Expr::FunctionCall { function, args, .. } if function.signature.name == "tuple" => {
-            Some(args.clone())
-        }
-        _ => None,
-    }
 }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
@@ -762,6 +762,25 @@ insert into test_abc select * from test_abc_random limit 1000;
 statement ok
 alter table test_abc recluster final;
 
+
+statement ok
+create table t14(a string, b string) cluster by(a,b)
+
+statement ok
+insert into t14 values('123456789', 'abc');
+
+statement ok
+insert into t14 values('12345678', 'efg');
+
+statement ok
+alter table t14 recluster
+
+query TIIIFFT
+select * from clustering_information('db_09_0008','t14')
+----
+(a, b) 1 0 0 0.0 1.0 {"00001":1}
+
+
 statement ok
 DROP DATABASE db_09_0008
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This Pull Request (PR) addresses and fixes a bug where the condition `min > max` could occur after sorting and then truncating fields. The specific changes are as follows:

1. **Bug Fix**: The original logic could result in a `min > max` situation when truncating fields after sorting, causing incorrect behavior.
2. **Improvement**: To prevent this issue, when the cluster key is of string type, a `substr` expression is introduced. This change ensures that the substring operation is applied before sorting, thereby avoiding the mentioned bug.

By implementing this change, the process ensures that when dealing with string type cluster keys, the sorting and truncating operations are performed in the correct order, preventing logical errors in data processing.

Before:
```sql
mysql> create table t14(a string, b string) cluster by(a,b);
Query OK, 0 rows affected (0.13 sec)

mysql> insert into t14 values('123456789', 'abc');
Query OK, 1 row affected (0.06 sec)

mysql> insert into t14 values('12345678', 'efg');
Query OK, 1 row affected (0.13 sec)

mysql> alter table t14 recluster;
Query OK, 2 rows affected (0.22 sec)

mysql> select * from clustering_information('default','t14');
+-------------+-------------------+----------------------+-------------------------+------------------+---------------+-----------------------+
| cluster_key | total_block_count | constant_block_count | unclustered_block_count | average_overlaps | average_depth | block_depth_histogram |
+-------------+-------------------+----------------------+-------------------------+------------------+---------------+-----------------------+
| (a, b)      |                 1 |                    0 |                       0 |              NaN |           NaN | {}                    |
+-------------+-------------------+----------------------+-------------------------+------------------+---------------+-----------------------+
1 row in set (0.10 sec)
Read 1 rows, 448.00 B in 0.071 sec., 14.09 rows/sec., 6.16 KiB/sec.

mysql> select * from t14;
+-----------+------+
| a         | b    |
+-----------+------+
| 12345678  | efg  |
| 123456789 | abc  |
+-----------+------+
2 rows in set (0.07 sec)
Read 2 rows, 73.00 B in 0.017 sec., 118.18 rows/sec., 4.21 KiB/sec.
```
After:
```sql
mysql> alter table t14 recluster;
Query OK, 2 rows affected (0.22 sec)

mysql> select * from clustering_information('default','t14');
+-------------+-------------------+----------------------+-------------------------+------------------+---------------+-----------------------+
| cluster_key | total_block_count | constant_block_count | unclustered_block_count | average_overlaps | average_depth | block_depth_histogram |
+-------------+-------------------+----------------------+-------------------------+------------------+---------------+-----------------------+
| (a, b)      |                 1 |                    0 |                       0 |              0.0 |           0.0 | {"00001":1}           |
+-------------+-------------------+----------------------+-------------------------+------------------+---------------+-----------------------+
1 row in set (0.10 sec)
Read 1 rows, 448.00 B in 0.071 sec., 14.09 rows/sec., 6.16 KiB/sec.

mysql> select * from t14;
+-----------+------+
| a         | b    |
+-----------+------+
| 123456789 | abc  |
| 12345678  | efg  |
+-----------+------+
2 rows in set (0.10 sec)
Read 2 rows, 73.00 B in 0.013 sec., 155.4 rows/sec., 5.54 KiB/sec.
```

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15667)
<!-- Reviewable:end -->
