### PR TITLE
fix(query): window panic when max_block_size is small

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
@@ -395,6 +395,10 @@ impl<T: Number> TransformWindow<T> {
         if lhs == rhs {
             return true;
         }
+        if lhs.block < self.first_block {
+            return false;
+        }
+
         if self.frame_unit.is_rows() && for_computing_bound {
             // For ROWS frame, the row's peer is only the row itself.
             return false;

--- a/tests/sqllogictests/suites/query/window_function/expr_in_window.test
+++ b/tests/sqllogictests/suites/query/window_function/expr_in_window.test
@@ -307,3 +307,51 @@ USE default
 
 statement ok
 DROP DATABASE expr_in_window
+
+statement ok
+create or replace table t4(a int, b int, c int);
+
+statement ok
+insert into t4 values (1, 1, 1),(2, 2, 1), (3, 4, 1), (5, 6, 1),(3, 2, 1),(4, 6, 1),(7,8,1),(9,10,1),(8,2,1),(3,5,1),(4,5,1),(2,3,1),(4,2,1),(2,6,1);
+
+query TT
+SELECT a, lag(a, 2) OVER (ORDER BY c) from t4;
+----
+1 NULL
+2 NULL
+3 1
+5 2
+3 3
+4 5
+7 3
+9 4
+8 7
+3 9
+4 8
+2 3
+4 4
+2 2
+
+statement ok
+set max_block_size=1;
+
+query TT
+SELECT a, lag(a, 2) OVER (ORDER BY c) from t4;
+----
+1 NULL
+2 NULL
+3 1
+5 2
+3 3
+4 5
+7 3
+9 4
+8 7
+3 9
+4 8
+2 3
+4 4
+2 2
+
+statement ok
+drop table t4;

--- a/tests/sqllogictests/suites/query/window_function/expr_in_window.test
+++ b/tests/sqllogictests/suites/query/window_function/expr_in_window.test
@@ -354,4 +354,7 @@ SELECT a, lag(a, 2) OVER (ORDER BY c) from t4;
 2 2
 
 statement ok
+unset max_block_size;
+
+statement ok
 drop table t4;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In function `are_peers`, If lhs.block is smaller than first_block, `are_peers` directly returns false.

Because peer_group_start maybe the same as the partition start.

Fix : https://github.com/datafuselabs/databend/issues/15916

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15949)
<!-- Reviewable:end -->
