### PR TITLE
refactor: optimize reading scalar columns

### DIFF
--- a/src/common/metrics/src/metrics/storage.rs
+++ b/src/common/metrics/src/metrics/storage.rs
@@ -133,6 +133,10 @@ static REMOTE_IO_READ_MILLISECONDS: LazyLock<Histogram> =
     LazyLock::new(|| register_histogram_in_milliseconds("fuse_remote_io_read_milliseconds"));
 static REMOTE_IO_DESERIALIZE_MILLISECONDS: LazyLock<Histogram> =
     LazyLock::new(|| register_histogram_in_milliseconds("fuse_remote_io_deserialize_milliseconds"));
+
+static REMOTE_IO_COLUMNS_AS_SCALAR: LazyLock<Counter> =
+    LazyLock::new(|| register_counter("fuse_remote_io_col_as_scalar_count"));
+
 static BLOCK_WRITE_NUMS: LazyLock<Counter> =
     LazyLock::new(|| register_counter("fuse_block_write_nums"));
 static BLOCK_WRITE_BYTES: LazyLock<Counter> =
@@ -467,6 +471,10 @@ pub fn metrics_inc_commit_aborts() {
 
 pub fn metrics_inc_remote_io_seeks(c: u64) {
     REMOTE_IO_SEEKS.inc_by(c);
+}
+
+pub fn metrics_inc_remote_io_columns_as_scalar(c: u64) {
+    REMOTE_IO_COLUMNS_AS_SCALAR.inc_by(c);
 }
 
 pub fn metrics_inc_remote_io_seeks_after_merged(c: u64) {

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -1156,7 +1156,7 @@ impl TableField {
 
     pub fn is_nested(&self) -> bool {
         matches!(
-            self.data_type,
+            self.data_type.remove_nullable(),
             TableDataType::Tuple { .. } | TableDataType::Array(_) | TableDataType::Map(_)
         )
     }

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache.rs
@@ -304,6 +304,7 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
             bufs.push(IoSlice::new(slick));
         }
         f.write_all_vectored(&mut bufs)?;
+        f.flush()?;
         self.cache.put(cache_key.0, bytes_len);
         Ok(())
     }

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache.rs
@@ -304,7 +304,7 @@ where C: Cache<String, u64, DefaultHashBuilder, FileSize> + Send + Sync + 'stati
             bufs.push(IoSlice::new(slick));
         }
         f.write_all_vectored(&mut bufs)?;
-        f.flush()?;
+        f.sync_data()?;
         self.cache.put(cache_key.0, bytes_len);
         Ok(())
     }

--- a/src/query/storages/common/cache_manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache_manager/src/cache_manager.rs
@@ -44,6 +44,7 @@ use crate::ColumnArrayMeter;
 use crate::CompactSegmentInfoMeter;
 use crate::InvertedIndexFileMeter;
 use crate::PrunePartitionsCache;
+use crate::SegmentInfoCache;
 
 static DEFAULT_FILE_META_DATA_CACHE_ITEMS: u64 = 3000;
 
@@ -58,6 +59,7 @@ pub struct CacheManager {
     inverted_index_file_cache: Option<InvertedIndexFileCache>,
     prune_partitions_cache: Option<PrunePartitionsCache>,
     file_meta_data_cache: Option<FileMetaDataCache>,
+    deserialized_segment_info_cache: Option<SegmentInfoCache>,
     table_data_cache: Option<TableDataCache>,
     table_column_array_cache: Option<ColumnArrayCache>,
 }
@@ -128,6 +130,7 @@ impl CacheManager {
                 prune_partitions_cache: None,
                 file_meta_data_cache: None,
                 table_statistic_cache: None,
+                deserialized_segment_info_cache: None,
                 table_data_cache,
                 table_column_array_cache,
             }));
@@ -141,6 +144,9 @@ impl CacheManager {
                 CompactSegmentInfoMeter {},
                 "segment_info",
             );
