### PR TITLE
feat: improve selectivity accuracy

### DIFF
--- a/src/query/sql/src/planner/optimizer/property/selectivity.rs
+++ b/src/query/sql/src/planner/optimizer/property/selectivity.rs
@@ -164,7 +164,7 @@ impl<'a> SelectivityEstimator<'a> {
 
     fn compute_selectivity_comparison_expr(
         &mut self,
-        op: ComparisonOp,
+        mut op: ComparisonOp,
         left: &ScalarExpr,
         right: &ScalarExpr,
         update: bool,
@@ -222,14 +222,19 @@ impl<'a> SelectivityEstimator<'a> {
                         }
                         Ok(selectivity)
                     }
-                    _ => Self::compute_binary_comparison_selectivity(
-                        &op,
-                        &const_datum,
-                        update,
-                        column_ref,
-                        column_stat,
-                        &mut self.updated_column_indexes,
-                    ),
+                    _ => {
+                        if let ScalarExpr::ConstantExpr(_) = left {
+                            op = op.reverse();
+                        }
+                        Self::compute_binary_comparison_selectivity(
+                            &op,
+                            &const_datum,
+                            update,
+                            column_ref,
+                            column_stat,
+                            &mut self.updated_column_indexes,
+                        )
+                    }
                 };
             }
             (ScalarExpr::ConstantExpr(_), ScalarExpr::ConstantExpr(_)) => {

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -16,7 +16,7 @@ explain select t1.a from t1 where a > 0
 Filter
 ├── output columns: [t1.a (#0)]
 ├── filters: [t1.a (#0) > 0]
-├── estimated rows: 0.20
+├── estimated rows: 0.00
 └── TableScan
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
@@ -34,18 +34,18 @@ explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a an
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.b (#1), t1.a (#0)]
 ├── filters: [t1.a (#0) > 3 OR t2.a (#2) > 5 AND t1.a (#0) > 1]
-├── estimated rows: 0.13
+├── estimated rows: 0.00
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.b (#1), t1.a (#0)]
     ├── join type: INNER
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [t2.a (#2)]
     ├── filters: []
-    ├── estimated rows: 0.35
+    ├── estimated rows: 0.00
     ├── Filter(Build)
     │   ├── output columns: [t1.a (#0), t1.b (#1)]
     │   ├── filters: [t1.a (#0) > 3 OR t1.a (#0) > 1]
-    │   ├── estimated rows: 0.36
+    │   ├── estimated rows: 0.00
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
@@ -620,18 +620,18 @@ explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b 
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 ├── filters: [t1.a (#0) > 1 AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4]
-├── estimated rows: 0.54
+├── estimated rows: 2.78
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
-    ├── estimated rows: 1.50
+    ├── estimated rows: 4.17
     ├── Filter(Build)
     │   ├── output columns: [t1.a (#0), t1.b (#1)]
     │   ├── filters: [t1.a (#0) > 1 OR t1.b (#1) < 3]
-    │   ├── estimated rows: 0.36
+    │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
@@ -663,18 +663,18 @@ explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b 
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 ├── filters: [t1.a (#0) > 1 AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4 OR t1.a (#0) = 2]
-├── estimated rows: 0.65
+├── estimated rows: 3.33
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
-    ├── estimated rows: 1.80
+    ├── estimated rows: 5.00
     ├── Filter(Build)
     │   ├── output columns: [t1.a (#0), t1.b (#1)]
     │   ├── filters: [t1.a (#0) > 1 OR t1.b (#1) < 3 OR t1.a (#0) = 2]
-    │   ├── estimated rows: 0.36
+    │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t1
     │       ├── output columns: [a (#0), b (#1)]
@@ -759,22 +759,22 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
-├── estimated rows: 4.42
+├── estimated rows: 22.73
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 │   ├── filters: [t1.a (#0) > 1 AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4]
-│   ├── estimated rows: 0.54
+│   ├── estimated rows: 2.78
 │   └── HashJoin
 │       ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 │       ├── join type: CROSS
 │       ├── build keys: []
 │       ├── probe keys: []
 │       ├── filters: []
-│       ├── estimated rows: 1.50
+│       ├── estimated rows: 4.17
 │       ├── Filter(Build)
 │       │   ├── output columns: [t1.a (#0), t1.b (#1)]
 │       │   ├── filters: [t1.a (#0) > 1 OR t1.b (#1) < 3]
-│       │   ├── estimated rows: 0.36
+│       │   ├── estimated rows: 1.00
 │       │   └── TableScan
 │       │       ├── table: default.default.t1
 │       │       ├── output columns: [a (#0), b (#1)]
@@ -821,26 +821,26 @@ Limit
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 ├── limit: 3
 ├── offset: 0
-├── estimated rows: 0.99
+├── estimated rows: 3.00
 └── Sort
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
     ├── sort keys: [a DESC NULLS LAST]
-    ├── estimated rows: 0.99
+    ├── estimated rows: 3.47
     └── Filter
         ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
         ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2) AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4]
-        ├── estimated rows: 0.99
+        ├── estimated rows: 3.47
         └── HashJoin
             ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
             ├── join type: CROSS
             ├── build keys: []
             ├── probe keys: []
             ├── filters: []
-            ├── estimated rows: 2.03
+            ├── estimated rows: 4.17
             ├── Filter(Build)
             │   ├── output columns: [t1.a (#0), t1.b (#1)]
             │   ├── filters: [t1.a (#0) > 1 OR t1.b (#1) < 2 OR t1.b (#1) < 3]
-            │   ├── estimated rows: 0.49
+            │   ├── estimated rows: 1.00
             │   └── TableScan
             │       ├── table: default.default.t1
             │       ├── output columns: [a (#0), b (#1)]
@@ -875,11 +875,11 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
-├── estimated rows: 1.80
+├── estimated rows: 5.00
 ├── Filter(Build)
 │   ├── output columns: [t1.a (#0), t1.b (#1)]
 │   ├── filters: [t1.a (#0) > 1 OR t1.b (#1) < 2]
-│   ├── estimated rows: 0.36
+│   ├── estimated rows: 1.00
 │   └── TableScan
 │       ├── table: default.default.t1
 │       ├── output columns: [a (#0), b (#1)]
@@ -1116,18 +1116,18 @@ Limit
 ├── output columns: [b.id (#2), b.c1 (#3), a.c1 (#1), a.id (#0)]
 ├── limit: 1
 ├── offset: 0
-├── estimated rows: 0.08
+├── estimated rows: 1.00
 └── HashJoin
     ├── output columns: [b.id (#2), b.c1 (#3), a.c1 (#1), a.id (#0)]
     ├── join type: INNER
     ├── build keys: [a.id (#0)]
     ├── probe keys: [b.id (#2)]
     ├── filters: []
-    ├── estimated rows: 0.08
+    ├── estimated rows: 1.00
     ├── Filter(Build)
     │   ├── output columns: [a.id (#0), a.c1 (#1)]
     │   ├── filters: [is_true(a.c1 (#1) >= 1683648000), is_true(a.c1 (#1) <= 1683734400)]
-    │   ├── estimated rows: 0.20
+    │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.a
     │       ├── output columns: [id (#0), c1 (#1)]
@@ -1141,7 +1141,7 @@ Limit
     └── Filter(Probe)
         ├── output columns: [b.id (#2), b.c1 (#3)]
         ├── filters: [is_true(b.c1 (#3) >= 1683648000), is_true(b.c1 (#3) <= 1683734400)]
-        ├── estimated rows: 0.40
+        ├── estimated rows: 2.00
         └── TableScan
             ├── table: default.default.b
             ├── output columns: [id (#2), c1 (#3)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -91,11 +91,11 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
-├── estimated rows: 1.64
+├── estimated rows: 0.00
 ├── Filter(Build)
 │   ├── output columns: [t.number (#0)]
 │   ├── filters: [t.number (#0) > 1]
-│   ├── estimated rows: 0.20
+│   ├── estimated rows: 0.00
 │   └── TableScan
 │       ├── table: default.default.t
 │       ├── output columns: [number (#0)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -31,7 +31,7 @@ HashJoin
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.a (#2) > 0)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 3.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
@@ -67,11 +67,11 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.a (#2) > 0)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 3.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
@@ -143,11 +143,11 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.b (#3) > 0)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 3.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
@@ -179,11 +179,11 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.a (#2) > 0), is_true(t2.b (#3) > 0)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 3.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
@@ -219,11 +219,11 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.a (#2) > 0)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 3.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -31,7 +31,7 @@ HashJoin
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.a (#2) > 3)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 0.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
@@ -64,18 +64,18 @@ explain select * from t1 inner join t2 on t1.a = t2.a where t2.a <= 2 or (t1.a >
 Filter
 ├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t2.a (#2)]
 ├── filters: [is_true(t2.a (#2) <= 2 OR t1.a (#0) > 1 AND t2.a (#2) > 1)]
-├── estimated rows: 0.45
+├── estimated rows: 3.50
 └── HashJoin
     ├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t2.a (#2)]
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
     ├── filters: []
-    ├── estimated rows: 1.26
+    ├── estimated rows: 3.50
     ├── Filter(Build)
     │   ├── output columns: [t2.a (#2), t2.b (#3)]
     │   ├── filters: [is_true(t2.a (#2) <= 2 OR t2.a (#2) > 1)]
-    │   ├── estimated rows: 1.08
+    │   ├── estimated rows: 3.00
     │   └── TableScan
     │       ├── table: default.default.t2
     │       ├── output columns: [a (#2), b (#3)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -31,7 +31,7 @@ HashJoin
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.a (#2) > 0)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 3.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
@@ -135,11 +135,11 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.a (#2) > 0)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 3.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]
@@ -175,11 +175,11 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3)]
 │   ├── filters: [is_true(t2.b (#3) > 0)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 3.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2), b (#3)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -31,7 +31,7 @@ HashJoin
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2)]
 │   ├── filters: [is_true(t2.a (#2) > 3)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 0.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2)]
@@ -71,7 +71,7 @@ HashJoin
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2)]
 │   ├── filters: [is_true(t2.a (#2) > 3)]
-│   ├── estimated rows: 0.60
+│   ├── estimated rows: 0.00
 │   └── TableScan
 │       ├── table: default.default.t2
 │       ├── output columns: [a (#2)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_scan.test
@@ -14,7 +14,7 @@ explain select * from t as a(id) where a.id > 1;
 Filter
 ├── output columns: [a.x (#0)]
 ├── filters: [is_true(a.id (#0) > 1)]
-├── estimated rows: 0.40
+├── estimated rows: 1.00
 └── TableScan
     ├── table: default.default.t
     ├── output columns: [x (#0)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
@@ -33,11 +33,11 @@ explain select 1 from range_t where i > 20
 EvalScalar
 ├── output columns: [1 (#2)]
 ├── expressions: [1]
-├── estimated rows: 0.40
+├── estimated rows: 0.00
 └── Filter
     ├── output columns: []
     ├── filters: [is_true(range_t.i (#1) > 20)]
-    ├── estimated rows: 0.40
+    ├── estimated rows: 0.00
     └── TableScan
         ├── table: default.default.range_t
         ├── output columns: [i (#1)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/selectivity/pr_16069.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/selectivity/pr_16069.test
@@ -1,0 +1,26 @@
+statement ok
+create or replace table t as select * from numbers(100);
+
+statement ok
+analyze table t;
+
+query T
+explain select * from t where 10 < number or 20 < number;
+----
+Filter
+├── output columns: [t.number (#0)]
+├── filters: [10 < t.number (#0) OR 20 < t.number (#0)]
+├── estimated rows: 97.64
+└── TableScan
+    ├── table: default.default.t
+    ├── output columns: [number (#0)]
+    ├── read rows: 100
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [10 < t.number (#0) OR 20 < t.number (#0)], limit: NONE]
+    └── estimated rows: 100.00
+
+statement ok
+drop table t;

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -62,11 +62,11 @@ explain select * from v where a > 1
 ----
 UnionAll
 ├── output columns: [t1.a (#0), t1.b (#1)]
-├── estimated rows: 0.80
+├── estimated rows: 2.00
 ├── Filter
 │   ├── output columns: [t1.a (#0), t1.b (#1)]
 │   ├── filters: [is_true(t1.a (#0) > 1)]
-│   ├── estimated rows: 0.40
+│   ├── estimated rows: 1.00
 │   └── TableScan
 │       ├── table: default.default.t1
 │       ├── output columns: [a (#0), b (#1)]
@@ -80,7 +80,7 @@ UnionAll
 └── Filter
     ├── output columns: [t2.a (#2), t2.b (#3)]
     ├── filters: [is_true(t2.a (#2) > 1)]
-    ├── estimated rows: 0.40
+    ├── estimated rows: 1.00
     └── TableScan
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
@@ -22,7 +22,7 @@ TableScan
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <range pruning: 1 to 0>]
 ├── push downs: [filters: [t1.a (#0) > 0], limit: NONE]
-└── estimated rows: 0.20
+└── estimated rows: 0.00
 
 query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a and t2.a > 5 and t1.a > 1)
@@ -30,14 +30,14 @@ explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a an
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.b (#1), t1.a (#0)]
 ├── filters: [t1.a (#0) > 3 OR t2.a (#2) > 5 AND t1.a (#0) > 1]
-├── estimated rows: 0.13
+├── estimated rows: 0.00
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.b (#1), t1.a (#0)]
     ├── join type: INNER
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [t2.a (#2)]
     ├── filters: []
-    ├── estimated rows: 0.35
+    ├── estimated rows: 0.00
     ├── TableScan(Build)
     │   ├── table: default.default.t1
     │   ├── output columns: [a (#0), b (#1)]
@@ -47,7 +47,7 @@ Filter
     │   ├── partitions scanned: 0
     │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
     │   ├── push downs: [filters: [t1.a (#0) > 3 OR t1.a (#0) > 1], limit: NONE]
-    │   └── estimated rows: 0.36
+    │   └── estimated rows: 0.00
     └── TableScan(Probe)
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
@@ -608,14 +608,14 @@ explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b 
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 ├── filters: [t1.a (#0) > 1 AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4]
-├── estimated rows: 0.54
+├── estimated rows: 2.78
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
-    ├── estimated rows: 1.50
+    ├── estimated rows: 4.17
     ├── TableScan(Build)
     │   ├── table: default.default.t1
     │   ├── output columns: [a (#0), b (#1)]
@@ -625,7 +625,7 @@ Filter
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
     │   ├── push downs: [filters: [t1.a (#0) > 1 OR t1.b (#1) < 3], limit: NONE]
-    │   └── estimated rows: 0.36
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
@@ -643,14 +643,14 @@ explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b 
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 ├── filters: [t1.a (#0) > 1 AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4 OR t1.a (#0) = 2]
-├── estimated rows: 0.65
+├── estimated rows: 3.33
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
     ├── filters: []
-    ├── estimated rows: 1.80
+    ├── estimated rows: 5.00
     ├── TableScan(Build)
     │   ├── table: default.default.t1
     │   ├── output columns: [a (#0), b (#1)]
@@ -660,7 +660,7 @@ Filter
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
     │   ├── push downs: [filters: [t1.a (#0) > 1 OR t1.b (#1) < 3 OR t1.a (#0) = 2], limit: NONE]
-    │   └── estimated rows: 0.36
+    │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.default.t2
         ├── output columns: [a (#2), b (#3)]
@@ -735,18 +735,18 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
-├── estimated rows: 4.42
+├── estimated rows: 22.73
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 │   ├── filters: [t1.a (#0) > 1 AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4]
-│   ├── estimated rows: 0.54
+│   ├── estimated rows: 2.78
 │   └── HashJoin
 │       ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 │       ├── join type: CROSS
 │       ├── build keys: []
 │       ├── probe keys: []
 │       ├── filters: []
-│       ├── estimated rows: 1.50
+│       ├── estimated rows: 4.17
 │       ├── TableScan(Build)
 │       │   ├── table: default.default.t1
 │       │   ├── output columns: [a (#0), b (#1)]
@@ -756,7 +756,7 @@ HashJoin
 │       │   ├── partitions scanned: 1
 │       │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │       │   ├── push downs: [filters: [t1.a (#0) > 1 OR t1.b (#1) < 3], limit: NONE]
-│       │   └── estimated rows: 0.36
+│       │   └── estimated rows: 1.00
 │       └── TableScan(Probe)
 │           ├── table: default.default.t2
 │           ├── output columns: [a (#2), b (#3)]
@@ -785,22 +785,22 @@ Limit
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 ├── limit: 3
 ├── offset: 0
-├── estimated rows: 0.99
+├── estimated rows: 3.00
 └── Sort
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
     ├── sort keys: [a DESC NULLS LAST]
-    ├── estimated rows: 0.99
+    ├── estimated rows: 3.47
     └── Filter
         ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
         ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2) AND t2.a (#2) > 2 OR t1.b (#1) < 3 AND t2.b (#3) < 4]
-        ├── estimated rows: 0.99
+        ├── estimated rows: 3.47
         └── HashJoin
             ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
             ├── join type: CROSS
             ├── build keys: []
             ├── probe keys: []
             ├── filters: []
-            ├── estimated rows: 2.03
+            ├── estimated rows: 4.17
             ├── TableScan(Build)
             │   ├── table: default.default.t1
             │   ├── output columns: [a (#0), b (#1)]
@@ -810,7 +810,7 @@ Limit
             │   ├── partitions scanned: 1
             │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
             │   ├── push downs: [filters: [t1.a (#0) > 1 OR t1.b (#1) < 2 OR t1.b (#1) < 3], limit: NONE]
-            │   └── estimated rows: 0.49
+            │   └── estimated rows: 1.00
             └── TableScan(Probe)
                 ├── table: default.default.t2
                 ├── output columns: [a (#2), b (#3)]
@@ -831,7 +831,7 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
-├── estimated rows: 1.80
+├── estimated rows: 5.00
 ├── TableScan(Build)
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
@@ -841,7 +841,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [t1.a (#0) > 1 OR t1.b (#1) < 2], limit: NONE]
-│   └── estimated rows: 0.36
+│   └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
@@ -87,7 +87,7 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── filters: []
-├── estimated rows: 1.64
+├── estimated rows: 0.00
 ├── TableScan(Build)
 │   ├── table: default.default.t
 │   ├── output columns: [number (#0)]
@@ -97,7 +97,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
 │   ├── push downs: [filters: [t.number (#0) > 1], limit: NONE]
-│   └── estimated rows: 0.20
+│   └── estimated rows: 0.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: []

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -37,7 +37,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
@@ -59,7 +59,7 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
@@ -69,7 +69,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
@@ -123,7 +123,7 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
@@ -133,7 +133,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [is_true(t2.b (#3) > 0)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
@@ -155,7 +155,7 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
@@ -165,7 +165,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [and_filters(t2.a (#2) > 0, t2.b (#3) > 0)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
@@ -187,7 +187,7 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
@@ -197,7 +197,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -37,7 +37,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 0.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
@@ -56,14 +56,14 @@ explain select * from t1 inner join t2 on t1.a = t2.a where t2.a <= 2 or (t1.a >
 Filter
 ├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t2.a (#2)]
 ├── filters: [is_true(t2.a (#2) <= 2 OR t1.a (#0) > 1 AND t2.a (#2) > 1)]
-├── estimated rows: 0.45
+├── estimated rows: 3.50
 └── HashJoin
     ├── output columns: [t1.a (#0), t1.b (#1), t2.b (#3), t2.a (#2)]
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
     ├── filters: []
-    ├── estimated rows: 1.26
+    ├── estimated rows: 3.50
     ├── TableScan(Build)
     │   ├── table: default.default.t2
     │   ├── output columns: [a (#2), b (#3)]
@@ -73,7 +73,7 @@ Filter
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
     │   ├── push downs: [filters: [is_true(t2.a (#2) <= 2 OR t2.a (#2) > 1)], limit: NONE]
-    │   └── estimated rows: 1.08
+    │   └── estimated rows: 3.00
     └── TableScan(Probe)
         ├── table: default.default.t1
         ├── output columns: [a (#0), b (#1)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -37,7 +37,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
@@ -123,7 +123,7 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
@@ -133,7 +133,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]
@@ -155,7 +155,7 @@ HashJoin
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
 ├── filters: []
-├── estimated rows: 0.80
+├── estimated rows: 4.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── output columns: [a (#2), b (#3)]
@@ -165,7 +165,7 @@ HashJoin
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [is_true(t2.b (#3) > 0)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 3.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0), b (#1)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -37,7 +37,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 0.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0)]
@@ -69,7 +69,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <range pruning: 1 to 0>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
-│   └── estimated rows: 0.60
+│   └── estimated rows: 0.00
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── output columns: [a (#0)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_scan.test
@@ -14,7 +14,7 @@ explain select * from t as a(id) where a.id > 1;
 Filter
 ├── output columns: [a.x (#0)]
 ├── filters: [is_true(a.id (#0) > 1)]
-├── estimated rows: 0.40
+├── estimated rows: 1.00
 └── TableScan
     ├── table: default.default.t
     ├── output columns: [x (#0)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/range_pruner.test
@@ -28,7 +28,7 @@ explain select 1 from range_t where i > 20
 EvalScalar
 ├── output columns: [1 (#2)]
 ├── expressions: [1]
-├── estimated rows: 0.40
+├── estimated rows: 0.00
 └── TableScan
     ├── table: default.default.range_t
     ├── output columns: []
@@ -38,7 +38,7 @@ EvalScalar
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <range pruning: 1 to 0>]
     ├── push downs: [filters: [is_true(range_t.i (#1) > 20)], limit: NONE]
-    └── estimated rows: 0.40
+    └── estimated rows: 0.00
 
 query T
 explain select number from numbers(10) where number > 5 and try_cast(get(try_parse_json(number::String),'xx') as varchar) < '10' and 1 = 0;

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/union.test
@@ -54,7 +54,7 @@ explain select * from v where a > 1
 ----
 UnionAll
 ├── output columns: [t1.a (#0), t1.b (#1)]
-├── estimated rows: 0.80
+├── estimated rows: 2.00
 ├── TableScan
 │   ├── table: default.default.t1
 │   ├── output columns: [a (#0), b (#1)]
@@ -64,7 +64,7 @@ UnionAll
 │   ├── partitions scanned: 1
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
-│   └── estimated rows: 0.40
+│   └── estimated rows: 1.00
 └── TableScan
     ├── table: default.default.t2
     ├── output columns: [a (#2), b (#3)]
@@ -74,7 +74,7 @@ UnionAll
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
     ├── push downs: [filters: [is_true(t2.a (#2) > 1)], limit: NONE]
-    └── estimated rows: 0.40
+    └── estimated rows: 1.00
 
 query T
 explain select * from v limit 3

--- a/tests/sqllogictests/suites/tpcds/tpcds_join_order.test
+++ b/tests/sqllogictests/suites/tpcds/tpcds_join_order.test
@@ -7839,17 +7839,17 @@ HashJoin: INNER
 ├── Build
 │   └── HashJoin: INNER
 │       ├── Build
-│       │   └── HashJoin: INNER
-│       │       ├── Build
-│       │       │   └── Scan: default.tpcds.store (#2) (read rows: 1)
-│       │       └── Probe
-│       │           └── HashJoin: INNER
-│       │               ├── Build
-│       │               │   └── Scan: default.tpcds.date_dim (#1) (read rows: 73049)
-│       │               └── Probe
-│       │                   └── Scan: default.tpcds.store_sales (#0) (read rows: 28810)
+│       │   └── Scan: default.tpcds.store (#2) (read rows: 1)
 │       └── Probe
-│           └── Scan: default.tpcds.household_demographics (#3) (read rows: 7200)
+│           └── HashJoin: INNER
+│               ├── Build
+│               │   └── HashJoin: INNER
+│               │       ├── Build
+│               │       │   └── Scan: default.tpcds.date_dim (#1) (read rows: 73049)
+│               │       └── Probe
+│               │           └── Scan: default.tpcds.store_sales (#0) (read rows: 28810)
+│               └── Probe
+│                   └── Scan: default.tpcds.household_demographics (#3) (read rows: 7200)
 └── Probe
     └── Scan: default.tpcds.customer (#4) (read rows: 1000)
 
@@ -8854,13 +8854,13 @@ HashJoin: CROSS
 │       ├── Build
 │       │   └── HashJoin: INNER
 │       │       ├── Build
-│       │       │   └── Scan: default.tpcds.web_page (#7) (read rows: 0)
+│       │       │   └── HashJoin: INNER
+│       │       │       ├── Build
+│       │       │       │   └── Scan: default.tpcds.web_page (#7) (read rows: 0)
+│       │       │       └── Probe
+│       │       │           └── Scan: default.tpcds.web_sales (#4) (read rows: 7212)
 │       │       └── Probe
-│       │           └── HashJoin: INNER
-│       │               ├── Build
-│       │               │   └── Scan: default.tpcds.household_demographics (#5) (read rows: 7200)
-│       │               └── Probe
-│       │                   └── Scan: default.tpcds.web_sales (#4) (read rows: 7212)
+│       │           └── Scan: default.tpcds.household_demographics (#5) (read rows: 7200)
 │       └── Probe
 │           └── Scan: default.tpcds.time_dim (#6) (read rows: 86400)
 └── Probe
@@ -8868,13 +8868,13 @@ HashJoin: CROSS
         ├── Build
         │   └── HashJoin: INNER
         │       ├── Build
-        │       │   └── Scan: default.tpcds.web_page (#3) (read rows: 0)
+        │       │   └── HashJoin: INNER
+        │       │       ├── Build
+        │       │       │   └── Scan: default.tpcds.web_page (#3) (read rows: 0)
+        │       │       └── Probe
+        │       │           └── Scan: default.tpcds.web_sales (#0) (read rows: 7212)
         │       └── Probe
-        │           └── HashJoin: INNER
-        │               ├── Build
-        │               │   └── Scan: default.tpcds.household_demographics (#1) (read rows: 7200)
-        │               └── Probe
-        │                   └── Scan: default.tpcds.web_sales (#0) (read rows: 7212)
+        │           └── Scan: default.tpcds.household_demographics (#1) (read rows: 7200)
         └── Probe
             └── Scan: default.tpcds.time_dim (#2) (read rows: 86400)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Improve selectivity accuracy, use ndv instead of default value.

```sql
root@localhost:8000/tpch_test> SELECT
  count()
FROM
  orders
WHERE
  o_orderdate >= to_date('1993-10-01')
  AND o_orderkey > 100;

SELECT
  count()
FROM
  orders
WHERE
  o_orderdate >= to_date('1993-10-01')
  AND o_orderkey > 100

┌─────────┐
│ count() │
│  UInt64 │
├─────────┤
│  110480 │
└─────────┘
```

Before:

```sql

EXPLAIN
SELECT
  count()
FROM
  orders
WHERE
  o_orderdate >= to_date('1993-10-01')
  AND o_orderkey > 100

-[ EXPLAIN ]-----------------------------------
AggregateFinal
├── output columns: [count() (#9)]
├── group by: []
├── aggregate functions: [count()]
├── estimated rows: 1.00
└── AggregatePartial
    ├── group by: []
    ├── aggregate functions: [count()]
    ├── estimated rows: 1.00
    └── Filter
        ├── output columns: []
        ├── filters: [orders.o_orderkey (#0) > 100, orders.o_orderdate (#4) >= '1993-10-01']
        ├── estimated rows: 30000.00
        └── TableScan
            ├── table: default.tpch_test.orders
            ├── output columns: [o_orderkey (#0), o_orderdate (#4)]
            ├── read rows: 150000
            ├── read size: 425.47 KiB
            ├── partitions total: 1
            ├── partitions scanned: 1
            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
            ├── push downs: [filters: [and_filters(orders.o_orderkey (#0) > 100, orders.o_orderdate (#4) >= '1993-10-01')], limit: NONE]
            └── estimated rows: 150000.00
```

Now
```sql
root@localhost:8000/tpch_test> EXPLAIN
SELECT
  count()
FROM
  orders
WHERE
  o_orderdate >= to_date('1993-10-01')
  AND o_orderkey > 100;

EXPLAIN
SELECT
  count()
FROM
  orders
WHERE
  o_orderdate >= to_date('1993-10-01')
  AND o_orderkey > 100

-[ EXPLAIN ]-----------------------------------
AggregateFinal
├── output columns: [count() (#9)]
├── group by: []
├── aggregate functions: [count()]
├── estimated rows: 1.00
└── AggregatePartial
    ├── group by: []
    ├── aggregate functions: [count()]
    ├── estimated rows: 1.00
    └── Filter
        ├── output columns: []
        ├── filters: [orders.o_orderkey (#0) > 100, orders.o_orderdate (#4) >= '1993-10-01']
        ├── estimated rows: 110145.53
        └── TableScan
            ├── table: default.tpch_test.orders
            ├── output columns: [o_orderkey (#0), o_orderdate (#4)]
            ├── read rows: 150000
            ├── read size: 425.47 KiB
            ├── partitions total: 1
            ├── partitions scanned: 1
            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
            ├── push downs: [filters: [and_filters(orders.o_orderkey (#0) > 100, orders.o_orderdate (#4) >= '1993-10-01')], limit: NONE]
            └── estimated rows: 150000.00
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16069)
<!-- Reviewable:end -->
