### PR TITLE
feat: allow tuple field name to contain '_'.

### DIFF
--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -1581,10 +1581,11 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
         |(_, _, fields, _)| {
             let (fields_name, fields_type): (Vec<String>, Vec<TypeName>) =
                 fields.into_iter().map(|(name, ty)| (name.name, ty)).unzip();
-            if fields_name
-                .iter()
-                .any(|field_name| !field_name.chars().all(|c| c.is_ascii_alphanumeric()))
-            {
+            if fields_name.iter().any(|field_name| {
+                !field_name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_')
+            }) {
                 return Err(nom::Err::Failure(ErrorKind::Other(
                     "Invalid tuple field name, only support alphanumeric characters",
                 )));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

this pr https://github.com/datafuselabs/databend/pull/15126/files limit it to is_ascii_alphanumeric()
but we often need '_'.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15965)
<!-- Reviewable:end -->
