### PR TITLE
fix(query): fix ambiguous time

### DIFF
--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -587,8 +587,28 @@ select to_date('1947-04-15')
 statement error 1006
 select to_date('1947-04-15 00:00:00')
 
+query T
+select to_timestamp('1990-09-16 01:00:00');
+----
+1990-09-16 01:00:00.000000
+
+query T
+select to_timestamp('1990-09-16 01:00:00', '%Y-%m-%d %H:%M:%S');
+----
+1990-09-16 01:00:00.000000
+
 statement ok
 set enable_dst_hour_fix = 1;
+
+query T
+select to_timestamp('1990-09-16 01:00:00');
+----
+1990-09-16 01:00:00.000000
+
+query T
+select to_timestamp('1990-09-16 01:00:00', '%Y-%m-%d %H:%M:%S');
+----
+1990-09-16 01:00:00.000000
 
 query T
 select to_datetime('1947-04-15 00:00:00')


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

if enable_dst_hour_fix, return earliest time, else return lastest time

```
// e.g.
// naive_datetime 1990-09-16T01:00:00 in Aisa/Shanghai
// t1.offset.fix = +09:00, t2.offset.fix = +08:00
// t1: 1990-09-16T01:00:00CDT, t2: 1990-09-16T01:00:00CST
// So if enable_dst_hour_fix = true return t1.
```
## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16046)
<!-- Reviewable:end -->
