### PR TITLE
fix(query): fix incorrect fast_memcmp function

### DIFF
--- a/src/common/hashtable/src/utils.rs
+++ b/src/common/hashtable/src/utils.rs
@@ -196,10 +196,15 @@ pub mod sse {
         }
 
         match size / 16 {
-            3 if !compare_sse2(a.add(32), b.add(32)) => false,
-            2 if !compare_sse2(a.add(16), b.add(16)) => false,
+            3 if !compare_sse2(a.add(32), b.add(32))
+                || !compare_sse2(a.add(16), b.add(16))
+                || !compare_sse2(a, b) =>
+            {
+                false
+            }
+            2 if !compare_sse2(a.add(16), b.add(16)) || !compare_sse2(a, b) => false,
             1 if !compare_sse2(a, b) => false,
-            _ => compare_sse2(a.add(size - 16), b.add(size - 16)),
+            _ => compare_sse2(a.add(size).sub(16), b.add(size).sub(16)),
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix the incorrect `fast_memcmp` function, we just compared the last 16 bytes if the first 16 bytes are equal.

This pr fixes the bug and compares the bytes by 16 bytes step.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16008)
<!-- Reviewable:end -->
