### PR TITLE
parquet add option `missing_field_as`.

### DIFF
--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -128,6 +128,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (96, "2024-07-02: Add: add using_share_endpoint field into DatabaseMeta"),
     (97, "2024-07-04: Add: missing_field_as in user.proto/OrcFileFormatParams"),
     (98, "2024-07-04: Add: add iceberg catalog option in catalog option"),
+    (99, "2024-07-08: Add: missing_field_as in user.proto/ParquetFileFormatParams"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -102,3 +102,4 @@ mod v095_share_endpoint_meta;
 mod v096_database_meta;
 mod v097_orc_format_params;
 mod v098_catalog_option;
+mod v099_parquet_format_params;

--- a/src/meta/proto-conv/tests/it/v099_parquet_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v099_parquet_format_params.rs
@@ -1,0 +1,49 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_app::principal::NullAs;
+use databend_common_meta_app::principal::ParquetFileFormatParams;
+use minitrace::func_name;
+
+use crate::common;
+
+// These bytes are built when a new version in introduced,
+
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+#[test]
+fn test_decode_v99_parquet_file_format_params() -> anyhow::Result<()> {
+    let parquet_file_format_params_v99 = vec![
+        10, 13, 70, 73, 69, 76, 68, 95, 68, 69, 70, 65, 85, 76, 84, 34, 0, 34, 1, 97, 160, 6, 99,
+        168, 6, 24,
+    ];
+    let want = || ParquetFileFormatParams {
+        missing_field_as: NullAs::FieldDefault,
+        null_if: vec!["".to_string(), "a".to_string()],
+    };
+    common::test_load_old(
+        func_name!(),
+        parquet_file_format_params_v99.as_slice(),
+        99,
+        want(),
+    )?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}

--- a/src/meta/protos/proto/file_format.proto
+++ b/src/meta/protos/proto/file_format.proto
@@ -91,6 +91,7 @@ message FileFormatParams {
 message ParquetFileFormatParams {
   uint64 ver = 100;
   uint64 min_reader_ver = 101;
+  optional string missing_field_as = 1;
   repeated string null_if = 4;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

the option was introduced experimentally in https://github.com/datafuselabs/databend/pull/14149,
now we fix it and write it to meta.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
