### PR TITLE
chore(query): remove wrap nullable in row fetch

### DIFF
--- a/src/query/service/src/pipelines/builders/builder_row_fetch.rs
+++ b/src/query/service/src/pipelines/builders/builder_row_fetch.rs
@@ -36,7 +36,6 @@ impl PipelineBuilder {
             row_fetch.row_id_col_offset,
             &row_fetch.source,
             row_fetch.cols_to_fetch.clone(),
-            row_fetch.need_wrap_nullable,
         )?;
         if !matches!(&*row_fetch.input, PhysicalPlan::MergeIntoSplit(_)) {
             self.main_pipeline.add_transform(processor)?;

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -343,7 +343,6 @@ pub trait PhysicalPlanReplacer {
             cols_to_fetch: plan.cols_to_fetch.clone(),
             fetched_fields: plan.fetched_fields.clone(),
             stat_info: plan.stat_info.clone(),
-            need_wrap_nullable: plan.need_wrap_nullable,
         }))
     }
 

--- a/src/query/sql/src/executor/physical_plans/physical_limit.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_limit.rs
@@ -162,7 +162,6 @@ impl PhysicalPlanBuilder {
             row_id_col_offset,
             cols_to_fetch,
             fetched_fields,
-            need_wrap_nullable: false,
             stat_info: Some(stat_info),
         }))
     }

--- a/src/query/sql/src/executor/physical_plans/physical_row_fetch.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_row_fetch.rs
@@ -33,8 +33,6 @@ pub struct RowFetch {
     pub cols_to_fetch: Projection,
     pub row_id_col_offset: usize,
     pub fetched_fields: Vec<DataField>,
-    pub need_wrap_nullable: bool,
-
     /// Only used for explain
     pub stat_info: Option<PlanStatsInfo>,
 }

--- a/src/query/sql/src/planner/plans/update.rs
+++ b/src/query/sql/src/planner/plans/update.rs
@@ -88,6 +88,7 @@ impl UpdatePlan {
             None,
             Some(&self.database),
             &self.table,
+            false,
         )
     }
 
@@ -137,6 +138,7 @@ pub fn generate_update_list(
     use_column_name_index: Option<usize>,
     database: Option<&str>,
     table: &str,
+    has_row_fetch: bool,
 ) -> Result<Vec<(FieldIndex, RemoteExpr<String>)>> {
     let column = ColumnBindingBuilder::new(
         PREDICATE_COLUMN_NAME.to_string(),
@@ -175,9 +177,14 @@ pub fn generate_update_list(
                         field.name(),
                         column_binding,
                     ) {
+                        let mut column_binding = column_binding.clone();
+                        if has_row_fetch {
+                            // If has row fetch, fetched target columns are origin data_type
+                            column_binding.data_type = Box::new(target_type.clone());
+                        };
                         right = Some(ScalarExpr::BoundColumnRef(BoundColumnRef {
                             span: None,
-                            column: column_binding.clone(),
+                            column: column_binding,
                         }));
                         break;
                     }

--- a/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
@@ -14,18 +14,15 @@
 
 use std::sync::Arc;
 
-use databend_common_arrow::arrow::bitmap::Bitmap;
 use databend_common_arrow::parquet::metadata::ColumnDescriptor;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::nullable::NullableColumn;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::BlockEntry;
-use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchema;
@@ -49,7 +46,6 @@ pub fn row_fetch_processor(
     row_id_col_offset: usize,
     source: &DataSourcePlan,
     projection: Projection,
-    need_wrap_nullable: bool,
 ) -> Result<RowFetcher> {
     let table = ctx.build_table_from_source_plan(source)?;
     let fuse_table = table
@@ -87,7 +83,6 @@ pub fn row_fetch_processor(
                             column_leaves.clone(),
                             max_threads,
                         ),
-                        need_wrap_nullable,
                     )
                 } else {
                     TransformRowsFetcher::create(
@@ -101,7 +96,6 @@ pub fn row_fetch_processor(
                             column_leaves.clone(),
                             max_threads,
                         ),
-                        need_wrap_nullable,
                     )
                 })
             }))
@@ -121,7 +115,6 @@ pub fn row_fetch_processor(
                             read_settings,
                             max_threads,
                         ),
-                        need_wrap_nullable,
                     )
                 } else {
                     TransformRowsFetcher::create(
@@ -135,7 +128,6 @@ pub fn row_fetch_processor(
                             read_settings,
                             max_threads,
                         ),
-                        need_wrap_nullable,
                     )
                 })
             }))
@@ -153,7 +145,6 @@ pub trait RowsFetcher {
 pub struct TransformRowsFetcher<F: RowsFetcher> {
     row_id_col_offset: usize,
     fetcher: F,
-    need_wrap_nullable: bool,
 }
 
 #[async_trait::async_trait]
@@ -197,11 +188,7 @@ where F: RowsFetcher + Send + Sync + 'static
         let fetched_block = self.fetcher.fetch(&row_id_column).await?;
 
         for col in fetched_block.columns().iter() {
-            if self.need_wrap_nullable {
-                data.add_column(wrap_true_validity(col, num_rows));
-            } else {
-                data.add_column(col.clone());
-            }
+            data.add_column(col.clone());
         }
 
         Ok(data)
@@ -216,26 +203,10 @@ where F: RowsFetcher + Send + Sync + 'static
         output: Arc<OutputPort>,
         row_id_col_offset: usize,
         fetcher: F,
-        need_wrap_nullable: bool,
     ) -> ProcessorPtr {
         ProcessorPtr::create(AsyncTransformer::create(input, output, Self {
             row_id_col_offset,
             fetcher,
-            need_wrap_nullable,
         }))
-    }
-}
-
-fn wrap_true_validity(column: &BlockEntry, num_rows: usize) -> BlockEntry {
-    let (value, data_type) = (&column.value, &column.data_type);
-    let col = value.convert_to_full_column(data_type, num_rows);
-    if matches!(col, Column::Null { .. }) || col.as_nullable().is_some() {
-        column.clone()
-    } else {
-        let col = Column::Nullable(Box::new(NullableColumn {
-            column: col,
-            validity: Bitmap::new_trued(num_rows),
-        }));
-        BlockEntry::new(data_type.wrap_nullable(), Value::Column(col))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
In PR:#15859,  we wrap nullable for row fetch columns. this pr remove wrap nullable and use origin datatype to reduce cost when `update_block`.
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- Fixes #[Link the issue here]
-->

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15914)
<!-- Reviewable:end -->
