### PR TITLE
feat: add tenant&queryid to udf client

### DIFF
--- a/src/query/service/src/pipelines/builders/builder_udf.rs
+++ b/src/query/service/src/pipelines/builders/builder_udf.rs
@@ -36,6 +36,7 @@ impl PipelineBuilder {
         } else {
             self.main_pipeline.try_add_async_transformer(|| {
                 Ok(TransformUdfServer::new_retry_wrapper(
+                    self.ctx.clone(),
                     self.func_ctx.clone(),
                     udf.udf_funcs.clone(),
                 ))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* add tenant&queryid to udf client in `TransformUdfServer`, enabling the external UDF server to track with the client, so we can do the billing based on the tenant and track the error via the queryid.
With this PR, the header works, from the UDF server(with the special databend_udf.py):
```
2024-07-06 13:37:39,519 - udfs.translate - INFO - [Tenant: ['txy004'] | QueryID: ['1e05f3bc-9f74-4951-8c08-d1cfd7049e28']] Batch 1 token count: 41
2024-07-06 13:37:39,519 - udfs.translate - INFO - [Tenant: ['txy004'] | QueryID: ['1e05f3bc-9f74-4951-8c08-d1cfd7049e28']] Translation complete. Total tokens used: 41

```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - This PR need a special databend_udf.py to fetch the headers, which only used by bendml now, hard to test.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15987)
<!-- Reviewable:end -->