+
+            let deserialized_segment_info_cache =
+                Self::new_item_cache(1000, "deserialized_segment_cache");
             let bloom_index_filter_cache = Self::new_in_memory_cache(
                 config.table_bloom_index_filter_size,
                 BloomIndexFilterMeter {},
@@ -183,6 +189,7 @@ impl CacheManager {
                 table_statistic_cache,
                 table_data_cache,
                 table_column_array_cache,
+                deserialized_segment_info_cache,
             }));
         }
 
@@ -227,6 +234,10 @@ impl CacheManager {
 
     pub fn get_file_meta_data_cache(&self) -> Option<FileMetaDataCache> {
         self.file_meta_data_cache.clone()
+    }
+
+    pub fn get_deserialized_segment_info_cache(&self) -> Option<SegmentInfoCache> {
+        self.deserialized_segment_info_cache.clone()
     }
 
     pub fn get_table_data_cache(&self) -> Option<TableDataCache> {

--- a/src/query/storages/common/cache_manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache_manager/src/cache_manager.rs
@@ -80,16 +80,18 @@ impl CacheManager {
                         .join(tenant_id.into())
                         .join("v1");
 
-                    let queue_size: u32 = if config.table_data_cache_population_queue_size > 0 {
-                        config.table_data_cache_population_queue_size
-                    } else {
-                        std::cmp::max(
-                            1,
-                            std::thread::available_parallelism()
-                                .expect("Cannot get thread count")
-                                .get() as u32,
-                        )
-                    };
+                    //                    let queue_size: u32 = if config.table_data_cache_population_queue_size > 0 {
+                    //                        config.table_data_cache_population_queue_size
+                    //                    } else {
+                    //                        std::cmp::max(
+                    //                            1,
+                    //                            std::thread::available_parallelism()
+                    //                                .expect("Cannot get thread count")
+                    //                                .get() as u32,
+                    //                        )
+                    //                    };
+
+                    let queue_size = 8;
 
                     info!(
                         "disk cache enabled, cache population queue size {}",

--- a/src/query/storages/common/cache_manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache_manager/src/cache_manager.rs
@@ -80,18 +80,16 @@ impl CacheManager {
                         .join(tenant_id.into())
                         .join("v1");
 
-                    //                    let queue_size: u32 = if config.table_data_cache_population_queue_size > 0 {
-                    //                        config.table_data_cache_population_queue_size
-                    //                    } else {
-                    //                        std::cmp::max(
-                    //                            1,
-                    //                            std::thread::available_parallelism()
-                    //                                .expect("Cannot get thread count")
-                    //                                .get() as u32,
-                    //                        )
-                    //                    };
-
-                    let queue_size = 8;
+                    let queue_size: u32 = if config.table_data_cache_population_queue_size > 0 {
+                        config.table_data_cache_population_queue_size
+                    } else {
+                        std::cmp::max(
+                            1,
+                            std::thread::available_parallelism()
+                                .expect("Cannot get thread count")
+                                .get() as u32,
+                        )
+                    };
 
                     info!(
                         "disk cache enabled, cache population queue size {}",

--- a/src/query/storages/common/cache_manager/src/caches.rs
+++ b/src/query/storages/common/cache_manager/src/caches.rs
@@ -42,6 +42,8 @@ pub type CompactSegmentInfoCache = NamedCache<
     InMemoryItemCacheHolder<CompactSegmentInfo, DefaultHashBuilder, CompactSegmentInfoMeter>,
 >;
 
+pub type SegmentInfoCache = NamedCache<InMemoryItemCacheHolder<SegmentInfo>>;
+
 /// In memory object cache of TableSnapshot
 pub type TableSnapshotCache = NamedCache<InMemoryItemCacheHolder<TableSnapshot>>;
 /// In memory object cache of TableSnapshotStatistics
@@ -95,12 +97,12 @@ impl CachedObject<CompactSegmentInfo, DefaultHashBuilder, CompactSegmentInfoMete
     }
 }
 
-impl CachedObject<CompactSegmentInfo, DefaultHashBuilder, CompactSegmentInfoMeter> for SegmentInfo {
-    type Cache = CompactSegmentInfoCache;
-    fn cache() -> Option<Self::Cache> {
-        CacheManager::instance().get_table_segment_cache()
-    }
-}
+// impl CachedObject<SegmentInfo> for SegmentInfo {
+//    type Cache = SegmentInfoCache;
+//    fn cache() -> Option<Self::Cache> {
+//        CacheManager::instance().get_deserialized_segment_info_cache()
+//    }
+//}
 
 impl CachedObject<TableSnapshot> for TableSnapshot {
     type Cache = TableSnapshotCache;
@@ -141,6 +143,13 @@ impl CachedObject<FileMetaData> for FileMetaData {
     type Cache = FileMetaDataCache;
     fn cache() -> Option<Self::Cache> {
         CacheManager::instance().get_file_meta_data_cache()
+    }
+}
+
+impl CachedObject<SegmentInfo> for SegmentInfo {
+    type Cache = SegmentInfoCache;
+    fn cache() -> Option<Self::Cache> {
+        CacheManager::instance().get_deserialized_segment_info_cache()
     }
 }
 

--- a/src/query/storages/common/table_meta/src/meta/v4/segment.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/segment.rs
@@ -177,19 +177,23 @@ impl SegmentInfo {
     }
 
     pub fn from_slice(bytes: &[u8]) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes);
+        let cursor = Cursor::new(bytes);
+        Self::from_reader(cursor)
+    }
+
+    pub fn from_reader(mut r: impl Read) -> Result<Self> {
         let SegmentHeader {
             version,
             encoding,
             compression,
             blocks_size,
             summary_size,
-        } = decode_segment_header(&mut cursor)?;
+        } = decode_segment_header(&mut r)?;
 
         let blocks: Vec<Arc<BlockMeta>> =
-            read_and_deserialize(&mut cursor, blocks_size, &encoding, &compression)?;
+            read_and_deserialize(&mut r, blocks_size, &encoding, &compression)?;
         let summary: Statistics =
-            read_and_deserialize(&mut cursor, summary_size, &encoding, &compression)?;
+            read_and_deserialize(&mut r, summary_size, &encoding, &compression)?;
 
         let mut segment = Self::new(blocks, summary);
 

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -241,6 +241,10 @@ impl FuseTable {
         matches!(self.storage_format, FuseStorageFormat::Native)
     }
 
+    pub fn get_storage_format(&self) -> FuseStorageFormat {
+        self.storage_format
+    }
+
     pub fn meta_location_generator(&self) -> &TableMetaLocationGenerator {
         &self.meta_location_generator
     }

--- a/src/query/storages/fuse/src/fuse_type.rs
+++ b/src/query/storages/fuse/src/fuse_type.rs
@@ -44,10 +44,20 @@ impl FuseTableType {
 
 /// Fuse engine table format.
 /// This is used to distinguish different table formats.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FuseStorageFormat {
     Parquet,
     Native,
+}
+
+impl FuseStorageFormat {
+    pub fn is_native(&self) -> bool {
+        self == &FuseStorageFormat::Native
+    }
+
+    pub fn is_parquet(&self) -> bool {
+        self == &FuseStorageFormat::Parquet
+    }
 }
 
 impl FromStr for FuseStorageFormat {

--- a/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader.rs
+++ b/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader.rs
@@ -67,6 +67,7 @@ impl AggIndexReader {
             agg.projection.clone(),
             false,
             false,
+            false,
             put_cache,
         )?;
 

--- a/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader_parquet.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use databend_common_arrow::arrow::io::parquet::read as pread;
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_exception::Result;
+use databend_common_expression::ColumnId;
 use databend_common_expression::DataBlock;
+use databend_storages_common_table_meta::meta::ColumnStatistics;
 use log::debug;
 
 use super::AggIndexReader;
@@ -91,9 +95,16 @@ impl AggIndexReader {
                 debug_assert_eq!(metadata.row_groups.len(), 1);
                 let row_group = &metadata.row_groups[0];
                 let columns_meta = build_columns_meta(row_group);
+                let column_stats: Option<HashMap<ColumnId, ColumnStatistics>> = None;
                 let res = self
                     .reader
-                    .read_columns_data_by_merge_io(read_settings, loc, &columns_meta, &None)
+                    .read_columns_data_by_merge_io(
+                        read_settings,
+                        loc,
+                        &columns_meta,
+                        &column_stats,
+                        &None,
+                    )
                     .await
                     .inspect_err(|e| debug!("Read aggregating index `{loc}` failed: {e}"))
                     .ok()?;

--- a/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
@@ -96,7 +96,7 @@ impl BlockReader {
     ) -> Result<DataBlock> {
         // Get the merged IO read result.
         let merge_io_read_result = self
-            .read_columns_data_by_merge_io(settings, &meta.location.0, &meta.col_metas, &None)
+            .read_columns_data_by_merge_io(settings, &meta.location.0, &meta.col_metas, &Some(&meta.col_stats), &None)
             .await?;
 
         self.deserialize_chunks_with_meta(meta, storage_format, merge_io_read_result)

--- a/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
@@ -96,7 +96,13 @@ impl BlockReader {
     ) -> Result<DataBlock> {
         // Get the merged IO read result.
         let merge_io_read_result = self
-            .read_columns_data_by_merge_io(settings, &meta.location.0, &meta.col_metas, &Some(&meta.col_stats), &None)
+            .read_columns_data_by_merge_io(
+                settings,
+                &meta.location.0,
+                &meta.col_metas,
+                &Some(&meta.col_stats),
+                &None,
+            )
             .await?;
 
         self.deserialize_chunks_with_meta(meta, storage_format, merge_io_read_result)

--- a/src/query/storages/fuse/src/io/read/block/block_reader_merge_io.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_merge_io.rs
@@ -20,6 +20,7 @@ use bytes::Bytes;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
+use databend_common_expression::Scalar;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::TableDataCache;
 use databend_storages_common_cache::TableDataCacheKey;
@@ -53,12 +54,14 @@ impl OwnerMemory {
 
 type CachedColumnData = Vec<(ColumnId, Arc<Bytes>)>;
 type CachedColumnArray = Vec<(ColumnId, Arc<SizedColumnArray>)>;
+type ScalarColumns = Vec<(ColumnId, Scalar)>;
 pub struct MergeIOReadResult {
     block_path: String,
     columns_chunk_offsets: HashMap<ColumnId, (ChunkIndex, Range<usize>)>,
     owner_memory: OwnerMemory,
     pub cached_column_data: CachedColumnData,
     pub cached_column_array: CachedColumnArray,
+    pub scalar_columns: ScalarColumns,
     table_data_cache: Option<TableDataCache>,
 }
 
@@ -66,6 +69,7 @@ pub struct MergeIOReadResult {
 pub enum DataItem<'a> {
     RawData(Bytes),
     ColumnArray(&'a Arc<SizedColumnArray>),
+    Scalar(&'a Scalar),
 }
 
 impl MergeIOReadResult {
@@ -81,6 +85,7 @@ impl MergeIOReadResult {
             owner_memory,
             cached_column_data: vec![],
             cached_column_array: vec![],
+            scalar_columns: vec![],
             table_data_cache,
         }
     }
@@ -103,6 +108,10 @@ impl MergeIOReadResult {
         // merge column array from cache
         for (column_id, data) in &self.cached_column_array {
             res.insert(*column_id, DataItem::ColumnArray(data));
+        }
+
+        for (column_id, data) in &self.scalar_columns {
+            res.insert(*column_id, DataItem::Scalar(data));
         }
 
         Ok(res)

--- a/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
@@ -15,6 +15,7 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt::Debug;
 use std::ops::Range;
 use std::time::Instant;
 
@@ -23,6 +24,7 @@ use databend_common_base::runtime::UnlimitedFuture;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
+use databend_common_expression::Scalar;
 use databend_common_metrics::storage::*;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::TableDataCacheKey;
@@ -132,7 +134,9 @@ impl BlockReader {
     }
 
     #[async_backtrace::framed]
-    pub async fn read_columns_data_by_merge_io<T: Borrow<HashMap<ColumnId, ColumnStatistics>>>(
+    pub async fn read_columns_data_by_merge_io<
+        T: Borrow<HashMap<ColumnId, ColumnStatistics>> + Debug,
+    >(
         &self,
         settings: &ReadSettings,
         location: &str,
@@ -160,13 +164,20 @@ impl BlockReader {
             }
 
             if let Some(stats) = cols_stats {
-                let stats = stats.borrow();
-                if let Some(stats) = stats.get(column_id) {
-                    // do not bother reading it at all
-                    if stats.min == stats.max {
-                        scalars.push((*column_id, stats.min.clone()));
-                        metrics_inc_remote_io_columns_as_scalar(1);
-                        continue;
+                // for non-nested field, apply the scalar inference optimization
+                if let Some(field) = self.project_field_set.get(column_id) {
+                    if !field.is_nested() {
+                        let stats = stats.borrow();
+                        if let Some(stats) = stats.get(column_id) {
+                            if stats.min == stats.max
+                                && !(stats.min != Scalar::Null && stats.null_count != 0)
+                            {
+                                // do not bother reading it at all
+                                scalars.push((*column_id, stats.min.clone()));
+                                metrics_inc_remote_io_columns_as_scalar(1);
+                                continue;
+                            }
+                        }
                     }
                 }
             }

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
@@ -70,6 +70,7 @@ impl BlockReader {
                 &settings,
                 &part.location,
                 &part.columns_meta,
+                &part.columns_stat,
                 ignore_column_ids,
             )
             .await?;

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::BufReader;
 use std::ops::Range;
@@ -34,6 +35,7 @@ use databend_common_expression::DataBlock;
 use databend_common_expression::Value;
 use databend_common_metrics::storage::*;
 use databend_storages_common_table_meta::meta::ColumnMeta;
+use databend_storages_common_table_meta::meta::ColumnStatistics;
 use opendal::Operator;
 
 use crate::fuse_part::FuseBlockPartInfo;
@@ -65,12 +67,14 @@ impl BlockReader {
 
         let part = FuseBlockPartInfo::from_part(part)?;
         let settings = ReadSettings::from_ctx(ctx)?;
+        // scalar column inference is not enabled for native format yet
+        let column_stats: Option<HashMap<ColumnId, ColumnStatistics>> = None;
         let read_res = self
             .read_columns_data_by_merge_io(
                 &settings,
                 &part.location,
                 &part.columns_meta,
-                &part.columns_stat,
+                &column_stats,
                 ignore_column_ids,
             )
             .await?;

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
@@ -238,6 +238,10 @@ impl BlockReader {
                             // since it is not nested, one column is enough
                             return Ok(Some(DeserializedArray::Cached(column_array)));
                         }
+
+                        DataItem::Scalar(_scalar) => {
+                            todo!()
+                        }
                     }
                 } else {
                     // If the column is the source of virtual columns, it may be ignored.

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
@@ -240,7 +240,8 @@ impl BlockReader {
                         }
 
                         DataItem::Scalar(_scalar) => {
-                            todo!()
+                            // scalar column inference is not enabled for native format yet
+                            unreachable!()
                         }
                     }
                 } else {

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
@@ -240,8 +240,9 @@ impl BlockReader {
                         }
 
                         DataItem::Scalar(_scalar) => {
-                            // scalar column inference is not enabled for native format yet
-                            unreachable!()
+                            unreachable!(
+                                "scalar column inference is not enabled for native format yet"
+                            )
                         }
                     }
                 } else {

--- a/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
@@ -57,6 +57,7 @@ pub fn column_chunks_to_record_batch(
                 builder.add_column_chunk(dfs_id, bytes.clone());
             }
             DataItem::ColumnArray(_) => {}
+            DataItem::Scalar(_) => {}
         }
     }
     let row_group = Box::new(builder.build());

--- a/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
@@ -118,9 +118,7 @@ impl BlockReader {
                     }
                     Value::Column(Column::from_arrow(cached.0.as_ref(), &data_type)?)
                 }
-                Some(DataItem::Scalar(scalar)) => {
-                    Value::Scalar(scalar)
-                }
+                Some(DataItem::Scalar(scalar)) => Value::Scalar((*scalar).clone()),
                 None => Value::Scalar(self.default_vals[i].clone()),
             };
             columns.push(BlockEntry::new(data_type, value));

--- a/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
@@ -78,6 +78,8 @@ impl BlockReader {
         {
             let data_type = field.data_type().into();
 
+            eprintln!("data_type {:?}", data_type);
+
             // NOTE, there is something tricky here:
             // - `column_chunks` always contains data of leaf columns
             // - here we may processing a nested type field
@@ -118,7 +120,10 @@ impl BlockReader {
                     }
                     Value::Column(Column::from_arrow(cached.0.as_ref(), &data_type)?)
                 }
-                Some(DataItem::Scalar(scalar)) => Value::Scalar((*scalar).clone()),
+                Some(DataItem::Scalar(scalar)) => {
+                    assert!(!column_node.is_nested);
+                    Value::Scalar((*scalar).clone())
+                }
                 None => Value::Scalar(self.default_vals[i].clone()),
             };
             columns.push(BlockEntry::new(data_type, value));

--- a/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
@@ -78,8 +78,6 @@ impl BlockReader {
         {
             let data_type = field.data_type().into();
 
-            eprintln!("data_type {:?}", data_type);
-
             // NOTE, there is something tricky here:
             // - `column_chunks` always contains data of leaf columns
             // - here we may processing a nested type field

--- a/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
@@ -118,6 +118,9 @@ impl BlockReader {
                     }
                     Value::Column(Column::from_arrow(cached.0.as_ref(), &data_type)?)
                 }
+                Some(DataItem::Scalar(scalar)) => {
+                    Value::Scalar(scalar)
+                }
                 None => Value::Scalar(self.default_vals[i].clone()),
             };
             columns.push(BlockEntry::new(data_type, value));

--- a/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader.rs
+++ b/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader.rs
@@ -116,6 +116,7 @@ impl VirtualColumnReader {
             Projection::Columns(vec![]),
             false,
             false,
+            false,
             put_cache,
         )?;
 

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -178,6 +178,7 @@ impl BloomIndexBuilder {
             projection,
             false,
             false,
+            self.storage_format.is_parquet(),
             false,
         )?;
 

--- a/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
@@ -30,6 +30,7 @@ use databend_common_pipeline_core::PipeItem;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache_manager::CachedObject;
 use databend_storages_common_table_meta::meta::BlockMeta;
+use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::Versioned;
 use log::info;
@@ -191,7 +192,7 @@ impl Processor for TransformSerializeSegment {
                 }
             }
             State::PreCommitSegment { location, segment } => {
-                if let Some(segment_cache) = SegmentInfo::cache() {
+                if let Some(segment_cache) = CompactSegmentInfo::cache() {
                     segment_cache.put(location.clone(), Arc::new(segment.as_ref().try_into()?));
                 }
 

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
@@ -116,6 +116,7 @@ impl MatchedAggregator {
                 projection,
                 false,
                 update_stream_columns,
+                table.storage_format.is_parquet(),
                 false,
             )
         }?;

--- a/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
@@ -210,6 +210,7 @@ impl Processor for CompactSource {
                                         &settings,
                                         &block.location.0,
                                         &block.col_metas,
+                                        &Some(&block.col_stats),
                                         &None,
                                     )
                                     .await

--- a/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
@@ -420,6 +420,7 @@ impl Processor for MutationSource {
                                     &settings,
                                     &fuse_part.location,
                                     &fuse_part.columns_meta,
+                                    &fuse_part.columns_stat,
                                     &None,
                                 )
                                 .await?;
@@ -442,6 +443,7 @@ impl Processor for MutationSource {
                             &settings,
                             &fuse_part.location,
                             &fuse_part.columns_meta,
+                            &fuse_part.columns_stat,
                             &None,
                         )
                         .await?;

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
@@ -301,6 +301,7 @@ impl Processor for ReadParquetDataSource<false> {
                                 &settings,
                                 &part.location,
                                 &part.columns_meta,
+                                &part.columns_stat,
                                 ignore_column_ids,
                             )
                             .await?;

--- a/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
@@ -244,6 +244,7 @@ impl<const BLOCKING_IO: bool> ParquetRowsFetcher<BLOCKING_IO> {
                         &settings,
                         &part.location,
                         &part.columns_meta,
+                        &part.columns_stat,
                         &None,
                     )
                     .await?;

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -56,6 +56,7 @@ impl FuseTable {
             projection,
             query_internal_columns,
             update_stream_columns,
+            self.storage_format.is_parquet(),
             put_cache,
         )
     }

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -26,6 +26,7 @@ use databend_common_metrics::storage::metrics_inc_recluster_build_task_milliseco
 use databend_common_metrics::storage::metrics_inc_recluster_segment_nums_scheduled;
 use databend_common_sql::BloomIndexColumns;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
+use databend_storages_common_table_meta::meta::SegmentInfo;
 use log::warn;
 use opendal::Operator;
 
@@ -229,6 +230,15 @@ impl FuseTable {
 
                 async move {
                     let pruned_segments = segment_pruner.pruning(batch).await?;
+                    // TODO just poc, pls do not do this
+                    let pruned_segments: Vec<_> = pruned_segments
+                        .into_iter()
+                        .map(|(loc, seg)| {
+                            let seg = CompactSegmentInfo::try_from(seg.as_ref())?;
+                            Ok((loc, Arc::new(seg)))
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+
                     Result::<_, ErrorCode>::Ok(pruned_segments)
                 }
             }));

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -630,6 +630,7 @@ impl AggregationContext {
                 &self.read_settings,
                 &block_meta.location.0,
                 &block_meta.col_metas,
+                &Some(&block_meta.col_stats),
                 &None,
             )
             .await?;

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -159,6 +159,7 @@ impl MergeIntoOperationAggregator {
                 projection,
                 false,
                 update_stream_columns,
+                table.storage_format.is_parquet(),
                 false,
             )
         }?;
@@ -175,6 +176,7 @@ impl MergeIntoOperationAggregator {
                     projection,
                     false,
                     update_stream_columns,
+                    table.storage_format.is_parquet(),
                     false,
                 )?;
                 Some(reader)

--- a/src/query/storages/fuse/src/operations/util.rs
+++ b/src/query/storages/fuse/src/operations/util.rs
@@ -142,6 +142,7 @@ pub async fn read_block(
             read_settings,
             &block_meta.location.0,
             &block_meta.col_metas,
+            &Some(&block_meta.col_stats),
             &None,
         )
         .await?;

--- a/src/query/storages/fuse/src/pruning/fuse_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/fuse_pruner.rs
@@ -337,7 +337,7 @@ impl FusePruner {
                                             block_pruner
                                                 .pruning(
                                                     segment_location.clone(),
-                                                    compact_segment_info.block_metas()?,
+                                                    compact_segment_info.blocks.clone(),
                                                 )
                                                 .await?,
                                         );
@@ -348,7 +348,7 @@ impl FusePruner {
                                         block_pruner
                                             .pruning(
                                                 segment_location.clone(),
-                                                compact_segment_info.block_metas()?,
+                                                compact_segment_info.blocks.clone(),
                                             )
                                             .await?,
                                     );
@@ -357,7 +357,7 @@ impl FusePruner {
                         }
                     } else {
                         for (location, info) in pruned_segments {
-                            let block_metas = info.block_metas()?;
+                            let block_metas = info.blocks.clone();
                             res.extend(block_pruner.pruning(location, block_metas).await?);
                         }
                     }

--- a/src/query/storages/fuse/src/pruning/segment_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/segment_pruner.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use databend_common_exception::Result;
 use databend_common_expression::TableSchemaRef;
 use databend_common_metrics::storage::*;
-use databend_storages_common_table_meta::meta::CompactSegmentInfo;
+use databend_storages_common_table_meta::meta::{CompactSegmentInfo, SegmentInfo};
 
 use crate::io::SegmentsIO;
 use crate::pruning::PruningContext;
@@ -43,7 +43,7 @@ impl SegmentPruner {
     pub async fn pruning(
         &self,
         segment_locs: Vec<SegmentLocation>,
-    ) -> Result<Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>> {
+    ) -> Result<Vec<(SegmentLocation, Arc<SegmentInfo>)>> {
         if segment_locs.is_empty() {
             return Ok(vec![]);
         }
@@ -54,7 +54,7 @@ impl SegmentPruner {
         let range_pruner = self.pruning_ctx.range_pruner.clone();
 
         for segment_location in segment_locs {
-            let info = SegmentsIO::read_compact_segment(
+            let info = SegmentsIO::read_normal_segment(
                 self.pruning_ctx.dal.clone(),
                 segment_location.location.clone(),
                 self.table_schema.clone(),

--- a/src/query/storages/fuse/src/pruning/segment_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/segment_pruner.rs
@@ -17,7 +17,8 @@ use std::sync::Arc;
 use databend_common_exception::Result;
 use databend_common_expression::TableSchemaRef;
 use databend_common_metrics::storage::*;
-use databend_storages_common_table_meta::meta::{CompactSegmentInfo, SegmentInfo};
+use databend_storages_common_table_meta::meta::CompactSegmentInfo;
+use databend_storages_common_table_meta::meta::SegmentInfo;
 
 use crate::io::SegmentsIO;
 use crate::pruning::PruningContext;

--- a/src/query/storages/system/src/caches_table.rs
+++ b/src/query/storages/system/src/caches_table.rs
@@ -60,6 +60,7 @@ impl SyncSystemTable for CachesTable {
         let table_snapshot_cache = cache_manager.get_table_snapshot_cache();
         let table_snapshot_statistic_cache = cache_manager.get_table_snapshot_statistics_cache();
         let segment_info_cache = cache_manager.get_table_segment_cache();
+        let deserialized_segment_info_cache = cache_manager.get_deserialized_segment_info_cache();
         let bloom_index_filter_cache = cache_manager.get_bloom_index_filter_cache();
         let bloom_index_meta_cache = cache_manager.get_bloom_index_meta_cache();
         let inverted_index_meta_cache = cache_manager.get_inverted_index_meta_cache();
@@ -85,6 +86,13 @@ impl SyncSystemTable for CachesTable {
         if let Some(segment_info_cache) = segment_info_cache {
             nodes.push(local_node.clone());
             names.push("segment_info_cache".to_string());
+            num_items.push(segment_info_cache.len() as u64);
+            size.push(segment_info_cache.size());
+        }
+
+        if let Some(segment_info_cache) = deserialized_segment_info_cache {
+            nodes.push(local_node.clone());
+            names.push("segment_info_deserialized_cache".to_string());
             num_items.push(segment_info_cache.len() as u64);
             size.push(segment_info_cache.size());
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

while reading columns, if zone map index of them shows that they are scalars (min == max), bypass reading, just construct scalar columns

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - covered by existing cases

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15972)
<!-- Reviewable:end -->
