### PR TITLE
feat: back compatibility of old share db

### DIFF
--- a/src/query/service/src/databases/share/dummy_share_database.rs
+++ b/src/query/service/src/databases/share/dummy_share_database.rs
@@ -1,0 +1,178 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str;
+use std::sync::Arc;
+
+use databend_common_catalog::table::Table;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_meta_app::schema::CommitTableMetaReply;
+use databend_common_meta_app::schema::CommitTableMetaReq;
+use databend_common_meta_app::schema::CreateTableReply;
+use databend_common_meta_app::schema::CreateTableReq;
+use databend_common_meta_app::schema::DatabaseInfo;
+use databend_common_meta_app::schema::DropTableByIdReq;
+use databend_common_meta_app::schema::DropTableReply;
+use databend_common_meta_app::schema::GetTableCopiedFileReply;
+use databend_common_meta_app::schema::GetTableCopiedFileReq;
+use databend_common_meta_app::schema::RenameTableReply;
+use databend_common_meta_app::schema::RenameTableReq;
+use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
+use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
+use databend_common_meta_app::schema::TableInfo;
+use databend_common_meta_app::schema::TruncateTableReply;
+use databend_common_meta_app::schema::TruncateTableReq;
+use databend_common_meta_app::schema::UndropTableReply;
+use databend_common_meta_app::schema::UndropTableReq;
+use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
+use databend_common_meta_app::schema::UpdateMultiTableMetaResult;
+use databend_common_meta_app::schema::UpsertTableOptionReply;
+use databend_common_meta_app::schema::UpsertTableOptionReq;
+
+use crate::databases::Database;
+use crate::databases::DatabaseContext;
+
+// Share Database implementation for `Database` trait.
+#[derive(Clone)]
+pub struct DummyShareDatabase {
+    db_info: DatabaseInfo,
+}
+
+impl DummyShareDatabase {
+    pub fn try_create(_ctx: DatabaseContext, db_info: DatabaseInfo) -> Result<Box<dyn Database>> {
+        Ok(Box::new(Self { db_info }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Database for DummyShareDatabase {
+    fn name(&self) -> &str {
+        self.db_info.name_ident.database_name()
+    }
+
+    fn get_db_info(&self) -> &DatabaseInfo {
+        &self.db_info
+    }
+
+    fn get_table_by_info(&self, _table_info: &TableInfo) -> Result<Arc<dyn Table>> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    // Get one table by db and table name.
+    #[async_backtrace::framed]
+    async fn get_table(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn list_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn list_tables_history(&self) -> Result<Vec<Arc<dyn Table>>> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn create_table(&self, _req: CreateTableReq) -> Result<CreateTableReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn drop_table_by_id(&self, _req: DropTableByIdReq) -> Result<DropTableReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn undrop_table(&self, _req: UndropTableReq) -> Result<UndropTableReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn commit_table_meta(&self, _req: CommitTableMetaReq) -> Result<CommitTableMetaReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn rename_table(&self, _req: RenameTableReq) -> Result<RenameTableReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn upsert_table_option(
+        &self,
+        _req: UpsertTableOptionReq,
+    ) -> Result<UpsertTableOptionReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn set_table_column_mask_policy(
+        &self,
+        _req: SetTableColumnMaskPolicyReq,
+    ) -> Result<SetTableColumnMaskPolicyReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn get_table_copied_file_info(
+        &self,
+        _req: GetTableCopiedFileReq,
+    ) -> Result<GetTableCopiedFileReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn truncate_table(&self, _req: TruncateTableReq) -> Result<TruncateTableReply> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
+    async fn retryable_update_multi_table_meta(
+        &self,
+        _req: UpdateMultiTableMetaReq,
+    ) -> Result<UpdateMultiTableMetaResult> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+}

--- a/src/query/service/src/databases/share/mod.rs
+++ b/src/query/service/src/databases/share/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod dummy_share_database;
 mod share_database;
 
 pub use share_database::ShareDatabase;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

feat: back compatibility of old share db.

old share db SQL schema is `create database from <share_name>`,and new share db schema is `create database from <share_name> using <share_endpoint>`.
for back compatibility, when `using_share_endpoint` is none, return `DummyShareDatabase` instead, which cannot do anything and make `show databases` worked.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - back compatibility of old share db

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16056)
<!-- Reviewable:end -->
