### PR TITLE
refactor: clustering_information support specify cluster keys

### DIFF
--- a/scripts/ci/ci-setup-chaos-meta.sh
+++ b/scripts/ci/ci-setup-chaos-meta.sh
@@ -13,21 +13,21 @@ k3d cluster create --config ./scripts/ci/meta-chaos/k3d.yaml meta-chaos
 echo "127.0.0.1 k3d-registry.localhost" | sudo tee -a /etc/hosts
 
 if kubectl version --client; then
-    echo "kubectl client already installed"
+	echo "kubectl client already installed"
 else
-    echo "install kubectl client"
-    curl -LO "https://dl.k8s.io/release/v1.29.5/bin/linux/amd64/kubectl"
-    chmod +x kubectl
-    sudo mv kubectl /usr/local/bin/
+	echo "install kubectl client"
+	curl -LO "https://dl.k8s.io/release/v1.29.5/bin/linux/amd64/kubectl"
+	chmod +x kubectl
+	sudo mv kubectl /usr/local/bin/
 fi
 
 if helm version; then
-    echo "helm already installed"
+	echo "helm already installed"
 else
-    echo "install helm"
-    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-    chmod 700 get_helm.sh
-    ./get_helm.sh
+	echo "install helm"
+	curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+	chmod 700 get_helm.sh
+	./get_helm.sh
 fi
 
 echo "make databend-meta image"
@@ -60,19 +60,19 @@ kubectl delete pvc --namespace databend data-test-databend-meta-0 data-test-data
 
 helm repo add databend https://charts.databend.rs
 helm install test databend/databend-meta \
-    --namespace databend \
-    --create-namespace \
-    --values scripts/ci/meta-chaos/meta-ha.yaml \
-    --set image.repository=k3d-registry.localhost:5111/databend-meta \
-    --set image.tag=meta-chaos \
-    --wait || true
+	--namespace databend \
+	--create-namespace \
+	--values scripts/ci/meta-chaos/meta-ha.yaml \
+	--set image.repository=k3d-registry.localhost:5111/databend-meta \
+	--set image.tag=meta-chaos \
+	--wait || true
 
 sleep 10
 echo "check if databend-meta nodes is ready"
 kubectl -n databend wait \
-    --for=condition=ready pod \
-    -l app.kubernetes.io/name=databend-meta \
-    --timeout 120s || true
+	--for=condition=ready pod \
+	-l app.kubernetes.io/name=databend-meta \
+	--timeout 120s || true
 
 kubectl get pods -A -o wide
 
@@ -83,9 +83,9 @@ kubectl apply -f scripts/ci/meta-chaos/verifier.yaml
 
 echo "check if databend-metaverifier node is ready"
 kubectl -n databend wait \
-    --for=condition=ready pod \
-    -l app.kubernetes.io/name=databend-metaverifier \
-    --timeout 120s || true
+	--for=condition=ready pod \
+	-l app.kubernetes.io/name=databend-metaverifier \
+	--timeout 120s || true
 
 echo "logs databend-metaverifier.."
 kubectl logs databend-metaverifier --namespace databend

--- a/src/query/service/tests/it/storages/fuse/table_functions/clustering_information_table.rs
+++ b/src/query/service/tests/it/storages/fuse/table_functions/clustering_information_table.rs
@@ -12,21 +12,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use std::sync::Arc;
-
 use databend_common_base::base::tokio;
-use databend_common_catalog::plan::PushDownInfo;
-use databend_common_catalog::table_args::TableArgs;
-use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Scalar;
-use databend_common_expression::SendableDataBlockStream;
-use databend_common_sql::executor::table_read_plan::ToReadDataSourcePlan;
-use databend_common_storages_fuse::table_functions::ClusteringInformationTable;
-use databend_query::sessions::QueryContext;
-use databend_query::stream::ReadDataBlockStream;
 use databend_query::test_kits::*;
 use tokio_stream::StreamExt;
 
