### PR TITLE
refactor: rename metrics & tweak system.caches table

### DIFF
--- a/src/common/metrics/src/metrics/cache.rs
+++ b/src/common/metrics/src/metrics/cache.rs
@@ -29,6 +29,8 @@ static CACHE_ACCESS_COUNT: LazyLock<FamilyCounter<CacheLabels>> =
     LazyLock::new(|| register_counter_family("cache_access_count"));
 static CACHE_MISS_COUNT: LazyLock<FamilyCounter<CacheLabels>> =
     LazyLock::new(|| register_counter_family("cache_miss_count"));
+static CACHE_MISS_BYTES: LazyLock<FamilyCounter<CacheLabels>> =
+    LazyLock::new(|| register_counter_family("cache_miss_bytes"));
 static CACHE_MISS_LOAD_MILLISECOND: LazyLock<FamilyHistogram<CacheLabels>> =
     LazyLock::new(|| register_histogram_family_in_milliseconds("cache_miss_load_millisecond"));
 static CACHE_HIT_COUNT: LazyLock<FamilyCounter<CacheLabels>> =
@@ -47,8 +49,15 @@ pub fn metrics_inc_cache_access_count(c: u64, cache_name: &str) {
 }
 
 pub fn metrics_inc_cache_miss_count(c: u64, cache_name: &str) {
-    // increment_gauge!(("fuse_memory_miss_count"), c as f64);
     CACHE_MISS_COUNT
+        .get_or_create(&CacheLabels {
+            cache_name: cache_name.to_string(),
+        })
+        .inc_by(c);
+}
+
+pub fn metrics_inc_cache_miss_bytes(c: u64, cache_name: &str) {
+    CACHE_MISS_BYTES
         .get_or_create(&CacheLabels {
             cache_name: cache_name.to_string(),
         })

--- a/src/query/service/tests/it/storages/testdata/caches_table.txt
+++ b/src/query/service/tests/it/storages/testdata/caches_table.txt
@@ -1,18 +1,18 @@
 ---------- TABLE INFO ------------
 DB.Table: 'system'.'caches', Table: caches-table_id:1, ver:0, Engine: SystemCache
 -------- TABLE CONTENTS ----------
-+-------------+----------------------------------+----------+----------+
-| Column 0    | Column 1                         | Column 2 | Column 3 |
-+-------------+----------------------------------+----------+----------+
-| 'test-node' | 'bloom_index_filter_cache'       | 0        | 0        |
-| 'test-node' | 'bloom_index_meta_cache'         | 0        | 0        |
-| 'test-node' | 'file_meta_data_cache'           | 0        | 0        |
-| 'test-node' | 'inverted_index_file_cache'      | 0        | 0        |
-| 'test-node' | 'inverted_index_meta_cache'      | 0        | 0        |
-| 'test-node' | 'prune_partitions_cache'         | 0        | 0        |
-| 'test-node' | 'segment_info_cache'             | 0        | 0        |
-| 'test-node' | 'table_snapshot_cache'           | 0        | 0        |
-| 'test-node' | 'table_snapshot_statistic_cache' | 0        | 0        |
-+-------------+----------------------------------+----------+----------+
++-------------+----------------------------------------------+----------+----------+
+| Column 0    | Column 1                                     | Column 2 | Column 3 |
++-------------+----------------------------------------------+----------+----------+
+| 'test-node' | 'memory_cache_bloom_index_file_meta_data'    | 0        | 0        |
+| 'test-node' | 'memory_cache_bloom_index_filter'            | 0        | 0        |
+| 'test-node' | 'memory_cache_compact_segment_info'          | 0        | 0        |
+| 'test-node' | 'memory_cache_inverted_index_file'           | 0        | 0        |
+| 'test-node' | 'memory_cache_inverted_index_file_meta_data' | 0        | 0        |
+| 'test-node' | 'memory_cache_parquet_file_meta'             | 0        | 0        |
+| 'test-node' | 'memory_cache_prune_partitions'              | 0        | 0        |
+| 'test-node' | 'memory_cache_table_snapshot'                | 0        | 0        |
+| 'test-node' | 'memory_cache_table_statistics'              | 0        | 0        |
++-------------+----------------------------------------------+----------+----------+
 
 

--- a/src/query/storages/common/cache/src/lib.rs
+++ b/src/query/storages/common/cache/src/lib.rs
@@ -35,7 +35,7 @@ pub use providers::LruDiskCacheHolder;
 pub use providers::TableDataCache;
 pub use providers::TableDataCacheBuilder;
 pub use providers::TableDataCacheKey;
-pub use providers::TABLE_DATA_CACHE_NAME;
+pub use providers::DISK_TABLE_DATA_CACHE_NAME;
 pub use read::CacheKey;
 pub use read::CachedReader;
 pub use read::InMemoryBytesCacheReader;

--- a/src/query/storages/common/cache/src/lib.rs
+++ b/src/query/storages/common/cache/src/lib.rs
@@ -19,8 +19,10 @@ mod providers;
 mod read;
 
 pub use cache::CacheAccessor;
+pub use cache::CacheAccessorExt;
 pub use cache::Named;
 pub use cache::NamedCache;
+pub use databend_common_cache::CountableMeter;
 pub use providers::DiskCacheError;
 pub use providers::DiskCacheKey;
 pub use providers::DiskCacheResult;
@@ -33,6 +35,7 @@ pub use providers::LruDiskCacheHolder;
 pub use providers::TableDataCache;
 pub use providers::TableDataCacheBuilder;
 pub use providers::TableDataCacheKey;
+pub use providers::TABLE_DATA_CACHE_NAME;
 pub use read::CacheKey;
 pub use read::CachedReader;
 pub use read::InMemoryBytesCacheReader;

--- a/src/query/storages/common/cache/src/providers/mod.rs
+++ b/src/query/storages/common/cache/src/providers/mod.rs
@@ -29,4 +29,4 @@ pub use memory_cache::InMemoryItemCacheHolder;
 pub use table_data_cache::TableDataCache;
 pub use table_data_cache::TableDataCacheBuilder;
 pub use table_data_cache::TableDataCacheKey;
-pub use table_data_cache::TABLE_DATA_CACHE_NAME;
+pub use table_data_cache::DISK_TABLE_DATA_CACHE_NAME;

--- a/src/query/storages/common/cache/src/providers/mod.rs
+++ b/src/query/storages/common/cache/src/providers/mod.rs
@@ -29,3 +29,4 @@ pub use memory_cache::InMemoryItemCacheHolder;
 pub use table_data_cache::TableDataCache;
 pub use table_data_cache::TableDataCacheBuilder;
 pub use table_data_cache::TableDataCacheKey;
+pub use table_data_cache::TABLE_DATA_CACHE_NAME;

--- a/src/query/storages/common/cache_manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache_manager/src/cache_manager.rs
@@ -113,7 +113,7 @@ impl CacheManager {
         };
 
         // Cache of deserialized table data
-        let in_memory_table_data_cache = Self::new_cache_with_meter(
+        let in_memory_table_data_cache = Self::new_named_cache_with_meter(
             memory_cache_capacity,
             ColumnArrayMeter,
             "memory_cache_table_data",
@@ -135,29 +135,29 @@ impl CacheManager {
                 table_column_array_cache: in_memory_table_data_cache,
             }));
         } else {
-            let table_snapshot_cache = Self::new_cache(
+            let table_snapshot_cache = Self::new_named_cache(
                 config.table_meta_snapshot_count,
                 "memory_cache_table_snapshot",
             );
-            let table_statistic_cache = Self::new_cache(
+            let table_statistic_cache = Self::new_named_cache(
                 config.table_meta_statistic_count,
                 "memory_cache_table_statistics",
             );
-            let segment_info_cache = Self::new_cache_with_meter(
+            let segment_info_cache = Self::new_named_cache_with_meter(
                 config.table_meta_segment_bytes,
                 CompactSegmentInfoMeter {},
                 "memory_cache_compact_segment_info",
             );
-            let bloom_index_filter_cache = Self::new_cache_with_meter(
+            let bloom_index_filter_cache = Self::new_named_cache_with_meter(
                 config.table_bloom_index_filter_size,
                 BloomIndexFilterMeter {},
                 "memory_cache_bloom_index_filter",
             );
-            let bloom_index_meta_cache = Self::new_cache(
+            let bloom_index_meta_cache = Self::new_named_cache(
                 config.table_bloom_index_meta_count,
                 "memory_cache_bloom_index_file_meta_data",
             );
-            let inverted_index_meta_cache = Self::new_cache(
+            let inverted_index_meta_cache = Self::new_named_cache(
                 config.inverted_index_meta_count,
                 "memory_cache_inverted_index_file_meta_data",
             );
@@ -168,17 +168,17 @@ impl CacheManager {
             } else {
                 config.inverted_index_filter_size
             };
-            let inverted_index_file_cache = Self::new_cache_with_meter(
+            let inverted_index_file_cache = Self::new_named_cache_with_meter(
                 inverted_index_file_size,
                 InvertedIndexFileMeter {},
                 "memory_cache_inverted_index_file",
             );
-            let prune_partitions_cache = Self::new_cache(
+            let prune_partitions_cache = Self::new_named_cache(
                 config.table_prune_partitions_count,
                 "memory_cache_prune_partitions",
             );
 
-            let file_meta_data_cache = Self::new_cache(
+            let file_meta_data_cache = Self::new_named_cache(
                 DEFAULT_FILE_META_DATA_CACHE_ITEMS,
                 "memory_cache_parquet_file_meta",
             );
@@ -249,7 +249,7 @@ impl CacheManager {
     }
 
     // create cache that meters size by `Count`
-    fn new_cache<V>(
+    fn new_named_cache<V>(
         capacity: u64,
         name: impl Into<String>,
     ) -> Option<NamedCache<InMemoryItemCacheHolder<V>>> {
@@ -261,7 +261,7 @@ impl CacheManager {
     }
 
     // create cache that meters size by `meter`
-    fn new_cache_with_meter<V, M>(
+    fn new_named_cache_with_meter<V, M>(
         capacity: u64,
         meter: M,
         name: &str,

--- a/src/query/storages/common/cache_manager/src/cache_manager.rs
+++ b/src/query/storages/common/cache_manager/src/cache_manager.rs
@@ -111,10 +111,12 @@ impl CacheManager {
         } else {
             max_server_memory_usage * config.table_data_deserialized_memory_ratio / 100
         };
-        let table_column_array_cache = Self::new_in_memory_cache(
+
+        // Cache of deserialized table data
+        let in_memory_table_data_cache = Self::new_cache_with_meter(
             memory_cache_capacity,
             ColumnArrayMeter,
-            "table_data_column_array",
+            "memory_cache_table_data",
         );
 
         // setup in-memory table meta cache
@@ -130,30 +132,34 @@ impl CacheManager {
                 file_meta_data_cache: None,
                 table_statistic_cache: None,
                 table_data_cache,
-                table_column_array_cache,
+                table_column_array_cache: in_memory_table_data_cache,
             }));
         } else {
-            let table_snapshot_cache =
-                Self::new_item_cache(config.table_meta_snapshot_count, "table_snapshot");
-            let table_statistic_cache =
-                Self::new_item_cache(config.table_meta_statistic_count, "table_statistics");
-            let segment_info_cache = Self::new_in_memory_cache(
+            let table_snapshot_cache = Self::new_cache(
+                config.table_meta_snapshot_count,
+                "memory_cache_table_snapshot",
+            );
+            let table_statistic_cache = Self::new_cache(
+                config.table_meta_statistic_count,
+                "memory_cache_table_statistics",
+            );
+            let segment_info_cache = Self::new_cache_with_meter(
                 config.table_meta_segment_bytes,
                 CompactSegmentInfoMeter {},
-                "segment_info",
+                "memory_cache_compact_segment_info",
             );
-            let bloom_index_filter_cache = Self::new_in_memory_cache(
+            let bloom_index_filter_cache = Self::new_cache_with_meter(
                 config.table_bloom_index_filter_size,
                 BloomIndexFilterMeter {},
-                "bloom_index_filter",
+                "memory_cache_bloom_index_filter",
             );
-            let bloom_index_meta_cache = Self::new_item_cache(
+            let bloom_index_meta_cache = Self::new_cache(
                 config.table_bloom_index_meta_count,
-                "bloom_index_file_meta_data",
+                "memory_cache_bloom_index_file_meta_data",
             );
-            let inverted_index_meta_cache = Self::new_item_cache(
+            let inverted_index_meta_cache = Self::new_cache(
                 config.inverted_index_meta_count,
-                "inverted_index_file_meta_data",
+                "memory_cache_inverted_index_file_meta_data",
             );
 
             // setup in-memory inverted index filter cache
@@ -162,16 +168,20 @@ impl CacheManager {
             } else {
                 config.inverted_index_filter_size
             };
-            let inverted_index_file_cache = Self::new_in_memory_cache(
+            let inverted_index_file_cache = Self::new_cache_with_meter(
                 inverted_index_file_size,
                 InvertedIndexFileMeter {},
-                "inverted_index_file",
+                "memory_cache_inverted_index_file",
             );
-            let prune_partitions_cache =
-                Self::new_item_cache(config.table_prune_partitions_count, "prune_partitions");
+            let prune_partitions_cache = Self::new_cache(
+                config.table_prune_partitions_count,
+                "memory_cache_prune_partitions",
+            );
 
-            let file_meta_data_cache =
-                Self::new_item_cache(DEFAULT_FILE_META_DATA_CACHE_ITEMS, "parquet_file_meta");
+            let file_meta_data_cache = Self::new_cache(
+                DEFAULT_FILE_META_DATA_CACHE_ITEMS,
+                "memory_cache_parquet_file_meta",
+            );
             GlobalInstance::set(Arc::new(Self {
                 table_snapshot_cache,
                 segment_info_cache,
@@ -183,7 +193,7 @@ impl CacheManager {
                 file_meta_data_cache,
                 table_statistic_cache,
                 table_data_cache,
-                table_column_array_cache,
+                table_column_array_cache: in_memory_table_data_cache,
             }));
         }
 
@@ -239,7 +249,7 @@ impl CacheManager {
     }
 
     // create cache that meters size by `Count`
-    fn new_item_cache<V>(
+    fn new_cache<V>(
         capacity: u64,
         name: impl Into<String>,
     ) -> Option<NamedCache<InMemoryItemCacheHolder<V>>> {
@@ -251,7 +261,7 @@ impl CacheManager {
     }
 
     // create cache that meters size by `meter`
-    fn new_in_memory_cache<V, M>(
+    fn new_cache_with_meter<V, M>(
         capacity: u64,
         meter: M,
         name: &str,

--- a/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
@@ -23,7 +23,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_metrics::storage::*;
-use databend_storages_common_cache::CacheAccessor;
+use databend_storages_common_cache::CacheAccessorExt;
 use databend_storages_common_cache::TableDataCacheKey;
 use databend_storages_common_cache_manager::CacheManager;
 use databend_storages_common_table_meta::meta::ColumnMeta;
@@ -161,13 +161,15 @@ impl BlockReader {
                 let column_cache_key = TableDataCacheKey::new(location, *column_id, offset, len);
 
                 // first, check column array object cache
-                if let Some(cache_array) = column_array_cache.get(&column_cache_key) {
+                if let Some(cache_array) = column_array_cache.get_with_len(&column_cache_key, len) {
                     cached_column_array.push((*column_id, cache_array));
                     continue;
                 }
 
                 // and then, check column data cache
-                if let Some(cached_column_raw_data) = column_data_cache.get(&column_cache_key) {
+                if let Some(cached_column_raw_data) =
+                    column_data_cache.get_with_len(&column_cache_key, len)
+                {
                     cached_column_data.push((*column_id, cached_column_raw_data));
                     continue;
                 }

--- a/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
@@ -160,13 +160,13 @@ impl BlockReader {
 
                 let column_cache_key = TableDataCacheKey::new(location, *column_id, offset, len);
 
-                // first, check column array object cache
+                // first, check in memory table data cache
                 if let Some(cache_array) = column_array_cache.get_with_len(&column_cache_key, len) {
                     cached_column_array.push((*column_id, cache_array));
                     continue;
                 }
 
-                // and then, check column data cache
+                // and then, check on disk table data cache
                 if let Some(cached_column_raw_data) =
                     column_data_cache.get_with_len(&column_cache_key, len)
                 {
@@ -174,7 +174,7 @@ impl BlockReader {
                     continue;
                 }
 
-                // if all cache missed, prepare the ranges to be read
+                // if all caches missed, prepare the ranges to be read
                 ranges.push((*column_id, offset..(offset + len)));
 
                 // Perf

--- a/src/query/storages/system/src/caches_table.rs
+++ b/src/query/storages/system/src/caches_table.rs
@@ -33,7 +33,7 @@ use databend_common_storages_fuse::TableContext;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CountableMeter;
 use databend_storages_common_cache::NamedCache;
-use databend_storages_common_cache::TABLE_DATA_CACHE_NAME;
+use databend_storages_common_cache::DISK_TABLE_DATA_CACHE_NAME;
 use databend_storages_common_cache_manager::CacheManager;
 
 use crate::SyncOneBlockSystemTable;
@@ -117,7 +117,7 @@ impl SyncSystemTable for CachesTable {
         if let Some(table_data_cache) = table_data_cache {
             // table data cache is not a named cache yet
             columns.nodes.push(local_node.clone());
-            columns.names.push(TABLE_DATA_CACHE_NAME.to_string());
+            columns.names.push(DISK_TABLE_DATA_CACHE_NAME.to_string());
             columns.num_items.push(table_data_cache.len() as u64);
             columns.size.push(table_data_cache.size());
         }

--- a/src/query/storages/system/src/caches_table.rs
+++ b/src/query/storages/system/src/caches_table.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::hash::BuildHasher;
+use std::hash::Hash;
 use std::sync::Arc;
 
 use databend_common_catalog::table::Table;
@@ -29,6 +31,9 @@ use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_storages_fuse::TableContext;
 use databend_storages_common_cache::CacheAccessor;
+use databend_storages_common_cache::CountableMeter;
+use databend_storages_common_cache::NamedCache;
+use databend_storages_common_cache::TABLE_DATA_CACHE_NAME;
 use databend_storages_common_cache_manager::CacheManager;
 
 use crate::SyncOneBlockSystemTable;
@@ -36,6 +41,14 @@ use crate::SyncSystemTable;
 
 pub struct CachesTable {
     table_info: TableInfo,
+}
+
+#[derive(Default)]
+struct CachesTableColumns {
+    nodes: Vec<String>,
+    names: Vec<String>,
+    num_items: Vec<u64>,
+    size: Vec<u64>,
 }
 
 impl SyncSystemTable for CachesTable {
@@ -50,11 +63,6 @@ impl SyncSystemTable for CachesTable {
 
     fn get_full_data(&self, ctx: Arc<dyn TableContext>) -> Result<DataBlock> {
         let local_node = ctx.get_cluster().local_id.clone();
-        let mut nodes = Vec::new();
-        let mut names = Vec::new();
-        let mut num_items = Vec::new();
-        let mut size = Vec::new();
-
         let cache_manager = CacheManager::instance();
 
         let table_snapshot_cache = cache_manager.get_table_snapshot_cache();
@@ -69,87 +77,60 @@ impl SyncSystemTable for CachesTable {
         let table_data_cache = cache_manager.get_table_data_cache();
         let table_column_array_cache = cache_manager.get_table_data_array_cache();
 
+        let mut columns = CachesTableColumns::default();
+
         if let Some(table_snapshot_cache) = table_snapshot_cache {
-            nodes.push(local_node.clone());
-            names.push("table_snapshot_cache".to_string());
-            num_items.push(table_snapshot_cache.len() as u64);
-            size.push(table_snapshot_cache.size());
+            Self::append_row(&table_snapshot_cache, &local_node, &mut columns);
         }
         if let Some(table_snapshot_statistic_cache) = table_snapshot_statistic_cache {
-            nodes.push(local_node.clone());
-            names.push("table_snapshot_statistic_cache".to_string());
-            num_items.push(table_snapshot_statistic_cache.len() as u64);
-            size.push(table_snapshot_statistic_cache.size());
+            Self::append_row(&table_snapshot_statistic_cache, &local_node, &mut columns);
         }
 
         if let Some(segment_info_cache) = segment_info_cache {
-            nodes.push(local_node.clone());
-            names.push("segment_info_cache".to_string());
-            num_items.push(segment_info_cache.len() as u64);
-            size.push(segment_info_cache.size());
+            Self::append_row(&segment_info_cache, &local_node, &mut columns);
         }
 
         if let Some(bloom_index_filter_cache) = bloom_index_filter_cache {
-            nodes.push(local_node.clone());
-            names.push("bloom_index_filter_cache".to_string());
-            num_items.push(bloom_index_filter_cache.len() as u64);
-            size.push(bloom_index_filter_cache.size());
+            Self::append_row(&bloom_index_filter_cache, &local_node, &mut columns);
         }
 
         if let Some(bloom_index_meta_cache) = bloom_index_meta_cache {
-            nodes.push(local_node.clone());
-            names.push("bloom_index_meta_cache".to_string());
-            num_items.push(bloom_index_meta_cache.len() as u64);
-            size.push(bloom_index_meta_cache.size());
+            Self::append_row(&bloom_index_meta_cache, &local_node, &mut columns);
         }
 
         if let Some(inverted_index_meta_cache) = inverted_index_meta_cache {
-            nodes.push(local_node.clone());
-            names.push("inverted_index_meta_cache".to_string());
-            num_items.push(inverted_index_meta_cache.len() as u64);
-            size.push(inverted_index_meta_cache.size());
+            Self::append_row(&inverted_index_meta_cache, &local_node, &mut columns);
         }
 
         if let Some(inverted_index_file_cache) = inverted_index_file_cache {
-            nodes.push(local_node.clone());
-            names.push("inverted_index_file_cache".to_string());
-            num_items.push(inverted_index_file_cache.len() as u64);
-            size.push(inverted_index_file_cache.size());
+            Self::append_row(&inverted_index_file_cache, &local_node, &mut columns);
         }
 
         if let Some(prune_partitions_cache) = prune_partitions_cache {
-            nodes.push(local_node.clone());
-            names.push("prune_partitions_cache".to_string());
-            num_items.push(prune_partitions_cache.len() as u64);
-            size.push(prune_partitions_cache.size());
+            Self::append_row(&prune_partitions_cache, &local_node, &mut columns);
         }
 
         if let Some(file_meta_data_cache) = file_meta_data_cache {
-            nodes.push(local_node.clone());
-            names.push("file_meta_data_cache".to_string());
-            num_items.push(file_meta_data_cache.len() as u64);
-            size.push(file_meta_data_cache.size());
+            Self::append_row(&file_meta_data_cache, &local_node, &mut columns);
         }
 
         if let Some(table_data_cache) = table_data_cache {
-            nodes.push(local_node.clone());
-            names.push("table_data_cache".to_string());
-            num_items.push(table_data_cache.len() as u64);
-            size.push(table_data_cache.size());
+            // table data cache is not a named cache yet
+            columns.nodes.push(local_node.clone());
+            columns.names.push(TABLE_DATA_CACHE_NAME.to_string());
+            columns.num_items.push(table_data_cache.len() as u64);
+            columns.size.push(table_data_cache.size());
         }
 
         if let Some(table_column_array_cache) = table_column_array_cache {
-            nodes.push(local_node.clone());
-            names.push("table_column_array_cache".to_string());
-            num_items.push(table_column_array_cache.len() as u64);
-            size.push(table_column_array_cache.size());
+            Self::append_row(&table_column_array_cache, &local_node, &mut columns);
         }
 
         Ok(DataBlock::new_from_columns(vec![
-            StringType::from_data(nodes),
-            StringType::from_data(names),
-            UInt64Type::from_data(num_items),
-            UInt64Type::from_data(size),
+            StringType::from_data(columns.nodes),
+            StringType::from_data(columns.names),
+            UInt64Type::from_data(columns.num_items),
+            UInt64Type::from_data(columns.size),
         ]))
     }
 }
@@ -176,5 +157,21 @@ impl CachesTable {
             ..Default::default()
         };
         SyncOneBlockSystemTable::create(Self { table_info })
+    }
+
+    fn append_row<K, V, S, M, C>(
+        cache: &NamedCache<C>,
+        local_node: &str,
+        row: &mut CachesTableColumns,
+    ) where
+        C: CacheAccessor<K, V, S, M>,
+        K: Eq + Hash,
+        S: BuildHasher,
+        M: CountableMeter<K, Arc<V>>,
+    {
+        row.nodes.push(local_node.to_string());
+        row.names.push(cache.name().to_string());
+        row.num_items.push(cache.len() as u64);
+        row.size.push(cache.size());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

refactor: rename metrics & tweak system.caches table


- Column names of `system.caches` changed to 

~~~
+------------------------+--------------------------------------------+-----------+------+
| node                   | name                                       | num_items | size |
+------------------------+--------------------------------------------+-----------+------+
| pEkQjwILMUbTu1GSJ0Vla1 | disk_cache_table_data                      |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_bloom_index_file_meta_data    |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_bloom_index_filter            |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_compact_segment_info          |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_inverted_index_file           |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_inverted_index_file_meta_data |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_parquet_file_meta             |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_prune_partitions              |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_table_data                    |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_table_snapshot                |         0 |    0 |
| pEkQjwILMUbTu1GSJ0Vla1 | memory_cache_table_statistics              |         0 |    0 |
+------------------------+--------------------------------------------+-----------+------+

~~~

- Metric names changed to 

~~~
+-----------------------+--------------------------------------+---------+----------------------------------------------------+------------+
| node                  | metric                               | kind    | labels                                             | value      |
+-----------------------+--------------------------------------+---------+----------------------------------------------------+------------+
| opj7Vw9EjBbhQjnewuqWu | cache_access_count_total             | counter | {"cache_name":"disk_cache_table_data"}             | 18.0       |
| opj7Vw9EjBbhQjnewuqWu | cache_access_count_total             | counter | {"cache_name":"memory_cache_compact_segment_info"} | 3.0        |
| opj7Vw9EjBbhQjnewuqWu | cache_access_count_total             | counter | {"cache_name":"memory_cache_prune_partitions"}     | 2.0        |
| opj7Vw9EjBbhQjnewuqWu | cache_access_count_total             | counter | {"cache_name":"memory_cache_table_data"}           | 18.0       |
| opj7Vw9EjBbhQjnewuqWu | cache_access_count_total             | counter | {"cache_name":"memory_cache_table_snapshot"}       | 4.0        |
| opj7Vw9EjBbhQjnewuqWu | cache_hit_count_total                | counter | {"cache_name":"memory_cache_compact_segment_info"} | 1.0        |
| opj7Vw9EjBbhQjnewuqWu | cache_hit_count_total                | counter | {"cache_name":"memory_cache_table_snapshot"}       | 3.0        |
| opj7Vw9EjBbhQjnewuqWu | cache_miss_count_total               | counter | {"cache_name":"disk_cache_table_data"}             | 27428119.0 |
| opj7Vw9EjBbhQjnewuqWu | cache_miss_count_total               | counter | {"cache_name":"memory_cache_compact_segment_info"} | 2.0        |
| opj7Vw9EjBbhQjnewuqWu | cache_miss_count_total               | counter | {"cache_name":"memory_cache_prune_partitions"}     | 2.0        |
| opj7Vw9EjBbhQjnewuqWu | cache_miss_count_total               | counter | {"cache_name":"memory_cache_table_data"}           | 27428119.0 |
| opj7Vw9EjBbhQjnewuqWu | cache_miss_count_total               | counter | {"cache_name":"memory_cache_table_snapshot"}       | 1.0        |
| opj7Vw9EjBbhQjnewuqWu | cache_population_pending_count_total | counter | {"cache_name":"disk_cache_table_data"}             | 0.0        |
+-----------------------+--------------------------------------+---------+----------------------------------------------------+------------+
~~~

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - covered by existing test cases
## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15996)
<!-- Reviewable:end -->
