### PR TITLE
chore: reduce recluster depth threshold

### DIFF
--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -121,7 +121,7 @@ impl ReclusterMutator {
         );
         let depth_threshold = (snapshot.summary.block_count as f64 * avg_depth_threshold)
             .max(1.0)
-            .min(64.0);
+            .min(16.0);
 
         let mut max_tasks = 1;
         let cluster = ctx.get_cluster();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

reduce recluster depth threshold from 64 to 16.
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- Fixes #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15819)
<!-- Reviewable:end -->
