### PR TITLE
fix: rebuild missing bloom index while pruning

### DIFF
--- a/src/query/ee/tests/it/inverted_index/pruning.rs
+++ b/src/query/ee/tests/it/inverted_index/pruning.rs
@@ -70,7 +70,7 @@ async fn apply_block_pruning(
     let segment_locs = table_snapshot.segments.clone();
     let segment_locs = create_segment_location_vector(segment_locs, None);
 
-    FusePruner::create(&ctx, dal, schema, push_down, bloom_index_cols)?
+    FusePruner::create(&ctx, dal, schema, push_down, bloom_index_cols, None)?
         .read_pruning(segment_locs)
         .await
 }

--- a/src/query/service/tests/it/storages/fuse/pruning.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning.rs
@@ -63,7 +63,7 @@ async fn apply_block_pruning(
     let ctx: Arc<dyn TableContext> = ctx;
     let segment_locs = table_snapshot.segments.clone();
     let segment_locs = create_segment_location_vector(segment_locs, None);
-    FusePruner::create(&ctx, op, schema, push_down, bloom_index_cols)?
+    FusePruner::create(&ctx, op, schema, push_down, bloom_index_cols, None)?
         .read_pruning(segment_locs)
         .await
         .map(|v| v.into_iter().map(|(_, v)| v).collect())

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -45,6 +45,8 @@ pub use write::write_data;
 pub use write::BlockBuilder;
 pub use write::BlockSerialization;
 pub use write::BlockWriter;
+pub use write::BloomIndexBuilder;
+pub use write::BloomIndexState;
 pub use write::CachedMetaWriter;
 pub use write::InvertedIndexBuilder;
 pub use write::InvertedIndexWriter;

--- a/src/query/storages/fuse/src/io/write/mod.rs
+++ b/src/query/storages/fuse/src/io/write/mod.rs
@@ -24,6 +24,8 @@ pub use block_writer::write_data;
 pub use block_writer::BlockBuilder;
 pub use block_writer::BlockSerialization;
 pub use block_writer::BlockWriter;
+pub use block_writer::BloomIndexBuilder;
+pub use block_writer::BloomIndexState;
 pub use block_writer::InvertedIndexBuilder;
 pub(crate) use inverted_index_writer::create_index_schema;
 pub(crate) use inverted_index_writer::create_tokenizer_manager;

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -295,6 +295,7 @@ impl FuseTable {
             cluster_key_meta,
             cluster_keys,
             bloom_index_cols,
+            None,
         )?;
 
         let block_metas = pruner.stream_pruning(blocks).await?;

--- a/src/query/storages/fuse/src/operations/delete.rs
+++ b/src/query/storages/fuse/src/operations/delete.rs
@@ -251,6 +251,7 @@ impl FuseTable {
             self.schema_with_stream(),
             &push_down,
             self.bloom_index_cols(),
+            None,
         )?;
 
         if let Some(inverse) = filters.map(|f| f.inverted_filter) {

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -198,6 +198,8 @@ impl FuseTable {
             v
         };
 
+        // during re-cluster, we do not rebuild missing bloom index
+        let bloom_index_builder = None;
         // Only use push_down here.
         let pruning_ctx = PruningContext::try_create(
             ctx,
@@ -208,6 +210,7 @@ impl FuseTable {
             vec![],
             BloomIndexColumns::None,
             max_concurrency,
+            bloom_index_builder,
         )?;
 
         let segment_pruner = SegmentPruner::create(pruning_ctx.clone(), schema)?;

--- a/src/query/storages/fuse/src/pruning/block_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/block_pruner.rs
@@ -166,7 +166,7 @@ impl BlockPruner {
                                     pruning_stats.set_blocks_bloom_pruning_before(1);
                                 }
                                 let keep = bloom_pruner
-                                    .should_keep(&index_location, index_size, &block_meta.col_stats, column_ids)
+                                    .should_keep(&index_location, index_size, &block_meta.col_stats, column_ids, &block_meta)
                                     .await
                                     && limit_pruner.within_limit(row_count);
                                 if keep {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


Fix missing bloom index during block pruning that uses bloom index.

to be detailed


- Fixes #15670


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
