### PR TITLE
fix: when upgrade snapshot v002 to v003, put kvs after expire index

### DIFF
--- a/src/meta/README.md
+++ b/src/meta/README.md
@@ -99,8 +99,8 @@ History versions that are not included in the above chart:
 | Meta version        | Backward compatible with |
 |:--------------------|:-------------------------|
 | [0.9.41,   1.2.212) | [0.9.41,  1.2.212)       |
-| [1.2.212,  1.2.479) | [0.9.41,  1.2.479)      |
-| [1.2.479, +∞)       | [1.2.212, +∞)            |
+| [1.2.212,  1.2.479) | [0.9.41,  1.2.479)       |
+| [1.2.479, +∞)       | [1.2.288, +∞)            |
 
 
 - `1.2.53` Incompatible, rolling upgrade is allowed without snapshot transmitting.
@@ -120,6 +120,9 @@ History versions that are not included in the above chart:
 - `1.2.528` 2024-06-13 Remove on-disk data version `V001`. The first version using `V002` is `1.2.53`, 2023-08-08.
   Therefore, since `1.2.528`, the oldest compatible version is `1.2.53`.
   Consequently, compatibility remains unchanged from this version onward.
+
+- `1.2.552` 2024-07-02 Introduce on-disk `V003`, using `rotbl` format snapshot,
+  which is compatible with `V002`. The oldest compatible version is `1.2.288`(`1.2.212~1.2.287` are removed).
     
 
 ## Compatibility of databend-meta on-disk data

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -270,11 +270,15 @@ async fn benchmark_get_table(client: &Arc<ClientHandle>, prefix: u64, client_num
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 struct TableCopyFileConfig {
     file_cnt: u64,
+    ttl_ms: Option<u64>,
 }
 
 impl Default for TableCopyFileConfig {
     fn default() -> Self {
-        Self { file_cnt: 100 }
+        Self {
+            file_cnt: 100,
+            ttl_ms: None,
+        }
     }
 }
 
@@ -312,7 +316,9 @@ async fn benchmark_table_copy_file(
         let put_op = txn_op_put(
             &copied_file_ident,
             serialize_struct(&copied_file_value).unwrap(),
-        );
+        )
+        .with_ttl(param.ttl_ms);
+
         txn.if_then.push(put_op);
     }
 

--- a/src/meta/service/src/version.rs
+++ b/src/meta/service/src/version.rs
@@ -115,10 +115,8 @@ pub(crate) mod raft {
             add_provide(("install_snapshot", 1), "2023-11-16", (1,  2, 212)),
             add_provide(("install_snapshot", 2), "2024-05-06", (1,  2, 453)),
             del_provide(("install_snapshot", 0), "2024-05-21", (1,  2, 479)),
-            // TODO: fix the date and version when merged
-            del_provide(("install_snapshot", 2), "2024-06-11", (1,  2, 518)),
-            // TODO: fix the date and version when merged
-            add_provide(("install_snapshot", 3), "2024-06-11", (1,  2, 518)),
+            del_provide(("install_snapshot", 2), "2024-07-02", (1,  2, 552)),
+            add_provide(("install_snapshot", 3), "2024-07-02", (1,  2, 552)),
         ];
 
         /// The client features that raft server depends on.
@@ -147,10 +145,8 @@ pub(crate) mod raft {
             add_optional(("install_snapshot", 1), "2023-11-16", (1,  2, 212)),
             add_require( ("install_snapshot", 1), "2023-05-21", (1,  2, 479)),
             del_require( ("install_snapshot", 0), "2024-05-21", (1,  2, 479)),
-            // TODO: fix the date and version when merged
-            del_require( ("install_snapshot", 1), "2024-06-11", (1,  2, 518)),
-            // TODO: fix the date and version when merged
-            add_require( ("install_snapshot", 3), "2024-06-11", (1,  2, 518)),
+            del_require( ("install_snapshot", 1), "2024-07-02", (1,  2, 552)),
+            add_require( ("install_snapshot", 3), "2024-07-02", (1,  2, 552)),
             
         ];
 

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -82,6 +82,13 @@ impl pb::TxnOp {
         }
     }
 
+    pub fn with_ttl(mut self, ttl_ms: Option<u64>) -> Self {
+        if let Some(pb::txn_op::Request::Put(p)) = &mut self.request {
+            p.ttl_ms = ttl_ms;
+        }
+        self
+    }
+
     /// Create a new `TxnOp` with a `Delete` operation.
     pub fn delete(key: impl ToString) -> Self {
         Self::delete_exact(key, None)

--- a/tests/compat/meta_meta/test_meta_meta.sh
+++ b/tests/compat/meta_meta/test_meta_meta.sh
@@ -101,7 +101,7 @@ bring_up_databend_meta "$leader_meta_ver" "1" --single
 
 echo " === Feed data to leader"
 ./bins/current/bin/databend-metabench \
-    --rpc 'table_copy_file:{"file_cnt":5}' \
+    --rpc 'table_copy_file:{"file_cnt":5,"ttl_ms":86400999}' \
     --client 1 \
     --number 100 \
     --prefix "1" \
@@ -117,7 +117,7 @@ curl -qs $(admin_addr 1)/v1/cluster/status
 
 echo " === Feed more data to leader"
 ./bins/current/bin/databend-metabench \
-    --rpc 'table_copy_file:{"file_cnt":5}' \
+    --rpc 'table_copy_file:{"file_cnt":5,"ttl_ms":86400999}' \
     --client 1 \
     --number 100 \
     --prefix "1" \


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: when upgrade snapshot v002 to v003, put kvs after expire index

V002 snapshot stores expire index(with prefix `exp-/`) after kvs(with prefix `kv--/`).
When upgrade, the kvs must be cached so that the the output V003
snapshot has correct key order.

Other changes:

- databend-metabench support `ttl_ms` to specify the time to last for a key

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15947)
<!-- Reviewable:end -->
