### PR TITLE
chore(storage): limit compact num when recluster

### DIFF
--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -151,14 +151,7 @@ impl BlockCompactMutator {
                     checker.generate_part(segments, &mut parts);
                 }
 
-                let residual_segment_cnt = checker.segments.len();
-                let residual_block_cnt = checker
-                    .segments
-                    .iter()
-                    .fold(0, |acc, e| acc + e.1.summary.block_count);
-                if checker.compacted_segment_cnt + residual_segment_cnt >= num_segment_limit
-                    || checker.compacted_block_cnt + residual_block_cnt >= num_block_limit as u64
-                {
+                if checker.is_limit_reached(num_segment_limit, num_block_limit) {
                     is_end = true;
                     break;
                 }
@@ -388,6 +381,16 @@ impl SegmentCompactChecker {
     pub fn finalize(&mut self, parts: &mut Vec<PartInfoPtr>) {
         let final_segments = std::mem::take(&mut self.segments);
         self.generate_part(final_segments, parts);
+    }
+
+    pub fn is_limit_reached(&self, num_segment_limit: usize, num_block_limit: usize) -> bool {
+        let residual_segment_cnt = self.segments.len();
+        let residual_block_cnt = self
+            .segments
+            .iter()
+            .fold(0, |acc, e| acc + e.1.summary.block_count);
+        self.compacted_segment_cnt + residual_segment_cnt >= num_segment_limit
+            || self.compacted_block_cnt + residual_block_cnt >= num_block_limit as u64
     }
 }
 

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -187,7 +187,11 @@ impl BlockCompactMutator {
         metrics_inc_compact_block_build_lazy_part_milliseconds(elapsed_time.as_millis() as u64);
 
         let cluster = self.ctx.get_cluster();
-        let partitions = if cluster.is_empty() || parts.len() < cluster.nodes.len() * max_threads {
+        let enable_distributed_compact = settings.get_enable_distributed_compact()?;
+        let partitions = if !enable_distributed_compact
+            || cluster.is_empty()
+            || parts.len() < cluster.nodes.len() * max_threads
+        {
             // NOTE: The snapshot schema does not contain the stream column.
             let column_ids = self
                 .compact_params

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -356,6 +356,11 @@ impl ReclusterMutator {
         &mut self,
         compact_segments: Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>,
     ) -> Result<bool> {
+        let settings = self.ctx.get_settings();
+        let max_threads = settings.get_max_threads()? as usize;
+        let num_segment_limit = max_threads;
+        let num_block_limit = settings.get_compact_max_block_selection()? as usize;
+
         let mut parts = Vec::new();
         let mut checker =
             SegmentCompactChecker::new(self.block_per_seg as u64, Some(self.cluster_key_id));
@@ -366,12 +371,15 @@ impl ReclusterMutator {
             for segments in segments_vec {
                 checker.generate_part(segments, &mut parts);
             }
+
+            if checker.is_limit_reached(num_segment_limit, num_block_limit) {
+                break;
+            }
         }
         // finalize the compaction.
         checker.finalize(&mut parts);
 
         let cluster = self.ctx.get_cluster();
-        let max_threads = self.ctx.get_settings().get_max_threads()? as usize;
         let partitions = if cluster.is_empty() || parts.len() < cluster.nodes.len() * max_threads {
             // NOTE: The snapshot schema does not contain the stream column.
             let column_ids = self.snapshot.schema.to_leaf_column_id_set();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When ReclusterTasks::Compact, limit the number of selected segments and blocks.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15926)
<!-- Reviewable:end -->
