### PR TITLE
chore(query): string_to_date/ts should not ignore error

### DIFF
--- a/src/common/io/src/cursor_ext/cursor_read_datetime_ext.rs
+++ b/src/common/io/src/cursor_ext/cursor_read_datetime_ext.rs
@@ -80,7 +80,7 @@ where T: AsRef<[u8]>
         let mut v =
             std::str::from_utf8(buf.as_slice()).map_err_to_code(ErrorCode::BadBytes, || {
                 format!(
-                    "UTF-8 Conversion Failed: Unable to convert value {:?} to UTF-8.",
+                    "UTF-8 Conversion Failed: Unable to convert value {:?} to UTF-8",
                     buf
                 )
             })?;
@@ -93,7 +93,7 @@ where T: AsRef<[u8]>
             .parse::<NaiveDate>()
             .map_err_to_code(ErrorCode::BadBytes, || {
                 format!(
-                    "Date Parsing Error: The value '{}' could not be parsed into a valid Date.",
+                    "Date Parsing Error: The value '{}' could not be parsed into a valid Date",
                     v
                 )
             })?;
@@ -148,7 +148,7 @@ where T: AsRef<[u8]>
                 let size = self.keep_read(&mut buf, |f| f.is_ascii_digit());
                 if size == 0 {
                     return Err(ErrorCode::BadBytes(
-                        "Microsecond Parsing Error: Expecting a format like [.123456] for microseconds part.",
+                        "Microsecond Parsing Error: Expecting a format like [.123456] for microseconds part",
                     ));
                 }
                 let mut scales: i64 =
@@ -238,14 +238,14 @@ where T: AsRef<[u8]>
                             Ok(DateTimeResType::Date(d))
                         } else {
                             Err(ErrorCode::BadBytes(format!(
-                                "Local Time Error: No valid local time found for timezone '{:?}' with date '{}'.",
+                                "Local Time Error: No valid local time found for timezone '{:?}' with date '{}'",
                                 tz, d
                             )))
                         }
                     }
                     LocalResult::Single(t) => Ok(DateTimeResType::Datetime(t)),
                     LocalResult::Ambiguous(t1, t2) => Err(ErrorCode::BadBytes(format!(
-                        "Ambiguous Local Time: The local time is ambiguous, with possible times ranging from {:?} to {:?}.",
+                        "Ambiguous Local Time: The local time is ambiguous, with possible times ranging from {:?} to {:?}",
                         t1, t2
                     ))),
                 }
@@ -293,7 +293,7 @@ where T: AsRef<[u8]>
                 }
             } else {
                 Err(ErrorCode::BadBytes(format!(
-                    "Invalid Timezone Offset: The minute offset '{}' is outside the valid range. Expected range is [00-59] within a timezone gap of [-14:00, +14:00].",
+                    "Invalid Timezone Offset: The minute offset '{}' is outside the valid range. Expected range is [00-59] within a timezone gap of [-14:00, +14:00]",
                     minute_offset
                 )))
             }
@@ -309,7 +309,7 @@ where T: AsRef<[u8]>
                         if self.keep_read(buf, |f| f.is_ascii_digit()) != 2 {
                             // +08[other byte]00 will err in there, e.g. +08-00
                             return Err(ErrorCode::BadBytes(
-                                "Timezone Parsing Error: Incorrect format in hour part. The time zone format must conform to the ISO 8601 standard.",
+                                "Timezone Parsing Error: Incorrect format in hour part. The time zone format must conform to the ISO 8601 standard",
                             ));
                         }
                         let minute_offset: i32 =
@@ -328,7 +328,7 @@ where T: AsRef<[u8]>
                     }
                 } else {
                     Err(ErrorCode::BadBytes(format!(
-                        "Invalid Timezone Offset: The hour offset '{}' is outside the valid range. Expected range is [00-14] within a timezone gap of [-14:00, +14:00].",
+                        "Invalid Timezone Offset: The hour offset '{}' is outside the valid range. Expected range is [00-14] within a timezone gap of [-14:00, +14:00]",
                         hour_offset
                     )))
                 }
