### PR TITLE
chore: add `errors` column and more tests for `system.queries_profiling` table

### DIFF
--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -164,6 +164,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'engine_full'                     | 'system'             | 'views_with_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'error_integration'               | 'system'             | 'tasks'                | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'error_message'                   | 'system'             | 'notification_history' | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'errors'                          | 'system'             | 'queries_profiling'    | 'Variant'             | 'VARIANT'           | ''       | ''       | 'NO'     | ''       |
 | 'event_date'                      | 'system'             | 'query_log'            | 'Date'                | 'DATE'              | ''       | ''       | 'NO'     | ''       |
 | 'event_time'                      | 'system'             | 'query_log'            | 'Timestamp'           | 'TIMESTAMP'         | ''       | ''       | 'NO'     | ''       |
 | 'example'                         | 'system'             | 'functions'            | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/storages/system/src/queries_profiling.rs
+++ b/src/query/storages/system/src/queries_profiling.rs
@@ -75,6 +75,7 @@ impl SyncSystemTable for QueriesProfilingTable {
         let mut plan_id: Vec<Option<u32>> = Vec::with_capacity(total_size);
         let mut parent_id: Vec<Option<u32>> = Vec::with_capacity(total_size);
         let mut plan_name: Vec<Option<String>> = Vec::with_capacity(total_size);
+        let mut errors = Vec::with_capacity(total_size);
         let mut statistics = Vec::with_capacity(total_size);
 
         for (query_id, query_profiles) in queries_profiles {
@@ -84,6 +85,7 @@ impl SyncSystemTable for QueriesProfilingTable {
                 plan_id.push(query_plan_profile.id);
                 parent_id.push(query_plan_profile.parent_id);
                 plan_name.push(query_plan_profile.name.clone());
+                errors.push(serde_json::to_vec(&query_plan_profile.errors).unwrap());
 
                 let mut statistics_map =
                     HashMap::with_capacity(query_plan_profile.statistics.len());
@@ -104,6 +106,7 @@ impl SyncSystemTable for QueriesProfilingTable {
                 plan_id.push(query_plan_profile.id);
                 parent_id.push(query_plan_profile.parent_id);
                 plan_name.push(query_plan_profile.name.clone());
+                errors.push(serde_json::to_vec(&query_plan_profile.errors).unwrap());
 
                 let mut statistics_map =
                     HashMap::with_capacity(query_plan_profile.statistics.len());
@@ -122,6 +125,7 @@ impl SyncSystemTable for QueriesProfilingTable {
             UInt32Type::from_opt_data(plan_id),
             UInt32Type::from_opt_data(parent_id),
             StringType::from_opt_data(plan_name),
+            VariantType::from_data(errors),
             VariantType::from_data(statistics),
         ]))
     }
@@ -144,6 +148,7 @@ impl QueriesProfilingTable {
                 "plan_name",
                 TableDataType::Nullable(Box::new(TableDataType::String)),
             ),
+            TableField::new("errors", TableDataType::Variant),
             TableField::new("statistics", TableDataType::Variant),
         ]);
 

--- a/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
@@ -47,7 +47,3 @@ select errors != '[]' from system.queries_profiling where query_id = (select que
 ----
 1
 
-query B
-select errors != '[]' from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT 10014') AND plan_id = 0
-----
-0

--- a/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
@@ -10,14 +10,6 @@ statement ok
 drop table if exists tbl_01_0014 all
 
 statement ok
-SELECT number FROM numbers_mt(5) where number < 2
-
-query BBBB
-select count(*)=2, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT number FROM numbers_mt(5) WHERE number < 2')
-----
-1 1 1 1
-
-statement ok
 SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 3
 
 query BBBB

--- a/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
@@ -1,0 +1,40 @@
+statement ok
+SELECT 10014
+
+query BBBB
+select count(*)=2, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)=1 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT 10014')
+----
+true true true true
+
+statement ok
+drop table if exists tbl_01_0014 all
+
+statement ok
+SELECT number FROM numbers_mt(5) where number < 2
+
+query BBBB
+select count(*)=2, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT number FROM numbers_mt(5) WHERE number < 2')
+----
+true true true true
+
+statement ok
+SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 3
+
+query BBBB
+select count(*)=6, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 3')
+----
+true true true true
+
+statement ok
+CREATE TABLE tbl_01_0014 (test VARCHAR)
+
+statement ok
+INSERT INTO tbl_01_0014 VALUES ('a'), ('b'), ('c'), ('d'), ('e')
+
+statement ok
+select test from tbl_01_0014
+
+query BBBB
+select count(*)=1, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT test FROM tbl_01_0014')
+----
+true true true true

