### PR TITLE
chore: add more test case about create table fail

### DIFF
--- a/tests/sqllogictests/suites/base/issues/issue_15664.test
+++ b/tests/sqllogictests/suites/base/issues/issue_15664.test
@@ -34,3 +34,24 @@ query I
 select * from test_table;
 ----
 2
+
+statement ok
+drop table if exists test_table_2;
+
+statement ok
+CREATE OR REPLACE TABLE test_table_2 as select 1;
+
+statement error 1006
+CREATE OR REPLACE TABLE test_table_2 as select 1/0;
+
+statement error 2308
+UNDROP TABLE test_table_2
+
+statement ok
+drop table if exists test_table;
+
+statement ok
+drop table if exists test_table_1;
+
+statement ok
+drop table if exists test_table_2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore: add more test case about create table fail

the semantics of `table id list` is:
* only create success table id can be added;
* it is a stack.

so, after execute:
```
// return table id a
CREATE OR REPLACE TABLE test_table_2 as select 1;

// create table fail
CREATE OR REPLACE TABLE test_table_2 as select 1/0;
```

the last table id is `a`, so
```
UNDROP TABLE test_table_2
```
will fail, because `Table 'test_table_2' already exists`.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): add more test cases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15765)
<!-- Reviewable:end -->