@@ -41,43 +30,21 @@ async fn test_clustering_information_table_read() -> Result<()> {
     fixture.create_default_database().await?;
     fixture.create_default_table().await?;
 
-    // func args
-    let arg_db = Scalar::String(db.clone());
-    let arg_tbl = Scalar::String(tbl.clone());
-
-    {
-        let expected = vec![
-            "+----------+----------+----------+----------+----------+----------+----------+",
-            "| Column 0 | Column 1 | Column 2 | Column 3 | Column 4 | Column 5 | Column 6 |",
-            "+----------+----------+----------+----------+----------+----------+----------+",
-            "| '(id)'   | 0        | 0        | 0        | 0        | 0        | '{}'     |",
-            "+----------+----------+----------+----------+----------+----------+----------+",
-        ];
-
-        expects_ok(
-            "empty_data_set",
-            test_drive_clustering_information(
-                TableArgs::new_positioned(vec![arg_db.clone(), arg_tbl.clone()]),
-                ctx.clone(),
-            )
-            .await,
-            expected,
-        )
-        .await?;
-    }
-
     {
         let qry = format!("insert into {}.{} values(1, (2, 3)),(2, (4, 6))", db, tbl);
         let _ = execute_query(ctx.clone(), qry.as_str()).await?;
         let expected = vec![
-            "+----------+----------+----------+----------+----------+----------+---------------+",
-            "| Column 0 | Column 1 | Column 2 | Column 3 | Column 4 | Column 5 | Column 6      |",
-            "+----------+----------+----------+----------+----------+----------+---------------+",
-            "| '(id)'   | 1        | 0        | 0        | 0        | 1        | '{\"00001\":1}' |",
-            "+----------+----------+----------+----------+----------+----------+---------------+",
+            "+----------+----------+----------+----------+----------+---------------+",
+            "| Column 0 | Column 1 | Column 2 | Column 3 | Column 4 | Column 5      |",
+            "+----------+----------+----------+----------+----------+---------------+",
+            "| '(id)'   | 1        | 0        | 0        | 1        | '{\"00001\":1}' |",
+            "+----------+----------+----------+----------+----------+---------------+",
         ];
 
-        let qry = format!("select * from clustering_information('{}', '{}')", db, tbl);
+        let qry = format!(
+            "select * exclude(timestamp) from clustering_information('{}', '{}')",
+            db, tbl
+        );
 
         expects_ok(
             "clustering_information",
@@ -106,20 +73,4 @@ async fn test_clustering_information_table_read() -> Result<()> {
     }
 
     Ok(())
-}
-
-async fn test_drive_clustering_information(
-    tbl_args: TableArgs,
-    ctx: Arc<QueryContext>,
-) -> Result<SendableDataBlockStream> {
-    let func = ClusteringInformationTable::create("system", "clustering_information", 1, tbl_args)?;
-    let source_plan = func
-        .clone()
-        .as_table()
-        .read_plan(ctx.clone(), Some(PushDownInfo::default()), true)
-        .await?;
-    ctx.set_partitions(source_plan.parts.clone())?;
-    func.as_table()
-        .read_data_block_stream(ctx, &source_plan)
-        .await
 }

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -574,9 +574,13 @@ impl ReclusterMutator {
             });
         }
 
+        let mut selected_idx = IndexSet::new();
         if !unfinished_parts.is_empty() {
             warn!("Recluster: unfinished_parts is not empty after calculate the blocks overlaps");
-            // todo: re-sort the unfinished parts firstly.
+            // re-sort the unfinished parts firstly.
+            unfinished_parts.keys().for_each(|idx| {
+                selected_idx.insert(*idx);
+            });
         }
 
         let sum_depth: usize = block_depths.iter().sum();
