### PR TITLE
feat: add meta-service config sled_max_cache_size_mb

### DIFF
--- a/src/binaries/meta/entry.rs
+++ b/src/binaries/meta/entry.rs
@@ -89,7 +89,10 @@ pub async fn entry(conf: Config) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    init_sled_db(conf.raft_config.raft_dir.clone());
+    init_sled_db(
+        conf.raft_config.raft_dir.clone(),
+        conf.raft_config.sled_cache_size(),
+    );
 
     let single_or_join = if conf.raft_config.single {
         "single".to_string()

--- a/src/binaries/metactl/snapshot.rs
+++ b/src/binaries/metactl/snapshot.rs
@@ -67,7 +67,7 @@ pub async fn export_data(config: &Config) -> anyhow::Result<()> {
     match config.raft_dir {
         None => export_from_running_node(config).await?,
         Some(ref dir) => {
-            init_sled_db(dir.clone());
+            init_sled_db(dir.clone(), 64 * 1024 * 1024 * 1024);
             export_from_dir(config).await?;
         }
     }
@@ -80,7 +80,7 @@ pub async fn import_data(config: &Config) -> anyhow::Result<()> {
 
     let nodes = build_nodes(config.initial_cluster.clone(), config.id)?;
 
-    init_sled_db(raft_dir.clone());
+    init_sled_db(raft_dir.clone(), 64 * 1024 * 1024 * 1024);
 
     clear(config)?;
     let max_log_id = import_from_stdin_or_file(config).await?;

--- a/src/meta/embedded/src/meta_embedded.rs
+++ b/src/meta/embedded/src/meta_embedded.rs
@@ -92,7 +92,7 @@ impl MetaEmbedded {
     /// Initialize a global embedded meta store.
     /// The data in `path` won't be removed after program exit.
     pub async fn init_global_meta_store(path: String) -> Result<(), MetaStorageError> {
-        databend_common_meta_sled_store::init_sled_db(path);
+        databend_common_meta_sled_store::init_sled_db(path, 64 * 1024 * 1024 * 1024);
 
         {
             let mut m = GLOBAL_META_EMBEDDED.as_ref().lock().await;

--- a/src/meta/process/src/examples.rs
+++ b/src/meta/process/src/examples.rs
@@ -94,7 +94,7 @@ pub fn print_table_meta(config: &Config) -> anyhow::Result<()> {
 
     let raft_config = &config.raft_config;
 
-    init_sled_db(raft_config.raft_dir.clone());
+    init_sled_db(raft_config.raft_dir.clone(), 64 * 1024 * 1024 * 1024);
 
     for tree_iter_res in databend_common_meta_sled_store::iter::<Vec<u8>>() {
         let (_tree_name, item_iter) = tree_iter_res?;

--- a/src/meta/process/src/process_meta_dir.rs
+++ b/src/meta/process/src/process_meta_dir.rs
@@ -26,7 +26,7 @@ pub fn process_sled_db<F>(config: &Config, convert: F) -> anyhow::Result<()>
 where F: Fn(RaftStoreEntry) -> Result<Option<RaftStoreEntry>, anyhow::Error> {
     let raft_config = &config.raft_config;
 
-    init_sled_db(raft_config.raft_dir.clone());
+    init_sled_db(raft_config.raft_dir.clone(), 64 * 1024 * 1024 * 1024);
 
     let db = get_sled_db();
 

--- a/src/meta/raft-store/src/config.rs
+++ b/src/meta/raft-store/src/config.rs
@@ -110,6 +110,9 @@ pub struct RaftConfig {
     /// For test only: specifies the tree name prefix
     pub sled_tree_prefix: String,
 
+    /// The maximum memory in MB that sled can use for caching.
+    pub sled_max_cache_size_mb: u64,
+
     ///  The node name. If the user specifies a name,
     /// the user-supplied name is used, if not, the default name is used.
     pub cluster_name: String,
@@ -148,6 +151,7 @@ impl Default for RaftConfig {
             leave_id: None,
             id: 0,
             sled_tree_prefix: "".to_string(),
+            sled_max_cache_size_mb: 10 * 1024,
             cluster_name: "foo_cluster".to_string(),
             wait_leader_timeout: 70000,
         }
@@ -226,5 +230,10 @@ impl RaftConfig {
     /// sled does not allow to open multiple `sled::Db` in one process.
     pub fn tree_name(&self, name: impl std::fmt::Display) -> String {
         format!("{}{}", self.sled_tree_prefix, name)
+    }
+
+    /// Return the size of sled cache in bytes.
+    pub fn sled_cache_size(&self) -> u64 {
+        self.sled_max_cache_size_mb * 1024 * 1024
     }
 }

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -295,6 +295,7 @@ pub struct ConfigViaEnv {
     pub metasrv_join: Vec<String>,
     pub kvsrv_id: u64,
     pub sled_tree_prefix: String,
+    pub sled_max_cache_size_mb: u64,
     pub cluster_name: String,
 }
 
@@ -341,6 +342,7 @@ impl From<Config> for ConfigViaEnv {
             metasrv_join: cfg.raft_config.join,
             kvsrv_id: cfg.raft_config.id,
             sled_tree_prefix: cfg.raft_config.sled_tree_prefix,
+            sled_max_cache_size_mb: cfg.raft_config.sled_max_cache_size_mb,
             cluster_name: cfg.raft_config.cluster_name,
         }
     }
@@ -371,6 +373,7 @@ impl Into<Config> for ConfigViaEnv {
             leave_id: None,
             id: self.kvsrv_id,
             sled_tree_prefix: self.sled_tree_prefix,
+            sled_max_cache_size_mb: self.sled_max_cache_size_mb,
             cluster_name: self.cluster_name,
         };
         let log_config = LogConfig {
@@ -510,6 +513,10 @@ pub struct RaftConfig {
     #[clap(long, default_value = "")]
     pub sled_tree_prefix: String,
 
+    /// The maximum memory in MB that sled can use for caching. Default is 10GB
+    #[clap(long, default_value = "10240")]
+    pub sled_max_cache_size_mb: u64,
+
     /// The node name. If the user specifies a name, the user-supplied name is used,
     /// if not, the default name is used
     #[clap(long, default_value = "foo_cluster")]
@@ -546,6 +553,7 @@ impl From<RaftConfig> for InnerRaftConfig {
             leave_id: x.leave_id,
             id: x.id,
             sled_tree_prefix: x.sled_tree_prefix,
+            sled_max_cache_size_mb: x.sled_max_cache_size_mb,
             cluster_name: x.cluster_name,
             wait_leader_timeout: x.wait_leader_timeout,
         }
@@ -572,6 +580,7 @@ impl From<InnerRaftConfig> for RaftConfig {
             leave_id: inner.leave_id,
             id: inner.id,
             sled_tree_prefix: inner.sled_tree_prefix,
+            sled_max_cache_size_mb: inner.sled_max_cache_size_mb,
             cluster_name: inner.cluster_name,
             wait_leader_timeout: inner.wait_leader_timeout,
         }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: add meta-service config sled_max_cache_size_mb

Provide a config/CLI argument `sled_max_cache_size_mb` to specify the
max memory in MB sled is allowed to use. By default it is `10GB`.

Usage of letting meta-service use at most 64 GB for cache in `config.toml`:

```toml
[raft_config]
sled_max_cache_size_mb = 64000
```

- See: #15707

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)






## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15709)
<!-- Reviewable:end -->
