### PR TITLE
fix: stream error after alter table

### DIFF
--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -70,7 +70,6 @@ impl StreamHandler for RealStreamHandler {
         }
 
         let table_id = table_info.ident.table_id;
-        let schema = table_info.schema().clone();
         if !table.change_tracking_enabled() {
             let table_seq = table_info.ident.seq;
             // enable change tracking.
@@ -106,7 +105,7 @@ impl StreamHandler for RealStreamHandler {
                 abort_checker,
             )
             .await?;
-        table.check_changes_valid(&plan.table_database, &plan.table_name, change_desc.seq)?;
+        table.check_changes_valid(&table.get_table_info().desc, change_desc.seq)?;
 
         let db_id = table
             .get_table_info()
@@ -139,7 +138,6 @@ impl StreamHandler for RealStreamHandler {
                 engine: STREAM_ENGINE.to_string(),
                 options,
                 comment: plan.comment.clone().unwrap_or("".to_string()),
-                schema,
                 ..Default::default()
             },
             as_dropped: false,

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -433,7 +433,6 @@ impl QueryContextShared {
                     .ok_or_else(|| ErrorCode::Internal("Logical error, it's a bug."))?
                     .clone(),
             };
-            stream.check_source_valid(&source_table)?;
 
             let mut stream_info = stream.get_table_info().to_owned();
             stream_info.meta.schema = source_table.schema();

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -850,6 +850,7 @@ impl Table for FuseTable {
         table_name: &str,
         _consume: bool,
     ) -> Result<String> {
+        let db_tb_name = format!("'{}'.'{}'", database_name, table_name);
         let Some(ChangesDesc {
             seq,
             desc,
@@ -858,12 +859,11 @@ impl Table for FuseTable {
         }) = self.changes_desc.as_ref()
         else {
             return Err(ErrorCode::Internal(format!(
-                "No changes descriptor found in table {} {}",
-                database_name, table_name
+                "No changes descriptor found in table {db_tb_name}"
             )));
         };
 
-        self.check_changes_valid(database_name, table_name, *seq)?;
+        self.check_changes_valid(&db_tb_name, *seq)?;
         self.get_changes_query(
             mode,
             location,

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -402,15 +402,10 @@ impl FuseTable {
         Ok((del_blocks, add_blocks))
     }
 
-    pub fn check_changes_valid(
-        &self,
-        database_name: &str,
-        table_name: &str,
-        seq: u64,
-    ) -> Result<()> {
+    pub fn check_changes_valid(&self, desc: &str, seq: u64) -> Result<()> {
         if !self.change_tracking_enabled() {
             return Err(ErrorCode::IllegalStream(format!(
-                "Change tracking is not enabled on table '{database_name}.{table_name}'",
+                "Change tracking is not enabled on table {desc}",
             )));
         }
 
@@ -422,7 +417,7 @@ impl FuseTable {
             let begin_version = value.parse::<u64>()?;
             if begin_version > seq {
                 return Err(ErrorCode::IllegalStream(format!(
-                    "Change tracking has been missing for the time range requested on table '{database_name}.{table_name}'",
+                    "Change tracking has been missing for the time range requested on table {desc}",
                 )));
             }
         }

--- a/src/query/storages/stream/src/stream_table.rs
+++ b/src/query/storages/stream/src/stream_table.rs
@@ -57,11 +57,20 @@ pub enum StreamStatus {
 
 pub struct StreamTable {
     info: TableInfo,
+
+    source_table: Option<Arc<dyn Table>>,
 }
 
 impl StreamTable {
     pub fn try_create(info: TableInfo) -> Result<Box<dyn Table>> {
-        Ok(Box::new(StreamTable { info }))
+        Ok(Box::new(StreamTable {
+            info,
+            source_table: None,
+        }))
+    }
+
+    pub fn create(info: TableInfo, source_table: Option<Arc<dyn Table>>) -> Arc<dyn Table> {
+        Arc::new(StreamTable { info, source_table })
     }
 
     pub fn description() -> StorageDescription {
@@ -81,7 +90,24 @@ impl StreamTable {
         })
     }
 
+    pub fn check_source_valid(&self, source: &Arc<dyn Table>) -> Result<()> {
+        let desc = &source.get_table_info().desc;
+        if source.get_table_info().ident.table_id != self.source_table_id()? {
+            return Err(ErrorCode::IllegalStream(format!(
+                "Base table {} dropped, cannot read from stream {}",
+                desc, self.info.desc,
+            )));
+        }
+
+        let fuse_table = FuseTable::try_from_table(source.as_ref())?;
+        fuse_table.check_changes_valid(desc, self.offset()?)
+    }
+
     pub async fn source_table(&self, ctx: Arc<dyn TableContext>) -> Result<Arc<dyn Table>> {
+        if let Some(source) = &self.source_table {
+            return Ok(source.clone());
+        }
+
         let catalog = ctx.get_catalog(self.info.catalog()).await?;
         let source_table_name = self.source_table_name(catalog.as_ref()).await?;
         let source_database_name = self.source_database_name(catalog.as_ref()).await?;
@@ -93,20 +119,7 @@ impl StreamTable {
             )
             .await?;
 
-        if table.get_table_info().ident.table_id != self.source_table_id()? {
-            return Err(ErrorCode::IllegalStream(format!(
-                "Base table '{}'.'{}' dropped, cannot read from stream {}",
-                source_database_name, source_table_name, self.info.desc,
-            )));
-        }
-
-        let fuse_table = FuseTable::try_from_table(table.as_ref())?;
-        fuse_table.check_changes_valid(
-            &source_database_name,
-            &source_table_name,
-            self.offset()?,
-        )?;
-
+        self.check_source_valid(&table)?;
         Ok(table)
     }
 
@@ -155,7 +168,7 @@ impl StreamTable {
             })
     }
 
-    pub async fn source_database_name(&self, catalog: &dyn Catalog) -> Result<String> {
+    pub async fn source_database_id(&self, catalog: &dyn Catalog) -> Result<u64> {
         let source_db_id_opt = self
             .info
             .options()
@@ -184,7 +197,11 @@ impl StreamTable {
                     .parse::<u64>()?
             }
         };
+        Ok(source_db_id)
+    }
 
+    pub async fn source_database_name(&self, catalog: &dyn Catalog) -> Result<String> {
+        let source_db_id = self.source_database_id(catalog).await?;
         catalog.get_db_name_by_id(source_db_id).await
     }
 

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -583,6 +583,51 @@ drop table t7 all
 statement ok
 drop table t8 all
 
+###############
+# issue 15899 #
+###############
+
+statement ok
+create table t_15899(a int)
+
+statement ok
+insert into t_15899 values(1)
+
+statement ok
+create stream s_15899 on table t_15899 append_only = false
+
+statement ok
+insert into t_15899 values(2)
+
+statement ok
+alter table t_15899 add b int default 0
+
+statement ok
+insert into t_15899 values(3, 3)
+
+query II
+select a, b from t_15899 order by a
+----
+1 0
+2 0
+3 3
+
+query IITB
+select a, b, change$action, change$is_update from s_15899 order by a
+----
+2 0 INSERT 0
+3 3 INSERT 0
+
+statement ok
+drop stream s_15899
+
+statement ok
+drop table t_15899 all
+
+######################
+# end of issue 15899 #
+######################
+
 statement error 2733
 create stream s_err on table t4 at (stream => s3)
 
@@ -732,48 +777,6 @@ select a, b, change$action, change$is_update from test_stream_1.s2 order by a, b
 2 2 INSERT 0
 3 3 INSERT 0
 4 4 INSERT 0
-
-###############
-# issue 15899 #
-###############
-
-statement ok
-create table t_15899(a int)
-
-statement ok
-insert into t_15899 values(1)
-
-statement ok
-create stream s_15899 on table t_15899 append_only = false
-
-statement ok
-insert into t_15899 values(2)
-
-statement ok
-alter table t_15899 add b int default 0
-
-statement ok
-insert into t_15899 values(3, 3)
-
-query II
-select a, b from t_15899 order by a
-----
-1 0
-2 0
-3 3
-
-query IITB
-select a, b, change$action, change$is_update from s_15899 order by a
-----
-2 0 INSERT 0
-3 3 INSERT 0
-
-statement ok
-drop stream s_15899
-
-######################
-# end of issue 15899 #
-######################
 
 statement ok
 DROP DATABASE IF EXISTS test_stream_1

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -733,5 +733,47 @@ select a, b, change$action, change$is_update from test_stream_1.s2 order by a, b
 3 3 INSERT 0
 4 4 INSERT 0
 
+###############
+# issue 15899 #
+###############
+
+statement ok
+create table t_15899(a int)
+
+statement ok
+insert into t_15899 values(1)
+
+statement ok
+create stream s_15899 on table t_15899 append_only = false
+
+statement ok
+insert into t_15899 values(2)
+
+statement ok
+alter table t_15899 add b int default 0
+
+statement ok
+insert into t_15899 values(3, 3)
+
+query II
+select a, b from t_15899 order by a
+----
+1 0
+2 0
+3 3
+
+query IITB
+select a, b, change$action, change$is_update from s_15899 order by a
+----
+2 0 INSERT 0
+3 3 INSERT 0
+
+statement ok
+drop stream s_15899
+
+######################
+# end of issue 15899 #
+######################
+
 statement ok
 DROP DATABASE IF EXISTS test_stream_1

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -203,7 +203,7 @@ alter table t set options(change_tracking = false)
 query TT
 select name, invalid_reason from system.streams where database='test_stream' order by name
 ----
-s2 Change tracking is not enabled on table 'test_stream.t'
+s2 Change tracking is not enabled on table 'test_stream'.'t'
 
 statement ok
 drop table t all

--- a/tests/suites/0_stateless/12_time_travel/12_0005_changes_select.result
+++ b/tests/suites/0_stateless/12_time_travel/12_0005_changes_select.result
@@ -20,6 +20,6 @@ changes default timestamp at the first insertion end the deletion
 changes append_only timestamp at the first insertion
 3	3	INSERT	false
 change tracking is disabled
-Error: APIError: ResponseError with 2733: Change tracking is not enabled on table 'default.t12_0005'
+Error: APIError: ResponseError with 2733: Change tracking is not enabled on table 'default'.'t12_0005'
 change tracking has been missing for the time range requested
-Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'default.t12_0005'
+Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'default'.'t12_0005'

--- a/tests/suites/5_ee/05_stream/05_0002_ee_stream_create.result
+++ b/tests/suites/5_ee/05_stream/05_0002_ee_stream_create.result
@@ -1,11 +1,11 @@
-Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
+Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream'.'base'
 3	INSERT	false	true
 1
 2
-Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
+Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream'.'base'
 3	INSERT	false	true
-Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
-Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
-Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream.base'
+Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream'.'base'
+Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream'.'base'
+Error: APIError: ResponseError with 2733: Change tracking has been missing for the time range requested on table 'db_stream'.'base'
 3
 2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When a column is added to the source table after the stream has been created, the stream continues to use the outdated schema saved at the time of its creation. This can lead to runtime errors where the stream fails to find fields that were added to the source table after the stream's creation.

To address this issue, we made the following changes:

1. **Remove Schema in Streams**:
   - Streams no longer store the source table schema at creation time. Instead, they dynamically fetch the latest schema from the source table when needed.

2. **Update Schema Fetching Logic**:
   - Modified the stream processing logic to always retrieve the current schema from the source table. This ensures that any changes in the source table schema are immediately reflected in the stream's operations.
 
3. Another optimization is to batch fetch the table and database names in `system.streams`.

- Fixes #15899

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15907)
<!-- Reviewable:end -->
