### PR TITLE
refactor: optimize reading scalar columns 

### DIFF
--- a/src/common/metrics/src/metrics/storage.rs
+++ b/src/common/metrics/src/metrics/storage.rs
@@ -133,6 +133,10 @@ static REMOTE_IO_READ_MILLISECONDS: LazyLock<Histogram> =
     LazyLock::new(|| register_histogram_in_milliseconds("fuse_remote_io_read_milliseconds"));
 static REMOTE_IO_DESERIALIZE_MILLISECONDS: LazyLock<Histogram> =
     LazyLock::new(|| register_histogram_in_milliseconds("fuse_remote_io_deserialize_milliseconds"));
+
+static REMOTE_IO_COLUMNS_AS_SCALAR: LazyLock<Counter> =
+    LazyLock::new(|| register_counter("fuse_remote_io_col_as_scalar_count"));
+
 static BLOCK_WRITE_NUMS: LazyLock<Counter> =
     LazyLock::new(|| register_counter("fuse_block_write_nums"));
 static BLOCK_WRITE_BYTES: LazyLock<Counter> =
@@ -467,6 +471,10 @@ pub fn metrics_inc_commit_aborts() {
 
 pub fn metrics_inc_remote_io_seeks(c: u64) {
     REMOTE_IO_SEEKS.inc_by(c);
+}
+
+pub fn metrics_inc_remote_io_columns_as_scalar(c: u64) {
+    REMOTE_IO_COLUMNS_AS_SCALAR.inc_by(c);
 }
 
 pub fn metrics_inc_remote_io_seeks_after_merged(c: u64) {

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -1162,7 +1162,7 @@ impl TableField {
 
     pub fn is_nested(&self) -> bool {
         matches!(
-            self.data_type,
+            self.data_type.remove_nullable(),
             TableDataType::Tuple { .. } | TableDataType::Array(_) | TableDataType::Map(_)
         )
     }

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -241,6 +241,10 @@ impl FuseTable {
         matches!(self.storage_format, FuseStorageFormat::Native)
     }
 
+    pub fn get_storage_format(&self) -> FuseStorageFormat {
+        self.storage_format
+    }
+
     pub fn meta_location_generator(&self) -> &TableMetaLocationGenerator {
         &self.meta_location_generator
     }

--- a/src/query/storages/fuse/src/fuse_type.rs
+++ b/src/query/storages/fuse/src/fuse_type.rs
@@ -44,10 +44,20 @@ impl FuseTableType {
 
 /// Fuse engine table format.
 /// This is used to distinguish different table formats.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FuseStorageFormat {
     Parquet,
     Native,
+}
+
+impl FuseStorageFormat {
+    pub fn is_native(&self) -> bool {
+        self == &FuseStorageFormat::Native
+    }
+
+    pub fn is_parquet(&self) -> bool {
+        self == &FuseStorageFormat::Parquet
+    }
 }
 
 impl FromStr for FuseStorageFormat {

--- a/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader_parquet.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use databend_common_arrow::arrow::io::parquet::read as pread;
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_exception::Result;
+use databend_common_expression::ColumnId;
 use databend_common_expression::DataBlock;
+use databend_storages_common_table_meta::meta::ColumnStatistics;
 use log::debug;
 
 use super::AggIndexReader;
@@ -91,9 +95,16 @@ impl AggIndexReader {
                 debug_assert_eq!(metadata.row_groups.len(), 1);
                 let row_group = &metadata.row_groups[0];
                 let columns_meta = build_columns_meta(row_group);
+                let column_stats: Option<HashMap<ColumnId, ColumnStatistics>> = None;
                 let res = self
                     .reader
-                    .read_columns_data_by_merge_io(read_settings, loc, &columns_meta, &None)
+                    .read_columns_data_by_merge_io(
+                        read_settings,
+                        loc,
+                        &columns_meta,
+                        &column_stats,
+                        &None,
+                    )
                     .await
                     .inspect_err(|e| debug!("Read aggregating index `{loc}` failed: {e}"))
                     .ok()?;

--- a/src/query/storages/fuse/src/io/read/block/block_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader.rs
@@ -28,6 +28,7 @@ use databend_common_expression::DataField;
 use databend_common_expression::DataSchema;
 use databend_common_expression::FieldIndex;
 use databend_common_expression::Scalar;
+use databend_common_expression::TableField;
 use databend_common_expression::TableSchemaRef;
 use databend_common_sql::field_default_value;
 use databend_common_storage::ColumnNode;
@@ -45,6 +46,7 @@ pub struct BlockReader {
     pub(crate) projected_schema: TableSchemaRef,
     pub(crate) project_indices: BTreeMap<FieldIndex, (ColumnId, Field, DataType)>,
     pub(crate) project_column_nodes: Vec<ColumnNode>,
+    pub(crate) table_field_set: BTreeMap<ColumnId, TableField>,
     pub(crate) parquet_schema_descriptor: SchemaDescriptor,
     pub(crate) default_vals: Vec<Scalar>,
     pub query_internal_columns: bool,
@@ -136,7 +138,11 @@ impl BlockReader {
             .iter()
             .map(|c| (*c).clone())
             .collect();
+
         let project_indices = Self::build_projection_indices(&project_column_nodes);
+
+        let table_field_set =
+            BTreeMap::from_iter(schema.fields.iter().map(|f| (f.column_id, f.clone())));
 
         Ok(Arc::new(BlockReader {
             ctx,
@@ -145,6 +151,7 @@ impl BlockReader {
             projected_schema,
             project_indices,
             project_column_nodes,
+            table_field_set,
             parquet_schema_descriptor,
             default_vals,
             query_internal_columns,

--- a/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
@@ -20,6 +20,7 @@ use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::DataBlock;
+use databend_common_expression::Scalar;
 use databend_storages_common_cache_manager::SizedColumnArray;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ColumnMeta;
@@ -36,6 +37,7 @@ pub enum DeserializedArray<'a> {
     Cached(&'a Arc<SizedColumnArray>),
     Deserialized((ColumnId, Box<dyn Array>, usize)),
     NoNeedToCache(Box<dyn Array>),
+    Scalar(&'a (Scalar, usize)),
 }
 
 pub struct FieldDeserializationContext<'a> {
@@ -96,7 +98,13 @@ impl BlockReader {
     ) -> Result<DataBlock> {
         // Get the merged IO read result.
         let merge_io_read_result = self
-            .read_columns_data_by_merge_io(settings, &meta.location.0, &meta.col_metas, &None)
+            .read_columns_data_by_merge_io(
+                settings,
+                &meta.location.0,
+                &meta.col_metas,
+                &Some(&meta.col_stats),
+                &None,
+            )
             .await?;
 
         self.deserialize_chunks_with_meta(meta, storage_format, merge_io_read_result)

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
@@ -70,6 +70,7 @@ impl BlockReader {
                 &settings,
                 &part.location,
                 &part.columns_meta,
+                &part.columns_stat,
                 ignore_column_ids,
             )
             .await?;

--- a/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
@@ -57,6 +57,7 @@ pub fn column_chunks_to_record_batch(
                 builder.add_column_chunk(dfs_id, bytes.clone());
             }
             DataItem::ColumnArray(_) => {}
+            DataItem::Scalar(_) => {}
         }
     }
     let row_group = Box::new(builder.build());

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -178,7 +178,7 @@ impl BloomIndexBuilder {
             projection,
             false,
             false,
-            false,
+            self.storage_format.is_parquet(),
         )?;
 
         let settings = ReadSettings::from_ctx(&self.table_ctx)?;

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
@@ -116,7 +116,7 @@ impl MatchedAggregator {
                 projection,
                 false,
                 update_stream_columns,
-                false,
+                table.storage_format.is_parquet(),
             )
         }?;
 

--- a/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
@@ -210,6 +210,7 @@ impl Processor for CompactSource {
                                         &settings,
                                         &block.location.0,
                                         &block.col_metas,
+                                        &Some(&block.col_stats),
                                         &None,
                                     )
                                     .await

--- a/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
@@ -420,6 +420,7 @@ impl Processor for MutationSource {
                                     &settings,
                                     &fuse_part.location,
                                     &fuse_part.columns_meta,
+                                    &fuse_part.columns_stat,
                                     &None,
                                 )
                                 .await?;
@@ -442,6 +443,7 @@ impl Processor for MutationSource {
                             &settings,
                             &fuse_part.location,
                             &fuse_part.columns_meta,
+                            &fuse_part.columns_stat,
                             &None,
                         )
                         .await?;

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
@@ -301,6 +301,7 @@ impl Processor for ReadParquetDataSource<false> {
                                 &settings,
                                 &part.location,
                                 &part.columns_meta,
+                                &part.columns_stat,
                                 ignore_column_ids,
                             )
                             .await?;

--- a/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
@@ -244,6 +244,7 @@ impl<const BLOCKING_IO: bool> ParquetRowsFetcher<BLOCKING_IO> {
                         &settings,
                         &part.location,
                         &part.columns_meta,
+                        &part.columns_stat,
                         &None,
                     )
                     .await?;

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -630,6 +630,7 @@ impl AggregationContext {
                 &self.read_settings,
                 &block_meta.location.0,
                 &block_meta.col_metas,
+                &Some(&block_meta.col_stats),
                 &None,
             )
             .await?;

--- a/src/query/storages/fuse/src/operations/util.rs
+++ b/src/query/storages/fuse/src/operations/util.rs
@@ -142,6 +142,7 @@ pub async fn read_block(
             read_settings,
             &block_meta.location.0,
             &block_meta.col_metas,
+            &Some(&block_meta.col_stats),
             &None,
         )
         .await?;

--- a/tests/suites/1_stateful/05_formats/05_05_parquet/05_05_01_parquet_load_unload.result
+++ b/tests/suites/1_stateful/05_formats/05_05_parquet/05_05_01_parquet_load_unload.result
@@ -28,14 +28,14 @@ a"b	1	['a"b']	{"k":"v"}	2044-05-06 10:25:02.868894	10.01	('a',5)	['{"k":"v"}']	[
 NULL	2	['a'b']	[1]	2044-05-06 10:25:02.868894	-10.01	('b',10)	['[1]']	[('b',10)]
 <<<<
 >>>> copy into @s1/unload1/ from test_load_unload
-2	362	2986
+2	369	2986
 >>>> truncate table test_load_unload
 >>>> copy into test_load_unload from @s1/unload1.parquet force=true;
 unload1.parquet	2	0	NULL	NULL
 begin diff select
 end diff
 >>>> copy into @s1/unload2/ from test_load_unload
-2	362	2986
+2	369	2986
 begin diff parquet
 end diff
 >>>> truncate table test_load_unload

--- a/tests/suites/1_stateful/05_formats/05_05_parquet/05_05_01_parquet_load_unload.result
+++ b/tests/suites/1_stateful/05_formats/05_05_parquet/05_05_01_parquet_load_unload.result
@@ -28,14 +28,14 @@ a"b	1	['a"b']	{"k":"v"}	2044-05-06 10:25:02.868894	10.01	('a',5)	['{"k":"v"}']	[
 NULL	2	['a'b']	[1]	2044-05-06 10:25:02.868894	-10.01	('b',10)	['[1]']	[('b',10)]
 <<<<
 >>>> copy into @s1/unload1/ from test_load_unload
-2	369	2986
+2	362	2986
 >>>> truncate table test_load_unload
 >>>> copy into test_load_unload from @s1/unload1.parquet force=true;
 unload1.parquet	2	0	NULL	NULL
 begin diff select
 end diff
 >>>> copy into @s1/unload2/ from test_load_unload
-2	369	2986
+2	362	2986
 begin diff parquet
 end diff
 >>>> truncate table test_load_unload


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

while reading columns, if zone map index of them shows that they are scalars (min == max), bypass reading, just construct scalar columns

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15988)
<!-- Reviewable:end -->
