### PR TITLE
feat(query): add setting enable_strict_datetime_parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6170,7 +6170,7 @@ checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 [[package]]
 name = "dtparse"
 version = "2.0.0"
-source = "git+https://github.com/TCeason/dtparse.git?rev=0e21a79#0e21a799e5a43de0c8d5aef957e4f831f0ad9cbb"
+source = "git+https://github.com/TCeason/dtparse.git?rev=de0a15b#de0a15b5db5cf3f2c99f38a6535f669bc0ee7ea1"
 dependencies = [
  "chrono",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,6 +3477,7 @@ dependencies = [
  "databend-common-io",
  "databend-common-openai",
  "databend-common-vector",
+ "dtparse",
  "ethnum",
  "geo",
  "geo-types",
@@ -6165,6 +6166,17 @@ name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dtparse"
+version = "2.0.0"
+source = "git+https://github.com/TCeason/dtparse.git?rev=0e21a79#0e21a799e5a43de0c8d5aef957e4f831f0ad9cbb"
+dependencies = [
+ "chrono",
+ "lazy_static",
+ "num-traits",
+ "rust_decimal",
+]
 
 [[package]]
 name = "dunce"

--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -94,7 +94,7 @@ pub enum FunctionEval {
     },
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct FunctionContext {
     pub tz: TzLUT,
     pub now: DateTime<Utc>,
@@ -116,6 +116,30 @@ pub struct FunctionContext {
     pub parse_datetime_ignore_remainder: bool,
     pub enable_dst_hour_fix: bool,
     pub enable_strict_datetime_parser: bool,
+}
+
+impl Default for FunctionContext {
+    fn default() -> Self {
+        FunctionContext {
+            tz: Default::default(),
+            now: Default::default(),
+            rounding_mode: false,
+            disable_variant_check: false,
+            openai_api_chat_base_url: "".to_string(),
+            openai_api_embedding_base_url: "".to_string(),
+            openai_api_key: "".to_string(),
+            openai_api_version: "".to_string(),
+            openai_api_embedding_model: "".to_string(),
+            openai_api_completion_model: "".to_string(),
+            external_server_connect_timeout_secs: 0,
+            external_server_request_timeout_secs: 0,
+            external_server_request_batch_rows: 0,
+            geometry_output_format: Default::default(),
+            parse_datetime_ignore_remainder: false,
+            enable_dst_hour_fix: false,
+            enable_strict_datetime_parser: true,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -115,6 +115,7 @@ pub struct FunctionContext {
     pub geometry_output_format: GeometryDataType,
     pub parse_datetime_ignore_remainder: bool,
     pub enable_dst_hour_fix: bool,
+    pub enable_strict_datetime_parser: bool,
 }
 
 #[derive(Clone)]

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -28,6 +28,7 @@ databend-common-hashtable = { workspace = true }
 databend-common-io = { workspace = true }
 databend-common-openai = { workspace = true }
 databend-common-vector = { workspace = true }
+dtparse = { git = "https://github.com/TCeason/dtparse.git", rev = "d0df237" }
 ethnum = { workspace = true }
 geo = { workspace = true }
 geo-types = "0.7.13"

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -28,7 +28,7 @@ databend-common-hashtable = { workspace = true }
 databend-common-io = { workspace = true }
 databend-common-openai = { workspace = true }
 databend-common-vector = { workspace = true }
-dtparse = { git = "https://github.com/TCeason/dtparse.git", rev = "d0df237" }
+dtparse = { git = "https://github.com/TCeason/dtparse.git", rev = "de0a15b" }
 ethnum = { workspace = true }
 geo = { workspace = true }
 geo-types = "0.7.13"

--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -159,14 +159,6 @@ fn register_string_to_timestamp(registry: &mut FunctionRegistry) {
         ctx: &mut EvalContext,
     ) -> Value<TimestampType> {
         vectorize_with_builder_1_arg::<StringType, TimestampType>(|val, output, ctx| {
-            // if let Ok(timestamp) = val.parse::<i64>() {
-            // match int64_to_timestamp(timestamp) {
-            // Ok(ts) => {output.push(ts);
-            // return;
-            // }
-            // _ => {}
-            // }
-            // }
             let tz = ctx.func_ctx.tz.tz;
             let enable_dst_hour_fix = ctx.func_ctx.enable_dst_hour_fix;
             if ctx.func_ctx.enable_strict_datetime_parser {
@@ -534,12 +526,6 @@ fn register_string_to_date(registry: &mut FunctionRegistry) {
 
     fn eval_string_to_date(val: ValueRef<StringType>, ctx: &mut EvalContext) -> Value<DateType> {
         vectorize_with_builder_1_arg::<StringType, DateType>(|val, output, ctx| {
-            //   if let Ok(val) = val.parse::<i64>() {
-            // if let Ok(d) = check_date(val) {
-            // output.push(d);
-            // return;
-            // }
-            // }
             if ctx.func_ctx.enable_strict_datetime_parser {
                 match string_to_date(val, ctx.func_ctx.tz.tz, ctx.func_ctx.enable_dst_hour_fix) {
                     Ok(d) => output.push(d.num_days_from_ce() - EPOCH_DAYS_FROM_CE),

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -671,6 +671,7 @@ impl TableContext for QueryContext {
         let geometry_output_format = settings.get_geometry_output_format()?;
         let parse_datetime_ignore_remainder = settings.get_parse_datetime_ignore_remainder()?;
         let enable_dst_hour_fix = settings.get_enable_dst_hour_fix()?;
+        let enable_strict_datetime_parser = settings.get_enable_strict_datetime_parser()?;
         let query_config = &GlobalConfig::instance().query;
 
         Ok(FunctionContext {
@@ -692,6 +693,7 @@ impl TableContext for QueryContext {
             geometry_output_format,
             parse_datetime_ignore_remainder,
             enable_dst_hour_fix,
+            enable_strict_datetime_parser,
         })
     }
 

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -702,6 +702,12 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_strict_datetime_parser", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1),
+                    desc: "Strict datetime parser. Only support ISO 8601 as Default format.The best practice is to turn this parameter on.(enable by default)",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("disable_variant_check", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "Disable variant check to allow insert invalid JSON values",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -602,6 +602,10 @@ impl Settings {
         Ok(self.try_get_u64("parse_datetime_ignore_remainder")? != 0)
     }
 
+    pub fn get_enable_strict_datetime_parser(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_strict_datetime_parser")? != 0)
+    }
+
     pub fn get_enable_dst_hour_fix(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_dst_hour_fix")? != 0)
     }

--- a/tests/sqllogictests/suites/query/functions/02_0075_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0075_function_datetimes_tz.test
@@ -1,0 +1,681 @@
+statement ok
+set enable_strict_datetime_parser = 0;
+
+statement ok
+unset enable_query_result_cache;
+
+statement ok
+drop table if exists tt all
+
+statement ok
+set timezone='UTC'
+
+query T
+select to_timestamp(1630320462000000)
+----
+2021-08-30 10:47:42.000000
+
+query T
+select to_timestamp('2000-01-01 00:00:00')
+----
+2000-01-01 00:00:00.000000
+
+# Asia/Shanghai: +8:00
+statement ok
+set timezone='Asia/Shanghai'
+
+query T
+select to_timestamp(1630320462000000)
+----
+2021-08-30 18:47:42.000000
+
+query T
+select to_timestamp('2000-01-01 12:00:00')
+----
+2000-01-01 12:00:00.000000
+
+query T
+select to_timestamp('2000-01-01 12:00:00+08:00')
+----
+2000-01-01 12:00:00.000000
+
+query T
+select to_timestamp('2000-01-01 12:00:00+08')
+----
+2000-01-01 12:00:00.000000
+
+query T
+select to_timestamp('2000-01-01 12:00:00-08')
+----
+2000-01-02 04:00:00.000000
+
+query T
+select to_timestamp('2000-01-01 12:00:00+0811')
+----
+2000-01-01 11:49:00.000000
+
+query T
+select to_timestamp('2000-01-01 12:00:00-0811')
+----
+2000-01-02 04:11:00.000000
+
+statement error 1006
+select to_timestamp('2000-01-01 12:00:00-08112')
+
+statement error 1006
+select to_timestamp('2000-01-01 12:00:00-081')
+
+statement error 1006
+select to_timestamp('2000-01-01 12:00:00+08:')
+
+statement ok
+set timezone = 'UTC'
+
+statement ok
+create table tt (a timestamp)
+
+statement ok
+insert into table tt values ('2021-04-30 22:48:00'), (to_timestamp('2021-04-30 22:48:00'))
+
+query T
+select * from tt
+----
+2021-04-30 22:48:00.000000
+2021-04-30 22:48:00.000000
+
+
+statement ok
+set timezone = 'Asia/Shanghai'
+
+query T
+select * from tt
+----
+2021-05-01 06:48:00.000000
+2021-05-01 06:48:00.000000
+
+
+statement ok
+drop table tt
+
+statement ok
+set timezone = 'UTC'
+
+query I
+select to_yyyymm(to_timestamp(1619820000000000))
+----
+202104
+
+query I
+select to_yyyymmdd(to_timestamp(1619820000000000))
+----
+20210430
+
+query I
+select to_yyyymmddhhmmss(to_timestamp(1619820000000000))
+----
+20210430220000
+
+query T
+select to_start_of_month(to_timestamp(1619820000000000))
+----
+2021-04-01
+
+query I
+select to_month(to_timestamp(1619820000000000))
+----
+4
+
+query I
+select to_day_of_year(to_timestamp(1619820000000000))
+----
+120
+
+query I
+select to_day_of_month(to_timestamp(1619820000000000))
+----
+30
+
+query I
+select to_day_of_week(to_timestamp(1619820000000000))
+----
+5
+
+statement ok
+set timezone = 'Asia/Shanghai'
+
+query I
+select to_yyyymm(to_timestamp(1619820000000000))
+----
+202105
+
+query I
+select to_yyyymmdd(to_timestamp(1619820000000000))
+----
+20210501
+
+query I
+select to_yyyymmddhhmmss(to_timestamp(1619820000000000))
+----
+20210501060000
+
+query T
+select to_start_of_month(to_timestamp(1619820000000000))
+----
+2021-05-01
+
+query I
+select to_month(to_timestamp(1619820000000000))
+----
+5
+
+query I
+select to_day_of_year(to_timestamp(1619820000000000))
+----
+121
+
+query I
+select to_day_of_month(to_timestamp(1619820000000000))
+----
+1
+
+query I
+select to_day_of_week(to_timestamp(1619820000000000))
+----
+6
+
+query T
+select '==UTC=='
+----
+==UTC==
+
+statement ok
+set timezone = 'UTC'
+
+query T
+select to_start_of_second(to_timestamp(1619822911999000))
+----
+2021-04-30 22:48:31.000000
+
+query T
+select to_start_of_minute(to_timestamp(1619822911999000))
+----
+2021-04-30 22:48:00.000000
+
+query T
+select to_start_of_five_minutes(to_timestamp(1619822911999000))
+----
+2021-04-30 22:45:00.000000
+
+query T
+select to_start_of_ten_minutes(to_timestamp(1619822911999000))
+----
+2021-04-30 22:40:00.000000
+
+query T
+select to_start_of_fifteen_minutes(to_timestamp(1619822911999000))
+----
+2021-04-30 22:45:00.000000
+
+query T
+select time_slot(to_timestamp(1619822911999000))
+----
+2021-04-30 22:30:00.000000
+
+query T
+select to_start_of_hour(to_timestamp(1619822911999000))
+----
+2021-04-30 22:00:00.000000
+
+query T
+select to_start_of_day(to_timestamp(1619822911999000))
+----
+2021-04-30 00:00:00.000000
+
+query T
+select to_start_of_week(to_timestamp(1619822911999000))
+----
+2021-04-25
+
+statement ok
+set timezone = 'Asia/Shanghai'
+
+query T
+select to_start_of_second(to_timestamp(1619822911999000))
+----
+2021-05-01 06:48:31.000000
+
+query T
+select to_start_of_minute(to_timestamp(1619822911999000))
+----
+2021-05-01 06:48:00.000000
+
+query T
+select to_start_of_five_minutes(to_timestamp(1619822911999000))
+----
+2021-05-01 06:45:00.000000
+
+query T
+select to_start_of_ten_minutes(to_timestamp(1619822911999000))
+----
+2021-05-01 06:40:00.000000
+
+query T
+select to_start_of_fifteen_minutes(to_timestamp(1619822911999000))
+----
+2021-05-01 06:45:00.000000
+
+query T
+select time_slot(to_timestamp(1619822911999000))
+----
+2021-05-01 06:30:00.000000
+
+query T
+select to_start_of_hour(to_timestamp(1619822911999000))
+----
+2021-05-01 06:00:00.000000
+
+query T
+select to_start_of_day(to_timestamp(1619822911999000))
+----
+2021-05-01 00:00:00.000000
+
+query T
+select to_start_of_week(to_timestamp(1619822911999000))
+----
+2021-04-25
+
+statement ok
+set timezone = 'UTC'
+
+query T
+select add_months(to_timestamp(1619822911999000), 1)
+----
+2021-05-30 22:48:31.999000
+
+query T
+select to_timestamp(1583013600000000)
+----
+2020-02-29 22:00:00.000000
+
+
+query T
+select add_years(to_timestamp(1583013600000000), 1)
+----
+2021-02-28 22:00:00.000000
+
+
+statement ok
+set timezone = 'Asia/Shanghai'
+
+query T
+select add_months(to_timestamp(1619822911999000), 1)
+----
+2021-06-01 14:48:31.999000
+
+query T
+select to_timestamp(1583013600000000)
+----
+2020-03-01 06:00:00.000000
+
+query T
+select add_years(to_timestamp(1583013600000000), 1)
+----
+2021-03-01 14:00:00.000000
+
+statement ok
+set timezone= 'UTC';
+
+statement ok
+drop table if exists t;
+
+statement ok
+create table t(c1 timestamp);
+
+statement ok
+insert into t values('2017-12-01 22:46:53.000000'), ('2017-12-02 22:46:53.000000');
+
+
+query TT
+select c1, to_date(c1) from t;
+----
+2017-12-01 22:46:53.000000 2017-12-01
+2017-12-02 22:46:53.000000 2017-12-02
+
+statement ok
+set timezone='Asia/Shanghai'
+
+query TT
+select c1, to_date(c1) from t;
+----
+2017-12-02 06:46:53.000000 2017-12-02
+2017-12-03 06:46:53.000000 2017-12-03
+
+statement ok
+drop table if exists t;
+
+statement ok
+set timezone = 'UTC';
+
+query TT
+select to_date('2020-12-22') dt, to_timestamp(dt);
+----
+2020-12-22 2020-12-22 00:00:00.000000
+
+query TT
+select '2017-12-02 06:46:53.000000'::timestamp ts, to_date(ts);
+----
+2017-12-02 06:46:53.000000 2017-12-02
+
+statement ok
+set timezone = 'Asia/Shanghai';
+
+query TT
+select to_date('2020-12-22') dt, to_timestamp(dt);
+----
+2020-12-22 2020-12-22 00:00:00.000000
+
+query TT
+select '2017-12-02 06:46:53.000000'::timestamp ts, to_date(ts);
+----
+2017-12-02 06:46:53.000000 2017-12-02
+
+statement ok
+unset timezone;
+
+statement ok
+create table t(c1 date);
+
+statement ok
+insert into t values('2022-02-02');
+
+query T
+select c1, to_timestamp(c1) from t
+----
+2022-02-02 2022-02-02 00:00:00.000000
+
+statement ok
+set timezone='Asia/Shanghai';
+
+query T
+select c1, to_timestamp(c1) from t
+----
+2022-02-02 2022-02-02 00:00:00.000000
+
+statement ok
+drop table t;
+
+statement ok
+set timezone='Asia/Shanghai';
+
+query T
+select  count_if(y = true) from (select to_timestamp(to_date(number)) as ts, to_date(ts) = to_date(number)  y   from numbers(2000));
+----
+2000
+
+statement ok
+SET timezone ='America/Toronto';
+
+query T
+select  count_if(y = true) from (select to_timestamp(to_date(number)) as ts, to_date(ts) = to_date(number)  y   from numbers(2000));
+----
+2000
+
+statement ok
+set timezone = 'UTC';
+
+query T
+select  count_if(y = true) from (select to_timestamp(to_date(number)) as ts, to_date(ts) = to_date(number)  y   from numbers(2000));
+----
+2000
+
+statement ok
+set timezone='Europe/London';
+
+statement error 1006
+----
+select to_date(to_timestamp('2021-03-28 01:00'));
+
+statement error 1006
+----
+select '2021-03-28 01:59:59'::timestamp;
+
+statement ok
+set timezone='Asia/Shanghai';
+
+query T
+select to_date('1941-03-15');
+----
+1941-03-15
+
+query T
+select to_date('1941-03-15 00:00:00');
+----
+1941-03-15
+
+query T
+select to_date('1941-03-15 02:00:00');
+----
+1941-03-15
+
+statement ok
+set parse_datetime_ignore_remainder=1;
+
+statement ok
+set timezone='UTC';
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 00:58:59.000000
+
+statement ok
+set timezone='Asia/Shanghai';
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H');
+----
+2022-02-04 08:00:00.000000
+
+statement error 1006
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+
+query T
+select try_to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+----
+NULL
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时');
+----
+2022-02-04 08:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0900', '%Y年%m月%d日，%H时');
+----
+2022-02-04 08:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 08:58:59.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0900', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 07:58:59.000000
+
+statement ok
+set timezone='America/Los_Angeles';
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H');
+----
+2022-02-04 08:00:00.000000
+
+statement error 1006
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+
+query T
+select try_to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+----
+NULL
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时');
+----
+2022-02-04 08:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-03 16:58:59.000000
+
+statement ok
+set timezone='UTC';
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H');
+----
+2022-02-04 08:00:00.000000
+
+statement error 1006
+select to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+
+query T
+select try_to_timestamp('2022年02月04日，8时58分59秒', '%Y年%m月%d日，%H%z');
+----
+NULL
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时');
+----
+2022-02-04 08:00:00.000000
+
+query T
+select to_timestamp('2022年02月04日，8时58分59秒,时区：+0800', '%Y年%m月%d日，%H时%M分%S秒,时区：%z');
+----
+2022-02-04 00:58:59.000000
+
+statement ok
+unset timezone;
+
+statement ok
+unset parse_datetime_ignore_remainder;
+
+statement ok
+set timezone='Asia/Shanghai';
+
+statement ok
+unset enable_dst_hour_fix;
+
+statement error 1006
+select to_timestamp('1947-04-15 00:00:00')
+
+query T
+select try_to_timestamp('1947-04-15 00:00:00')
+----
+NULL
+
+statement error 1006
+select to_timestamp('1947-04-15 00:00:00', '%Y-%m-%d %H:%M:%S')
+
+query T
+select try_to_timestamp('1947-04-15 00:00:00', '%Y-%m-%d %H:%M:%S')
+----
+NULL
+
+query T
+select to_date('1947-04-15')
+----
+1947-04-15
+
+query T
+select to_date('1941-03-15 00:00:00');
+----
+1941-03-15
+
+query T
+select to_timestamp('1990-09-16 01:00:00');
+----
+1990-09-16 01:00:00.000000
+
+query T
+select to_timestamp('1990-09-16 01:00:00', '%Y-%m-%d %H:%M:%S');
+----
+1990-09-16 01:00:00.000000
+
+statement ok
+set enable_dst_hour_fix = 1;
+
+query T
+select to_timestamp('1990-09-16 01:00:00');
+----
+1990-09-16 01:00:00.000000
+
+query T
+select to_timestamp('1990-09-16 01:00:00', '%Y-%m-%d %H:%M:%S');
+----
+1990-09-16 01:00:00.000000
+
+query T
+select to_datetime('1947-04-15 00:00:00')
+----
+1947-04-15 01:00:00.000000
+
+query T
+select to_datetime('1947-04-15 00:00:00', '%Y-%m-%d %H:%M:%S')
+----
+1947-04-15 01:00:00.000000
+
+query T
+select to_date('1947-04-15 00:00:00')
+----
+1947-04-15
+
+query T
+select to_date('1947-04-15')
+----
+1947-04-15
+
+
+query T
+select to_date('2017-5-23 0:00:00')
+----
+2017-05-23
+
+query T
+select to_date('2018-1-22')
+----
+2018-01-22
+
+query T
+select to_date('2021/10/14')
+----
+2021-10-14
+
+query T
+select to_date('20201231')
+----
+2020-12-31
+
+query T
+select to_date('2017-3-16 0:00:00')
+----
+2017-03-16
+
+statement ok
+unset timezone;
+
+statement ok
+unset enable_dst_hour_fix;
+
+query T
+select to_timestamp('2017-02-03 14:55:08 ');
+----
+2017-02-03 14:55:08.000000
+
+statement error 1006
+select to_timestamp('1684275059752');
+
+statement ok
+unset enable_strict_datetime_parser;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary



Strict datetime parser. Only support ISO 8601 as Default format.The best practice is to turn this parameter on.(enable by default)

if disbale the setting `enable_strict_datetime_parser` , to_date/timestamp(expr) will use crate [`dtparse`](https://github.com/TCeason/dtparse/tree/master) try to convert string to date/timestamp.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16067)
<!-- Reviewable:end -->
