### PR TITLE
feat: support real-time retrieval of profiles from admin API (part 1)

### DIFF
--- a/src/query/service/src/servers/admin/admin_service.rs
+++ b/src/query/service/src/servers/admin/admin_service.rs
@@ -73,6 +73,10 @@ impl AdminService {
                 "/v1/cluster/list",
                 get(super::v1::cluster::cluster_list_handler),
             )
+            .at(
+                "v1/queries/:query_id/profiling",
+                get(super::v1::query_profiling::query_profiling_handler),
+            )
             .at("/debug/home", get(debug_home_handler))
             .at("/debug/pprof/profile", get(debug_pprof_handler))
             .at("/debug/async_tasks/dump", get(debug_dump_stack));

--- a/src/query/service/src/servers/admin/v1/query_profiling.rs
+++ b/src/query/service/src/servers/admin/v1/query_profiling.rs
@@ -1,0 +1,101 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use databend_common_base::runtime::profile::get_statistics_desc;
+use databend_common_base::runtime::profile::ProfileDesc;
+use databend_common_base::runtime::profile::ProfileStatisticsName;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
+use databend_common_pipeline_core::PlanProfile;
+use http::StatusCode;
+use poem::web::Json;
+use poem::web::Path;
+use poem::IntoResponse;
+
+use crate::clusters::ClusterHelper;
+use crate::servers::flight::v1::actions::GET_PROFILE;
+use crate::sessions::SessionManager;
+use crate::sessions::SessionType;
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn query_profiling_handler(
+    Path(query_id): Path<String>,
+) -> poem::Result<impl IntoResponse> {
+    let session_manager = SessionManager::instance();
+    #[derive(serde::Serialize)]
+    struct QueryProfiles {
+        query_id: String,
+        profiles: Vec<PlanProfile>,
+        statistics_desc: Arc<BTreeMap<ProfileStatisticsName, ProfileDesc>>,
+    }
+    let res = match session_manager.get_session_by_id(&query_id) {
+        Some(session) => {
+            // can get profile from current node
+            session.get_profile()
+        }
+        None => {
+            // need get profile from clusters
+            get_cluster_profile(&session_manager, &query_id)
+                .await
+                .map_err(|cause| {
+                    poem::Error::from_string(
+                        format!("Failed to fetch cluster nodes list. cause: {cause}"),
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                    )
+                })?
+        }
+    };
+
+    Ok(Json(QueryProfiles {
+        query_id: query_id.clone(),
+        profiles: res.unwrap_or_default(),
+        statistics_desc: get_statistics_desc(),
+    }))
+}
+
+async fn get_cluster_profile(
+    session_manager: &SessionManager,
+    query_id: &str,
+) -> Result<Option<Vec<PlanProfile>>, ErrorCode> {
+    let session = session_manager
+        .create_session(SessionType::HTTPAPI("QueryProfiling".to_string()))
+        .await?;
+
+    let ctx = Arc::new(session).create_query_context().await?;
+    let cluster = ctx.get_cluster();
+    let mut message = HashMap::with_capacity(cluster.nodes.len());
+
+    for node_info in &cluster.nodes {
+        if node_info.id != cluster.local_id {
+            message.insert(node_info.id.clone(), query_id.to_owned());
+        }
+    }
+
+    let settings = ctx.get_settings();
+    let timeout = settings.get_flight_client_timeout()?;
+    let res = cluster
+        .do_action::<String, Option<Vec<PlanProfile>>>(GET_PROFILE, message, timeout)
+        .await?;
+    for (_, profile) in res {
+        if let Some(profile) = profile {
+            return Ok(Some(profile));
+        }
+    }
+    Ok(None)
+}

