### PR TITLE
fix: Handle Duplicate Tombstones in Meta-Service List Operation

### DIFF
--- a/src/meta/api/src/kv_pb_api/upsert_pb.rs
+++ b/src/meta/api/src/kv_pb_api/upsert_pb.rs
@@ -73,7 +73,7 @@ impl<K: kvapi::Key> UpsertPB<K> {
     pub fn delete(key: K) -> Self {
         Self {
             key,
-            seq: MatchSeq::GE(0),
+            seq: MatchSeq::GE(1),
             value: Operation::Delete,
             value_meta: None,
         }

--- a/src/meta/raft-store/src/marked/internal_seq.rs
+++ b/src/meta/raft-store/src/marked/internal_seq.rs
@@ -52,7 +52,6 @@ impl InternalSeq {
         self.seq
     }
 
-    #[allow(dead_code)]
     pub fn is_tombstone(&self) -> bool {
         self.tombstone
     }

--- a/src/meta/types/src/cmd/mod.rs
+++ b/src/meta/types/src/cmd/mod.rs
@@ -145,7 +145,7 @@ impl UpsertKV {
     pub fn delete(key: impl ToString) -> Self {
         Self {
             key: key.to_string(),
-            seq: MatchSeq::GE(0),
+            seq: MatchSeq::GE(1),
             value: Operation::Delete,
             value_meta: None,
         }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: Handle Duplicate Tombstones in Meta-Service List Operation

**Problem Description:**

- During the scanning process of meta-service key-value stores (kvs),
  the system merges kvs from multiple levels. It is designed not to
  allow two identical tombstones with the same `seq` number. However, it
  is possible to encounter this scenario if two consecutive
  non-conditional delete operations are performed. These operations
  insert a tombstone without incrementing the `seq`, even if a tombstone
  already exists with the same `seq`.

**Solution Implemented:**

- The merging process of kvs has been adjusted to no longer use
  `assert()` to enforce inequality for two tombstone records. This
  change acknowledges that having two identical tombstones is both
  possible and permissible under certain conditions.

- To prevent meaningless non-conditional deletes, an assertion has been
  added to ensure that the `seq` of a record is greater than 0 using
  `MatchSeq::GE(1)`. This helps in maintaining the integrity of
  operations and avoiding unnecessary data manipulations.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

Link https://github.com/datafuselabs/databend/issues/15734

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15736)
<!-- Reviewable:end -->
