### PR TITLE
refactor: GrantEntry not store ownership privilege

### DIFF
--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -44,6 +44,7 @@ use databend_common_meta_types::SeqV;
 use databend_common_meta_types::TxnRequest;
 use enumflags2::make_bitflags;
 use log::debug;
+use log::error;
 use minitrace::func_name;
 
 use crate::role::role_api::RoleApi;
@@ -166,7 +167,7 @@ impl RoleApi for RoleMgr {
             Ok(_) => {
                 let mut quota = Quota::new(func_name!());
 
-                let u = check_and_upgrade_to_pb(&mut quota, key, &seq_value, self.kv_api.as_ref())
+                let u = check_and_upgrade_to_pb(&mut quota, &key, &seq_value, self.kv_api.as_ref())
                     .await?;
 
                 // Keep the original seq.
@@ -189,7 +190,7 @@ impl RoleApi for RoleMgr {
         let mut quota = Quota::new(func_name!());
 
         for (key, val) in values {
-            let u = check_and_upgrade_to_pb(&mut quota, key, &val, self.kv_api.as_ref()).await?;
+            let u = check_and_upgrade_to_pb(&mut quota, &key, &val, self.kv_api.as_ref()).await?;
             r.push(u);
         }
 
@@ -217,8 +218,16 @@ impl RoleApi for RoleMgr {
         let mut quota = Quota::new(func_name!());
 
         for (key, val) in values {
-            let u = check_and_upgrade_to_pb(&mut quota, key, &val, self.kv_api.as_ref()).await?;
-            r.push(u);
+            match check_and_upgrade_to_pb(&mut quota, &key, &val, self.kv_api.as_ref()).await {
+                Ok(u) => r.push(u),
+                // If we add a new item in OwnershipObject, and generate a new kv about this new item,
+                // After rollback the old version, deserialize will return Err Ownership can not be none.
+                // But get ownerships should try to ensure success because in this version.
+                Err(err) => error!(
+                    "deserialize key {} Got err {} while (get_ownerships)",
+                    &key, err
+                ),
+            }
         }
 
         Ok(r)
@@ -404,7 +413,7 @@ impl RoleApi for RoleMgr {
 
         // if can not get ownership, will directly return None.
         let seq_val =
-            check_and_upgrade_to_pb(&mut quota, key, &seq_value, self.kv_api.as_ref()).await?;
+            check_and_upgrade_to_pb(&mut quota, &key, &seq_value, self.kv_api.as_ref()).await?;
 
         Ok(Some(seq_val.data))
     }

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -366,26 +366,6 @@ impl RoleApi for RoleMgr {
                 }
             }
 
-            // account_admin has all privilege, no need to grant ownership.
-            if new_role != BUILTIN_ROLE_ACCOUNT_ADMIN {
-                let new_key = self.role_ident(new_role);
-                let SeqV {
-                    seq: new_seq,
-                    data: mut new_role_info,
-                    ..
-                } = self.get_role(&new_role.to_owned(), MatchSeq::GE(1)).await?;
-                new_role_info.grants.grant_privileges(
-                    &grant_object,
-                    make_bitflags!(UserPrivilegeType::{ Ownership }).into(),
-                );
-                new_role_info.update_role_time();
-                condition.push(txn_cond_seq(&new_key, Eq, new_seq));
-                if_then.push(txn_op_put(
-                    &new_key,
-                    serialize_struct(&new_role_info, ErrorCode::IllegalUserInfoFormat, || "")?,
-                ));
-            }
-
             let txn_req = TxnRequest {
                 condition: condition.clone(),
                 if_then: if_then.clone(),

--- a/src/query/management/src/serde/pb_serde.rs
+++ b/src/query/management/src/serde/pb_serde.rs
@@ -71,7 +71,7 @@ where
 /// it will just convert the data but do not write to backend storage.
 pub async fn check_and_upgrade_to_pb<T>(
     quota: &mut Quota,
-    key: String,
+    key: &String,
     seq_value: &SeqV,
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
 ) -> std::result::Result<SeqV<T>, MetaError>
@@ -103,7 +103,7 @@ where
 
     let res = kv_api
         .upsert_kv(UpsertKVReq::new(
-            &key,
+            key,
             MatchSeq::Exact(seq_value.seq),
             Operation::Update(value),
             None,

--- a/src/query/service/src/table_functions/show_grants/show_grants_table.rs
+++ b/src/query/service/src/table_functions/show_grants/show_grants_table.rs
@@ -300,7 +300,12 @@ async fn show_account_grants(
             )
         }
         "role" => {
-            if !current_user.grants.roles().contains(&name.to_string()) && !has_grant_priv {
+            let current_user_roles = ctx.get_all_effective_roles().await?;
+            let effective_roles_names: Vec<String> = current_user_roles
+                .iter()
+                .map(|role| role.name.to_string())
+                .collect();
+            if !effective_roles_names.contains(&name.to_string()) && !has_grant_priv {
                 let mut roles = current_user.grants.roles();
                 roles.sort();
                 return Err(ErrorCode::PermissionDenied(format!(
@@ -309,6 +314,7 @@ async fn show_account_grants(
                     roles.join(",")
                 )));
             }
+
             let role_info = user_api.get_role(&tenant, name.to_string()).await?;
             let related_roles = RoleCacheManager::instance()
                 .find_related_roles(&tenant, &role_info.grants.roles())

--- a/src/query/service/src/table_functions/show_grants/show_grants_table.rs
+++ b/src/query/service/src/table_functions/show_grants/show_grants_table.rs
@@ -36,8 +36,10 @@ use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRefExt;
+use databend_common_management::RoleApi;
 use databend_common_meta_app::principal::GrantEntry;
 use databend_common_meta_app::principal::GrantObject;
+use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::UserIdentity;
 use databend_common_meta_app::principal::UserPrivilegeSet;
 use databend_common_meta_app::principal::UserPrivilegeType;
@@ -52,6 +54,7 @@ use databend_common_pipeline_sources::AsyncSourcer;
 use databend_common_sql::validate_function_arg;
 use databend_common_users::RoleCacheManager;
 use databend_common_users::UserApiProvider;
+use itertools::Itertools;
 
 const SHOW_GRANTS: &str = "show_grants";
 
@@ -270,10 +273,12 @@ async fn show_account_grants(
         .await
         .is_ok();
 
+    let user_api = UserApiProvider::instance();
+
     // TODO: add permission check on reading user grants
-    let (grant_to, name, identity, grant_set) = match grant_type {
+    let (grant_to, name, identity, grant_set, roles) = match grant_type {
         "user" => {
-            let user = UserApiProvider::instance()
+            let user = user_api
                 .get_user(&tenant, UserIdentity::new(name, "%"))
                 .await?;
             if current_user.identity().username != name && !has_grant_priv {
@@ -291,6 +296,7 @@ async fn show_account_grants(
                 user.name.to_string(),
                 user.identity().display().to_string(),
                 user.grants,
+                None,
             )
         }
         "role" => {
@@ -303,14 +309,21 @@ async fn show_account_grants(
                     roles.join(",")
                 )));
             }
-            let role_info = UserApiProvider::instance()
-                .get_role(&tenant, name.to_string())
+            let role_info = user_api.get_role(&tenant, name.to_string()).await?;
+            let related_roles = RoleCacheManager::instance()
+                .find_related_roles(&tenant, &role_info.grants.roles())
                 .await?;
+            let mut roles: Vec<String> = related_roles
+                .iter()
+                .map(|role| role.name.to_string())
+                .collect();
+            roles.push(name.to_string());
             (
                 "ROLE".to_string(),
                 name.to_string(),
                 format!("ROLE `{}`", role_info.identity()),
                 role_info.grants,
+                Some(roles),
             )
         }
         _ => {
@@ -322,23 +335,27 @@ async fn show_account_grants(
     };
 
     // TODO: display roles list instead of the inherited roles
-    let user_roles = RoleCacheManager::instance()
+    let related_roles = RoleCacheManager::instance()
         .find_related_roles(&tenant, &grant_set.roles())
         .await?;
 
-    let grant_entries = user_roles
+    let roles: Vec<String> = if let Some(roles) = roles {
+        roles
+    } else {
+        related_roles
+            .iter()
+            .map(|role| role.name.to_string())
+            .sorted()
+            .collect()
+    };
+
+    let grant_entries = related_roles
         .into_iter()
         .map(|role| role.grants)
         .fold(grant_set, |a, b| a | b)
         .entries();
 
     let mut grant_list: Vec<String> = Vec::new();
-
-    // must split with two hashmap, hashmap key is catalog name.
-    // maybe contain: default.db1 and default.db2.t,
-    // It will re-write the exists key.
-    let mut catalog_db_ids: HashMap<String, Vec<(u64, String)>> = HashMap::new();
-    let mut catalog_table_ids: HashMap<String, Vec<(u64, u64, String)>> = HashMap::new();
 
     fn get_priv_str(grant_entry: &GrantEntry) -> String {
         if grant_entry.has_all_available_privileges() {
@@ -352,63 +369,124 @@ async fn show_account_grants(
     let mut object_id = vec![];
     let mut object_name = vec![];
     let mut privileges = vec![];
+    // must split with two hashmap, hashmap key is catalog name.
+    // maybe contain: default.db1 and default.db2.t,
+    // It will re-write the exists key.
+    let mut catalog_db_ids: HashMap<String, Vec<(u64, String)>> = HashMap::new();
+    let mut catalog_table_ids: HashMap<String, Vec<(u64, u64, String)>> = HashMap::new();
+
     for grant_entry in grant_entries {
         let object = grant_entry.object();
-        match object {
-            GrantObject::TableById(catalog_name, db_id, table_id) => {
-                let privileges_str = get_priv_str(&grant_entry);
-                if let Some(tables_id_priv) = catalog_table_ids.get(catalog_name) {
-                    let mut tables_id_priv = tables_id_priv.clone();
-                    tables_id_priv.push((*db_id, *table_id, privileges_str));
-                    catalog_table_ids.insert(catalog_name.clone(), tables_id_priv.clone());
-                } else {
-                    catalog_table_ids.insert(catalog_name.clone(), vec![(
-                        *db_id,
-                        *table_id,
-                        privileges_str,
-                    )]);
+        let privilege = get_priv_str(&grant_entry);
+        // Ownership will list ownerships kv
+        if privilege.to_lowercase() != "ownership" {
+            match object {
+                GrantObject::TableById(catalog_name, db_id, table_id) => {
+                    let privileges_str = get_priv_str(&grant_entry);
+                    if let Some(tables_id_priv) = catalog_table_ids.get_mut(catalog_name) {
+                        tables_id_priv.push((*db_id, *table_id, privileges_str));
+                    } else {
+                        catalog_table_ids.insert(catalog_name.clone(), vec![(
+                            *db_id,
+                            *table_id,
+                            privileges_str,
+                        )]);
+                    }
+                }
+                GrantObject::DatabaseById(catalog_name, db_id) => {
+                    let privileges_str = get_priv_str(&grant_entry);
+                    if let Some(dbs_id_priv) = catalog_db_ids.get_mut(catalog_name) {
+                        dbs_id_priv.push((*db_id, privileges_str));
+                    } else {
+                        catalog_db_ids.insert(catalog_name.clone(), vec![(*db_id, privileges_str)]);
+                    }
+                }
+                GrantObject::Database(catalog_name, database_name) => {
+                    object_name.push(format!("{}.{}.*", catalog_name, database_name));
+                    object_id.push(None);
+                    privileges.push(get_priv_str(&grant_entry));
+                    grant_list.push(format!("{} TO {}", grant_entry, identity));
+                }
+                GrantObject::Table(catalog_name, database_name, table_name) => {
+                    object_name.push(format!("{}.{}.{}", catalog_name, database_name, table_name));
+                    object_id.push(None);
+                    privileges.push(get_priv_str(&grant_entry));
+                    grant_list.push(format!("{} TO {}", grant_entry, identity));
+                }
+                GrantObject::Stage(stage_name) => {
+                    object_name.push(stage_name.to_string());
+                    object_id.push(None);
+                    privileges.push(get_priv_str(&grant_entry));
+                    grant_list.push(format!("{} TO {}", grant_entry, identity));
+                }
+                GrantObject::UDF(udf_name) => {
+                    object_name.push(udf_name.to_string());
+                    object_id.push(None);
+                    privileges.push(get_priv_str(&grant_entry));
+                    grant_list.push(format!("{} TO {}", grant_entry, identity));
+                }
+                GrantObject::Global => {
+                    // grant all on *.* to a
+                    object_name.push("*.*".to_string());
+                    object_id.push(None);
+                    privileges.push(get_priv_str(&grant_entry));
+                    grant_list.push(format!("{} TO {}", grant_entry, identity));
                 }
             }
-            GrantObject::DatabaseById(catalog_name, db_id) => {
-                let privileges_str = get_priv_str(&grant_entry);
-                if let Some(dbs_id_priv) = catalog_db_ids.get(catalog_name) {
-                    let mut dbs_id_priv = dbs_id_priv.clone();
-                    dbs_id_priv.push((*db_id, privileges_str));
-                    catalog_db_ids.insert(catalog_name.clone(), dbs_id_priv.clone());
-                } else {
-                    catalog_db_ids.insert(catalog_name.clone(), vec![(*db_id, privileges_str)]);
+        }
+    }
+
+    // If roles contains account_admin, it means this role has all roles.
+    // No need to display ownership.
+    if !roles.contains(&"account_admin".to_string()) {
+        let ownerships = user_api.role_api(&tenant).get_ownerships().await?;
+        // let mut catalog_db_ids: HashMap<String, Vec<(u64, String)>> = HashMap::new();
+        // let mut catalog_table_ids: HashMap<String, Vec<(u64, u64, String)>> = HashMap::new();
+        for ownership in ownerships {
+            if roles.contains(&ownership.data.role) {
+                match ownership.data.object {
+                    OwnershipObject::Database {
+                        catalog_name,
+                        db_id,
+                    } => {
+                        let privileges_str = "OWNERSHIP".to_string();
+                        if let Some(dbs_id_priv) = catalog_db_ids.get_mut(&catalog_name) {
+                            dbs_id_priv.push((db_id, privileges_str));
+                        } else {
+                            catalog_db_ids
+                                .insert(catalog_name.clone(), vec![(db_id, privileges_str)]);
+                        }
+                    }
+                    OwnershipObject::Table {
+                        catalog_name,
+                        db_id,
+                        table_id,
+                    } => {
+                        let privileges_str = "OWNERSHIP".to_string();
+                        if let Some(tables_id_priv) = catalog_table_ids.get_mut(&catalog_name) {
+                            tables_id_priv.push((db_id, table_id, privileges_str));
+                        } else {
+                            catalog_table_ids.insert(catalog_name.clone(), vec![(
+                                db_id,
+                                table_id,
+                                privileges_str,
+                            )]);
+                        }
+                    }
+                    OwnershipObject::Stage { name } => {
+                        object_name.push(name.to_string());
+                        object_id.push(None);
+                        privileges.push("OWNERSHIP".to_string());
+                        grant_list
+                            .push(format!("GRANT OWNERSHIP ON STAGE {} TO {}", name, identity));
+                    }
+                    OwnershipObject::UDF { name } => {
+                        object_name.push(name.to_string());
+                        object_id.push(None);
+                        privileges.push("OWNERSHIP".to_string());
+                        grant_list.push(format!("GRANT OWNERSHIP ON UDF {} TO {}", name, identity));
+                    }
                 }
-            }
-            GrantObject::Database(catalog_name, database_name) => {
-                object_name.push(format!("{}.{}.*", catalog_name, database_name));
-                object_id.push(None);
-                privileges.push(get_priv_str(&grant_entry));
-                grant_list.push(format!("{} TO {}", grant_entry, identity));
-            }
-            GrantObject::Table(catalog_name, database_name, table_name) => {
-                object_name.push(format!("{}.{}.{}", catalog_name, database_name, table_name));
-                object_id.push(None);
-                privileges.push(get_priv_str(&grant_entry));
-                grant_list.push(format!("{} TO {}", grant_entry, identity));
-            }
-            GrantObject::Stage(stage_name) => {
-                object_name.push(stage_name.to_string());
-                object_id.push(None);
-                privileges.push(get_priv_str(&grant_entry));
-                grant_list.push(format!("{} TO {}", grant_entry, identity));
-            }
-            GrantObject::UDF(udf_name) => {
-                object_name.push(udf_name.to_string());
-                object_id.push(None);
-                privileges.push(get_priv_str(&grant_entry));
-                grant_list.push(format!("{} TO {}", grant_entry, identity));
-            }
-            GrantObject::Global => {
-                // grant all on *.* to a
-                object_name.push("*.*".to_string());
-                object_id.push(None);
-                privileges.push(get_priv_str(&grant_entry));
-                grant_list.push(format!("{} TO {}", grant_entry, identity));
             }
         }
     }
@@ -481,10 +559,11 @@ async fn show_object_grant(
     db_name: &str,
 ) -> Result<Option<DataBlock>> {
     let tenant = ctx.get_tenant();
-    let roles = UserApiProvider::instance().get_roles(&tenant).await?;
+    let user_api = UserApiProvider::instance();
+    let roles = user_api.get_roles(&tenant).await?;
     let visibility_checker = ctx.get_visibility_checker().await?;
     let current_user = ctx.get_current_user()?.identity().username;
-    let (object, object_id, object_name) = match grant_type {
+    let (object, owner_object, object_id, object_name) = match grant_type {
         "table" => {
             let catalog = ctx.get_catalog(catalog_name).await?;
             let db_id = catalog
@@ -508,6 +587,11 @@ async fn show_object_grant(
             }
             (
                 GrantObject::TableById(catalog_name.to_string(), db_id, table_id),
+                OwnershipObject::Table {
+                    catalog_name: catalog_name.to_string(),
+                    db_id,
+                    table_id,
+                },
                 Some(table_id),
                 name,
             )
@@ -529,6 +613,10 @@ async fn show_object_grant(
             }
             (
                 GrantObject::DatabaseById(catalog_name.to_string(), db_id),
+                OwnershipObject::Database {
+                    catalog_name: catalog_name.to_string(),
+                    db_id,
+                },
                 Some(db_id),
                 name,
             )
@@ -540,7 +628,14 @@ async fn show_object_grant(
                     name, current_user
                 )));
             }
-            (GrantObject::UDF(name.to_string()), None, name)
+            (
+                GrantObject::UDF(name.to_string()),
+                OwnershipObject::UDF {
+                    name: name.to_string(),
+                },
+                None,
+                name,
+            )
         }
         "stage" => {
             if !visibility_checker.check_stage_visibility(name) {
@@ -549,7 +644,14 @@ async fn show_object_grant(
                     name, current_user
                 )));
             }
-            (GrantObject::Stage(name.to_string()), None, name)
+            (
+                GrantObject::Stage(name.to_string()),
+                OwnershipObject::Stage {
+                    name: name.to_string(),
+                },
+                None,
+                name,
+            )
         }
         _ => {
             return Err(ErrorCode::InvalidArgument(format!(
@@ -570,6 +672,15 @@ async fn show_object_grant(
             }
         }
     }
+
+    let ownerships = user_api.role_api(&tenant).get_ownerships().await?;
+    for ownership in ownerships {
+        if ownership.data.object == owner_object {
+            privileges.push("OWNERSHIP".to_string());
+            names.push(ownership.data.role);
+        }
+    }
+
     let object_ids = vec![object_id; privileges.len()];
     let object_names = vec![object_name; privileges.len()];
     let grant_tos: Vec<String> = vec!["ROLE".to_string(); privileges.len()];

--- a/tests/sqllogictests/suites/base/05_ddl/05_0017_ddl_grant_role.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0017_ddl_grant_role.test
@@ -161,6 +161,7 @@ show grants on udf isnotempty;
 ----
 USAGE isnotempty NULL ROLE role2 (empty)
 USAGE isnotempty NULL ROLE role3 (empty)
+OWNERSHIP isnotempty NULL ROLE account_admin (empty)
 
 query TT
 show grants on udf isnotempty where name!='role2' limit 1;
@@ -171,17 +172,20 @@ query TT
 show grants on stage s1;
 ----
 Read s1 NULL ROLE role2 (empty)
+OWNERSHIP s1 NULL ROLE account_admin (empty)
 
 query TT
 select * EXCLUDE(object_id) from show_grants('database', 'db1', 'default');
 ----
 CREATE,SELECT,INSERT,UPDATE,DELETE,DROP,ALTER,GRANT db1 ROLE role2 (empty)
 CREATE,SELECT,INSERT,UPDATE,DELETE,DROP,ALTER,GRANT db1 ROLE role3 (empty)
+OWNERSHIP db1 ROLE account_admin (empty)
 
 query TT
 select * EXCLUDE(object_id) from show_grants('table', 't', 'default', 'default');
 ----
 SELECT t ROLE role3 (empty)
+OWNERSHIP t ROLE account_admin (empty)
 
 statement ok
 DROP ROLE role1

--- a/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.result
+++ b/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.result
@@ -1,47 +1,52 @@
 === review init role3 grants ===
 UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
-OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
-SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+SELECT default.c_r.t  ROLE role3 GRANT SELECT ON 'default'.'c_r'.'t' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 UPDATE,DELETE default.c_r2.t2  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r2'.'t2' TO ROLE `role3`
+OWNERSHIP default.c_r.t  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
 === drop table c_r2.t2 ===
 === drop c_r2.t2 once ===
 UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
-OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
-SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+SELECT default.c_r.t  ROLE role3 GRANT SELECT ON 'default'.'c_r'.'t' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
+OWNERSHIP default.c_r.t  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
 === create same name table c_r2.t2 ===
 UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
-OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
-SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+SELECT default.c_r.t  ROLE role3 GRANT SELECT ON 'default'.'c_r'.'t' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 SELECT default.c_r2.t2  ROLE role3 GRANT SELECT ON 'default'.'c_r2'.'t2' TO ROLE `role3`
+OWNERSHIP default.c_r.t  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
 === drop c_r2.t2 twice ===
 UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
-OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
-SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+SELECT default.c_r.t  ROLE role3 GRANT SELECT ON 'default'.'c_r'.'t' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
+OWNERSHIP default.c_r.t  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
 === test database drop ===
 UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
-OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
+OWNERSHIP c_r  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.* TO ROLE `role3`
 SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
-SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+SELECT default.c_r.t  ROLE role3 GRANT SELECT ON 'default'.'c_r'.'t' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 UPDATE,DELETE default.c_r2.t2  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r2'.'t2' TO ROLE `role3`
+OWNERSHIP default.c_r.t  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
 === drop database c_r , c_r2 ===
 UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
@@ -59,9 +64,10 @@ UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_sch
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
 SELECT,INSERT c_r2  ROLE role3 GRANT SELECT,INSERT ON 'default'.'c_r2'.* TO ROLE `role3`
 SELECT default.system.one  ROLE role3 GRANT SELECT ON 'default'.'system'.'one' TO ROLE `role3`
-SELECT,OWNERSHIP default.c_r.t  ROLE role3 GRANT SELECT,OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
+SELECT default.c_r.t  ROLE role3 GRANT SELECT ON 'default'.'c_r'.'t' TO ROLE `role3`
 UPDATE,DELETE default.c_r1.t1  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r1'.'t1' TO ROLE `role3`
 UPDATE,DELETE default.c_r2.t2  ROLE role3 GRANT UPDATE,DELETE ON 'default'.'c_r2'.'t2' TO ROLE `role3`
+OWNERSHIP default.c_r.t  ROLE role3 GRANT OWNERSHIP ON 'default'.'c_r'.'t' TO ROLE `role3`
 === drop database c_r, c_r2, re-create c_r, c_r2 ===
 UPDATE information_schema  ROLE role3 GRANT UPDATE ON 'default'.'information_schema'.* TO ROLE `role3`
 INSERT c_r1  ROLE role3 GRANT INSERT ON 'default'.'c_r1'.* TO ROLE `role3`
@@ -72,6 +78,7 @@ SELECT,INSERT	*.*	NULL	ROLE	role1	GRANT SELECT,INSERT ON *.* TO ROLE `role1`
 SELECT,INSERT	*.*	NULL	USER	u1	GRANT SELECT,INSERT ON *.* TO 'u1'@'%'
 SELECT,INSERT	*.*	NULL	USER	u1	GRANT SELECT,INSERT ON *.* TO 'u1'@'%'
 INSERT c_r1  ROLE role3
+OWNERSHIP c_r1  ROLE account_admin
 SELECT,INSERT	*.*	NULL	USER	u1	GRANT SELECT,INSERT ON *.* TO 'u1'@'%'
 Need Err:
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Grant] is required on *.* for user 'u1'@'%' with roles [role1,role2]

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
@@ -54,9 +54,27 @@ test -- show tables from grant_db
 t
 Error: APIError: ResponseError with 1063: Permission denied: User 'a'@'%' does not have the required privileges for database 'system'
 test -- show columns from one from system
-Error: APIError: ResponseError with 1063: Permission denied: User 'a'@'%' does not have the required privileges for table 'system.one'
+dummy	TINYINT UNSIGNED	NO		NULL	NULL
 c1	INT	NO		NULL	NULL
-Error: APIError: ResponseError with 1063: Permission denied: User 'a'@'%' does not have the required privileges for table 'system.tables'
+catalog	VARCHAR	NO		NULL	NULL
+cluster_by	VARCHAR	NO		NULL	NULL
+comment	VARCHAR	NO		NULL	NULL
+created_on	TIMESTAMP	NO		NULL	NULL
+data_compressed_size	BIGINT UNSIGNED	YES		NULL	NULL
+data_size	BIGINT UNSIGNED	YES		NULL	NULL
+database	VARCHAR	NO		NULL	NULL
+dropped_on	TIMESTAMP	YES		NULL	NULL
+engine	VARCHAR	NO		NULL	NULL
+engine_full	VARCHAR	NO		NULL	NULL
+index_size	BIGINT UNSIGNED	YES		NULL	NULL
+is_transient	VARCHAR	NO		NULL	NULL
+name	VARCHAR	NO		NULL	NULL
+num_rows	BIGINT UNSIGNED	YES		NULL	NULL
+number_of_blocks	BIGINT UNSIGNED	YES		NULL	NULL
+number_of_segments	BIGINT UNSIGNED	YES		NULL	NULL
+owner	VARCHAR	YES		NULL	NULL
+table_id	BIGINT UNSIGNED	NO		NULL	NULL
+updated_on	TIMESTAMP	NO		NULL	NULL
 Error: APIError: ResponseError with 1063: Permission denied: User 'a'@'%' does not have the required privileges for database 'nogrant'
 1
 0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Due to the automatic granting of table ownership to the current user's role when creating a table, this may cause the value of a certain role to expand rapidly, thereby causing a meta OOM (Out of Memory). To fix this issue, the following modifications have been made in this PR:

1. Ownership is no longer update to the role.

2. The "show grants" statement will obtain the ownership permissions of the corresponding resource through the function "get_ownerships".

3. The new method for visibility check has added "get_ownerships" to obtain the ownership status of the object. As a result, "show tables/databases/stage/functions" will increase one meta access.
"use db/show tables/show streams" can only see the database level, so to prevent some roles that only have table permissions from being unable to execute the above SQL, "get_ownerships" is called to increase one meta call. This may slow down the execution speed.

4. After "get_ownerships" reports an error, it no longer returns an error. If we add a new item to OwnershipObject and generate a new key-value pair about this new item. After rolling back to the old version, deserialization will return an error stating that ownership cannot be none. However, "get ownerships" should try to ensure success because in this version.

Note:

If you need to roll back to a version before this PR for some special reasons after using the version after this PR, since the role no longer records ownership information, statements like "show tables" will return an empty result. At this time, you need to record the object and role ownership before rolling back, and manually login with account_admin user and execute "grant ownership on object to role role_name;" after rolling back.

- Fixes https://github.com/datafuselabs/databend/issues/15707

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15730)
<!-- Reviewable:end -->
