### PR TITLE
refactor: add non-async version of mete-client API request_sync

### DIFF
--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::fmt::Formatter;
 
 use databend_common_base::base::tokio::sync::oneshot::Sender;
+use databend_common_base::runtime::TrackingPayload;
 use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
@@ -47,6 +48,8 @@ pub struct ClientWorkerRequest {
 
     /// Tracing span for this request
     pub(crate) span: Span,
+
+    pub(crate) tracking_payload: Option<TrackingPayload>,
 }
 
 impl fmt::Debug for ClientWorkerRequest {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add non-async version of mete-client API request_sync

`ClientHandle::request_sync(req)` behave the same as the async version
`ClientHandle::request(req)`, which can be used in non-async
environment.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15786)
<!-- Reviewable:end -->
