### PR TITLE
fix(storage): stream show columns maybe error

### DIFF
--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -197,6 +197,11 @@ drop stream t1
 statement ok
 drop table t1 all
 
+query T
+show columns from s2
+----
+a INT YES (empty) NULL NULL
+
 statement ok
 alter table t set options(change_tracking = false)
 
@@ -212,6 +217,10 @@ query TTT
 select name, invalid_reason from system.streams where database='test_stream' order by name
 ----
 s2 Unknown table 't'
+
+query T
+show columns from s2
+----
 
 statement ok
 create table t(a int) change_tracking = true


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When a stream is invalid, the show columns command attempts to retrieve column information and fails, throwing an error. This happens because the command relies on the stream to fetch the latest schema of the source table. If the stream is invalid, it cannot provide the necessary schema information, leading to an error.

If an invalid stream is detected, the command now returns an empty result instead of raising an error.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15964)
<!-- Reviewable:end -->