@@ -353,13 +353,13 @@ where T: AsRef<[u8]>
                     )
                 } else {
                     Err(ErrorCode::BadBytes(format!(
-                        "Invalid Timezone Offset: The hour offset '{}' is outside the valid range. Expected range is [00-14] within a timezone gap of [-14:00, +14:00].",
+                        "Invalid Timezone Offset: The hour offset '{}' is outside the valid range. Expected range is [00-14] within a timezone gap of [-14:00, +14:00]",
                         hour_offset
                     )))
                 }
             }
             _ => Err(ErrorCode::BadBytes(
-                "Timezone Parsing Error: Incorrect format. The time zone format must conform to the ISO 8601 standard.",
+                "Timezone Parsing Error: Incorrect format. The time zone format must conform to the ISO 8601 standard",
             )),
         }
     }

--- a/src/query/expression/src/types/date.rs
+++ b/src/query/expression/src/types/date.rs
@@ -253,9 +253,12 @@ pub fn string_to_date(
     match reader.read_date_text(&tz) {
         Ok(d) => match reader.must_eof() {
             Ok(..) => Ok(d),
-            Err(_) => Err(ErrorCode::BadArguments("")),
+            Err(_) => Err(ErrorCode::BadArguments("unexpected argument")),
         },
-        Err(e) => Err(e),
+        Err(e) => match e.code() {
+            ErrorCode::BAD_BYTES => Err(e),
+            _ => Err(ErrorCode::BadArguments("unexpected argument")),
+        },
     }
 }
 

--- a/src/query/expression/src/types/date.rs
+++ b/src/query/expression/src/types/date.rs
@@ -19,6 +19,7 @@ use std::ops::Range;
 use chrono::NaiveDate;
 use chrono_tz::Tz;
 use databend_common_arrow::arrow::buffer::Buffer;
+use databend_common_exception::ErrorCode;
 use databend_common_io::cursor_ext::BufferReadDateTimeExt;
 use databend_common_io::cursor_ext::ReadBytesExt;
 use num_traits::AsPrimitive;
@@ -244,14 +245,17 @@ impl ArgType for DateType {
 }
 
 #[inline]
