### PR TITLE
fix: merge into unresolved conflict

### DIFF
--- a/src/query/catalog/src/lock.rs
+++ b/src/query/catalog/src/lock.rs
@@ -20,6 +20,13 @@ use databend_common_pipeline_core::LockGuard;
 
 use crate::table_context::TableContext;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LockTableOption {
+    NoLock,
+    LockWithRetry,
+    LockNoRetry,
+}
+
 #[async_trait::async_trait]
 pub trait Lock: Sync + Send {
     fn lock_type(&self) -> LockType;
@@ -34,5 +41,5 @@ pub trait Lock: Sync + Send {
         &self,
         ctx: Arc<dyn TableContext>,
         should_retry: bool,
-    ) -> Result<Option<LockGuard>>;
+    ) -> Result<Option<Arc<LockGuard>>>;
 }

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -47,6 +47,7 @@ use databend_common_meta_app::storage::StorageParams;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_pipeline_core::processors::PlanProfile;
 use databend_common_pipeline_core::InputError;
+use databend_common_pipeline_core::LockGuard;
 use databend_common_settings::Settings;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::DataOperator;
@@ -65,6 +66,7 @@ use xorf::BinaryFuse16;
 
 use crate::catalog::Catalog;
 use crate::cluster_info::Cluster;
+use crate::lock::LockTableOption;
 use crate::merge_into_join::MergeIntoJoin;
 use crate::plan::DataSourcePlan;
 use crate::plan::PartInfoPtr;
@@ -339,4 +341,12 @@ pub trait TableContext: Send + Sync {
     ) -> Result<Arc<dyn Table>> {
         unimplemented!()
     }
+
+    async fn acquire_table_lock(
+        self: Arc<Self>,
+        catalog_name: &str,
+        db_name: &str,
+        tbl_name: &str,
+        lock_opt: &LockTableOption,
+    ) -> Result<Option<Arc<LockGuard>>>;
 }

--- a/src/query/ee/tests/it/inverted_index/index_refresh.rs
+++ b/src/query/ee/tests/it/inverted_index/index_refresh.rs
@@ -20,7 +20,6 @@ use databend_common_catalog::table::TableExt;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableIndexReq;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::RefreshTableIndexPlan;
 use databend_common_storages_fuse::io::read::InvertedIndexReader;
 use databend_common_storages_fuse::io::MetaReaders;
@@ -87,7 +86,6 @@ async fn test_fuse_do_refresh_inverted_index() -> Result<()> {
         table: fixture.default_table_name(),
         index_name: index_name.clone(),
         segment_locs: None,
-        lock_opt: LockTableOption::LockWithRetry,
     };
     let interpreter = RefreshTableIndexInterpreter::try_create(ctx.clone(), refresh_index_plan)?;
     let _ = interpreter.execute(ctx.clone()).await?;

--- a/src/query/ee/tests/it/inverted_index/pruning.rs
+++ b/src/query/ee/tests/it/inverted_index/pruning.rs
@@ -36,7 +36,6 @@ use databend_common_expression::TableSchemaRefExt;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableIndexReq;
 use databend_common_sql::plans::CreateTablePlan;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::RefreshTableIndexPlan;
 use databend_common_sql::BloomIndexColumns;
 use databend_common_storages_fuse::pruning::create_segment_location_vector;
@@ -526,7 +525,6 @@ async fn test_block_pruner() -> Result<()> {
         table: test_tbl_name.to_string(),
         index_name: index_name.clone(),
         segment_locs: None,
-        lock_opt: LockTableOption::LockWithRetry,
     };
     let interpreter = RefreshTableIndexInterpreter::try_create(ctx.clone(), refresh_index_plan)?;
     let _ = interpreter.execute(ctx.clone()).await?;

--- a/src/query/pipeline/core/src/pipeline.rs
+++ b/src/query/pipeline/core/src/pipeline.rs
@@ -66,7 +66,7 @@ pub struct Pipeline {
     max_threads: usize,
     pub pipes: Vec<Pipe>,
     on_init: Option<InitCallback>,
-    lock_guards: Vec<LockGuard>,
+    lock_guards: Vec<Arc<LockGuard>>,
 
     on_finished_chain: FinishedCallbackChain,
 
@@ -205,13 +205,13 @@ impl Pipeline {
         }
     }
 
