### PR TITLE
feat(query): alter user support modify current password

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -1073,8 +1073,17 @@ impl AccessChecker for PrivilegeAccess {
                 self.validate_access(&GrantObject::Global, UserPrivilegeType::Super, false)
                     .await?;
             }
-            Plan::AlterUser(_)
-            | Plan::RenameDatabase(_)
+            Plan::AlterUser(plan) => {
+                let current_user = self.ctx.get_current_user()?;
+                // Only alter current user's password do not need to check privileges.
+                if plan.user.username == current_user.name && plan.user_option.is_none() {
+                    return Ok(());
+                }
+                self.validate_access(&GrantObject::Global, UserPrivilegeType::Alter, false)
+                    .await?;
+            }
+
+            Plan::RenameDatabase(_)
             | Plan::RevertTable(_)
             | Plan::AlterUDF(_)
             | Plan::AlterShareTenants(_)

--- a/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.result
+++ b/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.result
@@ -1,0 +1,10 @@
+-- reset users
+-- prepare user and tables for tests
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
+Error: APIError: RequestError: Query Page failed with status 401 Unauthorized: {"error":{"code":"401","message":"wrong password"}}
+Error: APIError: RequestError: Start Query failed with status 401 Unauthorized: {"error":{"code":"401","message":"wrong password"}}
+testuser1 password is 123
+testuser2 password not modify
+-- reset users

--- a/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+export TEST_USER_PASSWORD="password"
+export TEST_USER_CONNECT="bendsql --user=testuser1 --password=password --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
+export TEST_USER2_CONNECT="bendsql --user=testuser2 --password=password --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
+
+echo '-- reset users'
+echo "DROP USER IF EXISTS 'testuser1'" | $BENDSQL_CLIENT_CONNECT
+echo "DROP USER IF EXISTS 'testuser2'" | $BENDSQL_CLIENT_CONNECT
+
+echo '-- prepare user and tables for tests'
+echo "CREATE USER 'testuser1' IDENTIFIED BY '$TEST_USER_PASSWORD'" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE USER 'testuser2' IDENTIFIED BY '$TEST_USER_PASSWORD'" | $BENDSQL_CLIENT_CONNECT
+echo "alter user 'testuser2' identified by '123'" | $TEST_USER_CONNECT
+echo "alter user 'testuser1' identified by '123' with default_role='role1'" | $TEST_USER_CONNECT
+echo "alter user 'testuser1' identified by '123' with disabled=true" | $TEST_USER_CONNECT
+
+# Note: this query in bendsql will return err, because bendsql will call auth in poll, after password modified, in next poll the auth failed, it will return err.
+# testuser1@localhost:8000/default> alter user 'testuser1' identified by '123';
+# error: APIError: RequestError: Query Page failed with status 401 Unauthorized: {"error":{"code":"401","message":"wrong password"}}
+echo "alter user 'testuser1' identified by '123'" | $TEST_USER_CONNECT
+
+export TEST_USER_MODIFY_CONNECT="bendsql --user=testuser1 --password=123 --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
+
+echo "select 1" | $TEST_USER_CONNECT
+echo "select 'testuser1 password is 123'" | $TEST_USER_MODIFY_CONNECT
+echo "select 'testuser2 password not modify'" | $TEST_USER2_CONNECT
+
+echo '-- reset users'
+echo "DROP USER IF EXISTS 'testuser1'" | $BENDSQL_CLIENT_CONNECT
+echo "DROP USER IF EXISTS 'testuser2'" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

alter user support modify current password

Note: 

* If alter with auth_option, it should check privilege.
* in bendsql alter current user's password will return err, because bendsql will call auth in poll, after password modified, in next poll the auth failed, it will return err. But it is not databend-query bug.
* 
```
# testuser1@localhost:8000/default> alter user 'testuser1' identified by '123';
# error: APIError: RequestError: Query Page failed with status 401 Unauthorized: {"error":{"code":"401","message":"wrong password"}}
```
- Fixes https://github.com/datafuselabs/databend/issues/15961


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15962)
<!-- Reviewable:end -->
