### PR TITLE
feat: optimize loser tree, disable peek top2

### DIFF
--- a/src/query/pipeline/transforms/src/processors/transforms/sort/algorithm.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/algorithm.rs
@@ -25,6 +25,7 @@ use super::Cursor;
 use super::Rows;
 
 pub trait SortAlgorithm {
+    const SHOULD_PEEK_TOP2: bool;
     type Rows: Rows;
     type PeekMut<'b>: Deref<Target = Reverse<Cursor<Self::Rows>>> + DerefMut
     where Self: 'b;
@@ -56,6 +57,7 @@ pub trait SortAlgorithm {
 pub type HeapSort<R> = BinaryHeap<Reverse<Cursor<R>>>;
 
 impl<R: Rows> SortAlgorithm for BinaryHeap<Reverse<Cursor<R>>> {
+    const SHOULD_PEEK_TOP2: bool = true;
     type Rows = R;
     type PeekMut<'a> = binary_heap::PeekMut<'a, Reverse<Cursor<R>>> where R:'a;
     fn with_capacity(capacity: usize) -> Self {
@@ -122,6 +124,7 @@ impl<R: Rows> fmt::Debug for LoserTreeSort<R> {
 }
 
 impl<R: Rows> SortAlgorithm for LoserTreeSort<R> {
+    const SHOULD_PEEK_TOP2: bool = false;
     type Rows = R;
     type PeekMut<'a> = LoserTreePeekMut<'a,Self::Rows>  where Self: 'a;
     fn with_capacity(capacity: usize) -> Self {

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/algorithm.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/algorithm.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::fmt;
+use std::cmp::Ordering;
 use std::cmp::Reverse;
 use std::collections::binary_heap;
 use std::collections::BinaryHeap;
@@ -21,8 +22,11 @@ use std::ops::DerefMut;
 
 use super::loser_tree;
 use super::utils::find_bigger_child_of_root;
-use super::Cursor;
+use super::Cursor as RawCursor;
+use super::CursorOrder;
 use super::Rows;
+
+pub type Cursor<R> = RawCursor<R, ItemCursorOrder>;
 
 pub trait SortAlgorithm {
     const SHOULD_PEEK_TOP2: bool;
@@ -198,5 +202,18 @@ impl<R: Rows> DerefMut for LoserTreePeekMut<'_, R> {
 impl<R: Rows> Drop for LoserTreePeekMut<'_, R> {
     fn drop(&mut self) {
         self.0.tree.adjust_top();
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ItemCursorOrder;
+
+impl<R: Rows> CursorOrder<R> for ItemCursorOrder {
+    fn eq(a: &RawCursor<R, Self>, b: &RawCursor<R, Self>) -> bool {
+        a.current() == b.current()
+    }
+
+    fn cmp(a: &RawCursor<R, Self>, b: &RawCursor<R, Self>) -> Ordering {
+        a.current().cmp(&b.current())
     }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/cursor.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/cursor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
+use std::marker::PhantomData;
 
 use databend_common_expression::Column;
 
@@ -20,24 +21,28 @@ use super::rows::Rows;
 
 /// A cursor point to a certain row in a data block.
 #[derive(Clone)]
-pub struct Cursor<R: Rows> {
+pub struct Cursor<R, O>
+where
+    R: Rows,
+    O: CursorOrder<R>,
+{
     pub input_index: usize,
     pub row_index: usize,
 
     num_rows: usize,
+    _o: PhantomData<O>,
 
     /// rows within [`Cursor`] should be monotonic.
     rows: R,
 }
 
-impl<R: Rows> Cursor<R> {
+impl<R, O> Cursor<R, O>
+where
+    R: Rows,
+    O: CursorOrder<R>,
+{
     pub fn new(input_index: usize, rows: R) -> Self {
-        Self {
-            input_index,
-            row_index: 0,
-            num_rows: rows.len(),
-            rows,
-        }
+        O::new_cursor(input_index, rows)
     }
 
     #[inline]
@@ -72,7 +77,7 @@ impl<R: Rows> Cursor<R> {
         self.rows.to_column()
     }
 
-    pub fn cursor_mut(&self) -> CursorMut<'_, R> {
+    pub fn cursor_mut(&self) -> CursorMut<'_, R, O> {
         CursorMut {
             row_index: self.row_index,
             cursor: self,
@@ -80,58 +85,74 @@ impl<R: Rows> Cursor<R> {
     }
 }
 
-impl<R: Rows> Ord for Cursor<R> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        if self.input_index == other.input_index {
-            return self.row_index.cmp(&other.row_index);
+pub trait CursorOrder<R: Rows>: Sized + Copy {
+    fn eq(a: &Cursor<R, Self>, b: &Cursor<R, Self>) -> bool;
+
+    fn cmp(a: &Cursor<R, Self>, b: &Cursor<R, Self>) -> Ordering;
+
+    fn new_cursor(input_index: usize, rows: R) -> Cursor<R, Self> {
+        Cursor::<R, Self> {
+            input_index,
+            row_index: 0,
+            num_rows: rows.len(),
+            rows,
+            _o: PhantomData,
         }
-        self.current()
-            .cmp(&other.current())
-            .then_with(|| self.input_index.cmp(&other.input_index))
     }
 }
 
-impl<R: Rows> PartialEq for Cursor<R> {
+impl<R, O> Ord for Cursor<R, O>
+where
+    R: Rows,
+    O: CursorOrder<R>,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        O::cmp(self, other)
+    }
+}
+
+impl<R, O> PartialEq for Cursor<R, O>
+where
+    R: Rows,
+    O: CursorOrder<R>,
+{
     fn eq(&self, other: &Self) -> bool {
-        (self.input_index == other.input_index && self.row_index == other.row_index)
-            || self.current() == other.current()
+        O::eq(self, other)
     }
 }
 
-impl<R: Rows> Eq for Cursor<R> {}
+impl<R, O> Eq for Cursor<R, O>
+where
+    R: Rows,
+    O: CursorOrder<R>,
+{
+}
 
-impl<R: Rows> PartialOrd for Cursor<R> {
+impl<R, O> PartialOrd for Cursor<R, O>
+where
+    R: Rows,
+    O: CursorOrder<R>,
+{
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'a, R: Rows> PartialEq<Cursor<R>> for CursorMut<'a, R> {
-    fn eq(&self, other: &Cursor<R>) -> bool {
-        (self.cursor.input_index == other.input_index && self.row_index == other.row_index)
-            || self.current() == other.current()
-    }
-}
-
-impl<'a, R: Rows> PartialOrd<Cursor<R>> for CursorMut<'a, R> {
-    fn partial_cmp(&self, other: &Cursor<R>) -> Option<Ordering> {
-        Some(if self.cursor.input_index == other.input_index {
-            self.row_index.cmp(&other.row_index)
-        } else {
-            self.current()
-                .cmp(&other.current())
-                .then_with(|| self.cursor.input_index.cmp(&other.input_index))
-        })
-    }
-}
-
-pub struct CursorMut<'a, R: Rows> {
+pub struct CursorMut<'a, R, O>
+where
+    R: Rows,
+    O: CursorOrder<R>,
+{
     pub row_index: usize,
 
-    cursor: &'a Cursor<R>,
+    cursor: &'a Cursor<R, O>,
 }
 
-impl<'a, R: Rows> CursorMut<'a, R> {
+impl<'a, R, O> CursorMut<'a, R, O>
+where
+    R: Rows,
+    O: CursorOrder<R>,
+{
     pub fn advance(&mut self) -> usize {
         let res = self.row_index;
         self.row_index += 1;

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/cursor.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/cursor.rs
@@ -142,7 +142,7 @@ impl<'a, R: Rows> CursorMut<'a, R> {
         self.row_index == self.cursor.num_rows
     }
 
-    pub fn current(&self) -> R::Item<'_> {
+    pub fn current<'b>(&'b self) -> R::Item<'a> {
         self.cursor.rows.row(self.row_index)
     }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/cursor.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/cursor.rs
@@ -78,23 +78,25 @@ impl<R: Rows> Cursor<R> {
             cursor: self,
         }
     }
+
+    fn same_index(&self, other: &Self) -> bool {
+        self.input_index == other.input_index && self.row_index == other.row_index
+    }
 }
 
 impl<R: Rows> Ord for Cursor<R> {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.input_index == other.input_index {
-            return self.row_index.cmp(&other.row_index);
+        if self.same_index(other) {
+            Ordering::Equal
+        } else {
+            self.current().cmp(&other.current())
         }
-        self.current()
-            .cmp(&other.current())
-            .then_with(|| self.input_index.cmp(&other.input_index))
     }
 }
 
 impl<R: Rows> PartialEq for Cursor<R> {
     fn eq(&self, other: &Self) -> bool {
-        (self.input_index == other.input_index && self.row_index == other.row_index)
-            || self.current() == other.current()
+        self.same_index(other) || self.current() == other.current()
     }
 }
 
@@ -108,19 +110,16 @@ impl<R: Rows> PartialOrd for Cursor<R> {
 
 impl<'a, R: Rows> PartialEq<Cursor<R>> for CursorMut<'a, R> {
     fn eq(&self, other: &Cursor<R>) -> bool {
-        (self.cursor.input_index == other.input_index && self.row_index == other.row_index)
-            || self.current() == other.current()
+        self.same_index(other) || self.current() == other.current()
     }
 }
 
 impl<'a, R: Rows> PartialOrd<Cursor<R>> for CursorMut<'a, R> {
     fn partial_cmp(&self, other: &Cursor<R>) -> Option<Ordering> {
-        Some(if self.cursor.input_index == other.input_index {
-            self.row_index.cmp(&other.row_index)
+        Some(if self.same_index(other) {
+            Ordering::Equal
         } else {
-            self.current()
-                .cmp(&other.current())
-                .then_with(|| self.cursor.input_index.cmp(&other.input_index))
+            self.current().cmp(&other.current())
         })
     }
 }
@@ -144,5 +143,9 @@ impl<'a, R: Rows> CursorMut<'a, R> {
 
     pub fn current<'b>(&'b self) -> R::Item<'a> {
         self.cursor.rows.row(self.row_index)
+    }
+
+    fn same_index(&self, other: &Cursor<R>) -> bool {
+        self.cursor.input_index == other.input_index && self.row_index == other.row_index
     }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
@@ -199,19 +199,19 @@ where
 
         let cursor_finished = match (count, next_cursor) {
             (count, None) => {
-        self.temp_sorted_num_rows += count;
-        self.push_output_indices((input_index, start, count));
+                self.temp_sorted_num_rows += count;
+                self.push_output_indices((input_index, start, count));
 
-        // `self.sorted_cursors.peek_mut` will return a `PeekMut` object which allows us to modify the top element of the sorted_cursors.
-        // The sorted_cursors will adjust itself automatically when the `PeekMut` object is dropped (RAII).
-        let mut peek_mut = self.sorted_cursors.peek_mut();
-        let cursor = &mut peek_mut.0;
-        cursor.row_index += count;
+                // `self.sorted_cursors.peek_mut` will return a `PeekMut` object which allows us to modify the top element of the sorted_cursors.
+                // The sorted_cursors will adjust itself automatically when the `PeekMut` object is dropped (RAII).
+                let mut peek_mut = self.sorted_cursors.peek_mut();
+                let cursor = &mut peek_mut.0;
+                cursor.row_index += count;
 
                 let cursor_finished = cursor.is_finished();
                 if cursor_finished {
-            // Pop the current `cursor`.
-            A::pop_mut(peek_mut);
+                    // Pop the current `cursor`.
+                    A::pop_mut(peek_mut);
                 }
                 cursor_finished
             }

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
@@ -23,7 +23,6 @@ use databend_common_expression::DataSchemaRef;
 use databend_common_expression::SortColumnDescription;
 
 use super::algorithm::*;
-use super::Cursor;
 use super::Rows;
 
 #[async_trait::async_trait]
@@ -196,7 +195,7 @@ where
                     .min(start + max_rows - self.temp_sorted_num_rows);
                 let mut p = cursor.cursor_mut();
                 p.advance();
-                while p.row_index < limit && p.le(next_cursor) {
+                while p.row_index < limit && p.current().le(&next_cursor.current()) {
                     // If the cursor is smaller than the next cursor, don't need to push the cursor back to the sorted_cursors.
                     p.advance();
                 }

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
@@ -174,7 +174,15 @@ where
             (count, None)
         } else if !A::SHOULD_PEEK_TOP2 {
             debug_assert!(!cursor.is_finished());
-            (1, None)
+            let limit = cursor
+                .num_rows()
+                .min(cursor.row_index + max_rows - self.temp_sorted_num_rows);
+            let mut p = cursor.cursor_mut();
+            p.advance();
+            while p.row_index < limit && p.current() == cursor.current() {
+                p.advance();
+            }
+            (p.row_index - cursor.row_index, None)
         } else {
             let next_cursor = &self.sorted_cursors.peek_top2().0;
             if cursor.last().le(&next_cursor.current()) {

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
@@ -169,80 +169,56 @@ where
         let start = cursor.row_index;
 
         let max_rows = self.limit.unwrap_or(self.batch_rows).min(self.batch_rows);
-        let (count, next_cursor) = if self.sorted_cursors.len() == 1 {
-            let count = (cursor.num_rows() - start).min(max_rows - self.temp_sorted_num_rows);
-            (count, None)
+        let count = if self.sorted_cursors.len() == 1 {
+            (cursor.num_rows() - start).min(max_rows - self.temp_sorted_num_rows)
         } else if !A::SHOULD_PEEK_TOP2 {
             debug_assert!(!cursor.is_finished());
             let limit = cursor
                 .num_rows()
-                .min(cursor.row_index + max_rows - self.temp_sorted_num_rows);
+                .min(start + max_rows - self.temp_sorted_num_rows);
             let mut p = cursor.cursor_mut();
             p.advance();
             let previous = &cursor.current();
-            while p.row_index < limit && p.current().eq(previous) {
+            while p.row_index < limit && &p.current() == previous {
                 p.advance();
             }
-            (p.row_index - cursor.row_index, None)
+            p.row_index - start
         } else {
             let next_cursor = &self.sorted_cursors.peek_top2().0;
-            if cursor.last().le(&next_cursor.current()) {
+            if cursor.last() <= next_cursor.current() {
                 // Short Path:
                 // If the last row of current block is smaller than the next cursor,
                 // we can drain the whole block.
-                let count = (cursor.num_rows() - start).min(max_rows - self.temp_sorted_num_rows);
-                (count, None)
+                (cursor.num_rows() - start).min(max_rows - self.temp_sorted_num_rows)
             } else {
-                (0, Some(next_cursor))
-            }
-        };
-
-        let cursor_finished = match (count, next_cursor) {
-            (count, None) => {
-                self.temp_sorted_num_rows += count;
-                self.push_output_indices((input_index, start, count));
-
-                // `self.sorted_cursors.peek_mut` will return a `PeekMut` object which allows us to modify the top element of the sorted_cursors.
-                // The sorted_cursors will adjust itself automatically when the `PeekMut` object is dropped (RAII).
-                let mut peek_mut = self.sorted_cursors.peek_mut();
-                let cursor = &mut peek_mut.0;
-                cursor.row_index += count;
-
-                let cursor_finished = cursor.is_finished();
-                if cursor_finished {
-                    // Pop the current `cursor`.
-                    A::pop_mut(peek_mut);
-                }
-                cursor_finished
-            }
-            (0, Some(next_cursor)) => {
                 let mut cursor = cursor.cursor_mut();
+                let mut temp_sorted_num_rows = self.temp_sorted_num_rows;
+                let next = &next_cursor.current();
                 while !cursor.is_finished()
-                    && cursor.le(next_cursor)
-                    && self.temp_sorted_num_rows < max_rows
+                    && &cursor.current() <= next
+                    && temp_sorted_num_rows < max_rows
                 {
                     // If the cursor is smaller than the next cursor, don't need to push the cursor back to the sorted_cursors.
-                    self.temp_sorted_num_rows += 1;
+                    temp_sorted_num_rows += 1;
                     cursor.advance();
                 }
-
-                let cursor_finished = cursor.is_finished();
-                let row_index = cursor.row_index;
-
-                self.push_output_indices((input_index, start, row_index - start));
-
-                if cursor_finished {
-                    // Pop the current `cursor`.
-                    self.sorted_cursors.pop();
-                } else {
-                    self.sorted_cursors.peek_mut().0.row_index = row_index;
-                }
-                cursor_finished
+                cursor.row_index - start
             }
-            _ => unreachable!(),
         };
 
-        if cursor_finished {
+        self.temp_sorted_num_rows += count;
+        self.push_output_indices((input_index, start, count));
+
+        // `self.sorted_cursors.peek_mut` will return a `PeekMut` object which allows us to modify the top element of the sorted_cursors.
+        // The sorted_cursors will adjust itself automatically when the `PeekMut` object is dropped (RAII).
+        let mut peek_mut = self.sorted_cursors.peek_mut();
+        let cursor = &mut peek_mut.0;
+        cursor.row_index += count;
+
+        if cursor.is_finished() {
+            // Pop the current `cursor`.
+            A::pop_mut(peek_mut);
+
             // We have read all rows of this block, need to release the old memory and read a new one.
             let temp_block = DataBlock::take_by_slices_limit_from_blocks(
                 &self.buffer,

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/merger.rs
@@ -179,7 +179,8 @@ where
                 .min(cursor.row_index + max_rows - self.temp_sorted_num_rows);
             let mut p = cursor.cursor_mut();
             p.advance();
-            while p.row_index < limit && p.current() == cursor.current() {
+            let previous = &cursor.current();
+            while p.row_index < limit && p.current().eq(previous) {
                 p.advance();
             }
             (p.row_index - cursor.row_index, None)

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge.rs
@@ -30,7 +30,6 @@ use super::sort::algorithm::HeapSort;
 use super::sort::algorithm::LoserTreeSort;
 use super::sort::algorithm::SortAlgorithm;
 use super::sort::CommonRows;
-use super::sort::Cursor;
 use super::sort::DateConverter;
 use super::sort::DateRows;
 use super::sort::Rows;
@@ -88,7 +87,7 @@ impl<R: Rows> TransformSortMerge<R> {
 impl<R: Rows> MergeSort<R> for TransformSortMerge<R> {
     const NAME: &'static str = "TransformSortMerge";
 
-    fn add_block(&mut self, block: DataBlock, init_cursor: Cursor<R>) -> Result<()> {
+    fn add_block(&mut self, block: DataBlock, init_rows: R, _input_index: usize) -> Result<()> {
         if unlikely(self.aborting.load(Ordering::Relaxed)) {
             return Err(ErrorCode::AbortedQuery(
                 "Aborted query, because the server is shutting down or the query was killed.",
@@ -101,7 +100,7 @@ impl<R: Rows> MergeSort<R> for TransformSortMerge<R> {
 
         self.num_bytes += block.memory_size();
         self.num_rows += block.num_rows();
-        self.buffer.push(Some((block, init_cursor.to_column())));
+        self.buffer.push(Some((block, init_rows.to_column())));
 
         Ok(())
     }

--- a/tests/sqllogictests/suites/query/window_function/named_window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/named_window_basic.test
@@ -280,7 +280,7 @@ SELECT * FROM (SELECT row_number() OVER w rn FROM empsalary WINDOW w AS (PARTITI
 
 # Window func in order by
 query II
-SELECT a, sum(a) OVER w FROM t1 WINDOW w AS (PARTITION BY a) ORDER BY count() OVER w DESC
+SELECT a, sum(a) OVER w FROM t1 WINDOW w AS (PARTITION BY a) ORDER BY count() OVER w DESC, a
 ----
 1 3
 1 3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Simply disable peek top2 for loser tree, but it seems to work? NEED more test case.
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- Fixes 
-->
link #15925

[pprof.samples.cpu.heap.pb.gz](https://github.com/user-attachments/files/16100670/pprof.samples.cpu.heap.pb.gz)
![heap](https://github.com/datafuselabs/databend/assets/18322364/6182fbdc-09ca-4322-89d6-fe51f9a1e1ec)

[pprof.samples.cpu.loser.pb.gz](https://github.com/user-attachments/files/16100671/pprof.samples.cpu.loser.pb.gz)
![loser](https://github.com/datafuselabs/databend/assets/18322364/0c478954-a276-4448-bd08-0b765c6f6deb)

### data set
tpc-h 10G
### sql
select * from orders order by o_orderdate desc, o_totalprice desc ignore_result;

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15979)
<!-- Reviewable:end -->