-pub fn string_to_date(date_str: impl AsRef<[u8]>, tz: Tz) -> Option<NaiveDate> {
+pub fn string_to_date(
+    date_str: impl AsRef<[u8]>,
+    tz: Tz,
+) -> databend_common_exception::Result<NaiveDate> {
     let mut reader = Cursor::new(std::str::from_utf8(date_str.as_ref()).unwrap().as_bytes());
     match reader.read_date_text(&tz) {
         Ok(d) => match reader.must_eof() {
-            Ok(..) => Some(d),
-            Err(_) => None,
+            Ok(..) => Ok(d),
+            Err(e) => Err(ErrorCode::BadArguments(format!("{}", e))),
         },
-        Err(_) => None,
+        Err(e) => Err(e),
     }
 }
 

--- a/src/query/expression/src/types/date.rs
+++ b/src/query/expression/src/types/date.rs
@@ -253,7 +253,7 @@ pub fn string_to_date(
     match reader.read_date_text(&tz) {
         Ok(d) => match reader.must_eof() {
             Ok(..) => Ok(d),
-            Err(e) => Err(ErrorCode::BadArguments(format!("{}", e))),
+            Err(_) => Err(ErrorCode::BadArguments("")),
         },
         Err(e) => Err(e),
     }

--- a/src/query/expression/src/types/timestamp.rs
+++ b/src/query/expression/src/types/timestamp.rs
@@ -269,7 +269,7 @@ pub fn string_to_timestamp(
         Ok(dt) => match dt {
             DateTimeResType::Datetime(dt) => match reader.must_eof() {
                 Ok(..) => Ok(dt),
-                Err(e) => Err(ErrorCode::BadArguments(format!("{}", e))),
+                Err(_) => Err(ErrorCode::BadArguments("")),
             },
             _ => unreachable!(),
         },

--- a/src/query/expression/src/types/timestamp.rs
+++ b/src/query/expression/src/types/timestamp.rs
@@ -19,6 +19,7 @@ use std::ops::Range;
 use chrono::DateTime;
 use chrono_tz::Tz;
 use databend_common_arrow::arrow::buffer::Buffer;
+use databend_common_exception::ErrorCode;
 use databend_common_io::cursor_ext::BufferReadDateTimeExt;
 use databend_common_io::cursor_ext::DateTimeResType;
 use databend_common_io::cursor_ext::ReadBytesExt;
@@ -259,17 +260,20 @@ pub fn microseconds_to_days(micros: i64) -> i32 {
 }
 
 #[inline]
-pub fn string_to_timestamp(ts_str: impl AsRef<[u8]>, tz: Tz) -> Option<DateTime<Tz>> {
+pub fn string_to_timestamp(
+    ts_str: impl AsRef<[u8]>,
+    tz: Tz,
+) -> databend_common_exception::Result<DateTime<Tz>> {
     let mut reader = Cursor::new(std::str::from_utf8(ts_str.as_ref()).unwrap().as_bytes());
     match reader.read_timestamp_text(&tz, false) {
         Ok(dt) => match dt {
             DateTimeResType::Datetime(dt) => match reader.must_eof() {
-                Ok(..) => Some(dt),
-                Err(_) => None,
+                Ok(..) => Ok(dt),
+                Err(e) => Err(ErrorCode::BadArguments(format!("{}", e))),
             },
             _ => unreachable!(),
         },
-        Err(_) => None,
+        Err(e) => Err(e),
     }
 }
 

--- a/src/query/expression/src/types/timestamp.rs
+++ b/src/query/expression/src/types/timestamp.rs
@@ -269,11 +269,14 @@ pub fn string_to_timestamp(
         Ok(dt) => match dt {
             DateTimeResType::Datetime(dt) => match reader.must_eof() {
                 Ok(..) => Ok(dt),
-                Err(_) => Err(ErrorCode::BadArguments("")),
+                Err(_) => Err(ErrorCode::BadArguments("unexpected argument")),
             },
             _ => unreachable!(),
         },
-        Err(e) => Err(e),
+        Err(e) => match e.code() {
+            ErrorCode::BAD_BYTES => Err(e),
+            _ => Err(ErrorCode::BadArguments("unexpected argument")),
+        },
     }
 }
 

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -455,10 +455,7 @@ fn register_string_to_date(registry: &mut FunctionRegistry) {
             |val, output, ctx| match string_to_date(val, ctx.func_ctx.tz.tz) {
                 Ok(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
                 Err(e) => {
-                    ctx.set_error(
-                        output.len(),
-                        format!("cannot parse to type `DATE`. {}", e),
-                    );
+                    ctx.set_error(output.len(), format!("cannot parse to type `DATE`. {}", e));
                     output.push(0);
                 }
             },

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -157,9 +157,12 @@ fn register_string_to_timestamp(registry: &mut FunctionRegistry) {
     ) -> Value<TimestampType> {
         vectorize_with_builder_1_arg::<StringType, TimestampType>(|val, output, ctx| {
             match string_to_timestamp(val, ctx.func_ctx.tz.tz) {
-                Some(ts) => output.push(ts.timestamp_micros()),
-                None => {
-                    ctx.set_error(output.len(), "cannot parse to type `TIMESTAMP`");
+                Ok(ts) => output.push(ts.timestamp_micros()),
+                Err(e) => {
+                    ctx.set_error(
+                        output.len(),
+                        format!("cannot parse to type `TIMESTAMP`, error is {}", e),
+                    );
                     output.push(0);
                 }
             }
@@ -450,9 +453,12 @@ fn register_string_to_date(registry: &mut FunctionRegistry) {
     fn eval_string_to_date(val: ValueRef<StringType>, ctx: &mut EvalContext) -> Value<DateType> {
         vectorize_with_builder_1_arg::<StringType, DateType>(
             |val, output, ctx| match string_to_date(val, ctx.func_ctx.tz.tz) {
-                Some(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
-                None => {
-                    ctx.set_error(output.len(), "cannot parse to type `DATE`");
+                Ok(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
+                Err(e) => {
+                    ctx.set_error(
+                        output.len(),
+                        format!("cannot parse to type `DATE`, error is {}", e),
+                    );
                     output.push(0);
                 }
             },

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -161,7 +161,7 @@ fn register_string_to_timestamp(registry: &mut FunctionRegistry) {
                 Err(e) => {
                     ctx.set_error(
                         output.len(),
-                        format!("cannot parse to type `TIMESTAMP`, error is {}", e),
+                        format!("cannot parse to type `TIMESTAMP`. {}", e),
                     );
                     output.push(0);
                 }
@@ -457,7 +457,7 @@ fn register_string_to_date(registry: &mut FunctionRegistry) {
                 Err(e) => {
                     ctx.set_error(
                         output.len(),
-                        format!("cannot parse to type `DATE`, error is {}", e),
+                        format!("cannot parse to type `DATE`. {}", e),
                     );
                     output.push(0);
                 }

--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -997,8 +997,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                     return;
                 }
             }
-            match as_str(val).and_then(|val| string_to_date(val.as_bytes(), ctx.func_ctx.tz.tz)) {
-                Some(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
+            let val = as_str(val);
+            match val {
+                Some(val) => match string_to_date(val.as_bytes(), ctx.func_ctx.tz.tz) {
+                    Ok(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
+                    Err(e) => {
+                        ctx.set_error(
+                            output.len(),
+                            format!("unable to cast to type `DATE`, error is {}", e),
+                        );
+                        output.push(0);
+                    }
+                },
                 None => {
                     ctx.set_error(output.len(), "unable to cast to type `DATE`");
                     output.push(0);
@@ -1017,10 +1027,12 @@ pub fn register(registry: &mut FunctionRegistry) {
                     return;
                 }
             }
-            match as_str(val)
-                .and_then(|str_value| string_to_date(str_value.as_bytes(), ctx.func_ctx.tz.tz))
-            {
-                Some(date) => output.push(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
+            let val = as_str(val);
+            match val {
+                Some(val) => match string_to_date(val.as_bytes(), ctx.func_ctx.tz.tz) {
+                    Ok(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
+                    Err(_) => output.push_null(),
+                },
                 None => output.push_null(),
             }
         }),
@@ -1036,10 +1048,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                     return;
                 }
             }
-            match as_str(val)
-                .and_then(|val| string_to_timestamp(val.as_bytes(), ctx.func_ctx.tz.tz))
-            {
-                Some(ts) => output.push(ts.timestamp_micros()),
+            let val = as_str(val);
+            match val {
+                Some(val) => match string_to_timestamp(val.as_bytes(), ctx.func_ctx.tz.tz) {
+                    Ok(ts) => output.push(ts.timestamp_micros()),
+                    Err(e) => {
+                        ctx.set_error(
+                            output.len(),
+                            format!("unable to cast to type `TIMESTAMP`, error is {}", e),
+                        );
+                        output.push(0);
+                    }
+                },
                 None => {
                     ctx.set_error(output.len(), "unable to cast to type `TIMESTAMP`");
                     output.push(0);
@@ -1059,11 +1079,17 @@ pub fn register(registry: &mut FunctionRegistry) {
                         return;
                     }
                 }
-                match as_str(val)
-                    .and_then(|val| string_to_timestamp(val.as_bytes(), ctx.func_ctx.tz.tz))
-                {
-                    Some(ts) => output.push(ts.timestamp_micros()),
-                    None => output.push_null(),
+                let val = as_str(val);
+                match val {
+                    Some(val) => match string_to_timestamp(val.as_bytes(), ctx.func_ctx.tz.tz) {
+                        Ok(ts) => output.push(ts.timestamp_micros()),
+                        Err(_) => {
+                            output.push_null();
+                        }
+                    },
+                    None => {
+                        output.push_null();
+                    }
                 }
             },
         ),

--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -1004,7 +1004,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     Err(e) => {
                         ctx.set_error(
                             output.len(),
-                            format!("unable to cast to type `DATE`, error is {}", e),
+                            format!("unable to cast to type `DATE`. {}", e),
                         );
                         output.push(0);
                     }
@@ -1055,7 +1055,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     Err(e) => {
                         ctx.set_error(
                             output.len(),
-                            format!("unable to cast to type `TIMESTAMP`, error is {}", e),
+                            format!("unable to cast to type `TIMESTAMP`. {}", e),
                         );
                         output.push(0);
                     }

--- a/src/query/functions/tests/it/scalars/testdata/cast.txt
+++ b/src/query/functions/tests/it/scalars/testdata/cast.txt
@@ -1362,7 +1362,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_TIMESTAMP('2022')
-  | ^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP` while evaluating function `to_timestamp('2022')`
+  | ^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('2022')`
 
 
 
@@ -1370,7 +1370,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_TIMESTAMP('2022-01')
-  | ^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP` while evaluating function `to_timestamp('2022-01')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('2022-01')`
 
 
 
@@ -1387,7 +1387,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_TIMESTAMP('A NON-TIMESTAMP STR')
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP` while evaluating function `to_timestamp('A NON-TIMESTAMP STR')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`, error is BadBytes. Code: 1046, Text = Date Parsing Error: The value 'A NON-TIME' could not be parsed into a valid Date., cause: input contains invalid characters. while evaluating function `to_timestamp('A NON-TIMESTAMP STR')`
 
 
 
@@ -1562,7 +1562,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_DATE('2022')
-  | ^^^^^^^^^^^^^^^ cannot parse to type `DATE` while evaluating function `to_date('2022')`
+  | ^^^^^^^^^^^^^^^ cannot parse to type `DATE`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('2022')`
 
 
 
@@ -1570,7 +1570,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_DATE('2022-01')
-  | ^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE` while evaluating function `to_date('2022-01')`
+  | ^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('2022-01')`
 
 
 
@@ -1587,7 +1587,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_DATE('A NON-DATE STR')
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE` while evaluating function `to_date('A NON-DATE STR')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE`, error is BadBytes. Code: 1046, Text = Date Parsing Error: The value 'A NON-DATE' could not be parsed into a valid Date., cause: input contains invalid characters. while evaluating function `to_date('A NON-DATE STR')`
 
 
 

--- a/src/query/functions/tests/it/scalars/testdata/cast.txt
+++ b/src/query/functions/tests/it/scalars/testdata/cast.txt
@@ -1362,7 +1362,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_TIMESTAMP('2022')
-  | ^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('2022')`
+  | ^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`. BadArguments. Code: 1006, Text = unexpected argument. while evaluating function `to_timestamp('2022')`
 
 
 
@@ -1370,7 +1370,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_TIMESTAMP('2022-01')
-  | ^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('2022-01')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`. BadArguments. Code: 1006, Text = unexpected argument. while evaluating function `to_timestamp('2022-01')`
 
 
 
@@ -1562,7 +1562,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_DATE('2022')
-  | ^^^^^^^^^^^^^^^ cannot parse to type `DATE`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('2022')`
+  | ^^^^^^^^^^^^^^^ cannot parse to type `DATE`. BadArguments. Code: 1006, Text = unexpected argument. while evaluating function `to_date('2022')`
 
 
 
@@ -1570,7 +1570,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_DATE('2022-01')
-  | ^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('2022-01')`
+  | ^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE`. BadArguments. Code: 1006, Text = unexpected argument. while evaluating function `to_date('2022-01')`
 
 
 

--- a/src/query/functions/tests/it/scalars/testdata/cast.txt
+++ b/src/query/functions/tests/it/scalars/testdata/cast.txt
@@ -1362,7 +1362,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_TIMESTAMP('2022')
-  | ^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('2022')`
+  | ^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('2022')`
 
 
 
@@ -1370,7 +1370,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_TIMESTAMP('2022-01')
-  | ^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('2022-01')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('2022-01')`
 
 
 
@@ -1387,7 +1387,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_TIMESTAMP('A NON-TIMESTAMP STR')
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`, error is BadBytes. Code: 1046, Text = Date Parsing Error: The value 'A NON-TIME' could not be parsed into a valid Date., cause: input contains invalid characters. while evaluating function `to_timestamp('A NON-TIMESTAMP STR')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `TIMESTAMP`. BadBytes. Code: 1046, Text = Date Parsing Error: The value 'A NON-TIME' could not be parsed into a valid Date, cause: input contains invalid characters. while evaluating function `to_timestamp('A NON-TIMESTAMP STR')`
 
 
 
@@ -1562,7 +1562,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_DATE('2022')
-  | ^^^^^^^^^^^^^^^ cannot parse to type `DATE`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('2022')`
+  | ^^^^^^^^^^^^^^^ cannot parse to type `DATE`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('2022')`
 
 
 
@@ -1570,7 +1570,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_DATE('2022-01')
-  | ^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('2022-01')`
+  | ^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('2022-01')`
 
 
 
@@ -1587,7 +1587,7 @@ error:
   --> SQL:1:1
   |
 1 | TO_DATE('A NON-DATE STR')
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE`, error is BadBytes. Code: 1046, Text = Date Parsing Error: The value 'A NON-DATE' could not be parsed into a valid Date., cause: input contains invalid characters. while evaluating function `to_date('A NON-DATE STR')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot parse to type `DATE`. BadBytes. Code: 1046, Text = Date Parsing Error: The value 'A NON-DATE' could not be parsed into a valid Date, cause: input contains invalid characters. while evaluating function `to_date('A NON-DATE STR')`
 
 
 

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -1625,7 +1625,7 @@ error:
   --> SQL:1:1
   |
 1 | to_date(parse_json('"abc"'))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `DATE`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('"abc"')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `DATE`. BadArguments. Code: 1006, Text = unexpected argument. while evaluating function `to_date('"abc"')`
 
 
 
@@ -1642,7 +1642,7 @@ error:
   --> SQL:1:1
   |
 1 | to_timestamp(parse_json('"abc"'))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `TIMESTAMP`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('"abc"')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `TIMESTAMP`. BadArguments. Code: 1006, Text = unexpected argument. while evaluating function `to_timestamp('"abc"')`
 
 
 

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -1625,7 +1625,7 @@ error:
   --> SQL:1:1
   |
 1 | to_date(parse_json('"abc"'))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `DATE` while evaluating function `to_date('"abc"')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `DATE`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('"abc"')`
 
 
 
@@ -1642,7 +1642,7 @@ error:
   --> SQL:1:1
   |
 1 | to_timestamp(parse_json('"abc"'))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `TIMESTAMP` while evaluating function `to_timestamp('"abc"')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `TIMESTAMP`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('"abc"')`
 
 
 

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -1625,7 +1625,7 @@ error:
   --> SQL:1:1
   |
 1 | to_date(parse_json('"abc"'))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `DATE`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('"abc"')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `DATE`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_date('"abc"')`
 
 
 
@@ -1642,7 +1642,7 @@ error:
   --> SQL:1:1
   |
 1 | to_timestamp(parse_json('"abc"'))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `TIMESTAMP`, error is StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('"abc"')`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to cast to type `TIMESTAMP`. StorageOther. Code: 4000, Text = unexpected end of file (failed to fill whole buffer). while evaluating function `to_timestamp('"abc"')`
 
 
 

--- a/tests/sqllogictests/suites/base/03_common/03_0023_insert_into_array.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0023_insert_into_array.test
@@ -257,7 +257,7 @@ CREATE TABLE t12(id Int, arr Array(Date)) Engine = Fuse
 statement ok
 INSERT INTO t12 (id, arr) VALUES(1, ['2021-01-01', '2022-01-01']), (2, ['1990-12-01', '2030-01-12'])
 
-statement error (?s).*cannot parse to type `DATE`, error is
+statement error (?s).*cannot parse to type `DATE`.
 INSERT INTO t12 (id, arr) VALUES(3, ['1000000-01-01', '2000000-01-01'])
 
 query IT
@@ -281,7 +281,7 @@ CREATE TABLE t13(id Int, arr Array(Timestamp)) Engine = Fuse
 statement ok
 INSERT INTO t13 (id, arr) VALUES(1, ['2021-01-01 01:01:01', '2022-01-01 01:01:01']), (2, ['1990-12-01 10:11:12', '2030-01-12 22:00:00'])
 
-statement error (?s).*cannot parse to type `TIMESTAMP`, error is
+statement error (?s).*cannot parse to type `TIMESTAMP`.
 INSERT INTO t13 (id, arr) VALUES(3, ['1000000-01-01 01:01:01', '2000000-01-01 01:01:01'])
 
 query IT

--- a/tests/sqllogictests/suites/base/03_common/03_0023_insert_into_array.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0023_insert_into_array.test
@@ -257,7 +257,7 @@ CREATE TABLE t12(id Int, arr Array(Date)) Engine = Fuse
 statement ok
 INSERT INTO t12 (id, arr) VALUES(1, ['2021-01-01', '2022-01-01']), (2, ['1990-12-01', '2030-01-12'])
 
-statement error (?s)1006.*cannot parse to type `DATE` while evaluating function `to_date\('1000000\-01\-01'\)`
+statement error (?s).*cannot parse to type `DATE`, error is
 INSERT INTO t12 (id, arr) VALUES(3, ['1000000-01-01', '2000000-01-01'])
 
 query IT
@@ -281,7 +281,7 @@ CREATE TABLE t13(id Int, arr Array(Timestamp)) Engine = Fuse
 statement ok
 INSERT INTO t13 (id, arr) VALUES(1, ['2021-01-01 01:01:01', '2022-01-01 01:01:01']), (2, ['1990-12-01 10:11:12', '2030-01-12 22:00:00'])
 
-statement error (?s)1006.*cannot parse to type `TIMESTAMP` while evaluating function `to_timestamp\('1000000\-01\-01 01:01:01'\)`
+statement error (?s).*cannot parse to type `TIMESTAMP`, error is
 INSERT INTO t13 (id, arr) VALUES(3, ['1000000-01-01 01:01:01', '2000000-01-01 01:01:01'])
 
 query IT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- Fixes #[Link the issue here]
-->

string_to_date/ts should not ignore error

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15878)
<!-- Reviewable:end -->
