### PR TITLE
chore: Pin opendal to released version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10375,8 +10375,9 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.46.0"
-source = "git+https://github.com/Xuanwo/opendal?rev=a392106#a392106af00919749b198e95d52b773308551ea1"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3ba698f2258bebdf7a3a38862bb6ef1f96d351627002686dacc228f805bdd6"
 dependencies = [
  "anyhow",
  "async-backtrace",
@@ -12197,9 +12198,9 @@ checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
 
 [[package]]
 name = "reqsign"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01edce6b6c31a16ebc7525ac58c747a6d78bbce33e76bbebd350d6bc25b23e06"
+checksum = "70fe66d4cd0b5ed9b1abbfe639bf6baeaaf509f7da2d51b31111ba945be59286"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,7 @@ minitrace-opentelemetry = "0.6.5"
 mysql_async = { version = "0.34", default-features = false, features = ["rustls-tls"] }
 once_cell = "1.15.0"
 openai_api_rust = "0.1"
-opendal = { version = "0.46.0", features = [
+opendal = { version = "0.47.0", features = [
     "layers-minitrace",
     "layers-prometheus-client",
     "layers-async-backtrace",
@@ -393,7 +393,6 @@ deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "81593e9" }
 ethnum = { git = "https://github.com/ariesdevil/ethnum-rs", rev = "4cb05f1" }
 icelake = { git = "https://github.com/icelake-io/icelake", rev = "be8b2c2" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
-opendal = { git = "https://github.com/Xuanwo/opendal", rev = "a392106" }
 orc-rust = { git = "https://github.com/youngsofun/datafusion-orc", branch = "pub" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", tag = "databend-alpha.4" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore: Pin opendal to released version

OpenDAL has released v0.47.0. This PR pinned opendal back to released version. No other changes.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other: chore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15766)
<!-- Reviewable:end -->
