### PR TITLE
fix: multi-tbl insert with lateral flattern panics

### DIFF
--- a/src/query/service/src/pipelines/builders/builder_insert_multi_table.rs
+++ b/src/query/service/src/pipelines/builders/builder_insert_multi_table.rs
@@ -42,16 +42,6 @@ use crate::sql::evaluator::CompoundBlockOperator;
 impl PipelineBuilder {
     pub(crate) fn build_duplicate(&mut self, plan: &Duplicate) -> Result<()> {
         self.build_pipeline(&plan.input)?;
-
-        // Reorder the result for select clause
-        PipelineBuilder::build_result_projection(
-            &self.func_ctx,
-            plan.input.output_schema()?,
-            &plan.project_columns,
-            &mut self.main_pipeline,
-            false,
-        )?;
-
         self.main_pipeline.duplicate(true, plan.n)?;
         Ok(())
     }

--- a/src/query/sql/src/executor/physical_plans/physical_multi_table_insert.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_multi_table_insert.rs
@@ -23,13 +23,10 @@ use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::UpdateStreamMetaReq;
 
 use crate::executor::PhysicalPlan;
-use crate::ColumnBinding;
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Duplicate {
     pub plan_id: u32,
     pub input: Box<PhysicalPlan>,
-    // When input source is select clause, record the order of the select results.
-    pub project_columns: Vec<ColumnBinding>,
     pub n: usize,
 }
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0100_insert_multi_table_issue_15821.sql
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0100_insert_multi_table_issue_15821.sql
@@ -1,0 +1,69 @@
+
+statement ok
+create or replace database issue_15821;
+
+statement ok
+use issue_15821;
+
+statement ok
+CREATE or replace TABLE tim_hortons_transactions (
+    transaction_id INT,
+    customer_id INT,
+    items VARIANT
+);
+
+
+statement ok
+INSERT INTO tim_hortons_transactions (transaction_id, customer_id, items)
+VALUES
+    (101, 1, parse_json('[{"item":"coffee", "price":2.50}, {"item":"donut", "price":1.20}]')),
+    (102, 2, parse_json('[{"item":"bagel", "price":1.80}, {"item":"muffin", "price":2.00}]')),
+    (103, 3, parse_json('[{"item":"timbit_assortment", "price":5.00}]'));
+
+
+
+
+statement ok
+create or replace table target1 ( id int, customer int, purchased_item string, price float, dummy int);
+
+statement ok
+create or replace table target2 ( id int, customer int, purchased_item string, price float, dummy int);
+
+query TT
+INSERT
+first
+    WHEN
+            (lower(purchased_item) = 'coffee' OR lower(purchased_item) = 'donut') and purchased_item_len > 0
+        THEN
+            INTO target1
+    WHEN
+            (lower(purchased_item) = 'bagel' OR lower(purchased_item) = 'muffin') and purchased_item_len > 0
+        THEN
+            INTO target2
+SELECT transaction_id, customer_id, purchased_item, price, purchased_item_len
+FROM (
+         SELECT
+             t.transaction_id,
+             t.customer_id,
+             f.value:item::STRING AS purchased_item,
+                 length(f.value:item::STRING) AS purchased_item_len,
+             f.value:price::FLOAT AS price
+         FROM
+             tim_hortons_transactions t,
+             LATERAL FLATTEN(input => t.items) f
+     ) data;
+----
+2 2
+
+
+query TTTTT
+select * from target1 order by purchased_item;
+----
+101 1 coffee 6.0 3
+101 1 donut 5.0 1
+
+query TTTTT
+select * from target2 order by purchased_item;
+----
+102 2 bagel 5.0 2
+102 2 muffin 6.0 2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

no need to project before building the pipeline of multi-table insert's `Duplicate` plan.

Predicates of  `ChunkFilter` are "bound to" the output  schema of query, 

https://github.com/datafuselabs/databend/blob/6068e42ceb23c57add7331ddf665063aa5faa4e5/src/query/service/src/interpreters/interpreter_insert_multi_table.rs#L111-L121 

extra projection of the query result is not necessary (and may be harmful).

- Fixes #15821

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15822)
<!-- Reviewable:end -->
