### PR TITLE
chore(query): show user functions should display built-in udfs

### DIFF
--- a/src/query/storages/system/src/user_functions_table.rs
+++ b/src/query/storages/system/src/user_functions_table.rs
@@ -181,6 +181,7 @@ impl UserFunctionsTable {
     #[async_backtrace::framed]
     async fn get_udfs(ctx: Arc<dyn TableContext>) -> Result<Vec<UserDefinedFunction>> {
         let tenant = ctx.get_tenant();
+
         UserApiProvider::instance().list_udf(&tenant).await
     }
 }

--- a/src/query/users/src/user_udf.rs
+++ b/src/query/users/src/user_udf.rs
@@ -90,10 +90,13 @@ impl UserApiProvider {
     pub async fn list_udf(&self, tenant: &Tenant) -> Result<Vec<UserDefinedFunction>> {
         let udf_api = self.udf_api(tenant);
 
-        let udfs = udf_api
+        let mut udfs = udf_api
             .list_udf()
             .await
             .map_err(|e| e.add_message_back("while list UDFs"))?;
+
+        // Extend the existing `udfs` vector with built-in UDFs.
+        udfs.extend(self.get_configured_udfs().into_values());
 
         Ok(udfs)
     }

--- a/tests/sqllogictests/suites/udf_server/udf_builtin.test
+++ b/tests/sqllogictests/suites/udf_server/udf_builtin.test
@@ -7,6 +7,11 @@ select ping('test');
 ----
 test
 
+query T
+select name from system.user_functions;
+----
+ping
+
 statement error 2603
 CREATE FUNCTION ping(STRING) RETURNS STRING LANGUAGE python HANDLER = 'ping' ADDRESS = 'http://0.0.0.0:8815';
 

--- a/tests/sqllogictests/suites/udf_server/user_functions_table.test
+++ b/tests/sqllogictests/suites/udf_server/user_functions_table.test
@@ -58,6 +58,7 @@ SELECT definition FROM SYSTEM.USER_FUNCTIONS ORDER BY name;
  (UInt8 NULL, UInt16 NULL, UInt32 NULL, UInt64 NULL) RETURNS UInt64 NULL LANGUAGE python HANDLER = add_unsigned ADDRESS = http://0.0.0.0:8815
  (a, b, c, d, e) -> a + c * (e / b) - d
  (p) -> NOT is_null(p)
+ (String NULL) RETURNS String NULL LANGUAGE python HANDLER = ping ADDRESS = http://0.0.0.0:8815
 
 # DROP FUNCTIONS
 statement ok

--- a/tests/suites/0_stateless/20+_others/20_0016_udf_timestamp.result
+++ b/tests/suites/0_stateless/20+_others/20_0016_udf_timestamp.result
@@ -1,4 +1,6 @@
 ==TEST SHOW USER FUNCTIONS==
 isnotempty	NULL		{"parameters":["p"]}	SQL	yyyy-mm-dd HH:MM:SS.ssssss
+ping	NULL	Built-in UDF	{"arg_types":["String NULL"],"return_type":"String NULL"}	python	yyyy-mm-dd HH:MM:SS.ssssss
 ==TEST SELECT * FROM SYSTEM.USER_FUNCTIONS==
 isnotempty	NULL		{"parameters":["p"]}	SQL	 (p) -> NOT is_null(p)	yyyy-mm-dd HH:MM:SS.ssssss
+ping	NULL	Built-in UDF	{"arg_types":["String NULL"],"return_type":"String NULL"}	python	 (String NULL) RETURNS String NULL LANGUAGE python HANDLER = ping ADDRESS = http://0.0.0.0:8815	yyyy-mm-dd HH:MM:SS.ssssss


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

show user functions should display built-in udfs

- Fixes #https://github.com/datafuselabs/databend/pull/15938


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15990)
<!-- Reviewable:end -->
