### PR TITLE
fix(jwks): refresh the jwks store on key id not found

### DIFF
--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -99,7 +99,7 @@ pub struct JwkKeyStore {
     cached_keys: Arc<RwLock<HashMap<String, PubKey>>>,
     pub(crate) last_refreshed_at: RwLock<Option<Instant>>,
     pub(crate) refresh_interval: Duration,
-    pub(crate) load_keys_func: Option<Box<dyn Fn() -> HashMap<String, PubKey>>>,
+    pub(crate) load_keys_func: Option<Arc<dyn Fn() -> HashMap<String, PubKey> + Send + Sync>>,
 }
 
 impl JwkKeyStore {
@@ -116,7 +116,10 @@ impl JwkKeyStore {
     }
 
     // only for test to mock the keys
-    pub fn with_load_keys_func(mut self, func: Box<dyn Fn() -> HashMap<String, PubKey>>) -> Self {
+    pub fn with_load_keys_func(
+        mut self,
+        func: Arc<dyn Fn() -> HashMap<String, PubKey> + Send + Sync>,
+    ) -> Self {
         self.load_keys_func = Some(func);
         self
     }

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -170,7 +170,7 @@ impl JwkKeyStore {
             }
         };
 
-        // the JWKS keys are not always changed, but when it changes, we can have a log about this.
+        // the JWKS keys are not always changes, but when it changed, we can have a log about this.
         if !new_keys.keys().eq(old_keys.keys()) {
             info!("JWKS keys changed.");
         }

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -176,7 +176,7 @@ impl JwkKeyStore {
         }
         *self.cached_keys.write() = new_keys;
         self.last_refreshed_at.write().replace(Instant::now());
-        Ok(self.cached_keys.read().clone())
+        Ok(old_keys)
     }
 
     #[async_backtrace::framed]
@@ -198,7 +198,7 @@ impl JwkKeyStore {
         };
 
         // happy path: the key_id is found in the store
-        if let Some(key) = self.cached_keys.read().get(&key_id) {
+        if let Some(key) = keys.get(&key_id) {
             return Ok(key.clone());
         }
 

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -142,7 +142,7 @@ impl JwkKeyStore {
         if need_reload || force {
             let old_keys = self.keys.read().clone();
             let new_keys = self.load_keys().await?;
-            if !new_keys.keys().into_iter().eq(old_keys.keys()) {
+            if !new_keys.keys().eq(old_keys.keys()) {
                 info!("JWKS keys changed.");
             }
             *self.keys.write() = new_keys;

--- a/src/query/users/src/jwt/mod.rs
+++ b/src/query/users/src/jwt/mod.rs
@@ -19,3 +19,5 @@ pub use authenticator::CustomClaims;
 pub use authenticator::EnsureUser;
 pub use authenticator::JwtAuthenticator;
 pub use authenticator::PubKey;
+pub use jwk::JwkKey;
+pub use jwk::JwkKeyStore;

--- a/src/query/users/tests/it/jwt/authenticator.rs
+++ b/src/query/users/tests/it/jwt/authenticator.rs
@@ -80,7 +80,7 @@ async fn test_jwk_key_store_retry_on_key_not_found() -> Result<()> {
     let func_calls = Arc::new(AtomicUsize::new(0));
     let func_calls_cloned = func_calls.clone();
 
-    let mock_load_keys = Box::new(move || -> HashMap<String, PubKey> {
+    let mock_load_keys = Arc::new(move || -> HashMap<String, PubKey> {
         let mut keys_map = HashMap::new();
         keys_map.insert(
             "key1".to_string(),

--- a/src/query/users/tests/it/jwt/authenticator.rs
+++ b/src/query/users/tests/it/jwt/authenticator.rs
@@ -12,11 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
 use base64::engine::general_purpose;
 use base64::prelude::*;
 use databend_common_base::base::tokio;
 use databend_common_exception::Result;
+use databend_common_users::JwkKeyStore;
 use databend_common_users::JwtAuthenticator;
+use databend_common_users::PubKey;
 use jwt_simple::prelude::*;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
@@ -65,5 +72,30 @@ async fn test_parse_non_custom_claim() -> Result<()> {
 
     let res = auth.parse_jwt_claims(token1.as_str()).await?;
     assert_eq!(res.custom.role, None);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_jwk_key_store_retry_on_key_not_found() -> Result<()> {
+    let func_calls = Arc::new(AtomicUsize::new(0));
+    let func_calls_cloned = func_calls.clone();
+
+    let mock_load_keys = Box::new(move || -> HashMap<String, PubKey> {
+        let mut keys_map = HashMap::new();
+        keys_map.insert(
+            "key1".to_string(),
+            PubKey::RSA256(RS256KeyPair::generate(2048).unwrap().public_key()),
+        );
+        func_calls_cloned.fetch_add(1, Ordering::SeqCst);
+        keys_map
+    });
+    let store = JwkKeyStore::new("".to_string()).with_load_keys_func(mock_load_keys);
+
+    let r = store.get_key(Some("key2".to_string())).await;
+    assert_eq!(
+        r.unwrap_err().message(),
+        "key id key2 not found in jwk store"
+    );
+    assert_eq!(func_calls.load(Ordering::SeqCst), 2);
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Currently we have a 1 minute timeout to refresh the keys from JWKS endpoint. However when the JWKS rotated, it will causes the databend-query not available within this 1 minute.

This PR made the following changes:

1. when we got key id not found, retry fetching the jwks immediately
2. when we got network issue while requesting jwks uri, fallback to the cached jwks when possible
3. when the keys were changed, add a log 

## Tests

- [x] Unit Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15921)
<!-- Reviewable:end -->
