### PR TITLE
fix(query): to_timestmap should always return err if parse err

### DIFF
--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -273,9 +273,7 @@ fn string_to_format_timestmap(
         .any(|&pattern| format.contains(pattern));
     let res = if ctx.func_ctx.parse_datetime_ignore_remainder {
         let mut parsed = Parsed::new();
-        if parse_and_remainder(&mut parsed, timestamp, StrftimeItems::new(format)).is_err() {
-            return Ok((0, true));
-        }
+        parse_and_remainder(&mut parsed, timestamp, StrftimeItems::new(format))?;
         // Additional checks and adjustments for parsed timestamp
         if parsed.month.is_none() {
             parsed.month = Some(1);

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -1621,4 +1621,3 @@ fn months_between(date_a: i32, date_b: i32) -> f64 {
     // Total difference including fractional part
     total_months_diff as f64 + day_fraction
 }
-

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -1084,10 +1084,8 @@ select to_timestamp('2022年02月04日，8时58分59秒', '');
 ----
 NULL
 
-query T
+statement error 1006
 select to_timestamp('10000-09-09 01:46:39', '%Y-%m-%d %H:%M:%S');
-----
-NULL
 
 statement error 1006
 select to_timestamp('10000-09-09 01:46:39', '%s-%m-%d %H:%M:%S');

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -463,8 +463,11 @@ select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H'
 ----
 2022-02-04 16:00:00.000000
 
-query T
+statement error 1006
 select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+
+query T
+select try_to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
 ----
 NULL
 
@@ -486,8 +489,11 @@ select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H'
 ----
 2022-02-04 00:00:00.000000
 
-query T
+statement error 1006
 select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+
+query T
+select try_to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
 ----
 NULL
 
@@ -509,8 +515,11 @@ select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H'
 ----
 2022-02-04 08:00:00.000000
 
-query T
+statement error 1006
 select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+
+query T
+select try_to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
 ----
 NULL
 

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -456,12 +456,20 @@ statement ok
 set parse_datetime_ignore_remainder=1;
 
 statement ok
+set timezone='UTC';
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 00:58:59.000000
+
+statement ok
 set timezone='Asia/Shanghai';
 
 query T
 select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H');
 ----
-2022-02-04 16:00:00.000000
+2022-02-04 08:00:00.000000
 
 statement error 1006
 select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
@@ -474,12 +482,22 @@ NULL
 query T
 select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时');
 ----
-2022-02-04 16:00:00.000000
+2022-02-04 08:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0900', '%Y年%m月%d日，%H时');
+----
+2022-02-04 08:00:00.000000
 
 query T
 select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
 ----
 2022-02-04 08:58:59.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0900', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 07:58:59.000000
 
 statement ok
 set timezone='America/Los_Angeles';
@@ -487,7 +505,7 @@ set timezone='America/Los_Angeles';
 query T
 select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H');
 ----
-2022-02-04 00:00:00.000000
+2022-02-04 08:00:00.000000
 
 statement error 1006
 select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
@@ -500,7 +518,7 @@ NULL
 query T
 select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时');
 ----
-2022-02-04 00:00:00.000000
+2022-02-04 08:00:00.000000
 
 query T
 select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
@@ -538,3 +556,4 @@ unset timezone;
 
 statement ok
 unset parse_datetime_ignore_remainder;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. to_timestmap should always return err if parse err

If do not want to see err in to_timestamp, could use try_to_timesmtap

2. to_timestmap(string, format), if not asign the string tz or format do not parse tz, the string use with current session timezone

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

-->

- Fixes #https://github.com/datafuselabs/databend/issues/15849


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15850)
<!-- Reviewable:end -->
