### PR TITLE
refactor: fuse statistics table function

### DIFF
--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0020_analyze.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0020_analyze.test
@@ -26,17 +26,18 @@ select * from t order by a
 6
 7
 
-query ok
+query TI
 select * from fuse_statistic('db_09_0020', 't')
+----
 
 
 statement ok
 analyze table `t`
 
-query T
+query TI
 select * from fuse_statistic('db_09_0020', 't')
 ----
-(0,3);
+a 3
 
 statement ok
 insert into t values (5)
@@ -63,18 +64,18 @@ select segment_count,block_count from fuse_snapshot('db_09_0020', 't') limit 1
 ----
 6 6
 
-query T
+query TI
 select * from fuse_statistic('db_09_0020', 't')
 ----
-(0,3);
+a 3
 
 statement ok
 analyze table `t`
 
-query T
+query TI
 select * from fuse_statistic('db_09_0020', 't')
 ----
-(0,3);
+a 3
 
 statement ok
 optimize table t compact
@@ -84,34 +85,34 @@ select segment_count,block_count from fuse_snapshot('db_09_0020', 't') limit 1
 ----
 1 1
 
-query T
+query TI
 select * from fuse_statistic('db_09_0020', 't')
 ----
-(0,3);
+a 3
 
 statement ok
 analyze table `t`
 
-query T
+query TI
 select * from fuse_statistic('db_09_0020', 't')
 ----
-(0,3);
+a 3
 
 statement ok
 delete from t where a=5
 
-query T
+query TI
 select * from fuse_statistic('db_09_0020', 't')
 ----
-(0,3);
+a 3
 
 statement ok
 analyze table `t`
 
-query T
+query TI
 select * from fuse_statistic('db_09_0020', 't')
 ----
-(0,3);
+a 3
 
 statement ok
 DROP TABLE t


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Before:
```
mysql> select * from FUSE_STATISTIC('tpcds', 'store_sales');
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| column_distinct_values                                                                                                                                                                                                                             |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| (1,46010);(19,208977);(16,384548);(13,19156);(14,210353);(12,20116);(9,242239);(0,1843);(8,301);(4,225218);(22,555892);(15,413756);(20,466008);(17,587549);(3,90768);(11,10052);(2,18290);(7,6);(21,613722);(5,7286);(10,99);(18,79443);(6,50065); |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Now:
```
mysql> select * from FUSE_STATISTIC('tpcds', 'store_sales') order by distinct_count;
+-----------------------+----------------+
| column_name           | distinct_count |
+-----------------------+----------------+
| ss_store_sk           |              6 |
| ss_quantity           |             99 |
| ss_promo_sk           |            301 |
| ss_sold_date_sk       |           1843 |
| ss_hdemo_sk           |           7286 |
| ss_wholesale_cost     |          10052 |
| ss_item_sk            |          18290 |
| ss_sales_price        |          19156 |
| ss_list_price         |          20116 |
| ss_sold_time_sk       |          46010 |
| ss_addr_sk            |          50065 |
| ss_ext_tax            |          79443 |
| ss_customer_sk        |          90768 |
| ss_coupon_amt         |         208977 |
| ss_ext_discount_amt   |         210353 |
| ss_cdemo_sk           |         225218 |
| ss_ticket_number      |         242239 |
| ss_ext_wholesale_cost |         384548 |
| ss_ext_sales_price    |         413756 |
| ss_net_paid           |         466008 |
| ss_net_profit         |         555892 |
| ss_ext_list_price     |         587549 |
| ss_net_paid_inc_tax   |         613722 |
+-----------------------+----------------+
23 rows in set (0.04 sec)
Read 23 rows, 696.00 B in 0.027 sec., 856.82 rows/sec., 25.32 KiB/sec.
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15954)
<!-- Reviewable:end -->
