### PR TITLE
refactor: optimize building bloom index for scalar.

### DIFF
--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -88,13 +88,12 @@ impl DataBlock {
         );
 
         let entry0 = blocks[0].get_by_offset(column_index);
-        if matches!(entry0.value, Value::Scalar(_)) {
-            if blocks
+        if matches!(entry0.value, Value::Scalar(_))
+            && blocks
                 .iter()
                 .all(|b| b.get_by_offset(column_index) == entry0)
-            {
-                return Ok(entry0.value.clone());
-            }
+        {
+            return Ok(entry0.value.clone());
         }
 
         let columns_iter = blocks.iter().map(|block| {

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -87,13 +87,13 @@ impl DataBlock {
                 .all_equal()
         );
 
-        if let Value::Scalar(v0) = &blocks[0].get_by_offset(column_index).value {
-            let v0 = Value::Scalar(v0.clone());
+        let entry0 = blocks[0].get_by_offset(column_index);
+        if matches!(entry0.value, Value::Scalar(_)) {
             if blocks
                 .iter()
-                .all(|b| b.get_by_offset(column_index).value == v0)
+                .all(|b| b.get_by_offset(column_index) == entry0)
             {
-                return Ok(v0);
+                return Ok(entry0.value.clone());
             }
         }
 

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -59,40 +59,54 @@ impl DataBlock {
         if blocks.is_empty() {
             return Err(ErrorCode::EmptyData("Can't concat empty blocks"));
         }
+        let block_refs = blocks.iter().collect::<Vec<_>>();
 
         if blocks.len() == 1 {
             return Ok(blocks[0].clone());
         }
 
-        let concat_columns = (0..blocks[0].num_columns())
-            .map(|i| {
-                debug_assert!(
-                    blocks
-                        .iter()
-                        .map(|block| &block.get_by_offset(i).data_type)
-                        .all_equal()
-                );
-
-                let columns_iter = blocks.iter().map(|block| {
-                    let entry = &block.get_by_offset(i);
-                    match &entry.value {
-                        Value::Scalar(s) => {
-                            ColumnBuilder::repeat(&s.as_ref(), block.num_rows(), &entry.data_type)
-                                .build()
-                        }
-                        Value::Column(c) => c.clone(),
-                    }
-                });
-                Ok(BlockEntry::new(
-                    blocks[0].get_by_offset(i).data_type.clone(),
-                    Value::Column(Column::concat_columns(columns_iter)?),
-                ))
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let num_columns = blocks[0].num_columns();
+        let mut concat_columns = Vec::with_capacity(num_columns);
+        for i in 0..num_columns {
+            concat_columns.push(BlockEntry::new(
+                blocks[0].get_by_offset(i).data_type.clone(),
+                Self::concat_columns(&block_refs, i)?,
+            ))
+        }
 
         let num_rows = blocks.iter().map(|c| c.num_rows()).sum();
 
         Ok(DataBlock::new(concat_columns, num_rows))
+    }
+
+    pub fn concat_columns(blocks: &[&DataBlock], column_index: usize) -> Result<Value<AnyType>> {
+        debug_assert!(
+            blocks
+                .iter()
+                .map(|block| &block.get_by_offset(column_index).data_type)
+                .all_equal()
+        );
+
+        if let Value::Scalar(v0) = &blocks[0].get_by_offset(column_index).value {
+            let v0 = Value::Scalar(v0.clone());
+            if blocks
+                .iter()
+                .all(|b| b.get_by_offset(column_index).value == v0)
+            {
+                return Ok(v0);
+            }
+        }
+
+        let columns_iter = blocks.iter().map(|block| {
+            let entry = &block.get_by_offset(column_index);
+            match &entry.value {
+                Value::Scalar(s) => {
+                    ColumnBuilder::repeat(&s.as_ref(), block.num_rows(), &entry.data_type).build()
+                }
+                Value::Column(c) => c.clone(),
+            }
+        });
+        Ok(Value::Column(Column::concat_columns(columns_iter)?))
     }
 }
 

--- a/src/query/service/src/test_kits/block_writer.rs
+++ b/src/query/service/src/test_kits/block_writer.rs
@@ -114,7 +114,7 @@ impl<'a> BlockWriter<'a> {
         let maybe_bloom_index = BloomIndex::try_create(
             FunctionContext::default(),
             location.1,
-            &[block],
+            block,
             bloom_columns_map,
         )?;
         if let Some(bloom_index) = maybe_bloom_index {

--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -183,7 +183,7 @@ impl BloomIndex {
     pub fn try_create(
         func_ctx: FunctionContext,
         version: u64,
-        data_blocks_tobe_indexed: &[&DataBlock],
+        block: &DataBlock,
         bloom_columns_map: BTreeMap<FieldIndex, TableField>,
     ) -> Result<Option<Self>> {
         // TODO refactor :
@@ -191,11 +191,11 @@ impl BloomIndex {
         // instead of passing it in
         assert_eq!(version, BlockFilter::VERSION);
 
-        if data_blocks_tobe_indexed.is_empty() {
+        if block.is_empty() {
             return Err(ErrorCode::BadArguments("block is empty"));
         }
 
-        if data_blocks_tobe_indexed[0].num_columns() == 0 {
+        if block.num_columns() == 0 {
             return Ok(None);
         }
 
@@ -203,7 +203,7 @@ impl BloomIndex {
         let mut filters = vec![];
         let mut column_distinct_count = HashMap::<usize, usize>::new();
         for (index, field) in bloom_columns_map.into_iter() {
-            let field_type = &data_blocks_tobe_indexed[0].get_by_offset(index).data_type;
+            let field_type = &block.get_by_offset(index).data_type;
             if !Xor8Filter::supported_type(field_type) {
                 continue;
             }
@@ -211,22 +211,21 @@ impl BloomIndex {
             let (column, data_type) = match field_type.remove_nullable() {
                 DataType::Map(box inner_ty) => {
                     // Add bloom filter for the value of map type
-                    let source_columns_iter = data_blocks_tobe_indexed.iter().map(|block| {
-                        let value = &block.get_by_offset(index).value;
-                        let column = value.convert_to_full_column(field_type, block.num_rows());
-                        let map_column = if field_type.is_nullable() {
-                            let nullable_column =
-                                NullableType::<MapType<AnyType, AnyType>>::try_downcast_column(
-                                    &column,
-                                )
+
+                    let column = match &block.get_by_offset(index).value {
+                        Value::Scalar(_) => continue,
+                        Value::Column(c) => c.clone(),
+                    };
+
+                    let map_column = if field_type.is_nullable() {
+                        let nullable_column =
+                            NullableType::<MapType<AnyType, AnyType>>::try_downcast_column(&column)
                                 .unwrap();
-                            nullable_column.column
-                        } else {
-                            MapType::<AnyType, AnyType>::try_downcast_column(&column).unwrap()
-                        };
-                        map_column.values.values
-                    });
-                    let column = Column::concat_columns(source_columns_iter)?;
+                        nullable_column.column
+                    } else {
+                        MapType::<AnyType, AnyType>::try_downcast_column(&column).unwrap()
+                    };
+                    let column = map_column.values.values;
 
                     let val_type = match inner_ty {
                         DataType::Tuple(kv_tys) => kv_tys[1].clone(),
@@ -262,17 +261,14 @@ impl BloomIndex {
                     }
                 }
                 _ => {
-                    let source_columns_iter = data_blocks_tobe_indexed.iter().map(|block| {
-                        let value = &block.get_by_offset(index).value;
-                        value.convert_to_full_column(field_type, block.num_rows())
-                    });
-                    let column = Column::concat_columns(source_columns_iter)?;
-
-                    if Self::check_large_string(&column) {
+                    if let Value::Column(column) = &&block.get_by_offset(index).value {
+                        if Self::check_large_string(column) {
+                            continue;
+                        }
+                        (column.clone(), field_type.clone())
+                    } else {
                         continue;
                     }
-
-                    (column, field_type.clone())
                 }
             };
 

--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -260,9 +260,10 @@ impl BloomIndex {
                     }
                 }
                 _ => {
-                    if Self::check_large_string(column) {
+                    if Self::check_large_string(&column) {
                         continue;
                     }
+                    (column, field_type.clone())
                 }
             };
 

--- a/src/query/storages/common/index/tests/it/filters/bloom_filter.rs
+++ b/src/query/storages/common/index/tests/it/filters/bloom_filter.rs
@@ -145,14 +145,14 @@ fn test_bloom_filter() -> Result<()> {
             )),
         ]),
     ];
-    let blocks_ref = blocks.iter().collect::<Vec<_>>();
+    let block = DataBlock::concat(&blocks)?;
 
     let bloom_columns = bloom_columns_map(schema.clone(), vec![0, 1, 2, 3]);
     let bloom_fields = bloom_columns.values().cloned().collect::<Vec<_>>();
     let index = BloomIndex::try_create(
         FunctionContext::default(),
         LatestBloom::VERSION,
-        &blocks_ref,
+        &block,
         bloom_columns,
     )?
     .unwrap();
@@ -317,14 +317,14 @@ fn test_specify_bloom_filter() -> Result<()> {
         UInt8Type::from_data(vec![1, 2]),
         StringType::from_data(vec!["a", "b"]),
     ])];
-    let blocks_ref = blocks.iter().collect::<Vec<_>>();
+    let block = DataBlock::concat(&blocks)?;
 
     let bloom_columns = bloom_columns_map(schema.clone(), vec![0]);
     let fields = bloom_columns.values().cloned().collect::<Vec<_>>();
     let specify_index = BloomIndex::try_create(
         FunctionContext::default(),
         LatestBloom::VERSION,
-        &blocks_ref,
+        &block,
         bloom_columns,
     )?
     .unwrap();
@@ -356,7 +356,7 @@ fn test_string_bloom_filter() -> Result<()> {
         UInt8Type::from_data(vec![1, 2]),
         StringType::from_data(vec![&val, "bc"]),
     ])];
-    let blocks_ref = blocks.iter().collect::<Vec<_>>();
+    let block = DataBlock::concat(&blocks)?;
 
     // The average length of the string column exceeds 256 bytes.
     let bloom_columns = bloom_columns_map(schema.clone(), vec![0, 1]);
@@ -364,7 +364,7 @@ fn test_string_bloom_filter() -> Result<()> {
     let index = BloomIndex::try_create(
         FunctionContext::default(),
         LatestBloom::VERSION,
-        &blocks_ref,
+        &block,
         bloom_columns,
     )?
     .unwrap();

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -146,7 +146,7 @@ impl BloomIndexBuilder {
         let maybe_bloom_index = BloomIndex::try_create(
             self.table_ctx.get_function_context()?,
             bloom_location.1,
-            &[block],
+            block,
             self.bloom_columns_map.clone(),
         )?;
 
@@ -225,7 +225,7 @@ impl BloomIndexState {
         let maybe_bloom_index = BloomIndex::try_create(
             ctx.get_function_context()?,
             location.1,
-            &[block],
+            block,
             bloom_columns_map,
         )?;
         if let Some(bloom_index) = maybe_bloom_index {

--- a/tests/sqllogictests/suites/no_table_meta_cache/explain/auto_rebuild_missing_bloom_index.test
+++ b/tests/sqllogictests/suites/no_table_meta_cache/explain/auto_rebuild_missing_bloom_index.test
@@ -172,11 +172,20 @@ select * from t where c = 6;
 
 # - c = 6 will trigger the re-building of bloom index for another block
 # expects 2 rows
-query I
-select count() from @rebuild_missing_bloom_index_stage (pattern => '.*/_i_b_v2/.*.parquet');
-----
-2
+# scalar column do not need bloom index (range index is enough), so the re-build index contains only one colum
+# select from parquet do not support merging of schemas now, so use copy as workaround
 
+statement ok
+create or replace table t_index(`bloom(0)` binary, `bloom(1)` binary);
+
+statement ok
+copy into t_index from  @rebuild_missing_bloom_index_stage pattern = '.*/_i_b_v2/.*.parquet' file_format=(type=parquet missing_field_as=field_default);
+
+query I
+select is_null(`bloom(0)`) as b1, is_null(`bloom(1)`)  as b2 from t_index order by b2;
+----
+0 0
+0 1
 
 # re-generate other bloom index
 query TT

--- a/tests/sqllogictests/suites/no_table_meta_cache/explain_native/auto_rebuild_missing_bloom_index.test
+++ b/tests/sqllogictests/suites/no_table_meta_cache/explain_native/auto_rebuild_missing_bloom_index.test
@@ -150,12 +150,17 @@ query TT
 select * from t where c = 6;
 ----
 
-# - c = 6 will trigger the re-building of bloom index for another block
-# expects 2 rows
+statement ok
+create or replace table t_index(`bloom(0)` binary, `bloom(1)` binary);
+
+statement ok
+copy into t_index from  @rebuild_missing_bloom_index_stage pattern = '.*/_i_b_v2/.*.parquet' file_format=(type=parquet missing_field_as=field_default);
+
 query I
-select count() from @rebuild_missing_bloom_index_stage (pattern => '.*/_i_b_v2/.*.parquet');
+select is_null(`bloom(0)`) as b1, is_null(`bloom(1)`)  as b2 from t_index order by b2;
 ----
-2
+0 0
+0 1
 
 
 # re-generate other bloom index


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1.   DataBlock::concat is optimized when all block is scalar for some column.
2.  building of bloom index only take one block as input for now,  so no need to concat,  so the `convert_to_full` can be removed too.
3.  not need to generate bloom index for scalar column, it will never be used since range index is checked first.

part of https://github.com/datafuselabs/databend/issues/15908


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15910)
<!-- Reviewable:end -->
