### PR TITLE
fix: `fuse_snapshot` only show the latest snapshot for external table

### DIFF
--- a/.github/actions/test_sqllogic_standalone_linux/action.yml
+++ b/.github/actions/test_sqllogic_standalone_linux/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "storage format for databend query to test"
     required: true
     default: all
+  enable_table_meta_cache:
+    description: "Enable table meta cache"
+    required: false
+    default: true
 
 runs:
   using: "composite"
@@ -34,6 +38,7 @@ runs:
       shell: bash
       env:
         TEST_HANDLERS: ${{ inputs.handlers }}
+        CACHE_ENABLE_TABLE_META_CACHE: ${{ inputs.enable_table_meta_cache}}
       run: bash ./scripts/ci/ci-run-sqllogic-tests.sh ${{ inputs.dirs }}
 
     - name: Run native sqllogic Tests with Standalone mode
@@ -41,4 +46,5 @@ runs:
       shell: bash
       env:
         TEST_HANDLERS: ${{ inputs.handlers }}
+        CACHE_ENABLE_TABLE_META_CACHE: ${{ inputs.enable_table_meta_cache}}
       run: bash ./scripts/ci/ci-run-sqllogic-tests-native.sh ${{ inputs.dirs }}

--- a/.github/workflows/reuse.sqllogic.yml
+++ b/.github/workflows/reuse.sqllogic.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   management_mode:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_sqllogic_management_mode_linux
@@ -30,7 +30,7 @@ jobs:
           handlers: mysql,http
 
   standalone:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +61,7 @@ jobs:
           name: test-sqllogic-standalone-${{ matrix.dirs }}-${{ matrix.handler }}
 
   standalone_udf_server:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
     steps:
       - uses: actions/checkout@v4
       - name: Start UDF Server
@@ -82,7 +82,7 @@ jobs:
           name: test-sqllogic-standalone-udf_server
 
   standalone_cloud:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
     steps:
       - uses: actions/checkout@v4
       - name: Start Cloud Control Server
@@ -103,7 +103,7 @@ jobs:
           name: test-sqllogic-standalone-cloud
 
   standalone_minio:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +127,7 @@ jobs:
           name: test-sqllogic-standalone-${{ matrix.dirs }}-${{ matrix.handler }}
 
   cluster:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +157,7 @@ jobs:
           name: test-sqllogic-cluster-${{ matrix.dirs }}-${{ matrix.handler }}
 
   stage:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
     strategy:
       fail-fast: false
       matrix:
@@ -177,3 +177,27 @@ jobs:
         uses: ./.github/actions/artifact_failure
         with:
           name: test-sqllogic-stage-${{ matrix.storage }}
