### PR TITLE
refactor: adaptive entries count for `AppendEntriesRequest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,6 +3450,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-stoerr",
  "databend-common-tracing",
+ "deepsize",
  "derive_more",
  "log",
  "num-derive",
@@ -4553,6 +4554,7 @@ dependencies = [
  "databend-common-meta-types",
  "databend-common-metrics",
  "databend-common-tracing",
+ "deepsize",
  "derive_more",
  "env_logger",
  "feature-set",
@@ -5318,6 +5320,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10429,9 +10451,9 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.9.9"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f29df094119e6d79274ddec81e44189b4b9f59f1a38635920151e1264b6687c"
+checksum = "8809b74bd5176a346bee70b31c2ff9d0406a045356f6e89b23e28c7ea06f10b3"
 dependencies = [
  "anyerror",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,7 @@ clap = { version = "4.4.2", features = ["derive"] }
 codespan-reporting = "0.11"
 criterion = "0.5"
 dashmap = "5.4.0"
+deepsize = { version = "0.2.0" }
 deltalake = "0.17"
 derive-visitor = { version = "0.4.0", features = ["std-types-drive"] }
 derive_more = "0.99.17"
@@ -328,7 +329,7 @@ walkdir = "2.3.2"
 xorfilter-rs = "0.5"
 # openraft for debugging
 # openraft = { git = "https://github.com/drmingdrmer/openraft", branch = "release-0.9", features = [
-openraft = { version = "0.9.9", features = [
+openraft = { version = "0.9.12", features = [
     "serde",
     "tracing-log",
     "generic-snapshot-data",

--- a/src/common/base/src/display/display_option/mod.rs
+++ b/src/common/base/src/display/display_option/mod.rs
@@ -1,0 +1,44 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+/// Implement `Display` for `Option<T>` if T is `Display`.
+///
+/// It outputs a literal string `"None"` if it is None. Otherwise it invokes the Display
+/// implementation for T.
+pub struct DisplayOption<'a, T: fmt::Display>(pub &'a Option<T>);
+
+impl<'a, T: fmt::Display> fmt::Display for DisplayOption<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            None => {
+                write!(f, "None")
+            }
+            Some(x) => x.fmt(f),
+        }
+    }
+}
+
+pub trait DisplayOptionExt<'a, T: fmt::Display> {
+    fn display(&'a self) -> DisplayOption<'a, T>;
+}
+
+impl<T> DisplayOptionExt<'_, T> for Option<T>
+where T: fmt::Display
+{
+    fn display(&self) -> DisplayOption<T> {
+        DisplayOption(self)
+    }
+}

--- a/src/common/base/src/display/mod.rs
+++ b/src/common/base/src/display/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod display_option;

--- a/src/common/base/src/future.rs
+++ b/src/common/base/src/future.rs
@@ -20,6 +20,7 @@ use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
 
+use log::debug;
 use log::info;
 use pin_project_lite::pin_project;
 use tokio::time::Instant;
@@ -110,6 +111,19 @@ pub trait TimingFutureExt {
             if total >= threshold {
                 f(total, busy)
             }
+        })
+    }
+
+    /// Log elapsed time(total and busy) in DEBUG level when the future is ready.
+    fn debug_elapsed<'a>(
+        self,
+        ctx: impl fmt::Display + 'a,
+    ) -> TimingFuture<'a, Self, impl Fn(Duration, Duration)>
+    where
+        Self: Future + Sized,
+    {
+        self.timed::<'a>(move |total, busy| {
+            debug!("Elapsed: total: {:?}, busy: {:?}; {}", total, busy, ctx);
         })
     }
 

--- a/src/common/base/src/lib.rs
+++ b/src/common/base/src/lib.rs
@@ -29,6 +29,7 @@
 
 pub mod base;
 pub mod containers;
+pub mod display;
 pub mod future;
 pub mod mem_allocator;
 pub mod rangemap;

--- a/src/common/tracing/src/config.rs
+++ b/src/common/tracing/src/config.rs
@@ -38,7 +38,7 @@ impl Config {
                 dir: "./.databend/logs".to_string(),
                 format: "text".to_string(),
                 limit: 48,
-                prefix_filter: "databend_".to_string(),
+                prefix_filter: "databend_,openraft".to_string(),
             },
             stderr: StderrConfig {
                 on: true,
@@ -78,7 +78,7 @@ impl Default for FileConfig {
             dir: "./.databend/logs".to_string(),
             format: "json".to_string(),
             limit: 48,
-            prefix_filter: "databend_".to_string(),
+            prefix_filter: "databend_,openraft".to_string(),
         }
     }
 }

--- a/src/meta/raft-store/src/sm_v002/snapshot_store.rs
+++ b/src/meta/raft-store/src/sm_v002/snapshot_store.rs
@@ -342,8 +342,6 @@ impl SnapshotStoreV002 {
         mut temp: Box<SnapshotData>,
         meta: &SnapshotMeta,
     ) -> Result<SnapshotData, SnapshotStoreError> {
-        assert!(temp.is_temp());
-
         let src = temp.path().to_string();
 
         temp.sync_all()

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -40,6 +40,7 @@ databend-common-meta-stoerr = { workspace = true }
 databend-common-meta-types = { workspace = true }
 databend-common-metrics = { workspace = true }
 databend-common-tracing = { workspace = true }
+deepsize = { workspace = true }
 derive_more = { workspace = true }
 feature-set = { workspace = true }
 futures = { workspace = true }

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -383,7 +383,7 @@ impl Into<Config> for ConfigViaEnv {
                 file_dir: self.metasrv_log_file_dir,
                 file_format: self.metasrv_log_file_format,
                 file_limit: self.metasrv_log_file_limit,
-                file_prefix_filter: "databend_".to_string(),
+                file_prefix_filter: "databend_,openraft".to_string(),
             },
             stderr: StderrLogConfig {
                 stderr_on: self.metasrv_log_stderr_on,
@@ -654,8 +654,10 @@ pub struct FileLogConfig {
     #[serde(rename = "limit")]
     pub file_limit: usize,
 
-    /// Log prefix filter
-    #[clap(long = "log-file-prefix-filter", default_value = "databend_")]
+    /// Log prefix filter, separated by comma.
+    /// For example, `"databend_,openraft"` enables logging for `databend_*` crates and `openraft` crate.
+    /// This filter does not affect `WARNING` and `ERROR` log.
+    #[clap(long = "log-file-prefix-filter", default_value = "databend_,openraft")]
     #[serde(rename = "prefix_filter")]
     pub file_prefix_filter: String,
 }

--- a/src/meta/service/src/network.rs
+++ b/src/meta/service/src/network.rs
@@ -15,16 +15,13 @@
 use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
-use std::sync::Arc;
 use std::time::Duration;
 
-use anyerror::func_name;
 use anyerror::AnyError;
-use async_trait::async_trait;
 use backon::BackoffBuilder;
 use backon::ExponentialBuilder;
-use databend_common_base::containers::ItemManager;
-use databend_common_base::containers::Pool;
+use databend_common_base::base::tokio;
+use databend_common_base::base::tokio::time::Instant;
 use databend_common_base::future::TimingFutureExt;
 use databend_common_meta_sled_store::openraft;
 use databend_common_meta_sled_store::openraft::error::PayloadTooLarge;
@@ -46,6 +43,7 @@ use databend_common_meta_types::InstallSnapshotError;
 use databend_common_meta_types::InstallSnapshotRequest;
 use databend_common_meta_types::InstallSnapshotResponse;
 use databend_common_meta_types::MembershipNode;
+use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::NetworkError;
 use databend_common_meta_types::NodeId;
 use databend_common_meta_types::RPCError;
@@ -60,41 +58,16 @@ use databend_common_meta_types::VoteRequest;
 use databend_common_meta_types::VoteResponse;
 use databend_common_metrics::count::Count;
 use log::debug;
+use log::error;
 use log::info;
 use log::warn;
 use openraft::RaftNetwork;
-use tonic::client::GrpcService;
-use tonic::transport::channel::Channel;
+use tokio::sync::Mutex;
 
 use crate::metrics::raft_metrics;
 use crate::raft_client::RaftClient;
 use crate::raft_client::RaftClientApi;
 use crate::store::RaftStore;
-
-#[derive(Debug)]
-struct ChannelManager {}
-
-#[async_trait]
-impl ItemManager for ChannelManager {
-    type Key = String;
-    type Item = Channel;
-    type Error = tonic::transport::Error;
-
-    #[logcall::logcall(err = "debug")]
-    #[minitrace::trace]
-    async fn build(&self, addr: &Self::Key) -> Result<Channel, tonic::transport::Error> {
-        tonic::transport::Endpoint::new(addr.clone())?
-            .connect()
-            .await
-    }
-
-    #[logcall::logcall(err = "debug")]
-    #[minitrace::trace]
-    async fn check(&self, mut ch: Channel) -> Result<Channel, tonic::transport::Error> {
-        futures::future::poll_fn(|cx| ch.poll_ready(cx)).await?;
-        Ok(ch)
-    }
-}
 
 #[derive(Debug, Clone)]
 pub(crate) struct Backoff {
@@ -138,10 +111,10 @@ impl Backoff {
 impl Default for Backoff {
     fn default() -> Self {
         Self {
-            back_off_ratio: 2.0,
-            back_off_min_delay: Duration::from_secs(1),
-            back_off_max_delay: Duration::from_secs(60),
-            back_off_chances: 3,
+            back_off_ratio: 1.5,
+            back_off_min_delay: Duration::from_millis(50),
+            back_off_max_delay: Duration::from_millis(1_000),
+            back_off_chances: 10,
         }
     }
 }
@@ -150,17 +123,13 @@ impl Default for Backoff {
 pub struct Network {
     sto: RaftStore,
 
-    conn_pool: Arc<Pool<ChannelManager>>,
-
     backoff: Backoff,
 }
 
 impl Network {
     pub fn new(sto: RaftStore) -> Network {
-        let mgr = ChannelManager {};
         Network {
             sto,
-            conn_pool: Arc::new(Pool::new(mgr, Duration::from_millis(50))),
             backoff: Backoff::default(),
         }
     }
@@ -181,51 +150,104 @@ pub struct NetworkConnection {
     /// The endpoint of the target node.
     endpoint: Endpoint,
 
-    sto: RaftStore,
+    client: Mutex<Option<RaftClient>>,
 
-    conn_pool: Arc<Pool<ChannelManager>>,
+    sto: RaftStore,
 
     backoff: Backoff,
 }
 
 impl NetworkConnection {
+    /// Create a new RaftClient to the specified target node.
     #[logcall::logcall(err = "debug")]
     #[minitrace::trace]
-    pub async fn make_client(&mut self) -> Result<RaftClient, Unreachable> {
-        let target = self.target;
+    pub async fn new_client(&self, addr: &str) -> Result<RaftClient, tonic::transport::Error> {
+        info!(id = self.id; "Raft NetworkConnection connect: target={}: {}", self.target, addr);
 
-        let endpoint = self
-            .sto
-            .get_node_raft_endpoint(&target)
-            .await
-            .map_err(|e| {
-                let any_err = AnyError::new(&e)
-                    .add_context(|| format!("{} target: {}", func_name!(), self.target));
-                Unreachable::new(&any_err)
-            })?;
+        let channel = tonic::transport::Endpoint::new(addr.to_string())?
+            .connect()
+            .debug_elapsed(format!(
+                "Raft NetworkConnection new_client: connect target: {}",
+                self.target
+            ))
+            .await?;
 
-        let addr = format!("http://{}", endpoint);
+        let client = RaftClientApi::new(self.target, self.endpoint.clone(), channel);
 
-        debug!(id = self.id; "connect: target={}: {}", target, addr);
+        info!(
+            "Raft NetworkConnection connected to: target={}: {}",
+            self.target, addr
+        );
 
-        match self.conn_pool.get(&addr).await {
-            Ok(channel) => {
-                let client = RaftClientApi::new(target, endpoint.clone(), channel);
-                debug!("connected: target={}: {}", target, addr);
+        Ok(client)
+    }
 
-                self.endpoint = endpoint;
+    /// Take the last used client or create a new one.
+    #[logcall::logcall(err = "debug")]
+    #[minitrace::trace]
+    async fn take_client(&mut self) -> Result<RaftClient, Unreachable> {
+        let mut client = self.client.lock().await;
 
-                Ok(client)
-            }
-            Err(err) => {
-                raft_metrics::network::incr_connect_failure(&target, &endpoint.to_string());
-                let any_err = AnyError::new(&err).add_context(|| {
-                    format!("{} target: {}, addr: {}", func_name!(), self.target, addr)
-                });
+        if let Some(c) = client.take() {
+            return Ok(c);
+        }
 
-                Err(Unreachable::new(&any_err))
+        let n = 3;
+        for _i in 0..n {
+            let endpoint = self
+                .lookup_target_address()
+                .debug_elapsed(format!(
+                    "Raft NetworkConnection take_client lookup_target_address: target: {}",
+                    self.target
+                ))
+                .await
+                .map_err(|e| {
+                    let any_err = AnyError::new(&e).add_context(|| {
+                        format!(
+                            "Raft NetworkConnection fail to lookup target address: target={}",
+                            self.target
+                        )
+                    });
+                    warn!("{}", any_err);
+                    Unreachable::new(&any_err)
+                })?;
+
+            self.endpoint = endpoint;
+
+            let addr = format!("http://{}", self.endpoint);
+
+            let res = self.new_client(&addr).await;
+            match res {
+                Ok(c) => {
+                    return Ok(c);
+                }
+                Err(e) => {
+                    warn!(
+                        "Raft NetworkConnection fail to connect: target={}: addr={}: {}",
+                        self.target, &addr, e
+                    );
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
             }
         }
+
+        let any_err = AnyError::error(format!(
+            "Raft NetworkConnection fail to connect: target={}, retry={}",
+            self.target, n
+        ));
+        error!("{}", any_err);
+
+        Err(Unreachable::new(&any_err))
+    }
+
+    async fn lookup_target_address(&self) -> Result<Endpoint, MetaNetworkError> {
+        debug!(
+            "Raft NetworkConnection lookup target address: start: target={}",
+            self.target
+        );
+        let endpoint = self.sto.get_node_raft_endpoint(&self.target).await?;
+
+        Ok(endpoint)
     }
 
     pub(crate) fn report_metrics_snapshot(&self, success: bool) {
@@ -249,7 +271,13 @@ impl NetworkConnection {
     where
         E: std::error::Error,
     {
+        let start = Instant::now();
         let raft_req = GrpcHelper::encode_raft_request(rpc).map_err(|e| Unreachable::new(&e))?;
+        debug!(
+            "Raft NetworkConnection: new_append_entries_raft_req() encode_raft_request: target={}, elapsed={:?}",
+            self.target,
+            start.elapsed()
+        );
 
         if raft_req.data.len() <= GrpcConfig::advisory_encoding_size() {
             return Ok(raft_req);
@@ -350,13 +378,16 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
             "send_append_entries",
         );
 
-        let mut client = self.make_client().await?;
-
         let raft_req = self.new_append_entries_raft_req(&rpc)?;
         let req = GrpcHelper::traced_req(raft_req);
 
         let bytes = req.get_ref().data.len() as u64;
         raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
+
+        let mut client = self
+            .take_client()
+            .debug_elapsed("Raft NetworkConnection append_entries take_client()")
+            .await?;
 
         let grpc_res = client
             .append_entries(req)
@@ -367,6 +398,15 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
             self.target, grpc_res
         );
 
+        match &grpc_res {
+            Ok(_) => {
+                self.client.lock().await.replace(client);
+            }
+            Err(e) => {
+                warn!(target = self.target, rpc = rpc.summary(); "append_entries failed: {}", e);
+            }
+        }
+
         self.parse_grpc_resp(grpc_res)
     }
 
@@ -376,7 +416,7 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
         &mut self,
         vote: Vote,
         snapshot: Snapshot,
-        cancel: impl Future<Output = ReplicationClosed> + Send,
+        cancel: impl Future<Output = ReplicationClosed> + Send + 'static,
         option: RPCOption,
     ) -> Result<SnapshotResponse, StreamingError<Fatal>> {
         // This implementation just delegates to `Chunked::send_snapshot`,
@@ -404,13 +444,16 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
 
         let _g = snapshot_send_inflight(self.target).counter_guard();
 
-        let mut client = self.make_client().await?;
-
         let bytes = rpc.data.len() as u64;
         raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
 
         let v1_req = SnapshotChunkRequest::new_v1(rpc);
         let req = databend_common_tracing::inject_span_to_tonic_request(v1_req);
+
+        let mut client = self
+            .take_client()
+            .debug_elapsed("Raft NetworkConnection install_snapshot take_client()")
+            .await?;
 
         let grpc_res = client
             .install_snapshot_v1(req)
@@ -421,6 +464,15 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
             "install_snapshot resp target={}: {:?}",
             self.target, grpc_res
         );
+
+        match &grpc_res {
+            Ok(_) => {
+                self.client.lock().await.replace(client);
+            }
+            Err(e) => {
+                warn!(target = self.target; "install_snapshot failed: {}", e);
+            }
+        }
 
         let res = self.parse_grpc_resp(grpc_res);
         self.report_metrics_snapshot(res.is_ok());
@@ -437,8 +489,6 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     ) -> Result<VoteResponse, RPCError<RaftError>> {
         info!(id = self.id, target = self.target, rpc = rpc.summary(); "send_vote");
 
-        let mut client = self.make_client().await?;
-
         let raft_req = GrpcHelper::encode_raft_request(&rpc).map_err(|e| Unreachable::new(&e))?;
 
         let req = GrpcHelper::traced_req(raft_req);
@@ -446,8 +496,22 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
         let bytes = req.get_ref().data.len() as u64;
         raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
 
+        let mut client = self
+            .take_client()
+            .debug_elapsed("Raft NetworkConnection vote take_client()")
+            .await?;
+
         let grpc_res = client.vote(req).await;
         info!("vote: resp from target={} {:?}", self.target, grpc_res);
+
+        match &grpc_res {
+            Ok(_) => {
+                self.client.lock().await.replace(client);
+            }
+            Err(e) => {
+                warn!(target = self.target, rpc = rpc.summary(); "vote failed: {}", e);
+            }
+        }
 
         self.parse_grpc_resp(grpc_res)
     }
@@ -478,9 +542,9 @@ impl RaftNetworkFactory<TypeConfig> for Network {
             target,
             target_node: node.clone(),
             sto: self.sto.clone(),
-            conn_pool: self.conn_pool.clone(),
             backoff: self.backoff.clone(),
             endpoint: Default::default(),
+            client: Default::default(),
         }
     }
 }

--- a/src/meta/service/src/store/raft_log_storage_impl.rs
+++ b/src/meta/service/src/store/raft_log_storage_impl.rs
@@ -19,19 +19,24 @@ use std::time::Duration;
 
 use databend_common_base::base::tokio;
 use databend_common_base::base::tokio::io;
+use databend_common_base::display::display_option::DisplayOptionExt;
 use databend_common_meta_sled_store::openraft::storage::LogFlushed;
 use databend_common_meta_sled_store::openraft::storage::RaftLogStorage;
+use databend_common_meta_sled_store::openraft::EntryPayload;
 use databend_common_meta_sled_store::openraft::ErrorSubject;
 use databend_common_meta_sled_store::openraft::ErrorVerb;
 use databend_common_meta_sled_store::openraft::LogIdOptionExt;
 use databend_common_meta_sled_store::openraft::LogState;
 use databend_common_meta_sled_store::openraft::OptionalSend;
+use databend_common_meta_sled_store::openraft::RaftLogId;
 use databend_common_meta_sled_store::openraft::RaftLogReader;
 use databend_common_meta_types::Entry;
 use databend_common_meta_types::LogId;
+use databend_common_meta_types::Membership;
 use databend_common_meta_types::StorageError;
 use databend_common_meta_types::TypeConfig;
 use databend_common_meta_types::Vote;
+use deepsize::DeepSizeOf;
 use log::debug;
 use log::error;
 use log::info;
@@ -42,6 +47,57 @@ use crate::store::ToStorageError;
 
 impl RaftLogReader<TypeConfig> for RaftStore {
     #[minitrace::trace]
+    async fn limited_get_log_entries(
+        &mut self,
+        mut start: u64,
+        end: u64,
+    ) -> Result<Vec<Entry>, StorageError> {
+        let chunk_size = 8;
+        let max_size = 2 * 1024 * 1024;
+
+        let mut res = Vec::with_capacity(64);
+        let mut total_size = 0;
+
+        while start < end {
+            let chunk_end = std::cmp::min(start + chunk_size, end);
+            let entries = self.try_get_log_entries(start..chunk_end).await?;
+
+            for ent in entries {
+                let size = match &ent.payload {
+                    EntryPayload::Blank => 0,
+                    EntryPayload::Normal(log_entry) => log_entry.deep_size_of(),
+                    EntryPayload::Membership(_) => std::mem::size_of::<Membership>(),
+                };
+
+                debug!(
+                    "RaftStore::limited_get_log_entries: got log: log_id: {}, size: {}",
+                    ent.get_log_id(),
+                    size
+                );
+
+                res.push(ent);
+                total_size += size;
+
+                if total_size >= max_size {
+                    info!(
+                        "RaftStore::limited_get_log_entries: too many logs, early return: entries cnt: {}, total size: {}, res: [{}, {}]",
+                        res.len(),
+                        total_size,
+                        res.first().map(|x| x.get_log_id()).unwrap(),
+                        res.last().map(|x| x.get_log_id()).unwrap(),
+                    );
+
+                    return Ok(res);
+                }
+            }
+
+            start = chunk_end;
+        }
+
+        Ok(res)
+    }
+
+    #[minitrace::trace]
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send>(
         &mut self,
         range: RB,
@@ -51,13 +107,19 @@ impl RaftLogReader<TypeConfig> for RaftStore {
             self.id, range
         );
 
-        match self
+        let res = self
             .log
             .read()
             .await
-            .range_values(range)
-            .map_to_sto_err(ErrorSubject::Logs, ErrorVerb::Read)
-        {
+            .range_values(range.clone())
+            .map_to_sto_err(ErrorSubject::Logs, ErrorVerb::Read);
+
+        debug!(
+            "RaftStore::try_get_log_entries: done: self.id={}, range: {:?}",
+            self.id, range
+        );
+
+        match res {
             Ok(entries) => Ok(entries),
             Err(err) => {
                 raft_metrics::storage::incr_raft_storage_fail("try_get_log_entries", false);
@@ -201,7 +263,11 @@ impl RaftLogStorage<TypeConfig> for RaftStore {
             })
             .collect::<Vec<_>>();
 
-        info!("RaftStore::append([{:?}, {:?}]): start", first, last);
+        info!(
+            "RaftStore::append([{}, {}]): start",
+            first.display(),
+            last.display()
+        );
 
         let res = match self.log.write().await.append(entries).await {
             Err(err) => {
@@ -213,7 +279,11 @@ impl RaftLogStorage<TypeConfig> for RaftStore {
 
         callback.log_io_completed(res.map_err(|e| io::Error::new(ErrorKind::InvalidData, e)));
 
-        info!("RaftStore::append([{:?}, {:?}]): done", first, last);
+        info!(
+            "RaftStore::append([{}, {}]): done",
+            first.display(),
+            last.display()
+        );
 
         Ok(())
     }

--- a/src/meta/service/src/store/raft_state_machine_impl.rs
+++ b/src/meta/service/src/store/raft_state_machine_impl.rs
@@ -110,8 +110,6 @@ impl RaftStateMachine<TypeConfig> for RaftStore {
         );
         server_metrics::incr_applying_snapshot(-1);
 
-        assert!(snapshot.is_temp());
-
         let snapshot_store = SnapshotStoreV002::new(DATA_VERSION, self.inner.config.clone());
 
         let d = snapshot_store

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -46,7 +46,6 @@ use databend_common_meta_stoerr::MetaStorageError;
 use databend_common_meta_types::Endpoint;
 use databend_common_meta_types::LogId;
 use databend_common_meta_types::Membership;
-use databend_common_meta_types::MetaError;
 use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::MetaStartupError;
 use databend_common_meta_types::Node;
@@ -578,7 +577,10 @@ impl StoreInner {
         ns
     }
 
-    pub async fn get_node_raft_endpoint(&self, node_id: &NodeId) -> Result<Endpoint, MetaError> {
+    pub async fn get_node_raft_endpoint(
+        &self,
+        node_id: &NodeId,
+    ) -> Result<Endpoint, MetaNetworkError> {
         let endpoint = self
             .get_node(node_id)
             .await

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -15,6 +15,7 @@ anyerror = { workspace = true }
 databend-common-exception = { workspace = true }
 databend-common-meta-stoerr = { workspace = true }
 databend-common-tracing = { workspace = true }
+deepsize = { workspace = true }
 derive_more = { workspace = true }
 log = { workspace = true }
 num-derive = "0.3.3"

--- a/src/meta/types/build.rs
+++ b/src/meta/types/build.rs
@@ -47,91 +47,91 @@ fn build_proto() {
         .file_descriptor_set_path(out_dir.join("meta_descriptor.bin"))
         .type_attribute(
             "SeqV",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnGetRequest",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnPutRequest",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnDeleteRequest",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnDeleteByPrefixRequest",
-            "#[derive(Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnCondition.ConditionResult",
-            "#[derive(serde::Serialize, serde::Deserialize, num_derive::FromPrimitive)]",
+            "#[derive(serde::Serialize, serde::Deserialize, num_derive::FromPrimitive, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnCondition.target",
-            "#[derive(Eq,serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq,serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnOp.request",
-            "#[derive(Eq,serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq,serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnCondition",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnOp",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnRequest",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnGetResponse",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnPutResponse",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnDeleteResponse",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnDeleteByPrefixResponse",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnOpResponse.response",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize, derive_more::TryInto)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, derive_more::TryInto, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnOpResponse",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "TxnReply",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "WatchRequest",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "WatchResponse",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "Event",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
             "KVMeta",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .field_attribute(
             "TxnPutRequest.ttl_ms",

--- a/src/meta/types/src/cluster.rs
+++ b/src/meta/types/src/cluster.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 
 use crate::Endpoint;
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, deepsize::DeepSizeOf)]
 pub struct Node {
     /// Node name for display.
     pub name: String,
@@ -32,8 +32,8 @@ pub struct Node {
 
     /// For backward compatibility, it can not be removed.
     /// 2023-02-09
+    //#[deprecated(note = "it is listening addr, not advertise addr")]
     #[serde(skip)]
-    #[deprecated(note = "it is listening addr, not advertise addr")]
     pub grpc_api_addr: Option<String>,
 
     /// The address `ip:port` for a meta-client to connect to.

--- a/src/meta/types/src/cmd/meta_spec.rs
+++ b/src/meta/types/src/cmd/meta_spec.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use deepsize::Context;
+
 use crate::cmd::CmdContext;
 use crate::seq_value::KVMeta;
 use crate::time::Interval;
@@ -38,6 +40,12 @@ pub struct MetaSpec {
     /// For backward compatibility, this field is not serialized if it `None`, as if it does not exist.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) ttl: Option<Interval>,
+}
+
+impl deepsize::DeepSizeOf for MetaSpec {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        0
+    }
 }
 
 impl MetaSpec {

--- a/src/meta/types/src/cmd/mod.rs
+++ b/src/meta/types/src/cmd/mod.rs
@@ -27,13 +27,12 @@ use crate::TxnRequest;
 
 mod cmd_context;
 mod meta_spec;
-
 pub use cmd_context::CmdContext;
 pub use meta_spec::MetaSpec;
 
 /// A Cmd describes what a user want to do to raft state machine
 /// and is the essential part of a raft log.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, deepsize::DeepSizeOf)]
 pub enum Cmd {
     /// Add node if absent
     AddNode {
@@ -55,7 +54,7 @@ pub enum Cmd {
 }
 
 /// Update or insert a general purpose kv store
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, deepsize::DeepSizeOf)]
 pub struct UpsertKV {
     pub key: String,
 

--- a/src/meta/types/src/endpoint.rs
+++ b/src/meta/types/src/endpoint.rs
@@ -18,7 +18,7 @@ use anyerror::AnyError;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, deepsize::DeepSizeOf)]
 pub struct Endpoint {
     addr: String,
     port: u16,

--- a/src/meta/types/src/log_entry.rs
+++ b/src/meta/types/src/log_entry.rs
@@ -26,7 +26,7 @@ use crate::RaftTxId;
 /// The client and the serial together provides external consistency:
 /// If a client failed to recv the response, it  re-send another RaftRequest with the same
 /// "client" and "serial", thus the raft engine is able to distinguish if a request is duplicated.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, deepsize::DeepSizeOf)]
 pub struct LogEntry {
     /// When not None, it is used to filter out duplicated logs, which are caused by retries by client.
     pub txid: Option<RaftTxId>,

--- a/src/meta/types/src/match_seq.rs
+++ b/src/meta/types/src/match_seq.rs
@@ -24,7 +24,7 @@ use crate::SeqV;
 /// Describes what `seq` an operation must match to take effect.
 /// Every value written to meta data has a unique `seq` bound.
 /// Any conditioned or non-conditioned write operation can be done through the corresponding MatchSeq.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, deepsize::DeepSizeOf)]
 pub enum MatchSeq {
     // TODO(xp): remove Any, it is equivalent to GE(0)
     /// Any value is acceptable, i.e. does not check seq at all.

--- a/src/meta/types/src/operation.rs
+++ b/src/meta/types/src/operation.rs
@@ -20,7 +20,7 @@ use std::fmt::Formatter;
 pub type MetaId = u64;
 
 /// An operation that updates a field, delete it, or leave it as is.
-#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, deepsize::DeepSizeOf)]
 pub enum Operation<T> {
     Update(T),
     Delete,

--- a/src/meta/types/src/raft_txid.rs
+++ b/src/meta/types/src/raft_txid.rs
@@ -20,7 +20,7 @@ use serde::Serialize;
 
 /// RaftTxId is the essential info to identify an write operation to raft.
 /// Logs with the same RaftTxId are considered the same and only the first of them will be applied.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, deepsize::DeepSizeOf)]
 pub struct RaftTxId {
     /// The ID of the client which has sent the request.
     pub client: String,

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -2041,11 +2041,13 @@ pub struct FileLogConfig {
     #[serde(rename = "limit")]
     pub file_limit: usize,
 
-    /// Log prefix filter
+    /// Log prefix filter, separated by comma.
+    /// For example, `"databend_,openraft"` enables logging for `databend_*` crates and `openraft` crate.
+    /// This filter does not affect `WARNING` and `ERROR` log.
     #[clap(
         long = "log-file-prefix-filter",
         value_name = "VALUE",
-        default_value = "databend_"
+        default_value = "databend_,openraft"
     )]
     #[serde(rename = "prefix_filter")]
     pub file_prefix_filter: String,

--- a/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
+++ b/src/query/service/tests/it/storages/testdata/configs_table_basic.txt
@@ -30,7 +30,7 @@ DB.Table: 'system'.'configs', Table: configs-table_id:1, ver:0, Engine: SystemCo
 | 'log'     | 'file.level'                               | 'DEBUG'                                                        | ''       |
 | 'log'     | 'file.limit'                               | '48'                                                           | ''       |
 | 'log'     | 'file.on'                                  | 'true'                                                         | ''       |
-| 'log'     | 'file.prefix_filter'                       | 'databend_'                                                    | ''       |
+| 'log'     | 'file.prefix_filter'                       | 'databend_,openraft'                                           | ''       |
 | 'log'     | 'level'                                    | 'DEBUG'                                                        | ''       |
 | 'log'     | 'log_dir'                                  | 'null'                                                         | ''       |
 | 'log'     | 'log_level'                                | 'null'                                                         | ''       |


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: adaptive entries count for `AppendEntriesRequest`

Use `limited_get_log_entries()` to limit the count of log entries in a
`AppendEntries` request by size.
With this approach, every AppendEntries request won't exceed 2MB.
This address the issue with static configured number of entries in a
`AppendEntries` can not limit the RPC size. Such too big AppendEntries
RPC may timeout.

Other changes:

- Only reuse a connection if there is no error returned from the last RPC.
  When a raft RPC is finished, push the connection back for next RPC if it
  returns an `Ok`. Otherwise it drops the connection and the next RPC will
  re-create a new one. Such approach ensures no problematic connection
  will be used.

- Improve raft connection and logging filter. Support multi log prefix filter.

- Add `DisplayOption` to improve display for raft log id:
  `Option<LogId>::display()` returns an `Display` implementation.

- Log elapsed time for critical steps of `AppendEntries` RPC.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15805)
<!-- Reviewable:end -->
