### PR TITLE
chore(query): increase query runtime stack size

### DIFF
--- a/src/common/base/src/runtime/global_runtime.rs
+++ b/src/common/base/src/runtime/global_runtime.rs
@@ -51,8 +51,14 @@ impl GlobalQueryRuntime {
     pub fn init(num_cpus: usize) -> Result<()> {
         let thread_num = std::cmp::max(num_cpus, num_cpus::get() / 2);
         let thread_num = std::cmp::max(2, thread_num);
+        let thread_stack_size = 200 * 1024 * 1024;
 
-        let rt = Runtime::with_worker_threads(thread_num, Some("g-query-worker".to_owned()))?;
+        let rt = Runtime::with_worker_threads_stack_size(
+            thread_num,
+            Some("g-query-worker".to_owned()),
+            Some(thread_stack_size),
+        )?;
+
         GlobalInstance::set(Arc::new(GlobalQueryRuntime(rt)));
         Ok(())
     }

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -231,7 +231,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
                 ("max_inlist_to_or", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(3),
+                    value: UserSettingValue::UInt64(16),
                     desc: "Sets the maximum number of values that can be included in an IN expression to be converted to an OR operator.",
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

increase query runtime stack size to 200MB

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