@@ -585,7 +589,6 @@ impl ReclusterMutator {
             (10000.0 * sum_depth as f64 / block_depths.len() as f64).round() / 10000.0;
 
         // find the max point, gather the indices.
-        let mut selected_idx = IndexSet::new();
         if average_depth > depth_threshold {
             point_overlaps[max_point].iter().for_each(|idx| {
                 selected_idx.insert(*idx);

--- a/src/query/storages/fuse/src/table_functions/clustering_information/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_information/clustering_information.rs
@@ -13,24 +13,41 @@
 // limitations under the License.
 
 use std::cmp;
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use chrono::Utc;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::compare_scalars;
+use databend_common_expression::types::boolean::BooleanDomain;
+use databend_common_expression::types::decimal::DecimalDomain;
+use databend_common_expression::types::decimal::DecimalScalar;
+use databend_common_expression::types::nullable::NullableDomain;
 use databend_common_expression::types::number::NumberScalar;
+use databend_common_expression::types::string::StringDomain;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::NumberDomain;
+use databend_common_expression::types::SimpleDomain;
 use databend_common_expression::BlockEntry;
+use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataBlock;
+use databend_common_expression::Domain;
+use databend_common_expression::Expr;
+use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRefExt;
 use databend_common_expression::Value;
+use databend_common_functions::BUILTIN_FUNCTIONS;
+use databend_common_sql::analyze_cluster_keys;
+use databend_storages_common_index::statistics_to_domain;
+use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::SegmentInfo;
 use jsonb::Value as JsonbValue;
 use log::warn;
@@ -39,55 +56,96 @@ use serde_json::Value as JsonValue;
 
 use crate::io::SegmentsIO;
 use crate::sessions::TableContext;
+use crate::table_functions::cmp_with_null;
 use crate::FuseTable;
 use crate::Table;
 
 pub struct ClusteringInformation<'a> {
     pub ctx: Arc<dyn TableContext>,
     pub table: &'a FuseTable,
+    pub cluster_key: Option<String>,
 }
 
 struct ClusteringStatistics {
+    cluster_key: String,
+    timestamp: i64,
     total_block_count: u64,
     constant_block_count: u64,
-    unclustered_block_count: u64,
     average_overlaps: f64,
     average_depth: f64,
     block_depth_histogram: JsonValue,
 }
 
-impl Default for ClusteringStatistics {
-    fn default() -> Self {
-        ClusteringStatistics {
-            total_block_count: 0,
-            constant_block_count: 0,
-            unclustered_block_count: 0,
-            average_overlaps: 0.0,
-            average_depth: 0.0,
-            block_depth_histogram: json!({}),
-        }
-    }
-}
-
 impl<'a> ClusteringInformation<'a> {
-    pub fn new(ctx: Arc<dyn TableContext>, table: &'a FuseTable) -> Self {
-        Self { ctx, table }
+    pub fn new(
+        ctx: Arc<dyn TableContext>,
+        table: &'a FuseTable,
+        cluster_key: Option<String>,
+    ) -> Self {
+        Self {
+            ctx,
+            table,
+            cluster_key,
+        }
     }
 
     #[async_backtrace::framed]
     pub async fn get_clustering_info(&self) -> Result<DataBlock> {
-        if self.table.cluster_key_meta.is_none() {
-            return Err(ErrorCode::UnclusteredTable(format!(
-                "Unclustered table {}",
-                self.table.table_info.desc
-            )));
-        }
+        let mut default_cluster_key_id = None;
+        let (cluster_key, exprs) = match (self.table.cluster_key_str(), &self.cluster_key) {
+            (a, Some(b)) => {
+                let (cluster_key, exprs) =
+                    analyze_cluster_keys(self.ctx.clone(), Arc::new(self.table.clone()), b)?;
+                let exprs = exprs
+                    .iter()
+                    .map(|k| {
+                        k.project_column_ref(|index| {
+                            self.table.schema().field(*index).name().to_string()
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                if a.is_some() && a.unwrap() == &cluster_key {
+                    default_cluster_key_id = self.table.cluster_key_meta.clone().map(|v| v.0);
+                }
+                (cluster_key, exprs)
+            }
+            (Some(a), None) => {
+                let exprs = self.table.cluster_keys(self.ctx.clone());
+                let exprs = exprs
+                    .iter()
+                    .map(|k| k.as_expr(&BUILTIN_FUNCTIONS))
+                    .collect();
+                default_cluster_key_id = self.table.cluster_key_meta.clone().map(|v| v.0);
+                (a.clone(), exprs)
+            }
+            _ => {
+                return Err(ErrorCode::UnclusteredTable(format!(
+                    "Unclustered table {}",
+                    self.table.table_info.desc
+                )));
+            }
+        };
 
         let snapshot = self.table.read_table_snapshot().await?;
+        let now = Utc::now();
+        let timestamp = snapshot
+            .as_ref()
+            .map_or(now, |s| s.timestamp.unwrap_or(now))
+            .timestamp_micros();
         if snapshot.is_none() {
-            return self.build_block(ClusteringStatistics::default());
+            return self.build_block(ClusteringStatistics {
+                cluster_key,
+                timestamp,
+                total_block_count: 0,
+                constant_block_count: 0,
+                average_overlaps: 0.0,
+                average_depth: 0.0,
+                block_depth_histogram: json!({}),
+            });
         }
         let snapshot = snapshot.unwrap();
+
+        let schema = self.table.schema();
 
         // Gather all cluster statistics points to a hash Map.
         // Key: The cluster statistics points.
@@ -95,7 +153,6 @@ impl<'a> ClusteringInformation<'a> {
         //        1: The block indexes with key as max value;
         let mut points_map: HashMap<Vec<Scalar>, (Vec<u64>, Vec<u64>)> = HashMap::new();
         let mut constant_block_count = 0;
-        let mut unclustered_block_count = 0;
         let mut index = 0;
 
         let segments_io = SegmentsIO::create(
@@ -103,7 +160,6 @@ impl<'a> ClusteringInformation<'a> {
             self.table.operator.clone(),
             self.table.schema(),
         );
-        let default_cluster_key_id = self.table.cluster_key_meta.clone().unwrap().0;
         let total_block_count = snapshot.summary.block_count;
         let chunk_size = self.ctx.get_settings().get_max_threads()? as usize * 4;
         for chunk in snapshot.segments.chunks(chunk_size) {
@@ -113,26 +169,32 @@ impl<'a> ClusteringInformation<'a> {
 
             for segment in segments.into_iter().flatten() {
                 for block in &segment.blocks {
-                    if let Some(cluster_stats) = &block.cluster_stats {
-                        if cluster_stats.cluster_key_id != default_cluster_key_id {
-                            unclustered_block_count += 1;
-                        } else {
-                            if cluster_stats.is_const() {
-                                constant_block_count += 1;
-                            }
-                            points_map
-                                .entry(cluster_stats.min().clone())
-                                .and_modify(|v| v.0.push(index))
-                                .or_insert((vec![index], vec![]));
-                            points_map
-                                .entry(cluster_stats.max().clone())
-                                .and_modify(|v| v.1.push(index))
-                                .or_insert((vec![], vec![index]));
-                            index += 1;
+                    let (min, max) =
+                        get_min_max_stats(&exprs, block, schema.clone(), default_cluster_key_id);
+                    assert_eq!(min.len(), max.len());
+                    let (min, max) = match min.iter().cmp_by(max.iter(), cmp_with_null) {
+                        Ordering::Equal => {
+                            constant_block_count += 1;
+                            (min, max)
                         }
-                    } else {
-                        unclustered_block_count += 1;
-                    }
+                        Ordering::Less => (min, max),
+                        Ordering::Greater => {
+                            warn!(
+                                "clustering_information: please check your data and perform recluster to resort."
+                            );
+                            (max, min)
+                        }
+                    };
+
+                    points_map
+                        .entry(min)
+                        .and_modify(|v| v.0.push(index))
+                        .or_insert((vec![index], vec![]));
+                    points_map
+                        .entry(max)
+                        .and_modify(|v| v.1.push(index))
+                        .or_insert((vec![], vec![index]));
+                    index += 1;
                 }
             }
         }
@@ -144,7 +206,11 @@ impl<'a> ClusteringInformation<'a> {
         // value: (overlaps, depth).
         let mut unfinished_parts: HashMap<u64, (usize, usize)> = HashMap::new();
         let (keys, values): (Vec<_>, Vec<_>) = points_map.into_iter().unzip();
-        let indices = compare_scalars(keys, &self.table.cluster_key_types(self.ctx.clone()))?;
+        let cluster_key_types = exprs
+            .into_iter()
+            .map(|v| v.data_type().clone())
+            .collect::<Vec<_>>();
+        let indices = compare_scalars(keys, &cluster_key_types)?;
         for idx in indices.into_iter() {
             let start = &values[idx as usize].0;
             let end = &values[idx as usize].1;
@@ -164,12 +230,6 @@ impl<'a> ClusteringInformation<'a> {
                     stats.push(v);
                 }
             });
-        }
-        if !unfinished_parts.is_empty() {
-            warn!(
-                "clustering_information: please check your data and perform recluster to resort."
-            );
-            unclustered_block_count += unfinished_parts.len() as u64;
         }
 
         let mut sum_overlap = 0;
@@ -199,9 +259,10 @@ impl<'a> ClusteringInformation<'a> {
         );
         let block_depth_histogram = JsonValue::Object(objects);
         let info = ClusteringStatistics {
+            cluster_key,
+            timestamp,
             total_block_count,
             constant_block_count,
-            unclustered_block_count,
             average_overlaps,
             average_depth,
             block_depth_histogram,
@@ -211,15 +272,15 @@ impl<'a> ClusteringInformation<'a> {
     }
 
     fn build_block(&self, info: ClusteringStatistics) -> Result<DataBlock> {
-        let cluster_key = self
-            .table
-            .cluster_key_str()
-            .ok_or_else(|| ErrorCode::Internal("It's a bug"))?;
         Ok(DataBlock::new(
             vec![
                 BlockEntry::new(
                     DataType::String,
-                    Value::Scalar(Scalar::String(cluster_key.clone())),
+                    Value::Scalar(Scalar::String(info.cluster_key)),
+                ),
+                BlockEntry::new(
+                    DataType::Timestamp,
+                    Value::Scalar(Scalar::Timestamp(info.timestamp)),
                 ),
                 BlockEntry::new(
                     DataType::Number(NumberDataType::UInt64),
@@ -229,12 +290,6 @@ impl<'a> ClusteringInformation<'a> {
                     DataType::Number(NumberDataType::UInt64),
                     Value::Scalar(Scalar::Number(NumberScalar::UInt64(
                         info.constant_block_count,
-                    ))),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Scalar(Scalar::Number(NumberScalar::UInt64(
-                        info.unclustered_block_count,
                     ))),
                 ),
                 BlockEntry::new(
@@ -263,16 +318,13 @@ impl<'a> ClusteringInformation<'a> {
     pub fn schema() -> Arc<TableSchema> {
         TableSchemaRefExt::create(vec![
             TableField::new("cluster_key", TableDataType::String),
+            TableField::new("timestamp", TableDataType::Timestamp),
             TableField::new(
                 "total_block_count",
                 TableDataType::Number(NumberDataType::UInt64),
             ),
             TableField::new(
                 "constant_block_count",
-                TableDataType::Number(NumberDataType::UInt64),
-            ),
-            TableField::new(
-                "unclustered_block_count",
                 TableDataType::Number(NumberDataType::UInt64),
             ),
             TableField::new(
@@ -285,6 +337,142 @@ impl<'a> ClusteringInformation<'a> {
             ),
             TableField::new("block_depth_histogram", TableDataType::Variant),
         ])
+    }
+}
+
+fn get_min_max_stats(
+    exprs: &[Expr<String>],
+    block: &BlockMeta,
+    schema: Arc<TableSchema>,
+    default_key_id: Option<u32>,
+) -> (Vec<Scalar>, Vec<Scalar>) {
+    if let Some(default_key_id) = default_key_id {
+        if let Some(v) = block.cluster_stats.as_ref() {
+            if v.cluster_key_id == default_key_id {
+                return (v.min.clone(), v.max.clone());
+            }
+        }
+    }
+
+    let func_ctx = FunctionContext::default();
+    let mut mins = Vec::with_capacity(exprs.len());
+    let mut maxs = Vec::with_capacity(exprs.len());
+    let col_stats = &block.col_stats;
+    for expr in exprs {
+        let input_domains = expr
+            .column_refs()
+            .into_iter()
+            .map(|(name, ty)| {
+                let column_ids = schema.leaf_columns_of(&name);
+                let stats = column_ids
+                    .iter()
+                    .filter_map(|column_id| col_stats.get(column_id))
+                    .collect();
+
+                let domain = statistics_to_domain(stats, &ty);
+                (name, domain)
+            })
+            .collect();
+
+        let (_, domain_opt) =
+            ConstantFolder::fold_with_domain(expr, &input_domains, &func_ctx, &BUILTIN_FUNCTIONS);
+        let domain = domain_opt.unwrap_or_else(|| Domain::full(expr.data_type()));
+        let (min, max) = domain_to_minmax(&domain);
+        mins.push(min);
+        maxs.push(max);
+    }
+    (mins, maxs)
+}
+
+fn domain_to_minmax(domain: &Domain) -> (Scalar, Scalar) {
+    match domain {
+        Domain::Number(NumberDomain::Int8(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::Int8(*min)),
+            Scalar::Number(NumberScalar::Int8(*max)),
+        ),
+        Domain::Number(NumberDomain::Int16(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::Int16(*min)),
+            Scalar::Number(NumberScalar::Int16(*max)),
+        ),
+        Domain::Number(NumberDomain::Int32(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::Int32(*min)),
+            Scalar::Number(NumberScalar::Int32(*max)),
+        ),
+        Domain::Number(NumberDomain::Int64(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::Int64(*min)),
+            Scalar::Number(NumberScalar::Int64(*max)),
+        ),
+        Domain::Number(NumberDomain::UInt8(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::UInt8(*min)),
+            Scalar::Number(NumberScalar::UInt8(*max)),
+        ),
+        Domain::Number(NumberDomain::UInt16(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::UInt16(*min)),
+            Scalar::Number(NumberScalar::UInt16(*max)),
+        ),
+        Domain::Number(NumberDomain::UInt32(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::UInt32(*min)),
+            Scalar::Number(NumberScalar::UInt32(*max)),
+        ),
+        Domain::Number(NumberDomain::UInt64(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::UInt64(*min)),
+            Scalar::Number(NumberScalar::UInt64(*max)),
+        ),
+        Domain::Number(NumberDomain::Float32(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::Float32(*min)),
+            Scalar::Number(NumberScalar::Float32(*max)),
+        ),
+        Domain::Number(NumberDomain::Float64(SimpleDomain { min, max })) => (
+            Scalar::Number(NumberScalar::Float64(*min)),
+            Scalar::Number(NumberScalar::Float64(*max)),
+        ),
+        Domain::Decimal(DecimalDomain::Decimal128(SimpleDomain { min, max }, sz)) => (
+            Scalar::Decimal(DecimalScalar::Decimal128(*min, *sz)),
+            Scalar::Decimal(DecimalScalar::Decimal128(*max, *sz)),
+        ),
+        Domain::Decimal(DecimalDomain::Decimal256(SimpleDomain { min, max }, sz)) => (
+            Scalar::Decimal(DecimalScalar::Decimal256(*min, *sz)),
+            Scalar::Decimal(DecimalScalar::Decimal256(*max, *sz)),
+        ),
+        Domain::Boolean(BooleanDomain {
+            has_false,
+            has_true,
+        }) => (Scalar::Boolean(!*has_false), Scalar::Boolean(*has_true)),
+        Domain::String(StringDomain { min, max }) => {
+            let max = if let Some(max) = max {
+                Scalar::String(max.clone())
+            } else {
+                Scalar::Null
+            };
+            (Scalar::String(min.clone()), max)
+        }
+        Domain::Timestamp(SimpleDomain { min, max }) => {
+            (Scalar::Timestamp(*min), Scalar::Timestamp(*max))
+        }
+        Domain::Date(SimpleDomain { min, max }) => (Scalar::Date(*min), Scalar::Date(*max)),
+        Domain::Nullable(NullableDomain { has_null, value }) => {
+            if let Some(v) = value {
+                let (min, mut max) = domain_to_minmax(v);
+                if *has_null {
+                    max = Scalar::Null;
+                }
+                (min, max)
+            } else {
+                (Scalar::Null, Scalar::Null)
+            }
+        }
+        Domain::Tuple(fields) => {
+            let mut mins = Vec::with_capacity(fields.len());
+            let mut maxs = Vec::with_capacity(fields.len());
+            for filed in fields {
+                let (min, max) = domain_to_minmax(filed);
+                mins.push(min);
+                maxs.push(max);
+            }
+            (Scalar::Tuple(mins), Scalar::Tuple(maxs))
+        }
+        // cluster key only allow number|string|boolean|date|timestamp|decimal, so unreachable.
+        _ => (Scalar::Null, Scalar::Null),
     }
 }
 

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block_table.rs
@@ -32,7 +32,7 @@ use databend_common_pipeline_sources::AsyncSource;
 use databend_common_pipeline_sources::AsyncSourcer;
 
 use crate::sessions::TableContext;
-use crate::table_functions::parse_db_tb_ssid_args;
+use crate::table_functions::parse_db_tb_opt_args;
 use crate::table_functions::string_literal;
 use crate::table_functions::FuseBlock;
 use crate::table_functions::TableArgs;
@@ -57,7 +57,7 @@ impl FuseBlockTable {
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let (arg_database_name, arg_table_name, arg_snapshot_id) =
-            parse_db_tb_ssid_args(&table_args, FUSE_FUNC_BLOCK)?;
+            parse_db_tb_opt_args(&table_args, FUSE_FUNC_BLOCK)?;
 
         let engine = FUSE_FUNC_BLOCK.to_owned();
 

--- a/src/query/storages/fuse/src/table_functions/fuse_columns/fuse_column_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_columns/fuse_column_table.rs
@@ -32,7 +32,7 @@ use databend_common_pipeline_sources::AsyncSource;
 use databend_common_pipeline_sources::AsyncSourcer;
 
 use crate::sessions::TableContext;
-use crate::table_functions::parse_db_tb_ssid_args;
+use crate::table_functions::parse_db_tb_opt_args;
 use crate::table_functions::string_literal;
 use crate::table_functions::FuseColumn;
 use crate::table_functions::TableArgs;
@@ -57,7 +57,7 @@ impl FuseColumnTable {
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let (arg_database_name, arg_table_name, arg_snapshot_id) =
-            parse_db_tb_ssid_args(&table_args, FUSE_FUNC_COLUMN)?;
+            parse_db_tb_opt_args(&table_args, FUSE_FUNC_COLUMN)?;
 
         let engine = FUSE_FUNC_COLUMN.to_owned();
 

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment_table.rs
@@ -33,7 +33,7 @@ use databend_common_pipeline_sources::AsyncSourcer;
 
 use super::fuse_segment::FuseSegment;
 use crate::sessions::TableContext;
-use crate::table_functions::parse_db_tb_ssid_args;
+use crate::table_functions::parse_db_tb_opt_args;
 use crate::table_functions::string_literal;
 use crate::table_functions::TableArgs;
 use crate::table_functions::TableFunction;
@@ -57,7 +57,7 @@ impl FuseSegmentTable {
         table_args: TableArgs,
     ) -> Result<Arc<dyn TableFunction>> {
         let (arg_database_name, arg_table_name, arg_snapshot_id) =
-            parse_db_tb_ssid_args(&table_args, FUSE_FUNC_SEGMENT)?;
+            parse_db_tb_opt_args(&table_args, FUSE_FUNC_SEGMENT)?;
 
         let engine = FUSE_FUNC_SEGMENT.to_owned();
 

--- a/src/query/storages/fuse/src/table_functions/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/table_args.rs
@@ -53,25 +53,25 @@ pub fn parse_db_tb_args(table_args: &TableArgs, func_name: &str) -> Result<(Stri
     Ok((db, tbl))
 }
 
-pub fn parse_db_tb_ssid_args(
+pub fn parse_db_tb_opt_args(
     table_args: &TableArgs,
     func_name: &str,
 ) -> Result<(String, String, Option<String>)> {
     let args = table_args.expect_all_positioned(func_name, None)?;
     match args.len() {
         3 => {
-            let db = string_value(&args[0])?;
-            let tbl = string_value(&args[1])?;
-            let snapshot_id = string_value(&args[2])?;
-            Ok((db, tbl, Some(snapshot_id)))
+            let arg1 = string_value(&args[0])?;
+            let arg2 = string_value(&args[1])?;
+            let arg3 = string_value(&args[2])?;
+            Ok((arg1, arg2, Some(arg3)))
         }
         2 => {
-            let db = string_value(&args[0])?;
-            let tbl = string_value(&args[1])?;
-            Ok((db, tbl, None))
+            let arg1 = string_value(&args[0])?;
+            let arg2 = string_value(&args[1])?;
+            Ok((arg1, arg2, None))
         }
         _ => Err(ErrorCode::BadArguments(format!(
-            "expecting <database>, <table_name> and <snapshot_id> (as string literals), but got {:?}",
+            "expecting <database>, <table_name> and <opt_arg> (as string literals), but got {:?}",
             args
         ))),
     }

--- a/tests/cloud_control_server/simple_server.py
+++ b/tests/cloud_control_server/simple_server.py
@@ -44,9 +44,9 @@ def load_data_from_json():
                 notification_history_data = json.load(f)
                 notification_history = notification_pb2.NotificationHistory()
                 json_format.ParseDict(notification_history_data, notification_history)
-                NOTIFICATION_HISTORY_DB[
-                    notification_history.name
-                ] = notification_history
+                NOTIFICATION_HISTORY_DB[notification_history.name] = (
+                    notification_history
+                )
 
 
 def create_task_request_to_task(id, create_task_request):

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
@@ -569,10 +569,10 @@ insert into t10 values(-6),(-8)
 statement ok
 insert into t10 values(2),(5),(-7)
 
-query TIIIFFT
-select * from clustering_information('db_09_0008','t10')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0008','t10')
 ----
-(abs(a)) 4 1 1 1.3333 2.0 {"00002":3}
+(abs(a)) 4 1 2.0 2.75 {"00002":1,"00003":3}
 
 statement ok
 optimize table t10 compact
@@ -613,10 +613,10 @@ insert into t11 values(3)
 statement ok
 insert into t11 values(-6),(-8)
 
-query TIIIFFT
-select * from clustering_information('db_09_0008','t11')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0008','t11')
 ----
-(abs(a)) 4 1 0 2.0 2.75 {"00002":1,"00003":3}
+(abs(a)) 4 1 2.0 2.75 {"00002":1,"00003":3}
 
 statement ok
 optimize table t11 compact limit 2
@@ -775,10 +775,10 @@ insert into t14 values('12345678', 'efg');
 statement ok
 alter table t14 recluster
 
-query TIIIFFT
-select * from clustering_information('db_09_0008','t14')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0008','t14')
 ----
-(a, b) 1 0 0 0.0 1.0 {"00001":1}
+(a, b) 1 0 0.0 1.0 {"00001":1}
 
 
 statement ok
@@ -799,26 +799,26 @@ ALTER TABLE t15 cluster by(abs(a))
 statement ok
 insert into t15 values(2),(5),(-7)
 
-query TIIIFFT
-select * from clustering_information('db_09_0008','t15')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0008','t15')
 ----
-(abs(a)) 4 0 3 0.0 1.0 {"00001":1}
+(abs(a)) 4 1 2.0 2.75 {"00002":1,"00003":3}
 
 statement ok
 alter table t15 recluster
 
-query TIIIFFT
-select * from clustering_information('db_09_0008','t15')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0008','t15')
 ----
-(abs(a)) 3 0 0 2.0 3.0 {"00003":3}
+(abs(a)) 3 0 2.0 3.0 {"00003":3}
 
 statement ok
 alter table t15 recluster
 
-query TIIIFFT
-select * from clustering_information('db_09_0008','t15')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0008','t15')
 ----
-(abs(a)) 3 0 0 0.0 1.0 {"00001":3}
+(abs(a)) 3 0 0.0 1.0 {"00001":3}
 
 query III
 select segment_count, block_count, row_count from fuse_snapshot('db_09_0008','t15') limit 3

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
@@ -22,19 +22,26 @@ select *  from t09_0014 order by b, a
 1 3
 4 4
 
-query TIIIFFT
-select * from clustering_information('default','t09_0014')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('default','t09_0014')
 ----
-(b, a) 3 1 0 0.6667 1.6667 {"00001":1,"00002":2}
+(b, a) 3 1 0.6667 1.6667 {"00001":1,"00002":2}
 
-statement error 1006
-select * from clustering_information('default','t09_0014', '(a)')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('default','t09_0014', '(a)')
+----
+(a) 3 1 0.6667 1.6667 {"00001":1,"00002":2}
 
 statement ok
 ALTER TABLE t09_0014 DROP CLUSTER KEY
 
 statement error 1118
 select * from clustering_information('default','t09_0014')
+
+query TIIFFT
+select * exclude(timestamp) from clustering_information('default','t09_0014', '(b, a)')
+----
+(b, a) 3 1 0.6667 1.6667 {"00001":1,"00002":2}
 
 statement ok
 drop table t09_0014

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0015_remote_alter_cluster_key.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0015_remote_alter_cluster_key.test
@@ -19,10 +19,10 @@ INSERT INTO t09_0015_0 VALUES(0,3),(1,1)
 statement ok
 INSERT INTO t09_0015_0 VALUES(1,3),(2,1)
 
-query TIIIFFT
-select * from clustering_information('db1','t09_0015_0')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db1','t09_0015_0')
 ----
-(b, a) 2 0 0 1.0 2.0 {"00002":2}
+(b, a) 2 0 1.0 2.0 {"00002":2}
 
 statement ok
 ALTER TABLE t09_0015_0 CLUSTER BY(a,b)
@@ -30,10 +30,10 @@ ALTER TABLE t09_0015_0 CLUSTER BY(a,b)
 statement ok
 INSERT INTO t09_0015_0 VALUES(4,4)
 
-query TIIIFFT
-select * from clustering_information('db1','t09_0015_0')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db1','t09_0015_0')
 ----
-(a, b) 3 1 2 0.0 1.0 {"00001":1}
+(a, b) 3 1 0.6667 1.6667 {"00001":1,"00002":2}
 
 query II
 SELECT * FROM t09_0015_0 ORDER BY b,a

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
@@ -19,18 +19,18 @@ insert into t1 values(2,2),(5,5)
 statement ok
 insert into t1 values(4,4)
 
-query TIIIFFT
-select * from clustering_information('db_09_0016','t1')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0016','t1')
 ----
-(a + 1) 3 1 0 1.3333 2.0 {"00002":3}
+(a + 1) 3 1 1.3333 2.0 {"00002":3}
 
 statement ok
 ALTER TABLE t1 RECLUSTER FINAL WHERE a != 4
 
-query TIIIFFT
-select * from clustering_information('db_09_0016','t1')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0016','t1')
 ----
-(a + 1) 2 1 0 1.0 2.0 {"00002":2}
+(a + 1) 2 1 1.0 2.0 {"00002":2}
 
 query II
 select * from t1 order by a
@@ -64,10 +64,10 @@ insert into t3 values(1,'b'),(2,null)
 statement ok
 insert into t3 values(1,'a'),(2,null)
 
-query TIIIFFT
-select * from clustering_information('db_09_0016','t3')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0016','t3')
 ----
-(b) 2 0 0 1.0 2.0 {"00002":2}
+(b) 2 0 1.0 2.0 {"00002":2}
 
 statement ok
 insert into t3 values(3,'a'),(4,'c')
@@ -90,10 +90,10 @@ insert into t3 values(1,'123456780'),(2,'123456781')
 statement ok
 insert into t3 values(3,'123456782'),(4,'123456783')
 
-query TIIIFFT
-select * from clustering_information('db_09_0016','t3')
+query TIIFFT
+select * exclude(timestamp) from clustering_information('db_09_0016','t3')
 ----
-(b) 2 2 0 1.0 2.0 {"00002":2}
+(b) 2 2 1.0 2.0 {"00002":2}
 
 # Fix pr#13332
 statement ok

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
@@ -389,10 +389,10 @@ select a, b FROM test order by a
 4 4
 
 # since auto re-clustering is disabled, the table is not expected to be re-clustered
-query TIIIFFT
-select * FROM clustering_information('db_09_0023','test')
+query TIIFFT
+select * exclude(timestamp) FROM clustering_information('db_09_0023','test')
 ----
-(a + 1, b) 3 2 0 0.0 1.0 {"00001":3}
+(a + 1, b) 3 2 0.0 1.0 {"00001":3}
 
 statement ok
 DROP TABLE test

--- a/tests/sqllogictests/suites/management/management_calls.test
+++ b/tests/sqllogictests/suites/management/management_calls.test
@@ -20,12 +20,6 @@ call system$search_tables('call_t')
 
 
 query T
-call system$clustering_information('default', 'call_t')
-----
-(a + 1) 0 0 0 0.0 0.0 {}
-
-
-query T
 call admin$tenant_quota('admin')
 ----
 0 0 0 0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. enhances the `clustering_information` functionality by adding support for specifying cluster keys. 
By allowing users to specify cluster keys, they can now view the clustering information related to those keys. 
This feature provides valuable insights for users to define effective cluster keys.

2. Remove `unclustered_block_count`, add `timestamp` in `clustering_informaton`

3. recluster will resort the wrong clustered block first. 

```sql
mysql> create table t(a int, b int);
Query OK, 0 rows affected (0.13 sec)

mysql> insert into t values(1, 1),(2, 1);
Query OK, 2 rows affected (0.15 sec)

mysql> insert into t values(2, 2),(3, 2);
Query OK, 2 rows affected (0.16 sec)

mysql> select * from clustering_information('default','t');
ERROR 1105 (HY000): UnclusteredTable. Code: 1118, Text = Unclustered table 'default'.'t'.
mysql> select * from clustering_information('default','t','(a)');
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
| cluster_key | timestamp                  | total_block_count | constant_block_count | average_overlaps | average_depth | block_depth_histogram |
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
| (a)         | 2024-06-12 08:03:20.888347 |                 2 |                    0 |              1.0 |           2.0 | {"00002":2}           |
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
1 row in set (0.11 sec)
Read 1 rows, 448.00 B in 0.082 sec., 12.14 rows/sec., 5.31 KiB/sec.

mysql> select * from clustering_information('default','t','(b)');
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
| cluster_key | timestamp                  | total_block_count | constant_block_count | average_overlaps | average_depth | block_depth_histogram |
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
| (b)         | 2024-06-12 08:03:20.888347 |                 2 |                    2 |              0.0 |           1.0 | {"00001":2}           |
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
1 row in set (0.08 sec)
Read 1 rows, 448.00 B in 0.059 sec., 16.95 rows/sec., 7.42 KiB/sec.

mysql> select * from clustering_information('default','t','(a, b)');
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
| cluster_key | timestamp                  | total_block_count | constant_block_count | average_overlaps | average_depth | block_depth_histogram |
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
| (a, b)      | 2024-06-12 08:03:20.888347 |                 2 |                    0 |              0.0 |           1.0 | {"00001":2}           |
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
1 row in set (0.09 sec)
Read 1 rows, 448.00 B in 0.068 sec., 14.61 rows/sec., 6.39 KiB/sec.

mysql> alter table t cluster by(b);
Query OK, 0 rows affected (0.12 sec)

mysql> select * from clustering_information('default','t');
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
| cluster_key | timestamp                  | total_block_count | constant_block_count | average_overlaps | average_depth | block_depth_histogram |
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
| (b)         | 2024-06-12 08:03:40.234610 |                 2 |                    2 |              0.0 |           1.0 | {"00001":2}           |
+-------------+----------------------------+-------------------+----------------------+------------------+---------------+-----------------------+
1 row in set (0.09 sec)
Read 1 rows, 448.00 B in 0.062 sec., 16.01 rows/sec., 7.01 KiB/sec.
```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15783)
<!-- Reviewable:end -->