--- a/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
@@ -34,10 +34,10 @@ INSERT INTO tbl_01_0014 VALUES ('a'), ('b'), ('c'), ('d'), ('e')
 statement ok
 select test from tbl_01_0014
 
-query BBBB
-select count(*)=1, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT test FROM tbl_01_0014')
+query BBB
+select count(*)=1, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT test FROM tbl_01_0014')
 ----
-1 1 1 1
+1 1 1
 
 statement error
 select sleep(3.1)

--- a/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
@@ -4,7 +4,7 @@ SELECT 10014
 query BBBB
 select count(*)=2, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)=1 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT 10014')
 ----
-true true true true
+1 1 1 1
 
 statement ok
 drop table if exists tbl_01_0014 all
@@ -15,7 +15,7 @@ SELECT number FROM numbers_mt(5) where number < 2
 query BBBB
 select count(*)=2, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT number FROM numbers_mt(5) WHERE number < 2')
 ----
-true true true true
+1 1 1 1
 
 statement ok
 SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 3
@@ -23,7 +23,7 @@ SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 
 query BBBB
 select count(*)=6, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 3')
 ----
-true true true true
+1 1 1 1
 
 statement ok
 CREATE TABLE tbl_01_0014 (test VARCHAR)
@@ -37,4 +37,17 @@ select test from tbl_01_0014
 query BBBB
 select count(*)=1, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT test FROM tbl_01_0014')
 ----
-true true true true
+1 1 1 1
+
+statement error
+select sleep(3.1)
+
+query B
+select errors != '[]' from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT sleep(3.1)') AND plan_id = 0
+----
+1
+
+query B
+select errors != '[]' from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT 10014') AND plan_id = 0
+----
+0

--- a/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0014_system_queries_profiling.test
@@ -10,12 +10,20 @@ statement ok
 drop table if exists tbl_01_0014 all
 
 statement ok
+SELECT number FROM numbers_mt(5) where number < 2
+
+query BB
+select count(*)=2, SUM(statistics:MemoryUsage::int64)=0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT number FROM numbers_mt(5) WHERE number < 2')
+----
+1 1
+
+statement ok
 SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 3
 
-query BBBB
-select count(*)=6, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0, SUM(statistics:ScanBytes::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 3')
+query BBB
+select count(*)=6, SUM(statistics:MemoryUsage::int64)=0, SUM(statistics:CpuTime::int64)>0 from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT number % 3 AS c1 FROM numbers_mt(100) WHERE number > 2 GROUP BY number % 3')
 ----
-1 1 1 1
+1 1 1
 
 statement ok
 CREATE TABLE tbl_01_0014 (test VARCHAR)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```
root@localhost:8000/default> select errors from system.queries_profiling where query_id = (select query_id from system.query_log where query_text='SELECT sleep(3.1)') AND plan_id = 0;

SELECT
  errors
FROM
  system.queries_profiling
WHERE
  query_id = (
    SELECT
      query_id
    FROM
      system.query_log
    WHERE
      query_text = 'SELECT sleep(3.1)'
  )
  AND plan_id = 0

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                                                                                                              errors                                                                                                                                                                             │
│                                                                                                                                                                             Variant                                                                                                                                                                             │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ [{"CalculationError":{"message":"The maximum sleep time is 3 seconds. Requested: 3.1s while evaluating function `sleep(3.1)` in expr `sleep(3.1)`","detail":"","backtrace":""}},{"CalculationError":{"message":"The maximum sleep time is 3 seconds. Requested: 3.1s while evaluating function `sleep(3.1)` in expr `sleep(3.1)`","detail":"","backtrace":""}}] │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
1 row read in 0.071 sec. Processed 76 row, 113.36 KiB (1.07 thousand row/s, 1.56 MiB/s)
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16029)
<!-- Reviewable:end -->
