### PR TITLE
chore: re-enable musl-g++ link for musl build image

### DIFF
--- a/docker/build-tool/musl/Dockerfile
+++ b/docker/build-tool/musl/Dockerfile
@@ -20,6 +20,11 @@ RUN ln -s ${MUSL_TARGET}-gcc /usr/local/bin/musl-gcc
 
 RUN rustup target add ${MUSL_RUST_TARGET}
 
+# needed by geos-sys
+RUN ln -s ${MUSL_TARGET}-g++ /usr/local/bin/musl-g++
+RUN ln -s ${MUSL_TARGET}-ar /usr/local/bin/musl-ar
+
+
 # HACK: to link with libstdc++ statically
 # ref: https://github.com/rust-lang/rust/issues/36710#issuecomment-364623950
 COPY linker.sh /usr/local/bin/linker


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

re-enable musl-g++ link for musl build image. goes-sys seems to depend on it 

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - a test build (of musl build image)

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): a test build (of musl build image)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15679)
<!-- Reviewable:end -->
