### PR TITLE
refactor: remove unsafe impl Send+Sync for GlobalRegistry

### DIFF
--- a/src/common/base/src/runtime/metrics/registry.rs
+++ b/src/common/base/src/runtime/metrics/registry.rs
@@ -68,7 +68,7 @@ struct GlobalMetric {
     pub name: String,
     pub help: String,
     pub metric: Box<dyn Metric>,
-    pub creator: Box<dyn Fn(usize) -> Box<dyn Metric>>,
+    pub creator: Box<dyn Fn(usize) -> Box<dyn Metric> + Send>,
 }
 
 struct GlobalRegistryInner {
@@ -79,10 +79,6 @@ struct GlobalRegistryInner {
 pub struct GlobalRegistry {
     inner: Mutex<GlobalRegistryInner>,
 }
-
-unsafe impl Send for GlobalRegistry {}
-
-unsafe impl Sync for GlobalRegistry {}
 
 impl GlobalRegistry {
     pub fn create() -> GlobalRegistry {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: remove unsafe impl Send+Sync for GlobalRegistry

The internal `GlobalMetric::creator: Box<dyn Fn(usize) -> Box<dyn
Metric>>` could not be `Send` and result in undefined behavior.

In this commit add `Send` constrain to `GlobalMetric::creator`:

```
Box<dyn Fn(usize) -> Box<dyn Metric>>
```
becomes:
```
Box<dyn Fn(usize) -> Box<dyn Metric> + Send>
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15782)
<!-- Reviewable:end -->