+
+  standalone_no_table_meta_cache:
+    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
+    strategy:
+      fail-fast: false
+      matrix:
+        dirs:
+          - "no_table_meta_cache"
+        handler:
+          - "http"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/test_sqllogic_standalone_linux
+        timeout-minutes: 15
+        with:
+          dirs: ${{ matrix.dirs }}
+          handlers: ${{ matrix.handler }}
+          storage-format: all
+          enable_table_meta_cache: false
+      - name: Upload failure
+        if: failure()
+        uses: ./.github/actions/artifact_failure
+        with:
+          name: test-sqllogic-standalone-no-table-meta-cache-${{ matrix.dirs }}-${{ matrix.handler }}

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -236,8 +236,10 @@ pub trait TableContext: Send + Sync {
     fn set_on_error_mode(&self, mode: OnErrorMode);
     fn get_maximum_error_per_file(&self) -> Option<HashMap<String, ErrorCode>>;
 
-    // Get the storage data accessor operator from the session manager.
-    fn get_data_operator(&self) -> Result<DataOperator>;
+    /// Get the storage data accessor operator from the session manager.
+    /// Note that this is the application level data accessor, which may be different from
+    /// the table level data accessor (e.g., table with customized storage parameters).
+    fn get_application_level_data_operator(&self) -> Result<DataOperator>;
 
     async fn get_file_format(&self, name: &str) -> Result<FileFormatParams>;
 

--- a/src/query/service/src/interpreters/common/mod.rs
+++ b/src/query/service/src/interpreters/common/mod.rs
@@ -21,9 +21,12 @@ mod table;
 mod task;
 mod util;
 
+mod shared_table;
+
 pub use grant::validate_grant_object_exists;
 pub use notification::get_notification_client_config;
 pub use query_log::InterpreterQueryLog;
+pub use shared_table::save_share_table_info;
 pub use stream::dml_build_update_stream_req;
 pub use stream::query_build_update_stream_req;
 pub use stream::StreamTableUpdates;

--- a/src/query/service/src/interpreters/common/shared_table.rs
+++ b/src/query/service/src/interpreters/common/shared_table.rs
@@ -1,0 +1,33 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_catalog::table_context::TableContext;
+use databend_common_meta_app::share::ShareTableInfoMap;
+
+use crate::sessions::QueryContext;
+
+pub async fn save_share_table_info(
+    ctx: &QueryContext,
+    share_table_info: &Option<Vec<ShareTableInfoMap>>,
+) -> databend_common_exception::Result<()> {
+    if let Some(share_table_info) = share_table_info {
+        databend_common_storages_share::save_share_table_info(
+            ctx.get_tenant().tenant_name(),
+            ctx.get_application_level_data_operator()?.operator(),
+            share_table_info,
+        )
+        .await?;
+    }
+    Ok(())
+}

--- a/src/query/service/src/interpreters/common/shared_table.rs
+++ b/src/query/service/src/interpreters/common/shared_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::Result;
 use databend_common_meta_app::share::ShareTableInfoMap;
 
 use crate::sessions::QueryContext;
@@ -20,7 +21,7 @@ use crate::sessions::QueryContext;
 pub async fn save_share_table_info(
     ctx: &QueryContext,
     share_table_info: &Option<Vec<ShareTableInfoMap>>,
-) -> databend_common_exception::Result<()> {
+) -> Result<()> {
     if let Some(share_table_info) = share_table_info {
         databend_common_storages_share::save_share_table_info(
             ctx.get_tenant().tenant_name(),

--- a/src/query/service/src/interpreters/interpreter_database_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_create.rs
@@ -159,7 +159,7 @@ impl Interpreter for CreateDatabaseInterpreter {
 
             save_share_spec(
                 self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
+                self.ctx.get_application_level_data_operator()?.operator(),
                 Some(spec_vec),
                 Some(share_table_into),
             )

--- a/src/query/service/src/interpreters/interpreter_database_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_database_drop.rs
@@ -78,7 +78,7 @@ impl Interpreter for DropDatabaseInterpreter {
 
             save_share_spec(
                 self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
+                self.ctx.get_application_level_data_operator()?.operator(),
                 Some(spec_vec),
                 Some(share_table_into),
             )

--- a/src/query/service/src/interpreters/interpreter_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_index_refresh.rs
@@ -266,7 +266,7 @@ impl Interpreter for RefreshIndexInterpreter {
             }
         };
 
-        let data_accessor = self.ctx.get_data_operator()?;
+        let data_accessor = self.ctx.get_application_level_data_operator()?;
         let fuse_table = FuseTable::do_create(self.plan.table_info.clone())?;
         let fuse_table: Arc<FuseTable> = fuse_table.into();
 

--- a/src/query/service/src/interpreters/interpreter_share_alter_tenants.rs
+++ b/src/query/service/src/interpreters/interpreter_share_alter_tenants.rs
@@ -65,7 +65,7 @@ impl Interpreter for AlterShareTenantsInterpreter {
 
             save_share_spec(
                 self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
+                self.ctx.get_application_level_data_operator()?.operator(),
                 resp.spec_vec,
                 None,
             )
@@ -80,7 +80,7 @@ impl Interpreter for AlterShareTenantsInterpreter {
 
             save_share_spec(
                 self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
+                self.ctx.get_application_level_data_operator()?.operator(),
                 resp.spec_vec,
                 None,
             )

--- a/src/query/service/src/interpreters/interpreter_share_create.rs
+++ b/src/query/service/src/interpreters/interpreter_share_create.rs
@@ -53,7 +53,7 @@ impl Interpreter for CreateShareInterpreter {
 
         save_share_spec(
             self.ctx.get_tenant().tenant_name(),
-            self.ctx.get_data_operator()?.operator(),
+            self.ctx.get_application_level_data_operator()?.operator(),
             resp.spec_vec,
             None,
         )

--- a/src/query/service/src/interpreters/interpreter_share_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_share_drop.rs
@@ -53,7 +53,7 @@ impl Interpreter for DropShareInterpreter {
 
         save_share_spec(
             self.ctx.get_tenant().tenant_name(),
-            self.ctx.get_data_operator()?.operator(),
+            self.ctx.get_application_level_data_operator()?.operator(),
             resp.spec_vec,
             Some(vec![(self.plan.share.clone(), None)]),
         )

--- a/src/query/service/src/interpreters/interpreter_share_grant_object.rs
+++ b/src/query/service/src/interpreters/interpreter_share_grant_object.rs
@@ -63,7 +63,7 @@ impl Interpreter for GrantShareObjectInterpreter {
 
         save_share_spec(
             self.ctx.get_tenant().tenant_name(),
-            self.ctx.get_data_operator()?.operator(),
+            self.ctx.get_application_level_data_operator()?.operator(),
             resp.spec_vec,
             Some(vec![resp.share_table_info]),
         )

--- a/src/query/service/src/interpreters/interpreter_share_revoke_object.rs
+++ b/src/query/service/src/interpreters/interpreter_share_revoke_object.rs
@@ -63,7 +63,7 @@ impl Interpreter for RevokeShareObjectInterpreter {
 
         save_share_spec(
             self.ctx.get_tenant().tenant_name(),
-            self.ctx.get_data_operator()?.operator(),
+            self.ctx.get_application_level_data_operator()?.operator(),
             resp.spec_vec,
             Some(vec![resp.share_table_info]),
         )

--- a/src/query/service/src/interpreters/interpreter_table_add_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_add_column.rs
@@ -28,7 +28,6 @@ use databend_common_sql::field_default_value;
 use databend_common_sql::plans::AddColumnOption;
 use databend_common_sql::plans::AddTableColumnPlan;
 use databend_common_storages_fuse::FuseTable;
-use databend_common_storages_share::save_share_table_info;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 use databend_common_storages_view::view_table::VIEW_ENGINE;
 use databend_storages_common_table_meta::meta::TableSnapshot;
@@ -36,6 +35,7 @@ use databend_storages_common_table_meta::meta::Versioned;
 use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use log::info;
 
+use crate::interpreters::common::save_share_table_info;
 use crate::interpreters::interpreter_table_create::is_valid_column;
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -133,14 +133,7 @@ impl Interpreter for AddTableColumnInterpreter {
 
             let res = catalog.update_table_meta(table_info, req).await?;
 
-            if let Some(share_table_info) = res.share_table_info {
-                save_share_table_info(
-                    self.ctx.get_tenant().tenant_name(),
-                    self.ctx.get_data_operator()?.operator(),
-                    share_table_info,
-                )
-                .await?;
-            }
+            save_share_table_info(&self.ctx, &res.share_table_info).await?;
         };
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -315,6 +315,8 @@ impl CreateTableInterpreter {
         let mut stat = None;
         if !GlobalConfig::instance().query.management_mode {
             if let Some(snapshot_loc) = self.plan.options.get(OPT_KEY_SNAPSHOT_LOCATION) {
+                // using application level data operator is a temp workaround
+                // please see discussions https://github.com/datafuselabs/databend/pull/10424
                 let operator = self.ctx.get_application_level_data_operator()?.operator();
                 let reader = MetaReaders::table_snapshot_reader(operator);
 

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -251,7 +251,7 @@ impl CreateTableInterpreter {
         if let Some((spec_vec, share_table_info)) = reply.spec_vec {
             save_share_spec(
                 tenant.tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
+                self.ctx.get_application_level_data_operator()?.operator(),
                 Some(spec_vec),
                 Some(share_table_info),
             )
@@ -315,7 +315,7 @@ impl CreateTableInterpreter {
         let mut stat = None;
         if !GlobalConfig::instance().query.management_mode {
             if let Some(snapshot_loc) = self.plan.options.get(OPT_KEY_SNAPSHOT_LOCATION) {
-                let operator = self.ctx.get_data_operator()?.operator();
+                let operator = self.ctx.get_application_level_data_operator()?.operator();
                 let reader = MetaReaders::table_snapshot_reader(operator);
 
                 let params = LoadParams {
@@ -368,7 +368,7 @@ impl CreateTableInterpreter {
         if let Some((spec_vec, share_table_info)) = reply.spec_vec {
             save_share_spec(
                 self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
+                self.ctx.get_application_level_data_operator()?.operator(),
                 Some(spec_vec),
                 Some(share_table_info),
             )

--- a/src/query/service/src/interpreters/interpreter_table_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop.rs
@@ -153,7 +153,7 @@ impl Interpreter for DropTableInterpreter {
         if let Some((spec_vec, share_table_info)) = resp.spec_vec {
             save_share_spec(
                 self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
+                self.ctx.get_application_level_data_operator()?.operator(),
                 Some(spec_vec),
                 Some(share_table_info),
             )

--- a/src/query/service/src/interpreters/interpreter_table_drop_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop_column.rs
@@ -23,12 +23,12 @@ use databend_common_meta_app::schema::UpdateTableMetaReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_sql::plans::DropTableColumnPlan;
 use databend_common_sql::BloomIndexColumns;
-use databend_common_storages_share::save_share_table_info;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 use databend_common_storages_view::view_table::VIEW_ENGINE;
 use databend_storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 
 use crate::interpreters::common::check_referenced_computed_columns;
+use crate::interpreters::common::save_share_table_info;
 use crate::interpreters::interpreter_table_add_column::generate_new_snapshot;
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -130,14 +130,8 @@ impl Interpreter for DropTableColumnInterpreter {
         };
 
         let res = catalog.update_table_meta(table_info, req).await?;
-        if let Some(share_table_info) = res.share_table_info {
-            save_share_table_info(
-                self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
-                share_table_info,
-            )
-            .await?;
-        }
+
+        save_share_table_info(&self.ctx, &res.share_table_info).await?;
 
         Ok(PipelineBuildResult::create())
     }

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -44,7 +44,6 @@ use databend_common_sql::plans::Plan;
 use databend_common_sql::BloomIndexColumns;
 use databend_common_sql::Planner;
 use databend_common_storages_fuse::FuseTable;
-use databend_common_storages_share::save_share_table_info;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 use databend_common_storages_view::view_table::VIEW_ENGINE;
 use databend_common_users::UserApiProvider;
@@ -53,6 +52,7 @@ use databend_storages_common_index::BloomIndex;
 use databend_storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 
 use crate::interpreters::common::check_referenced_computed_columns;
+use crate::interpreters::common::save_share_table_info;
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
 use crate::schedulers::build_query_pipeline_without_render_result_set;
@@ -126,14 +126,8 @@ impl ModifyTableColumnInterpreter {
 
         let res = catalog.set_table_column_mask_policy(req).await?;
 
-        if let Some(share_table_info) = res.share_table_info {
-            save_share_table_info(
-                self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
-                share_table_info,
-            )
-            .await?;
-        }
+        save_share_table_info(&self.ctx, &res.share_table_info).await?;
+
         Ok(PipelineBuildResult::create())
     }
 
@@ -330,14 +324,7 @@ impl ModifyTableColumnInterpreter {
                 .update_table_meta(table.get_table_info(), req)
                 .await?;
 
-            if let Some(share_table_info) = res.share_table_info {
-                save_share_table_info(
-                    self.ctx.get_tenant().tenant_name(),
-                    self.ctx.get_data_operator()?.operator(),
-                    share_table_info,
-                )
-                .await?;
-            }
+            save_share_table_info(&self.ctx, &res.share_table_info).await?;
 
             return Ok(PipelineBuildResult::create());
         }
@@ -451,14 +438,7 @@ impl ModifyTableColumnInterpreter {
 
             let res = catalog.set_table_column_mask_policy(req).await?;
 
-            if let Some(share_table_info) = res.share_table_info {
-                save_share_table_info(
-                    self.ctx.get_tenant().tenant_name(),
-                    self.ctx.get_data_operator()?.operator(),
-                    share_table_info,
-                )
-                .await?;
-            }
+            save_share_table_info(&self.ctx, &res.share_table_info).await?;
         }
 
         Ok(PipelineBuildResult::create())
@@ -517,14 +497,7 @@ impl ModifyTableColumnInterpreter {
 
         let res = catalog.update_table_meta(table_info, req).await?;
 
-        if let Some(share_table_info) = res.share_table_info {
-            save_share_table_info(
-                self.ctx.get_tenant().tenant_name(),
-                self.ctx.get_data_operator()?.operator(),
-                share_table_info,
-            )
-            .await?;
-        }
+        save_share_table_info(&self.ctx, &res.share_table_info).await?;
 
         Ok(PipelineBuildResult::create())
     }

--- a/src/query/service/src/interpreters/interpreter_table_rename_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_rename_column.rs
@@ -23,12 +23,12 @@ use databend_common_meta_app::schema::UpdateTableMetaReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_sql::plans::RenameTableColumnPlan;
 use databend_common_sql::BloomIndexColumns;
-use databend_common_storages_share::save_share_table_info;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 use databend_common_storages_view::view_table::VIEW_ENGINE;
 use databend_storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 
 use crate::interpreters::common::check_referenced_computed_columns;
+use crate::interpreters::common::save_share_table_info;
 use crate::interpreters::interpreter_table_create::is_valid_column;
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -135,14 +135,7 @@ impl Interpreter for RenameTableColumnInterpreter {
 
             let res = catalog.update_table_meta(table_info, req).await?;
 
-            if let Some(share_table_info) = res.share_table_info {
-                save_share_table_info(
-                    self.ctx.get_tenant().tenant_name(),
-                    self.ctx.get_data_operator()?.operator(),
-                    share_table_info,
-                )
-                .await?;
-            }
+            save_share_table_info(&self.ctx, &res.share_table_info).await?;
         };
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/interpreters/interpreter_user_stage_create.rs
+++ b/src/query/service/src/interpreters/interpreter_user_stage_create.rs
@@ -115,7 +115,7 @@ impl Interpreter for CreateUserStageInterpreter {
 
         // create dir if new stage if not external stage
         if user_stage.stage_type != StageType::External {
-            let op = self.ctx.get_data_operator()?.operator();
+            let op = self.ctx.get_application_level_data_operator()?.operator();
             op.create_dir(&user_stage.stage_prefix()).await?
         }
 

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -824,8 +824,10 @@ impl TableContext for QueryContext {
         None
     }
 
-    // Get the storage data accessor operator from the session manager.
-    fn get_data_operator(&self) -> Result<DataOperator> {
+    /// Get the storage data accessor operator from the session manager.
+    /// Note that this is the application level data accessor, which may be different from
+    /// the table level data accessor (e.g., table with customized storage parameters).
+    fn get_application_level_data_operator(&self) -> Result<DataOperator> {
         Ok(self.shared.data_operator.clone())
     }
 

--- a/src/query/service/src/test_kits/check.rs
+++ b/src/query/service/src/test_kits/check.rs
@@ -121,7 +121,7 @@ pub async fn check_data_dir(
             } else if path.starts_with(prefix_last_snapshot_hint) && check_last_snapshot.is_some() {
                 let content = fixture
                     .default_ctx
-                    .get_data_operator()?
+                    .get_application_level_data_operator()?
                     .operator()
                     .read(entry_path)
                     .await?

--- a/src/query/service/tests/it/sessions/query_ctx.rs
+++ b/src/query/service/tests/it/sessions/query_ctx.rs
@@ -48,7 +48,7 @@ async fn test_get_storage_accessor_s3() -> Result<()> {
     let fixture = TestFixture::setup_with_config(&conf).await?;
     let ctx = fixture.new_query_ctx().await?;
 
-    let _ = ctx.get_data_operator()?;
+    let _ = ctx.get_application_level_data_operator()?;
 
     Ok(())
 }
@@ -61,7 +61,7 @@ async fn test_get_storage_accessor_fs() -> Result<()> {
     });
     let fixture = TestFixture::setup_with_config(&conf).await?;
     let ctx = fixture.new_query_ctx().await?;
-    let _ = ctx.get_data_operator()?;
+    let _ = ctx.get_application_level_data_operator()?;
 
     Ok(())
 }

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -715,8 +715,8 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn get_data_operator(&self) -> Result<DataOperator> {
-        self.ctx.get_data_operator()
+    fn get_application_level_data_operator(&self) -> Result<DataOperator> {
+        self.ctx.get_application_level_data_operator()
     }
 
     async fn get_file_format(&self, _name: &str) -> Result<FileFormatParams> {

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -653,8 +653,8 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    fn get_data_operator(&self) -> Result<DataOperator> {
-        self.ctx.get_data_operator()
+    fn get_application_level_data_operator(&self) -> Result<DataOperator> {
+        self.ctx.get_application_level_data_operator()
     }
 
     async fn get_file_format(&self, _name: &str) -> Result<FileFormatParams> {

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -145,7 +145,7 @@ async fn do_compact(ctx: Arc<QueryContext>, table: Arc<dyn Table>) -> Result<boo
 async fn test_safety() -> Result<()> {
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;
-    let operator = ctx.get_data_operator()?.operator();
+    let operator = ctx.get_application_level_data_operator()?.operator();
     let settings = ctx.get_settings();
     settings.set_max_threads(2)?;
     settings.set_max_storage_io_requests(4)?;
@@ -271,7 +271,7 @@ async fn test_safety() -> Result<()> {
         for idx in compact_segment_indices.into_iter() {
             let loc = locations.get(idx).unwrap();
             let compact_segment = SegmentsIO::read_compact_segment(
-                ctx.get_data_operator()?.operator(),
+                ctx.get_application_level_data_operator()?.operator(),
                 loc.clone(),
                 TestFixture::default_table_schema(),
                 false,

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -56,7 +56,7 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
     let ctx = fixture.new_query_ctx().await?;
     let location_generator = TableMetaLocationGenerator::with_prefix("_prefix".to_owned());
 
-    let data_accessor = ctx.get_data_operator()?.operator();
+    let data_accessor = ctx.get_application_level_data_operator()?.operator();
     let seg_writer = SegmentWriter::new(&data_accessor, &location_generator);
 
     let cluster_key_id = 0;
@@ -160,7 +160,7 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
 async fn test_safety_for_recluster() -> Result<()> {
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;
-    let operator = ctx.get_data_operator()?.operator();
+    let operator = ctx.get_application_level_data_operator()?.operator();
 
     let recluster_block_size = 300;
     ctx.get_settings()

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -640,7 +640,7 @@ pub struct CompactSegmentTestFixture {
 impl CompactSegmentTestFixture {
     fn try_new(ctx: &Arc<QueryContext>, block_per_seg: u64) -> Result<Self> {
         let location_gen = TableMetaLocationGenerator::with_prefix("test/".to_owned());
-        let data_accessor = ctx.get_data_operator()?;
+        let data_accessor = ctx.get_application_level_data_operator()?;
         Ok(Self {
             ctx: ctx.clone(),
             threshold: block_per_seg,
@@ -706,7 +706,7 @@ impl CompactSegmentTestFixture {
         block_per_seg: usize,
     ) -> Result<(Vec<Location>, Vec<BlockMeta>, Vec<SegmentInfo>)> {
         let location_gen = TableMetaLocationGenerator::with_prefix("test/".to_owned());
-        let data_accessor = ctx.get_data_operator()?.operator();
+        let data_accessor = ctx.get_application_level_data_operator()?.operator();
         let threads_nums = ctx.get_settings().get_max_threads()? as usize;
 
         let mut tasks = vec![];
@@ -854,7 +854,7 @@ impl CompactCase {
     ) -> Result<()> {
         // setup & run
         let compact_segment_reader = MetaReaders::segment_info_reader(
-            ctx.get_data_operator()?.operator(),
+            ctx.get_application_level_data_operator()?.operator(),
             TestFixture::default_table_schema(),
         );
         let mut case_fixture = CompactSegmentTestFixture::try_new(ctx, block_per_segment)?;
@@ -964,7 +964,7 @@ async fn test_compact_segment_with_cluster() -> Result<()> {
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;
     let location_gen = TableMetaLocationGenerator::with_prefix("test/".to_owned());
-    let data_accessor = ctx.get_data_operator()?.operator();
+    let data_accessor = ctx.get_application_level_data_operator()?.operator();
     let schema = TestFixture::default_table_schema();
 
     let settings = ctx.get_settings();

--- a/src/query/service/tests/it/storages/fuse/operations/table_analyze.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/table_analyze.rs
@@ -134,7 +134,7 @@ async fn test_table_update_analyze_statistics() -> Result<()> {
     // get segments summary
     let mut segment_summary = Statistics::default();
     let segment_reader = MetaReaders::segment_info_reader(
-        ctx.get_data_operator()?.operator(),
+        ctx.get_application_level_data_operator()?.operator(),
         TestFixture::default_table_schema(),
     );
     for segment in after_update.segments.iter() {

--- a/src/query/storages/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/src/io/snapshots.rs
@@ -216,12 +216,12 @@ impl SnapshotsIO {
     #[async_backtrace::framed]
     pub async fn read_chained_snapshot_lites(
         &self,
+        dal: Operator,
         location_generator: TableMetaLocationGenerator,
         root_snapshot: String,
         limit: Option<usize>,
     ) -> Result<Vec<TableSnapshotLite>> {
-        let table_snapshot_reader =
-            MetaReaders::table_snapshot_reader(self.ctx.get_data_operator()?.operator());
+        let table_snapshot_reader = MetaReaders::table_snapshot_reader(dal);
         let format_version = TableMetaLocationGenerator::snapshot_version(root_snapshot.as_str());
         let lite_snapshot_stream = table_snapshot_reader
             .snapshot_history(root_snapshot, format_version, location_generator)

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -164,27 +164,18 @@ impl FuseTable {
             let table_schema = self.schema_with_stream();
             let push_downs = plan.push_downs.clone();
             let query_ctx = ctx.clone();
-            let dal = self.operator.clone();
 
             // TODO: need refactor
             pipeline.set_on_init(move || {
                 let table = table.clone();
                 let table_schema = table_schema.clone();
                 let ctx = query_ctx.clone();
-                let dal = dal.clone();
                 let push_downs = push_downs.clone();
                 // let lazy_init_segments = lazy_init_segments.clone();
 
                 let partitions = Runtime::with_worker_threads(2, None)?.block_on(async move {
                     let (_statistics, partitions) = table
-                        .prune_snapshot_blocks(
-                            ctx,
-                            dal,
-                            push_downs,
-                            table_schema,
-                            lazy_init_segments,
-                            0,
-                        )
+                        .prune_snapshot_blocks(ctx, push_downs, table_schema, lazy_init_segments, 0)
                         .await?;
 
                     Result::<_, ErrorCode>::Ok(partitions)

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -75,6 +75,7 @@ impl<'a> FuseSnapshot<'a> {
                 // returned is as expected
                 let snapshot_lites = snapshots_io
                     .read_chained_snapshot_lites(
+                        self.table.operator.clone(),
                         meta_location_generator.clone(),
                         snapshot_location,
                         limit,

--- a/src/query/storages/share/src/share.rs
+++ b/src/query/storages/share/src/share.rs
@@ -45,15 +45,14 @@ pub fn share_table_info_location(tenant: &str, share_name: &str) -> String {
 pub async fn save_share_table_info(
     tenant: &str,
     operator: Operator,
-    share_table_info: Vec<ShareTableInfoMap>,
+    share_table_info: &[ShareTableInfoMap],
 ) -> Result<()> {
     for (share_name, share_table_info) in share_table_info {
-        let share_name = share_name.clone();
-        let location = share_table_info_location(tenant, &share_name);
+        let location = share_table_info_location(tenant, share_name);
         match share_table_info {
             Some(table_info_map) => {
                 operator
-                    .write(&location, serde_json::to_vec(&table_info_map)?)
+                    .write(&location, serde_json::to_vec(table_info_map)?)
                     .await?;
             }
             None => {
@@ -89,7 +88,7 @@ pub async fn save_share_spec(
 
     // save share table info
     if let Some(share_table_info) = share_table_info {
-        save_share_table_info(tenant, operator, share_table_info).await?
+        save_share_table_info(tenant, operator, &share_table_info).await?
     }
 
     Ok(())

--- a/tests/sqllogictests/suites/no_table_meta_cache/fuse_snapshot.test
+++ b/tests/sqllogictests/suites/no_table_meta_cache/fuse_snapshot.test
@@ -1,0 +1,35 @@
+statement ok
+create or replace database test_fuse_snapshot_without_meta_cache;
+
+statement ok
+use test_fuse_snapshot_without_meta_cache;
+
+
+statement ok
+create or replace table t(c int) 'fs:///tmp/test_fuse_snapshot_without_meta_cache/';
+
+# check table meta cache is disabled
+
+query TT
+select name, value from system.configs where  name = 'enable_table_meta_cache';
+----
+enable_table_meta_cache false
+
+# generate 3 snapshots
+
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(1);
+
+query I
+select count() from fuse_snapshot('test_fuse_snapshot_without_meta_cache', 't') limit 100;
+----
+3
+
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Before this PR, during the traversal of the table history, the application-level data operator is used. However, this approach fails to load the snapshot history of external tables because their storage parameters differ from those of the application-level data operator.

The confusing part is that during the process of writing a new snapshot, we also generate the snapshot cache. Therefore, on the node where data is written to the external table, despite the aforementioned issue, the traversal of the table history snapshot still works because the snapshot can be retrieved from the cache.

However, on other nodes that do not have the snapshot cache mentioned above, the issue persists. This results in `fuse_snapshot` only being able to return the most recent snapshot (the corresponding table snapshot cache is populated during table instantiation).

- fix

   - use table's data operator while traversing table history
   - use table's data operator in index refreshing

- refactors:

  - rename `TableContext::get_data_operator` to `get_application_level_data_operator`

      clarify that the data operator got from ctx is NOT Table's operator

  - de-dup code by introducing `shared_table::save_share_table_info`

- tweak CI script to test with table meta cache disabled

- Fixes #15724


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15721)
<!-- Reviewable:end -->