--- a/src/query/service/src/servers/admin/v1/query_profiling.rs
+++ b/src/query/service/src/servers/admin/v1/query_profiling.rs
@@ -55,7 +55,7 @@ pub async fn query_profiling_handler(
                 .await
                 .map_err(|cause| {
                     poem::Error::from_string(
-                        format!("Failed to fetch cluster nodes list. cause: {cause}"),
+                        format!("Failed to fetch cluster node profile. cause: {cause}"),
                         StatusCode::INTERNAL_SERVER_ERROR,
                     )
                 })?

--- a/src/query/service/src/servers/admin/v1/query_profiling.rs
+++ b/src/query/service/src/servers/admin/v1/query_profiling.rs
@@ -77,7 +77,7 @@ async fn get_cluster_profile(
         .create_session(SessionType::HTTPAPI("QueryProfiling".to_string()))
         .await?;
 
-    let ctx = session.create_query_context().await?;
+    let ctx = Arc::new(session).create_query_context().await?;
     let cluster = ctx.get_cluster();
     let mut message = HashMap::with_capacity(cluster.nodes.len());
 
@@ -92,5 +92,5 @@ async fn get_cluster_profile(
     let res = cluster
         .do_action::<String, Vec<PlanProfile>>(GET_PROFILE, message, timeout)
         .await?;
-    Ok(res.values().flatten().collect::<Vec<PlanProfile>>())
+    Ok(res.into_iter().flat_map(|(_key, value)| value).collect())
 }

--- a/src/query/service/src/servers/flight/v1/actions/flight_actions.rs
+++ b/src/query/service/src/servers/flight/v1/actions/flight_actions.rs
@@ -24,6 +24,7 @@ use futures_util::future::BoxFuture;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::servers::flight::v1::actions::get_profile::get_profile;
 use crate::servers::flight::v1::actions::init_query_env::init_query_env;
 use crate::servers::flight::v1::actions::init_query_env::INIT_QUERY_ENV;
 use crate::servers::flight::v1::actions::init_query_fragments::init_query_fragments;
@@ -34,6 +35,7 @@ use crate::servers::flight::v1::actions::start_prepared_query::start_prepared_qu
 use crate::servers::flight::v1::actions::system_action::system_action;
 use crate::servers::flight::v1::actions::truncate_table::truncate_table;
 use crate::servers::flight::v1::actions::truncate_table::TRUNCATE_TABLE;
+use crate::servers::flight::v1::actions::GET_PROFILE;
 use crate::servers::flight::v1::actions::INIT_QUERY_FRAGMENTS;
 use crate::servers::flight::v1::actions::KILL_QUERY;
 use crate::servers::flight::v1::actions::START_PREPARED_QUERY;
@@ -127,4 +129,5 @@ pub fn flight_actions() -> FlightActions {
         .action(KILL_QUERY, kill_query)
         .action(SET_PRIORITY, set_priority)
         .action(SYSTEM_ACTION, system_action)
+        .action(GET_PROFILE, get_profile)
 }

--- a/src/query/service/src/servers/flight/v1/actions/get_profile.rs
+++ b/src/query/service/src/servers/flight/v1/actions/get_profile.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use databend_common_exception::Result;
 use databend_common_pipeline_core::PlanProfile;
 
@@ -21,11 +19,11 @@ use crate::servers::flight::v1::actions::create_session;
 
 pub static GET_PROFILE: &str = "/actions/get_profile";
 
-pub async fn get_profile(query_id: String) -> Result<Option<Vec<PlanProfile>>> {
+pub async fn get_profile(query_id: String) -> Result<Vec<PlanProfile>> {
     let session = create_session()?;
-    let query_context = Arc::new(session).create_query_context().await?;
+    let query_context = session.create_query_context().await?;
     match query_context.get_session_by_id(&query_id) {
-        Some(session) => Ok(session.get_profile()),
-        None => Ok(None),
+        Some(session) => Ok(session.get_profile().unwrap_or_default()),
+        None => Ok(vec![]),
     }
 }

--- a/src/query/service/src/servers/flight/v1/actions/get_profile.rs
+++ b/src/query/service/src/servers/flight/v1/actions/get_profile.rs
@@ -12,13 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod background_tasks;
-pub mod cluster;
-pub mod config;
-pub mod instance_status;
-pub mod processes;
-pub mod query_profiling;
-pub mod settings;
-pub mod stream_status;
-pub mod system;
-pub mod tenant_tables;
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+use databend_common_pipeline_core::PlanProfile;
+
+use crate::servers::flight::v1::actions::create_session;
+
+pub static GET_PROFILE: &str = "/actions/get_profile";
+
+pub async fn get_profile(query_id: String) -> Result<Option<Vec<PlanProfile>>> {
+    let session = create_session()?;
+    let query_context = Arc::new(session).create_query_context().await?;
+    match query_context.get_session_by_id(&query_id) {
+        Some(session) => Ok(session.get_profile()),
+        None => Ok(None),
+    }
+}

--- a/src/query/service/src/servers/flight/v1/actions/mod.rs
+++ b/src/query/service/src/servers/flight/v1/actions/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod flight_actions;
+mod get_profile;
 mod init_query_env;
 mod init_query_fragments;
 mod kill_query;
@@ -28,6 +29,7 @@ use databend_common_exception::Result;
 use databend_common_settings::Settings;
 pub use flight_actions::flight_actions;
 pub use flight_actions::FlightActions;
+pub use get_profile::GET_PROFILE;
 pub use init_query_env::INIT_QUERY_ENV;
 pub use init_query_fragments::init_query_fragments;
 pub use init_query_fragments::INIT_QUERY_FRAGMENTS;

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -593,6 +593,13 @@ impl QueryContextShared {
             executor.change_priority(priority)
         }
     }
+
+    pub fn get_profile(&self) -> Option<Vec<PlanProfile>> {
+        self.executor
+            .read()
+            .upgrade()
+            .map(|executor| executor.get_plans_profile())
+    }
 }
 
 impl Drop for QueryContextShared {

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -27,6 +27,7 @@ use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserInfo;
 use databend_common_meta_app::principal::UserPrivilegeType;
 use databend_common_meta_app::tenant::Tenant;
+use databend_common_pipeline_core::PlanProfile;
 use databend_common_settings::Settings;
 use databend_common_users::GrantObjectVisibilityChecker;
 use databend_storages_common_txn::TxnManagerRef;
@@ -347,6 +348,12 @@ impl Session {
         if let Some(context_shared) = self.session_ctx.get_query_context_shared() {
             context_shared.set_priority(priority);
         }
+    }
+
+    pub fn get_profile(&self) -> Option<Vec<PlanProfile>> {
+        self.session_ctx
+            .get_query_context_shared()
+            .and_then(|x| x.get_profile())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Support get PlanProfile from admin API if the query is still running: `/v1/queries/:query_id/profiling`

This PR is part one. It only support the running query. If the query finish very quickly, it cannot get the result.

For the next part, It will maintain a cache queue for the latest 50 (could be config) queries's profile.

Example: `GET http://localhost:8080/v1/queries/46f89e47-9e27-4ca9-b87c-868d80678ec0/profiling`

RESPONSE:
<details>
{
  "query_id": "46f89e47-9e27-4ca9-b87c-868d80678ec0",
  "profiles": [
    {
      "id": 6,
      "name": "AggregatePartial",
      "parent_id": 4,
      "title": "max(number), sum(number)",
      "labels": [
        {
          "name": "Aggregate Functions",
          "value": [
            "max(number)",
            "sum(number)"
          ]
        },
        {
          "name": "Grouping keys",
          "value": [
            "numbers_mt.number (#0) % 3",
            "numbers_mt.number (#0) % 4",
            "numbers_mt.number (#0) % 5"
          ]
        }
      ],
      "statistics": [
        111359276793,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        23170576
      ],
      "errors": [
        
      ]
    },
    {
      "id": 7,
      "name": "EvalScalar",
      "parent_id": 6,
      "title": "numbers_mt.number (#0) % 3, numbers_mt.number (#0) % 4, numbers_mt.number (#0) % 5",
      "labels": [
        {
          "name": "List of Expressions",
          "value": [
            "numbers_mt.number (#0) % 3",
            "numbers_mt.number (#0) % 4",
            "numbers_mt.number (#0) % 5"
          ]
        }
      ],
      "statistics": [
        17133330215,
        0,
        0,
        0,
        68157440,
        749731840,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        1007472
      ],
      "errors": [
        
      ]
    },
    {
      "id": 1,
      "name": "Limit",
      "parent_id": null,
      "title": "LIMIT 5 OFFSET 0",
      "labels": [
        {
          "name": "Number of rows",
          "value": [
            "5"
          ]
        },
        {
          "name": "Offset",
          "value": [
            "0"
          ]
        }
      ],
      "statistics": [
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        32
      ],
      "errors": [
        
      ]
    },
    {
      "id": 4,
      "name": "AggregateFinal",
      "parent_id": 3,
      "title": "max(number), sum(number)",
      "labels": [
        {
          "name": "Aggregate Functions",
          "value": [
            "max(number)",
            "sum(number)"
          ]
        },
        {
          "name": "Grouping keys",
          "value": [
            "numbers_mt.number (#0) % 3",
            "numbers_mt.number (#0) % 4",
            "numbers_mt.number (#0) % 5"
          ]
        }
      ],
      "statistics": [
        63958,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        2492
      ],
      "errors": [
        
      ]
    },
    {
      "id": 3,
      "name": "Limit",
      "parent_id": 1,
      "title": "LIMIT 5 OFFSET 0",
      "labels": [
        {
          "name": "Number of rows",
          "value": [
            "5"
          ]
        },
        {
          "name": "Offset",
          "value": [
            "0"
          ]
        }
      ],
      "statistics": [
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        160
      ],
      "errors": [
        
      ]
    },
    {
      "id": 8,
      "name": "TableScan",
      "parent_id": 7,
      "title": "default.''.'numbers_mt'",
      "labels": [
        {
          "name": "Full table name",
          "value": [
            "default.''.'numbers_mt'"
          ]
        },
        {
          "name": "Total partitions",
          "value": [
            "15259"
          ]
        },
        {
          "name": "Columns (1 / 1)",
          "value": [
            "number"
          ]
        }
      ],
      "statistics": [
        2985702728,
        0,
        0,
        0,
        68157440,
        545259520,
        545259520,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        523968
      ],
      "errors": []
    }
  ],
  "statistics_desc": {
    "CpuTime": {
      "desc": "The time spent to process in nanoseconds",
      "display_name": "cpu time",
      "index": 0,
      "unit": "NanoSeconds",
      "plain_statistics": false
    },
    "WaitTime": {
      "desc": "The time spent to wait in nanoseconds, usually used to measure the time spent on waiting for I/O",
      "display_name": "wait time",
      "index": 1,
      "unit": "NanoSeconds",
      "plain_statistics": false
    },
    "ExchangeRows": {
      "desc": "The number of data rows exchange between nodes in cluster mode",
      "display_name": "exchange rows",
      "index": 2,
      "unit": "Rows",
      "plain_statistics": true
    },
    "ExchangeBytes": {
      "desc": "The number of data bytes exchange between nodes in cluster mode",
      "display_name": "exchange bytes",
      "index": 3,
      "unit": "Bytes",
      "plain_statistics": true
    },
    "OutputRows": {
      "desc": "The number of rows from the physical plan output to the next physical plan",
      "display_name": "output rows",
      "index": 4,
      "unit": "Rows",
      "plain_statistics": true
    },
    "OutputBytes": {
      "desc": "The number of bytes from the physical plan output to the next physical plan",
      "display_name": "output bytes",
      "index": 5,
      "unit": "Bytes",
      "plain_statistics": true
    },
    "ScanBytes": {
      "desc": "The bytes scanned of query",
      "display_name": "bytes scanned",
      "index": 6,
      "unit": "Bytes",
      "plain_statistics": true
    },
    "ScanCacheBytes": {
      "desc": "The bytes scanned from cache of query",
      "display_name": "bytes scanned from cache",
      "index": 7,
      "unit": "Bytes",
      "plain_statistics": true
    },
    "ScanPartitions": {
      "desc": "The partitions scanned of query",
      "display_name": "partitions scanned",
      "index": 8,
      "unit": "Count",
      "plain_statistics": true
    },
    "SpillWriteCount": {
      "desc": "The number of spilled by write",
      "display_name": "numbers spilled by write",
      "index": 9,
      "unit": "Count",
      "plain_statistics": true
    },
    "SpillWriteBytes": {
      "desc": "The bytes spilled by write",
      "display_name": "bytes spilled by write",
      "index": 10,
      "unit": "Bytes",
      "plain_statistics": true
    },
    "SpillWriteTime": {
      "desc": "The time spent to write spill in millisecond",
      "display_name": "spilled time by write",
      "index": 11,
      "unit": "MillisSeconds",
      "plain_statistics": false
    },
    "SpillReadCount": {
      "desc": "The number of spilled by read",
      "display_name": "numbers spilled by read",
      "index": 12,
      "unit": "Count",
      "plain_statistics": true
    },
    "SpillReadBytes": {
      "desc": "The bytes spilled by read",
      "display_name": "bytes spilled by read",
      "index": 13,
      "unit": "Bytes",
      "plain_statistics": true
    },
    "SpillReadTime": {
      "desc": "The time spent to read spill in millisecond",
      "display_name": "spilled time by read",
      "index": 14,
      "unit": "MillisSeconds",
      "plain_statistics": false
    },
    "RuntimeFilterPruneParts": {
      "desc": "The partitions pruned by runtime filter",
      "display_name": "parts pruned by runtime filter",
      "index": 15,
      "unit": "Count",
      "plain_statistics": true
    },
    "MemoryUsage": {
      "desc": "The real time memory usage",
      "display_name": "memory usage",
      "index": 16,
      "unit": "Bytes",
      "plain_statistics": false
    }
  }
}
</details>

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [x] No Test - Will introduce in next PR

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15958)
<!-- Reviewable:end -->