-    pub fn add_lock_guard(&mut self, guard: Option<LockGuard>) {
+    pub fn add_lock_guard(&mut self, guard: Option<Arc<LockGuard>>) {
         if let Some(guard) = guard {
             self.lock_guards.push(guard);
         }
     }
 
-    pub fn take_lock_guards(&mut self) -> Vec<LockGuard> {
+    pub fn take_lock_guards(&mut self) -> Vec<Arc<LockGuard>> {
         std::mem::take(&mut self.lock_guards)
     }
 

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -16,13 +16,13 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use databend_common_base::runtime::GlobalIORuntime;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::table::CompactionLimits;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_pipeline_core::ExecutionInfo;
 use databend_common_pipeline_core::Pipeline;
 use databend_common_sql::executor::physical_plans::MutationKind;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::OptimizeTableAction;
 use databend_common_sql::plans::OptimizeTablePlan;
 use log::info;
@@ -171,6 +171,7 @@ async fn compact_table(
         ctx.clear_segment_locations()?;
         ctx.set_executor(complete_executor.get_inner())?;
         complete_executor.execute()?;
+        drop(complete_executor);
 
         // reset the progress value
         ctx.get_write_progress().set(&progress_value);

--- a/src/query/service/src/interpreters/hook/hook.rs
+++ b/src/query/service/src/interpreters/hook/hook.rs
@@ -15,10 +15,10 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_pipeline_core::Pipeline;
 use databend_common_sql::executor::physical_plans::MutationKind;
-use databend_common_sql::plans::LockTableOption;
 use log::info;
 use log::warn;
 
@@ -123,12 +123,6 @@ impl HookOperator {
             table: self.table.to_owned(),
         };
 
-        hook_refresh(
-            self.ctx.clone(),
-            pipeline,
-            refresh_desc,
-            self.lock_opt.clone(),
-        )
-        .await;
+        hook_refresh(self.ctx.clone(), pipeline, refresh_desc).await;
     }
 }

--- a/src/query/service/src/interpreters/hook/refresh_hook.rs
+++ b/src/query/service/src/interpreters/hook/refresh_hook.rs
@@ -26,7 +26,6 @@ use databend_common_meta_app::schema::ListVirtualColumnsReq;
 use databend_common_meta_types::MetaId;
 use databend_common_pipeline_core::ExecutionInfo;
 use databend_common_pipeline_core::Pipeline;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::Plan;
 use databend_common_sql::plans::RefreshIndexPlan;
 use databend_common_sql::plans::RefreshTableIndexPlan;
@@ -55,12 +54,7 @@ pub struct RefreshDesc {
 
 /// Hook refresh action with a on-finished callback.
 /// errors (if any) are ignored.
-pub async fn hook_refresh(
-    ctx: Arc<QueryContext>,
-    pipeline: &mut Pipeline,
-    desc: RefreshDesc,
-    lock_opt: LockTableOption,
-) {
+pub async fn hook_refresh(ctx: Arc<QueryContext>, pipeline: &mut Pipeline, desc: RefreshDesc) {
     if pipeline.is_empty() {
         return;
     }
@@ -68,7 +62,7 @@ pub async fn hook_refresh(
     pipeline.set_on_finished(move |info: &ExecutionInfo| {
         if info.res.is_ok() {
             info!("execute pipeline finished successfully, starting run refresh job.");
-            match GlobalIORuntime::instance().block_on(do_refresh(ctx, desc, lock_opt)) {
+            match GlobalIORuntime::instance().block_on(do_refresh(ctx, desc)) {
                 Ok(_) => {
                     info!("execute refresh job successfully.");
                 }
@@ -81,11 +75,7 @@ pub async fn hook_refresh(
     });
 }
 
-async fn do_refresh(
-    ctx: Arc<QueryContext>,
-    desc: RefreshDesc,
-    lock_opt: LockTableOption,
-) -> Result<()> {
+async fn do_refresh(ctx: Arc<QueryContext>, desc: RefreshDesc) -> Result<()> {
     let table = ctx
         .get_table(&desc.catalog, &desc.database, &desc.table)
         .await?;
@@ -105,7 +95,7 @@ async fn do_refresh(
 
     // Generate sync inverted indexes.
     let inverted_index_plans =
-        generate_refresh_inverted_index_plan(ctx.clone(), &desc, table.clone(), lock_opt).await?;
+        generate_refresh_inverted_index_plan(ctx.clone(), &desc, table).await?;
     plans.extend_from_slice(&inverted_index_plans);
 
     // Generate virtual columns.
@@ -269,7 +259,6 @@ async fn generate_refresh_inverted_index_plan(
     ctx: Arc<QueryContext>,
     desc: &RefreshDesc,
     table: Arc<dyn Table>,
-    lock_opt: LockTableOption,
 ) -> Result<Vec<Plan>> {
     let segment_locs = ctx.get_segment_locations()?;
     let mut plans = vec![];
@@ -285,7 +274,6 @@ async fn generate_refresh_inverted_index_plan(
             table: desc.table.clone(),
             index_name: index.name.clone(),
             segment_locs: Some(segment_locs.clone()),
-            lock_opt: lock_opt.clone(),
         };
         plans.push(Plan::RefreshTableIndex(Box::new(plan)));
     }

--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_exception::Result;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::types::StringType;
@@ -31,7 +32,6 @@ use databend_common_sql::executor::physical_plans::MutationKind;
 use databend_common_sql::executor::physical_plans::TableScan;
 use databend_common_sql::executor::table_read_plan::ToReadDataSourcePlan;
 use databend_common_sql::executor::PhysicalPlan;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_storage::StageFileInfo;
 use databend_common_storages_stage::StageTable;
 use log::debug;

--- a/src/query/service/src/interpreters/interpreter_delete.rs
+++ b/src/query/service/src/interpreters/interpreter_delete.rs
@@ -17,6 +17,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use databend_common_base::base::ProgressValues;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::plan::Filters;
 use databend_common_catalog::plan::PartInfoType;
 use databend_common_catalog::plan::Partitions;
@@ -48,7 +49,6 @@ use databend_common_sql::plans::BoundColumnRef;
 use databend_common_sql::plans::ConstantExpr;
 use databend_common_sql::plans::EvalScalar;
 use databend_common_sql::plans::FunctionCall;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::RelOperator;
 use databend_common_sql::plans::ScalarItem;
 use databend_common_sql::plans::SubqueryDesc;
@@ -113,23 +113,10 @@ impl Interpreter for DeleteInterpreter {
         let db_name = self.plan.database_name.as_str();
         let tbl_name = self.plan.table_name.as_str();
 
-        // Add table lock.
-        let lock_guard = self
-            .ctx
-            .clone()
-            .acquire_table_lock(
-                catalog_name,
-                db_name,
-                tbl_name,
-                &LockTableOption::LockWithRetry,
-            )
-            .await?;
-
         let catalog = self.ctx.get_catalog(catalog_name).await?;
         let catalog_info = catalog.info();
-        let tbl = catalog
-            .get_table(&self.ctx.get_tenant(), db_name, tbl_name)
-            .await?;
+
+        let tbl = self.ctx.get_table(catalog_name, db_name, tbl_name).await?;
 
         // check mutability
         tbl.check_mutable()?;
@@ -224,7 +211,9 @@ impl Interpreter for DeleteInterpreter {
             return Ok(build_res);
         }
 
-        build_res.main_pipeline.add_lock_guard(lock_guard);
+        build_res
+            .main_pipeline
+            .add_lock_guard(self.plan.lock_guard.clone());
         // check if unconditional deletion
         let Some(filters) = filters else {
             let progress_values = ProgressValues {

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -15,6 +15,7 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::table::AppendMode;
 use databend_common_catalog::table::TableExt;
 use databend_common_exception::ErrorCode;
@@ -29,7 +30,6 @@ use databend_common_sql::executor::PhysicalPlanBuilder;
 use databend_common_sql::plans::insert::InsertValue;
 use databend_common_sql::plans::Insert;
 use databend_common_sql::plans::InsertInputSource;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::Plan;
 use databend_common_sql::NameResolutionContext;
 

--- a/src/query/service/src/interpreters/interpreter_table_index_refresh.rs
+++ b/src/query/service/src/interpreters/interpreter_table_index_refresh.rs
@@ -56,18 +56,6 @@ impl Interpreter for RefreshTableIndexInterpreter {
             .manager
             .check_enterprise_enabled(self.ctx.get_license_key(), Feature::InvertedIndex)?;
 
-        // Add table lock.
-        let lock_guard = self
-            .ctx
-            .clone()
-            .acquire_table_lock(
-                &self.plan.catalog,
-                &self.plan.database,
-                &self.plan.table,
-                &self.plan.lock_opt,
-            )
-            .await?;
-
         let table = self
             .ctx
             .get_table(&self.plan.catalog, &self.plan.database, &self.plan.table)
@@ -103,7 +91,6 @@ impl Interpreter for RefreshTableIndexInterpreter {
         let index_schema = TableSchemaRefExt::create(index_fields);
 
         let mut build_res = PipelineBuildResult::create();
-        build_res.main_pipeline.add_lock_guard(lock_guard);
 
         let fuse_table = FuseTable::try_from_table(table.as_ref())?;
         fuse_table

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use databend_common_catalog::catalog::Catalog;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::plan::Filters;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::table::TableExt;
@@ -31,7 +32,6 @@ use databend_common_sql::executor::physical_plans::FragmentKind;
 use databend_common_sql::executor::physical_plans::ReclusterSink;
 use databend_common_sql::executor::physical_plans::ReclusterSource;
 use databend_common_sql::executor::PhysicalPlan;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_storages_fuse::operations::ReclusterTasks;
 use databend_common_storages_fuse::FuseTable;
 use databend_storages_common_table_meta::meta::TableSnapshot;

--- a/src/query/service/src/interpreters/interpreter_table_truncate.rs
+++ b/src/query/service/src/interpreters/interpreter_table_truncate.rs
@@ -14,10 +14,10 @@
 
 use std::sync::Arc;
 
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::table::TableExt;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::plans::TruncateTablePlan;
 
 use crate::interpreters::Interpreter;

--- a/src/query/service/src/locks/lock_manager.rs
+++ b/src/query/service/src/locks/lock_manager.rs
@@ -96,7 +96,7 @@ impl LockManager {
         ctx: Arc<dyn TableContext>,
         lock: &T,
         should_retry: bool,
-    ) -> Result<Option<LockGuard>> {
+    ) -> Result<Option<Arc<LockGuard>>> {
         let user = ctx.get_current_user()?.name;
         let node = ctx.get_cluster().local_id.clone();
         let query_id = ctx.get_current_session_id();
@@ -200,7 +200,7 @@ impl LockManager {
             }?;
         }
 
-        Ok(Some(guard))
+        Ok(Some(Arc::new(guard)))
     }
 
     fn insert_lock(&self, revision: u64, lock_holder: Arc<LockHolder>) {

--- a/src/query/service/src/locks/table_lock/mod.rs
+++ b/src/query/service/src/locks/table_lock/mod.rs
@@ -59,7 +59,7 @@ impl Lock for TableLock {
         &self,
         ctx: Arc<dyn TableContext>,
         should_retry: bool,
-    ) -> Result<Option<LockGuard>> {
+    ) -> Result<Option<Arc<LockGuard>>> {
         self.lock_mgr.try_lock(ctx, self, should_retry).await
     }
 }

--- a/src/query/service/src/pipelines/executor/pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/pipeline_executor.rs
@@ -51,7 +51,7 @@ pub struct QueryWrapper {
     on_init_callback: Mutex<Option<InitCallback>>,
     on_finished_chain: Mutex<FinishedCallbackChain>,
     #[allow(unused)]
-    lock_guards: Vec<LockGuard>,
+    lock_guards: Vec<Arc<LockGuard>>,
     finish_condvar_wait: Arc<(Mutex<bool>, Condvar)>,
     finished_notify: Arc<WatchNotify>,
 }

--- a/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
@@ -68,7 +68,7 @@ pub struct QueryPipelineExecutor {
     finished_notify: Arc<WatchNotify>,
     finished_error: Mutex<Option<ErrorCode>>,
     #[allow(unused)]
-    lock_guards: Vec<LockGuard>,
+    lock_guards: Vec<Arc<LockGuard>>,
 }
 
 impl QueryPipelineExecutor {
@@ -173,7 +173,7 @@ impl QueryPipelineExecutor {
         on_init_callback: Mutex<Option<InitCallback>>,
         on_finished_chain: Mutex<FinishedCallbackChain>,
         settings: ExecutorSettings,
-        lock_guards: Vec<LockGuard>,
+        lock_guards: Vec<Arc<LockGuard>>,
     ) -> Result<Arc<QueryPipelineExecutor>> {
         let workers_condvar = WorkersCondvar::create(threads_num);
         let global_tasks_queue = QueryExecutorTasksQueue::create(threads_num);

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -38,6 +38,7 @@ use databend_common_base::base::ProgressValues;
 use databend_common_base::runtime::profile::Profile;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_base::runtime::TrySpawn;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::merge_into_join::MergeIntoJoin;
 use databend_common_catalog::plan::DataSourceInfo;
 use databend_common_catalog::plan::DataSourcePlan;
@@ -86,7 +87,6 @@ use databend_common_pipeline_core::processors::PlanProfile;
 use databend_common_pipeline_core::InputError;
 use databend_common_pipeline_core::LockGuard;
 use databend_common_settings::Settings;
-use databend_common_sql::plans::LockTableOption;
 use databend_common_sql::IndexType;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::DataOperator;
@@ -328,35 +328,6 @@ impl QueryContext {
 
     pub fn clear_tables_cache(&self) {
         self.shared.clear_tables_cache()
-    }
-
-    pub async fn acquire_table_lock(
-        self: Arc<Self>,
-        catalog_name: &str,
-        db_name: &str,
-        tbl_name: &str,
-        lock_opt: &LockTableOption,
-    ) -> Result<Option<LockGuard>> {
-        let enabled_table_lock = self.get_settings().get_enable_table_lock().unwrap_or(false);
-        if !enabled_table_lock {
-            return Ok(None);
-        }
-
-        let catalog = self.get_catalog(catalog_name).await?;
-        let tbl = catalog
-            .get_table(&self.get_tenant(), db_name, tbl_name)
-            .await?;
-        if tbl.engine() != "FUSE" {
-            return Ok(None);
-        }
-
-        // Add table lock.
-        let table_lock = LockManager::create_table_lock(tbl.get_table_info().clone())?;
-        match lock_opt {
-            LockTableOption::LockNoRetry => table_lock.try_lock(self, false).await,
-            LockTableOption::LockWithRetry => table_lock.try_lock(self, true).await,
-            LockTableOption::NoLock => Ok(None),
-        }
     }
 }
 
@@ -1307,6 +1278,35 @@ impl TableContext for QueryContext {
                     stage_info.file_format_params
                 )));
             }
+        }
+    }
+
+    async fn acquire_table_lock(
+        self: Arc<Self>,
+        catalog_name: &str,
+        db_name: &str,
+        tbl_name: &str,
+        lock_opt: &LockTableOption,
+    ) -> Result<Option<Arc<LockGuard>>> {
+        let enabled_table_lock = self.get_settings().get_enable_table_lock().unwrap_or(false);
+        if !enabled_table_lock {
+            return Ok(None);
+        }
+
+        let catalog = self.get_catalog(catalog_name).await?;
+        let tbl = catalog
+            .get_table(&self.get_tenant(), db_name, tbl_name)
+            .await?;
+        if tbl.engine() != "FUSE" {
+            return Ok(None);
+        }
+
+        // Add table lock.
+        let table_lock = LockManager::create_table_lock(tbl.get_table_info().clone())?;
+        match lock_opt {
+            LockTableOption::LockNoRetry => table_lock.try_lock(self, false).await,
+            LockTableOption::LockWithRetry => table_lock.try_lock(self, true).await,
+            LockTableOption::NoLock => Ok(None),
         }
     }
 }

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -26,6 +26,7 @@ use databend_common_base::runtime::profile::Profile;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::cluster_info::Cluster;
 use databend_common_catalog::database::Database;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::merge_into_join::MergeIntoJoin;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::PartInfoPtr;
@@ -127,6 +128,7 @@ use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MetaId;
 use databend_common_meta_types::SeqV;
 use databend_common_pipeline_core::InputError;
+use databend_common_pipeline_core::LockGuard;
 use databend_common_pipeline_core::PlanProfile;
 use databend_common_settings::Settings;
 use databend_common_sql::IndexType;
@@ -907,6 +909,16 @@ impl TableContext for CtxDelegation {
     }
 
     fn set_query_queued_duration(&self, _queued_duration: Duration) {
+        todo!()
+    }
+
+    async fn acquire_table_lock(
+        self: Arc<Self>,
+        _catalog_name: &str,
+        _db_name: &str,
+        _tbl_name: &str,
+        _lock_opt: &LockTableOption,
+    ) -> Result<Option<Arc<LockGuard>>> {
         todo!()
     }
 }

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -25,6 +25,7 @@ use databend_common_base::runtime::profile::Profile;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::cluster_info::Cluster;
 use databend_common_catalog::database::Database;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::merge_into_join::MergeIntoJoin;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::PartInfoPtr;
@@ -126,6 +127,7 @@ use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MetaId;
 use databend_common_meta_types::SeqV;
 use databend_common_pipeline_core::InputError;
+use databend_common_pipeline_core::LockGuard;
 use databend_common_pipeline_core::PlanProfile;
 use databend_common_settings::Settings;
 use databend_common_sql::IndexType;
@@ -816,6 +818,16 @@ impl TableContext for CtxDelegation {
     }
 
     fn set_query_queued_duration(&self, _queued_duration: Duration) {
+        todo!()
+    }
+
+    async fn acquire_table_lock(
+        self: Arc<Self>,
+        _catalog_name: &str,
+        _db_name: &str,
+        _tbl_name: &str,
+        _lock_opt: &LockTableOption,
+    ) -> Result<Option<Arc<LockGuard>>> {
         todo!()
     }
 }

--- a/src/query/sql/src/planner/binder/ddl/index.rs
+++ b/src/query/sql/src/planner/binder/ddl/index.rs
@@ -52,7 +52,6 @@ use crate::plans::CreateIndexPlan;
 use crate::plans::CreateTableIndexPlan;
 use crate::plans::DropIndexPlan;
 use crate::plans::DropTableIndexPlan;
-use crate::plans::LockTableOption;
 use crate::plans::Plan;
 use crate::plans::RefreshIndexPlan;
 use crate::plans::RefreshTableIndexPlan;
@@ -591,7 +590,6 @@ impl Binder {
             table,
             index_name,
             segment_locs: None,
-            lock_opt: LockTableOption::LockWithRetry,
         };
         Ok(Plan::RefreshTableIndex(Box::new(plan)))
     }

--- a/src/query/sql/src/planner/binder/delete.rs
+++ b/src/query/sql/src/planner/binder/delete.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use databend_common_ast::ast::DeleteStmt;
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::TableReference;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
@@ -87,6 +88,18 @@ impl<'a> Binder {
             ));
         };
 
+        // Add table lock before execution.
+        let lock_guard = self
+            .ctx
+            .clone()
+            .acquire_table_lock(
+                &catalog_name,
+                &database_name,
+                &table_name,
+                &LockTableOption::LockWithRetry,
+            )
+            .await?;
+
         let (table_expr, mut context) = self.bind_table_reference(bind_context, table).await?;
 
         context.allow_internal_columns(false);
@@ -122,6 +135,7 @@ impl<'a> Binder {
             bind_context: Box::new(context.clone()),
             selection,
             subquery_desc,
+            lock_guard,
         };
         Ok(Plan::Delete(Box::new(plan)))
     }

--- a/src/query/sql/src/planner/binder/merge_into.rs
+++ b/src/query/sql/src/planner/binder/merge_into.rs
@@ -28,6 +28,7 @@ use databend_common_ast::ast::MatchedClause;
 use databend_common_ast::ast::MergeIntoStmt;
 use databend_common_ast::ast::TableReference;
 use databend_common_ast::ast::UnmatchedClause;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::plan::InternalColumn;
 use databend_common_catalog::plan::InternalColumnType;
 use databend_common_exception::ErrorCode;
@@ -236,6 +237,21 @@ impl Binder {
 
         let (catalog_name, database_name, table_name) =
             self.normalize_object_identifier_triple(catalog, database, table_ident);
+
+        // Add table lock before execution.
+        let lock_guard = if merge_type != MergeIntoType::InsertOnly {
+            self.ctx
+                .clone()
+                .acquire_table_lock(
+                    &catalog_name,
+                    &database_name,
+                    &table_name,
+                    &LockTableOption::LockWithRetry,
+                )
+                .await?
+        } else {
+            None
+        };
 
         let table = self
             .ctx
@@ -575,6 +591,7 @@ impl Binder {
             can_try_update_column_only: self.can_try_update_column_only(&matched_clauses),
             enable_right_broadcast: false,
             lazy_columns,
+            lock_guard,
         };
 
         let s_expr = SExpr::create_unary(

--- a/src/query/sql/src/planner/binder/update.rs
+++ b/src/query/sql/src/planner/binder/update.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use databend_common_ast::ast::TableReference;
 use databend_common_ast::ast::UpdateStmt;
+use databend_common_catalog::lock::LockTableOption;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::NumberScalar;
@@ -76,6 +77,18 @@ impl Binder {
                 "should not happen, parser should have report error already",
             ));
         };
+
+        // Add table lock.
+        let lock_guard = self
+            .ctx
+            .clone()
+            .acquire_table_lock(
+                &catalog_name,
+                &database_name,
+                &table_name,
+                &LockTableOption::LockWithRetry,
+            )
+            .await?;
 
         let (table_expr, mut context) = self.bind_table_reference(bind_context, table).await?;
 
@@ -158,6 +171,7 @@ impl Binder {
             bind_context: Box::new(context),
             metadata: self.metadata.clone(),
             subquery_desc,
+            lock_guard,
         };
         Ok(Plan::Update(Box::new(plan)))
     }

--- a/src/query/sql/src/planner/plans/ddl/index.rs
+++ b/src/query/sql/src/planner/plans/ddl/index.rs
@@ -22,7 +22,6 @@ use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_types::MetaId;
 use databend_storages_common_table_meta::meta::Location;
 
-use crate::plans::LockTableOption;
 use crate::plans::Plan;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -82,5 +81,4 @@ pub struct RefreshTableIndexPlan {
     pub table: String,
     pub index_name: String,
     pub segment_locs: Option<Vec<Location>>,
-    pub lock_opt: LockTableOption,
 }

--- a/src/query/sql/src/planner/plans/ddl/stream.rs
+++ b/src/query/sql/src/planner/plans/ddl/stream.rs
@@ -16,7 +16,7 @@ use databend_common_catalog::table::NavigationPoint;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct CreateStreamPlan {
     pub create_option: CreateOption,
     pub tenant: Tenant,
@@ -30,7 +30,7 @@ pub struct CreateStreamPlan {
     pub comment: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct DropStreamPlan {
     pub if_exists: bool,
     pub tenant: Tenant,

--- a/src/query/sql/src/planner/plans/delete.rs
+++ b/src/query/sql/src/planner/plans/delete.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
+use databend_common_pipeline_core::LockGuard;
+
 use crate::optimizer::SExpr;
 use crate::plans::ScalarExpr;
 use crate::BindContext;
@@ -28,7 +32,7 @@ pub struct SubqueryDesc {
     pub outer_columns: ColumnSet,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct DeletePlan {
     pub catalog_name: String,
     pub database_name: String,
@@ -37,4 +41,17 @@ pub struct DeletePlan {
     pub bind_context: Box<BindContext>,
     pub selection: Option<ScalarExpr>,
     pub subquery_desc: Vec<SubqueryDesc>,
+    pub lock_guard: Option<Arc<LockGuard>>,
+}
+
+impl std::fmt::Debug for DeletePlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Delete")
+            .field("catalog_name", &self.catalog_name)
+            .field("database_name", &self.database_name)
+            .field("table_name", &self.table_name)
+            .field("selection", &self.selection)
+            .field("subquery_desc", &self.subquery_desc)
+            .finish()
+    }
 }

--- a/src/query/sql/src/planner/plans/merge_into.rs
+++ b/src/query/sql/src/planner/plans/merge_into.rs
@@ -27,6 +27,7 @@ use databend_common_expression::DataSchemaRef;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::FieldIndex;
 use databend_common_meta_types::MetaId;
+use databend_common_pipeline_core::LockGuard;
 
 use crate::binder::MergeIntoType;
 use crate::optimizer::ColumnSet;
@@ -88,6 +89,7 @@ pub struct MergeInto {
     pub can_try_update_column_only: bool,
     pub enable_right_broadcast: bool,
     pub lazy_columns: Option<HashSet<usize>>,
+    pub lock_guard: Option<Arc<LockGuard>>,
 }
 
 impl std::fmt::Debug for MergeInto {

--- a/src/query/sql/src/planner/plans/replace.rs
+++ b/src/query/sql/src/planner/plans/replace.rs
@@ -23,6 +23,7 @@ use databend_common_expression::FromData;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchemaRef;
 use databend_common_meta_types::MetaId;
+use databend_common_pipeline_core::LockGuard;
 
 use super::insert::format_insert_source;
 use crate::plans::InsertInputSource;
@@ -37,6 +38,7 @@ pub struct Replace {
     pub schema: TableSchemaRef,
     pub source: InsertInputSource,
     pub delete_when: Option<Expr>,
+    pub lock_guard: Option<Arc<LockGuard>>,
 }
 
 impl PartialEq for Replace {

--- a/src/query/sql/src/planner/plans/update.rs
+++ b/src/query/sql/src/planner/plans/update.rs
@@ -29,6 +29,7 @@ use databend_common_expression::FieldIndex;
 use databend_common_expression::RemoteExpr;
 use databend_common_expression::PREDICATE_COLUMN_NAME;
 use databend_common_functions::BUILTIN_FUNCTIONS;
+use databend_common_pipeline_core::LockGuard;
 
 use crate::binder::wrap_cast;
 use crate::binder::ColumnBindingBuilder;
@@ -41,7 +42,7 @@ use crate::BindContext;
 use crate::MetadataRef;
 use crate::Visibility;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct UpdatePlan {
     pub catalog: String,
     pub database: String,
@@ -51,6 +52,20 @@ pub struct UpdatePlan {
     pub bind_context: Box<BindContext>,
     pub metadata: MetadataRef,
     pub subquery_desc: Vec<SubqueryDesc>,
+    pub lock_guard: Option<Arc<LockGuard>>,
+}
+
+impl std::fmt::Debug for UpdatePlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Update")
+            .field("catalog", &self.catalog)
+            .field("database", &self.database)
+            .field("table", &self.table)
+            .field("update_list", &self.update_list)
+            .field("selection", &self.selection)
+            .field("subquery_desc", &self.subquery_desc)
+            .finish()
+    }
 }
 
 impl UpdatePlan {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In the current implementation, the get_table method is called before acquiring the table lock. As a result, the table metadata retrieved may not be the latest if another transaction modifies the table metadata between the get_table call and the lock acquisition. This can lead to conflicts during the commit phase when the transaction attempts to use outdated metadata.

To fix this bug, we moved the table lock acquisition to the binder phase. By acquiring the lock earlier, we ensure that the get_table method retrieves the latest table metadata.

Remove the table lock during index refresh as it does not involve table commit.


**Note:** It cannot ensure a 100% resolution of conflicts, but it can greatly reduce the likelihood of conflicts.

- Fixes #15824
- Fixes #15827
## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15884)
<!-- Reviewable:end -->
