### PR TITLE
fix: off by one mistake in auto compaction

### DIFF
--- a/src/query/storages/fuse/src/operations/common/generators/append_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/append_generator.rs
@@ -210,13 +210,17 @@ impl SnapshotGenerator for AppendGenerator {
             .get_auto_compaction_imperfect_blocks_threshold()?;
 
         if imperfect_count >= auto_compaction_imperfect_blocks_threshold {
-            // if imperfect_count is larger, slightly increase the number of blocks
-            // eligible for auto-compaction.
-            // this adjustment is intended to help reduce fragmentation over time.
+            // If imperfect_count is larger, SLIGHTLY increase the number of blocks
+            // eligible for auto-compaction, this adjustment is intended to help reduce
+            // fragmentation over time.
+            //
+            // To prevent the off-by-one mistake, we need to add 1 to it;
+            // this way, the potentially previously left non-compacted segment will
+            // also be included.
             let compact_num_block_hint = std::cmp::min(
                 imperfect_count,
                 (auto_compaction_imperfect_blocks_threshold as f64 * 1.5).ceil() as u64,
-            );
+            ) + 1;
             info!("set compact_num_block_hint to {compact_num_block_hint }");
             self.ctx
                 .set_compaction_num_block_hint(compact_num_block_hint);

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0040_auto_compaction_issue_15760.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0040_auto_compaction_issue_15760.test
@@ -1,0 +1,60 @@
+statement ok
+create or replace database i15760;
+
+statement ok
+use i15760;
+
+statement ok
+set auto_compaction_imperfect_blocks_threshold = 3;
+
+statement ok
+create or replace table t (c int) block_per_segment = 10 row_per_block = 3;
+
+# first block (after compaction)
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(1);
+
+
+# second block (after compaction)
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(1);
+
+
+# third block (after compaction)
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(1);
+
+
+query III
+select segment_count , block_count , row_count from fuse_snapshot('i15760', 't') limit 20;
+----
+1 3 9
+4 5 9
+3 4 8
+2 3 7
+1 2 6
+4 4 6
+3 3 5
+2 2 4
+1 1 3
+3 3 3
+2 2 2
+1 1 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

off-by-one mistake during auto compaction:

The potentially previously left non-compacted segment should also be included.

Fixes: #15760

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15761)
<!-- Reviewable:end -->
