### PR TITLE
fix: uuid() as default value result in copy error.

### DIFF
--- a/src/meta/app/src/principal/file_format.rs
+++ b/src/meta/app/src/principal/file_format.rs
@@ -107,6 +107,18 @@ impl FileFormatParams {
         }
     }
 
+    pub fn need_field_default(&self) -> bool {
+        match self {
+            FileFormatParams::Parquet(v) => v.missing_field_as == NullAs::FieldDefault,
+            FileFormatParams::Csv(v) => v.empty_field_as == EmptyFieldAs::FieldDefault,
+            FileFormatParams::NdJson(v) => {
+                v.null_field_as == NullAs::FieldDefault
+                    || v.missing_field_as == NullAs::FieldDefault
+            }
+            _ => true,
+        }
+    }
+
     pub fn try_from_reader(mut reader: FileFormatOptionsReader, old: bool) -> Result<Self> {
         let typ = reader.take_type()?;
         let params = match typ {

--- a/src/query/storages/parquet/src/parquet_rs/copy_into_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_rs/copy_into_table/table.rs
@@ -147,11 +147,7 @@ impl ParquetTableForCopy {
                                 operator.clone(),
                                 &file_meta_data,
                                 stage_table_info.schema.clone(),
-                                stage_table_info
-                                    .default_values
-                                    .as_ref()
-                                    .expect("default_values must be set for ParquetTableForCopy")
-                                    .clone(),
+                                stage_table_info.default_values.clone(),
                             )?,
                         );
                     }

--- a/src/query/storages/stage/src/read/load_context.rs
+++ b/src/query/storages/stage/src/read/load_context.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use databend_common_catalog::plan::StageTableInfo;
+use databend_common_catalog::query_kind::QueryKind;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::BlockThresholds;
@@ -32,6 +33,7 @@ pub struct LoadContext {
     pub schema: TableSchemaRef,
     pub default_values: Option<Vec<Scalar>>,
     pub pos_projection: Option<Vec<usize>>,
+    pub is_copy: bool,
 
     pub file_format_options_ext: FileFormatOptionsExt,
     pub block_compact_thresholds: BlockThresholds,
@@ -62,12 +64,14 @@ impl LoadContext {
             .collect::<Vec<_>>();
         let schema = TableSchemaRefExt::create(fields);
         let default_values = stage_table_info.default_values.clone();
+        let is_copy = ctx.get_query_kind() == QueryKind::CopyIntoTable;
         Ok(Self {
             table_context: ctx,
             block_compact_thresholds,
             schema,
             default_values,
             pos_projection,
+            is_copy,
             file_format_options_ext,
             error_handler: ErrorHandler {
                 on_error_mode,

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_empty_uuid.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_empty_uuid.test
@@ -1,0 +1,35 @@
+statement ok
+drop table if exists t_uuid
+
+statement ok
+create table t_uuid(id string default uuid(), a int)
+
+statement ok
+remove @data/csv/unload/uuid
+
+query
+copy into @data/csv/unload/uuid/ from (select '',1 )  file_format = (type = CSV)
+----
+1 5 5
+
+query
+copy into t_uuid from @data/csv/unload/uuid file_format = (type = CSV) RETURN_FAILED_ONLY=TRUE
+----
+
+query
+select * from t_uuid
+----
+NULL 1
+
+query
+copy into t_uuid from @data/csv/unload/uuid file_format = (type = CSV  empty_field_as=null) force=true RETURN_FAILED_ONLY=TRUE
+----
+
+query
+select * from t_uuid
+----
+NULL 1
+NULL 1
+
+query error not supported
+copy into t_uuid from @data/csv/unload/uuid file_format = (type = CSV  empty_field_as=field_default)

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_null_and_missing_uuid.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_null_and_missing_uuid.test
@@ -1,0 +1,66 @@
+statement ok
+drop table if exists t_uuid
+
+statement ok
+create table t_uuid(id string default uuid(), a int)
+
+statement ok
+remove @data/ndjson/unload/uuid
+
+query
+copy into @data/ndjson/unload/uuid/ from (select 1 as a)  file_format = (type = ndjson)
+----
+1 8 8
+
+query error Missing value
+copy into t_uuid from @data/ndjson/unload/uuid file_format = (type = ndjson) RETURN_FAILED_ONLY=TRUE
+
+query
+select * from t_uuid
+----
+
+query
+copy into t_uuid from @data/ndjson/unload/uuid file_format = (type = ndjson  missing_field_as=null) force=true RETURN_FAILED_ONLY=TRUE
+----
+
+query
+select * from t_uuid
+----
+NULL 1
+
+query error not supported
+copy into t_uuid from @data/ndjson/unload/uuid file_format = (type = ndjson  missing_field_as=field_default)
+
+
+
+statement ok
+remove @data/ndjson/unload/uuid
+
+query
+copy into @data/ndjson/unload/uuid/ from (select 1 as a, null as id)  file_format = (type = ndjson)
+----
+1 18 18
+
+query
+copy into t_uuid from @data/ndjson/unload/uuid file_format = (type = ndjson) RETURN_FAILED_ONLY=TRUE
+----
+
+query
+select * from t_uuid
+----
+NULL 1
+NULL 1
+
+query
+copy into t_uuid from @data/ndjson/unload/uuid file_format = (type = ndjson  null_field_as=null) force=true RETURN_FAILED_ONLY=TRUE
+----
+
+query
+select * from t_uuid
+----
+NULL 1
+NULL 1
+NULL 1
+
+query error not supported
+copy into t_uuid from @data/ndjson/unload/uuid file_format = (type = ndjson  null_field_as=field_default)

--- a/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_uuid.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_uuid.test
@@ -1,0 +1,24 @@
+statement ok
+drop table if exists t_uuid
+
+statement ok
+create table t_uuid(id string default uuid(), a int)
+
+statement ok
+remove @data/parquet/unload/uuid
+
+query
+copy into @data/parquet/unload/uuid/ from (select 1 as a)  file_format = (type = parquet)
+----
+1 64 377
+
+query error column id doesn't exist
+copy into t_uuid from @data/parquet/unload/uuid file_format = (type = parquet) RETURN_FAILED_ONLY=TRUE
+
+query
+select * from t_uuid
+----
+
+query error not supported
+copy into t_uuid from @data/parquet/unload/uuid file_format = (type = parquet  missing_field_as=field_default)
+

--- a/tests/sqllogictests/suites/stage/formats/tsv/tsv_empty_uuid.test
+++ b/tests/sqllogictests/suites/stage/formats/tsv/tsv_empty_uuid.test
@@ -1,0 +1,16 @@
+statement ok
+drop table if exists t_uuid
+
+statement ok
+create table t_uuid(id string default uuid(), a int)
+
+statement ok
+remove @data/tsv/unload/uuid
+
+query
+copy into @data/tsv/unload/uuid/ from (select '',1 )  file_format = (type = tsv)
+----
+1 3 3
+
+query error not supported
+copy into t_uuid from @data/tsv/unload/uuid file_format = (type = tsv) RETURN_FAILED_ONLY=TRUE


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix: 

```
create table t_uuid(id string default uuid(), a int)
copy into t_uuid(id, a) from .. // panic!
```

the error cases for now we met is  insert with stage using csv.
as a hot fix, problem is not solved totally, but limited the error cases (when format option `(empty|missing)_field_as=field_default` is specified);

I will try to sovle it in another pr.






## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15837)
<!-- Reviewable:end -->
