### PR TITLE
feat(query): support disable vacuum temporary files after query

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/handler.rs
+++ b/src/query/ee/src/storages/fuse/operations/handler.rs
@@ -57,7 +57,7 @@ impl VacuumHandler for RealVacuumHandler {
         &self,
         temporary_dir: String,
         retain: Option<Duration>,
-        vacuum_limit: Option<usize>,
+        vacuum_limit: usize,
     ) -> Result<usize> {
         do_vacuum_temporary_files(temporary_dir, retain, vacuum_limit).await
     }

--- a/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
@@ -33,9 +33,12 @@ const DEFAULT_RETAIN_DURATION: Duration = Duration::from_secs(60 * 60 * 24 * 3);
 pub async fn do_vacuum_temporary_files(
     temporary_dir: String,
     retain: Option<Duration>,
-    limit: Option<usize>,
+    limit: usize,
 ) -> Result<usize> {
-    let limit = limit.unwrap_or(usize::MAX);
+    if limit == 0 {
+        return Ok(0);
+    }
+
     let expire_time = retain.unwrap_or(DEFAULT_RETAIN_DURATION).as_millis() as i64;
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -126,12 +126,7 @@ async fn test_do_vacuum_temporary_files() -> Result<()> {
     );
 
     tokio::time::sleep(Duration::from_secs(2)).await;
-    do_vacuum_temporary_files(
-        "test_dir/".to_string(),
-        Some(Duration::from_secs(2)),
-        Some(1),
-    )
-    .await?;
+    do_vacuum_temporary_files("test_dir/".to_string(), Some(Duration::from_secs(2)), 1).await?;
 
     assert_eq!(2, operator.list("test_dir/").await?.len());
 
@@ -141,16 +136,11 @@ async fn test_do_vacuum_temporary_files() -> Result<()> {
         .write("test_dir/test5/finished", vec![1, 2])
         .await?;
 
-    do_vacuum_temporary_files(
-        "test_dir/".to_string(),
-        Some(Duration::from_secs(2)),
-        Some(2),
-    )
-    .await?;
+    do_vacuum_temporary_files("test_dir/".to_string(), Some(Duration::from_secs(2)), 2).await?;
     assert_eq!(operator.list("test_dir/").await?.len(), 2);
 
     tokio::time::sleep(Duration::from_secs(3)).await;
-    do_vacuum_temporary_files("test_dir/".to_string(), Some(Duration::from_secs(3)), None).await?;
+    do_vacuum_temporary_files("test_dir/".to_string(), Some(Duration::from_secs(3)), 1000).await?;
     assert!(operator.list_with("test_dir/").await?.is_empty());
 
     Ok(())

--- a/src/query/ee_features/vacuum_handler/src/vacuum_handler.rs
+++ b/src/query/ee_features/vacuum_handler/src/vacuum_handler.rs
@@ -47,7 +47,7 @@ pub trait VacuumHandler: Sync + Send {
         &self,
         temporary_dir: String,
         retain: Option<Duration>,
-        vacuum_limit: Option<usize>,
+        vacuum_limit: usize,
     ) -> Result<usize>;
 }
 
@@ -90,7 +90,7 @@ impl VacuumHandlerWrapper {
         &self,
         temporary_dir: String,
         retain: Option<Duration>,
-        vacuum_limit: Option<usize>,
+        vacuum_limit: usize,
     ) -> Result<usize> {
         self.handler
             .do_vacuum_temporary_files(temporary_dir, retain, vacuum_limit)

--- a/src/query/service/src/interpreters/interpreter_vacuum_temporary_files.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_temporary_files.rs
@@ -64,7 +64,7 @@ impl Interpreter for VacuumTemporaryFilesInterpreter {
             .do_vacuum_temporary_files(
                 temporary_files_prefix,
                 self.plan.retain,
-                self.plan.limit.map(|x| x as usize),
+                self.plan.limit.map(|x| x as usize).unwrap_or(usize::MAX),
             )
             .await?;
 

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -734,8 +734,8 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
                 ("max_vacuum_temp_files_after_query", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
-                    desc: "The maximum temp files will be removed after query. please enable vacuum feature. The default value is 0(all temp files)",
+                    value: UserSettingValue::UInt64(u64::MAX),
+                    desc: "The maximum temp files will be removed after query. please enable vacuum feature. disable if 0",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 })


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

feat(query): support disable vacuum temporary files after query

- Fixes #[Link the issue here]

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15673)
<!-- Reviewable:end -->
