### PR TITLE
refactor: improve raft connection and logging filter

### DIFF
--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -654,8 +654,10 @@ pub struct FileLogConfig {
     #[serde(rename = "limit")]
     pub file_limit: usize,
 
-    /// Log prefix filter
-    #[clap(long = "log-file-prefix-filter", default_value = "databend_")]
+    /// Log prefix filter, separated by comma.
+    /// For example, `"databend_,openraft"` enables logging for `databend_*` crates and `openraft` crate.
+    /// This filter does not affect `WARNING` and `ERROR` log.
+    #[clap(long = "log-file-prefix-filter", default_value = "databend_,openraft")]
     #[serde(rename = "prefix_filter")]
     pub file_prefix_filter: String,
 }

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -46,7 +46,6 @@ use databend_common_meta_stoerr::MetaStorageError;
 use databend_common_meta_types::Endpoint;
 use databend_common_meta_types::LogId;
 use databend_common_meta_types::Membership;
-use databend_common_meta_types::MetaError;
 use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::MetaStartupError;
 use databend_common_meta_types::Node;
@@ -578,7 +577,10 @@ impl StoreInner {
         ns
     }
 
-    pub async fn get_node_raft_endpoint(&self, node_id: &NodeId) -> Result<Endpoint, MetaError> {
+    pub async fn get_node_raft_endpoint(
+        &self,
+        node_id: &NodeId,
+    ) -> Result<Endpoint, MetaNetworkError> {
         let endpoint = self
             .get_node(node_id)
             .await


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: improve raft connection and logging filter

Only reuse a connection if there is no error returned from the last RPC.
When a raft RPC is finished, push the connection back for next RPC if it
returns an `Ok`. Otherwise it drops the connection and the next RPC will
re-create a new one. Such approach ensures no problematic connection
will be used.

Support multi log prefix filter.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15801)
<!-- Reviewable:end -->
