### PR TITLE
feat: Change 'inf' to 'Infinity' when unloading CSV/TSV

### DIFF
--- a/src/query/formats/src/common_settings.rs
+++ b/src/query/formats/src/common_settings.rs
@@ -21,8 +21,6 @@ pub struct InputCommonSettings {
     pub true_bytes: Vec<u8>,
     pub false_bytes: Vec<u8>,
     pub null_if: Vec<Vec<u8>>,
-    pub nan_bytes: Vec<u8>,
-    pub inf_bytes: Vec<u8>,
     pub timezone: Tz,
     pub disable_variant_check: bool,
     pub binary_format: BinaryFormat,

--- a/src/query/formats/src/field_decoder/fast_values.rs
+++ b/src/query/formats/src/field_decoder/fast_values.rs
@@ -44,7 +44,6 @@ use databend_common_expression::with_number_mapped_type;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::Scalar;
 use databend_common_io::constants::FALSE_BYTES_LOWER;
-use databend_common_io::constants::INF_BYTES_LOWER;
 use databend_common_io::constants::NAN_BYTES_LOWER;
 use databend_common_io::constants::NULL_BYTES_UPPER;
 use databend_common_io::constants::TRUE_BYTES_LOWER;
@@ -86,8 +85,6 @@ impl FastFieldDecoderValues {
                     NULL_BYTES_UPPER.as_bytes().to_vec(),
                     NAN_BYTES_LOWER.as_bytes().to_vec(),
                 ],
-                nan_bytes: NAN_BYTES_LOWER.as_bytes().to_vec(),
-                inf_bytes: INF_BYTES_LOWER.as_bytes().to_vec(),
                 timezone: format.timezone,
                 disable_variant_check: false,
                 binary_format: Default::default(),

--- a/src/query/formats/src/field_decoder/nested.rs
+++ b/src/query/formats/src/field_decoder/nested.rs
@@ -38,8 +38,6 @@ use databend_common_expression::with_decimal_type;
 use databend_common_expression::with_number_mapped_type;
 use databend_common_expression::ColumnBuilder;
 use databend_common_io::constants::FALSE_BYTES_LOWER;
-use databend_common_io::constants::INF_BYTES_LOWER;
-use databend_common_io::constants::NAN_BYTES_LOWER;
 use databend_common_io::constants::NULL_BYTES_LOWER;
 use databend_common_io::constants::NULL_BYTES_UPPER;
 use databend_common_io::constants::TRUE_BYTES_LOWER;
@@ -78,8 +76,6 @@ impl NestedValues {
                     NULL_BYTES_UPPER.as_bytes().to_vec(),
                     NULL_BYTES_LOWER.as_bytes().to_vec(),
                 ],
-                nan_bytes: NAN_BYTES_LOWER.as_bytes().to_vec(),
-                inf_bytes: INF_BYTES_LOWER.as_bytes().to_vec(),
                 timezone: options_ext.timezone,
                 disable_variant_check: options_ext.disable_variant_check,
                 binary_format: Default::default(),

--- a/src/query/formats/src/field_decoder/separated_text.rs
+++ b/src/query/formats/src/field_decoder/separated_text.rs
@@ -37,8 +37,6 @@ use databend_common_expression::with_number_mapped_type;
 use databend_common_expression::ColumnBuilder;
 use databend_common_io::constants::FALSE_BYTES_LOWER;
 use databend_common_io::constants::FALSE_BYTES_NUM;
-use databend_common_io::constants::INF_BYTES_LOWER;
-use databend_common_io::constants::NAN_BYTES_LOWER;
 use databend_common_io::constants::NULL_BYTES_ESCAPE;
 use databend_common_io::constants::TRUE_BYTES_LOWER;
 use databend_common_io::constants::TRUE_BYTES_NUM;
@@ -82,8 +80,6 @@ impl SeparatedTextDecoder {
                 true_bytes: TRUE_BYTES_LOWER.as_bytes().to_vec(),
                 false_bytes: FALSE_BYTES_LOWER.as_bytes().to_vec(),
                 null_if: vec![params.null_display.as_bytes().to_vec()],
-                nan_bytes: params.nan_display.as_bytes().to_vec(),
-                inf_bytes: INF_BYTES_LOWER.as_bytes().to_vec(),
                 timezone: options_ext.timezone,
                 disable_variant_check: options_ext.disable_variant_check,
                 binary_format: params.binary_format,
@@ -99,8 +95,6 @@ impl SeparatedTextDecoder {
                 null_if: vec![NULL_BYTES_ESCAPE.as_bytes().to_vec()],
                 true_bytes: TRUE_BYTES_NUM.as_bytes().to_vec(),
                 false_bytes: FALSE_BYTES_NUM.as_bytes().to_vec(),
-                nan_bytes: NAN_BYTES_LOWER.as_bytes().to_vec(),
-                inf_bytes: INF_BYTES_LOWER.as_bytes().to_vec(),
                 timezone: options_ext.timezone,
                 disable_variant_check: options_ext.disable_variant_check,
                 binary_format: Default::default(),

--- a/src/query/formats/src/field_encoder/csv.rs
+++ b/src/query/formats/src/field_encoder/csv.rs
@@ -17,7 +17,7 @@ use databend_common_expression::types::ValueType;
 use databend_common_expression::Column;
 use databend_common_io::constants::FALSE_BYTES_LOWER;
 use databend_common_io::constants::FALSE_BYTES_NUM;
-use databend_common_io::constants::INF_BYTES_LOWER;
+use databend_common_io::constants::INF_BYTES_LONG;
 use databend_common_io::constants::NULL_BYTES_ESCAPE;
 use databend_common_io::constants::TRUE_BYTES_LOWER;
 use databend_common_io::constants::TRUE_BYTES_NUM;
@@ -86,7 +86,7 @@ impl FieldEncoderCSV {
                     false_bytes: FALSE_BYTES_LOWER.as_bytes().to_vec(),
                     null_bytes: NULL_BYTES_ESCAPE.as_bytes().to_vec(),
                     nan_bytes: params.nan_display.as_bytes().to_vec(),
-                    inf_bytes: INF_BYTES_LOWER.as_bytes().to_vec(),
+                    inf_bytes: INF_BYTES_LONG.as_bytes().to_vec(),
                     timezone: options_ext.timezone,
                     binary_format: params.binary_format,
                     geometry_format: params.geometry_format,
@@ -108,7 +108,7 @@ impl FieldEncoderCSV {
                     false_bytes: FALSE_BYTES_NUM.as_bytes().to_vec(),
                     null_bytes: NULL_BYTES_ESCAPE.as_bytes().to_vec(),
                     nan_bytes: params.nan_display.as_bytes().to_vec(),
-                    inf_bytes: INF_BYTES_LOWER.as_bytes().to_vec(),
+                    inf_bytes: INF_BYTES_LONG.as_bytes().to_vec(),
                     timezone: options_ext.timezone,
                     binary_format: Default::default(),
                     geometry_format: Default::default(),

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_option_nan_inf.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_option_nan_inf.test
@@ -1,0 +1,68 @@
+statement ok
+drop stage if exists s1
+
+statement ok
+create stage s1
+
+statement ok
+create or replace table tt(a string, b string)
+
+statement ok
+create or replace table ff(a float, b float)
+
+## test load ##
+
+statement ok
+insert into tt values ('1.0', '2'), ('naN', 'inF'), ('Nan', 'infinity')
+
+query error Invalid CSV option value
+copy into @s1 from tt file_format = (type = CSV nan_display='may_nan')
+
+# nan_display is unload only, not affect load
+query 
+copy into @s1 from tt file_format = (type = CSV nan_display='null')
+----
+3 39 39
+
+query 
+copy into ff from @s1 file_format = (type = CSV) return_failed_only=true
+----
+
+query 
+select * from ff order by a
+----
+1.0 2.0
+NaN Infinity
+NaN Infinity
+
+## test unload ##
+
+statement ok
+remove @s1
+
+query 
+copy into @s1 from ff file_format = (type = CSV)
+----
+3 34 34
+
+query 
+select $1, $2 from @s1 (file_format=>'csv') order by $1
+----
+1.0 2.0
+NaN Infinity
+NaN Infinity
+
+statement ok
+remove @s1
+
+query 
+copy into @s1 from ff file_format = (type = CSV nan_display='null')
+----
+3 36 36
+
+query 
+select $1, $2 from @s1 (file_format=>'csv') order by $1
+----
+1.0 2.0
+null Infinity
+null Infinity


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

also:

- Add tests for CSV handling of NaN and Infinity values
- Remove unused code in CSV decoder

reasoning

1.  the name `Nan_Display` sound like a Unload-only option.
2.   `nan`, `inf`, `infinity` (case insensitive) should cover most cases. we can add `nan_if` like `null_if` until really need it. 

need doc change after merge : `Nan_Display` should be Unload only.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16028)
<!-- Reviewable:end -->
