### PR TITLE
refactor: load parquet use own can_auto_cast_to(). 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,8 +5416,6 @@ dependencies = [
 name = "databend-storages-common-stage"
 version = "0.1.0"
 dependencies = [
- "arrow-cast",
- "arrow-schema",
  "databend-common-catalog",
  "databend-common-exception",
  "databend-common-expression",

--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -571,13 +571,12 @@ pub fn can_auto_cast_to(
             }
             (_, _) => unreachable!(),
         },
-        (DataType::Tuple(src_tys), DataType::Tuple(dest_tys))
-            if src_tys.len() == dest_tys.len() =>
-        {
-            src_tys
-                .iter()
-                .zip(dest_tys)
-                .all(|(src_ty, dest_ty)| can_auto_cast_to(src_ty, dest_ty, auto_cast_rules))
+        (DataType::Tuple(src_tys), DataType::Tuple(dest_tys)) => {
+            src_tys.len() == dest_tys.len()
+                && src_tys
+                    .iter()
+                    .zip(dest_tys)
+                    .all(|(src_ty, dest_ty)| can_auto_cast_to(src_ty, dest_ty, auto_cast_rules))
         }
         (DataType::String, DataType::Decimal(_)) => true,
         (DataType::Decimal(x), DataType::Decimal(y)) => {

--- a/src/query/storages/common/stage/Cargo.toml
+++ b/src/query/storages/common/stage/Cargo.toml
@@ -7,8 +7,6 @@ publish = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-arrow-cast = { workspace = true }
-arrow-schema = { workspace = true, features = ["serde"] }
 databend-common-catalog = { workspace = true }
 databend-common-exception = { workspace = true }
 databend-common-expression = { workspace = true }

--- a/src/query/storages/common/stage/src/read/columnar/projection.rs
+++ b/src/query/storages/common/stage/src/read/columnar/projection.rs
@@ -57,7 +57,7 @@ pub fn project_columnar(
                     expr
                 } else {
                     // note: tuple field name is dropped here, matched by pos here
-                    if can_auto_cast_to(
+                    if can_auto_cast_to::<true>(
                         &from_field.data_type().into(),
                         &to_field.data_type().into(),
                         cast_rules,

--- a/tests/sqllogictests/suites/stage/formats/parquet/auto_cast.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/auto_cast.test
@@ -1,4 +1,40 @@
 statement ok
+drop stage if exists s1;
+
+statement ok
+create stage s1;
+
+statement ok
+create or replace table t(a int null);
+
+statement ok
+insert into table t values (1), (2);
+
+statement ok
+copy into @s1 from t;
+
+statement ok
+create or replace table t2(a int not null);
+
+statement ok
+copy into t2 from @s1;
+
+statement ok
+insert into table t values (null);
+
+statement ok
+copy into @s1 from t;
+
+statement error 1006.*fail to auto cast column
+copy into t2 from @s1;
+
+statement ok
+create or replace table t3(a string null);
+
+statement ok
+copy into t3 from @s1;
+
+statement ok
 drop table if exists ts;
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR updates the dependency from Arrow’s can_cast_types to our own can_auto_cast_to() function.

The can_auto_cast_to() function was mainly used for type_check, so it does not permit casting from nullable to non-nullable types, which loading data does. 


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16062)
<!-- Reviewable:end -->
