### PR TITLE
refactor: load parquet use own can_cast_to()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5415,8 +5415,6 @@ dependencies = [
 name = "databend-storages-common-stage"
 version = "0.1.0"
 dependencies = [
- "arrow-cast",
- "arrow-schema",
  "databend-common-catalog",
  "databend-common-exception",
  "databend-common-expression",

--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -571,13 +571,12 @@ pub fn can_auto_cast_to(
             }
             (_, _) => unreachable!(),
         },
-        (DataType::Tuple(src_tys), DataType::Tuple(dest_tys))
-            if src_tys.len() == dest_tys.len() =>
-        {
-            src_tys
-                .iter()
-                .zip(dest_tys)
-                .all(|(src_ty, dest_ty)| can_auto_cast_to(src_ty, dest_ty, auto_cast_rules))
+        (DataType::Tuple(src_tys), DataType::Tuple(dest_tys)) => {
+            src_tys.len() == dest_tys.len()
+                && src_tys
+                    .iter()
+                    .zip(dest_tys)
+                    .all(|(src_ty, dest_ty)| can_auto_cast_to(src_ty, dest_ty, auto_cast_rules))
         }
         (DataType::String, DataType::Decimal(_)) => true,
         (DataType::Decimal(x), DataType::Decimal(y)) => {

--- a/src/query/expression/src/types/variant.rs
+++ b/src/query/expression/src/types/variant.rs
@@ -154,7 +154,6 @@ impl ValueType for VariantType {
     }
 
     fn push_default(builder: &mut Self::ColumnBuilder) {
-        builder.put_slice(b"");
         builder.commit_row();
     }
 

--- a/src/query/functions/tests/it/main.rs
+++ b/src/query/functions/tests/it/main.rs
@@ -16,6 +16,7 @@
 #![feature(try_blocks)]
 #![feature(trait_alias)]
 #![feature(iter_collect_into)]
+#![feature(box_patterns)]
 #![allow(clippy::arc_with_non_send_sync)]
 
 // We can generate new test files via using `env REGENERATE_GOLDENFILES=1 cargo test` and `git diff` to show differs

--- a/src/query/functions/tests/it/scalars/can_cast.rs
+++ b/src/query/functions/tests/it/scalars/can_cast.rs
@@ -1,0 +1,146 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_exception::Result;
+use databend_common_expression::date_helper::TzLUT;
+use databend_common_expression::type_check::can_cast_to;
+use databend_common_expression::type_check::check_cast;
+use databend_common_expression::types::variant::cast_scalar_to_variant;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalDataType;
+use databend_common_expression::types::DecimalSize;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::BlockEntry;
+use databend_common_expression::ColumnBuilder;
+use databend_common_expression::DataBlock;
+use databend_common_expression::Evaluator;
+use databend_common_expression::Expr;
+use databend_common_expression::Expr::ColumnRef;
+use databend_common_expression::FunctionContext;
+use databend_common_expression::Scalar;
+use databend_common_expression::Value;
+use databend_common_functions::BUILTIN_FUNCTIONS;
+use roaring::RoaringTreemap;
+
+fn cast_simple_value(src_type: &DataType, dest_type: &DataType) -> Result<Expr> {
+    let n = 2;
+    let src_str = match dest_type {
+        DataType::Boolean => "false",
+        DataType::Timestamp | DataType::Date => "1970-01-01 00:00:00.000000",
+        _ => "0",
+    };
+    let value = match src_type {
+        DataType::String => Value::Column(
+            ColumnBuilder::repeat(&Scalar::String(src_str.to_string()).as_ref(), n, src_type)
+                .build(),
+        ),
+        DataType::Binary => Value::Column(
+            ColumnBuilder::repeat(
+                &Scalar::Binary(src_str.as_bytes().to_vec()).as_ref(),
+                n,
+                src_type,
+            )
+            .build(),
+        ),
+        DataType::Variant => {
+            let s = Scalar::String(src_str.to_string());
+            let mut buf = vec![];
+            cast_scalar_to_variant(s.as_ref(), TzLUT::default(), &mut buf);
+            let s = Scalar::Variant(buf);
+            Value::Column(ColumnBuilder::repeat(&s.as_ref(), n, src_type).build())
+        }
+        _ => Value::Column(ColumnBuilder::repeat_default(src_type, n).build()),
+    };
+
+    let block = DataBlock::new(vec![BlockEntry::new(src_type.clone(), value)], 2);
+    let func_ctx = FunctionContext::default();
+    let evaluator = Evaluator::new(&block, &func_ctx, &BUILTIN_FUNCTIONS);
+    let expr = ColumnRef {
+        span: None,
+        id: 0,
+        data_type: src_type.clone(),
+        display_name: "c1".to_string(),
+    };
+    let expr = check_cast(None, false, expr, dest_type, &BUILTIN_FUNCTIONS)?;
+    let r = evaluator.run(&expr)?;
+    let r0 = r.index(0).unwrap();
+    let exp = match dest_type {
+        DataType::Boolean => Scalar::Boolean(false),
+        DataType::Binary => Scalar::Binary("0".as_bytes().to_vec()),
+        DataType::Timestamp => Scalar::Timestamp(0),
+        DataType::Date => Scalar::Date(0),
+        DataType::Bitmap => {
+            let mut buf = vec![];
+            let rb = RoaringTreemap::from_iter([0].iter());
+            rb.serialize_into(&mut buf).unwrap();
+            Scalar::Bitmap(buf)
+        }
+        _ => Scalar::default_value(dest_type),
+    };
+    assert_eq!(
+        r0,
+        exp.as_ref(),
+        "wrong cast result: {src_type} -> {dest_type}: expect {exp:?}, got {r0:?}",
+    );
+    Ok(expr)
+}
+
+#[test]
+fn test_can_cast_to() {
+    let types = [
+        DataType::Number(NumberDataType::Float32),
+        DataType::Number(NumberDataType::Float64),
+        DataType::Number(NumberDataType::Int8),
+        DataType::Number(NumberDataType::UInt8),
+        DataType::Decimal(DecimalDataType::Decimal128(DecimalSize {
+            precision: 10,
+            scale: 2,
+        })),
+        DataType::Decimal(DecimalDataType::Decimal128(DecimalSize {
+            precision: 10,
+            scale: 0,
+        })),
+        DataType::Boolean,
+        DataType::Timestamp,
+        DataType::Date,
+        DataType::String,
+        DataType::Binary,
+        DataType::Variant,
+        DataType::Bitmap,
+        // todo: fix bug about default value of Geometry
+        // DataType::Geometry,
+    ];
+
+    // evaluating
+    for dst in &types {
+        if !matches!(dst, DataType::String | DataType::Variant) {
+            for src in &types {
+                if src != dst {
+                    let exp = can_cast_to(src, dst);
+                    let res = cast_simple_value(src, dst);
+                    if let Err(err) = &res {
+                        assert!(err.message().contains("unable to cast type"), "{err}");
+                        assert!(!err.message().contains("evaluating"), "{err}");
+                    };
+                    let res = res.is_ok();
+                    assert_eq!(
+                        res, exp,
+                        "{src} to {dst} is {}, but can_cast_to return {exp}",
+                        res
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/query/functions/tests/it/scalars/mod.rs
+++ b/src/query/functions/tests/it/scalars/mod.rs
@@ -41,6 +41,7 @@ mod datetime;
 mod geo;
 // NOTE:(everpcpc) result different on macos
 // TODO: fix this in running on linux
+mod can_cast;
 #[cfg(not(target_os = "macos"))]
 mod geo_h3;
 mod geometry;

--- a/src/query/storages/common/stage/Cargo.toml
+++ b/src/query/storages/common/stage/Cargo.toml
@@ -7,8 +7,6 @@ publish = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-arrow-cast = { workspace = true }
-arrow-schema = { workspace = true, features = ["serde"] }
 databend-common-catalog = { workspace = true }
 databend-common-exception = { workspace = true }
 databend-common-expression = { workspace = true }

--- a/src/query/storages/common/stage/src/read/columnar/projection.rs
+++ b/src/query/storages/common/stage/src/read/columnar/projection.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arrow_cast::can_cast_types;
-use arrow_schema::Field;
 use databend_common_exception::ErrorCode;
+use databend_common_expression::type_check::can_cast_to;
 use databend_common_expression::type_check::check_cast;
 use databend_common_expression::Expr;
 use databend_common_expression::RemoteExpr;
@@ -53,28 +52,27 @@ pub fn project_columnar(
                     display_name: from_field.name().clone(),
                 };
 
-                // find a better way to do check cast
                 if from_field.data_type == to_field.data_type {
                     expr
-                } else if can_cast_types(
-                    Field::from(from_field).data_type(),
-                    Field::from(to_field).data_type(),
-                ) {
-                    check_cast(
-                        None,
-                        false,
-                        expr,
-                        &to_field.data_type().into(),
-                        &BUILTIN_FUNCTIONS,
-                    )?
                 } else {
-                    return Err(ErrorCode::BadDataValueType(format!(
-                        "fail to load file {}: Cannot cast column {} from {:?} to {:?}",
-                        location,
-                        field_name,
-                        from_field.data_type(),
-                        to_field.data_type()
-                    )));
+                    // note: tuple field name is dropped here, matched by pos here
+                    if can_cast_to(&from_field.data_type().into(), &to_field.data_type().into()) {
+                        check_cast(
+                            None,
+                            false,
+                            expr,
+                            &to_field.data_type().into(),
+                            &BUILTIN_FUNCTIONS,
+                        )?
+                    } else {
+                        return Err(ErrorCode::BadDataValueType(format!(
+                            "fail to load file {}: Cannot cast column {} from {:?} to {:?}",
+                            location,
+                            field_name,
+                            from_field.data_type(),
+                            to_field.data_type()
+                        )));
+                    }
                 }
             }
             None => {

--- a/tests/sqllogictests/suites/stage/formats/parquet/auto_cast.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/auto_cast.test
@@ -1,4 +1,40 @@
 statement ok
+drop stage if exists s1;
+
+statement ok
+create stage s1;
+
+statement ok
+create or replace table t(a int null);
+
+statement ok
+insert into table t values (1), (2);
+
+statement ok
+copy into @s1 from t;
+
+statement ok
+create or replace table t2(a int not null);
+
+statement ok
+copy into t2 from @s1;
+
+statement ok
+insert into table t values (null);
+
+statement ok
+copy into @s1 from t;
+
+statement error 1006.*fail to auto cast column
+copy into t2 from @s1;
+
+statement ok
+create or replace table t3(a string null);
+
+statement ok
+copy into t3 from @s1;
+
+statement ok
 drop table if exists ts;
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR updates the dependency from Arrow’s can_cast_types to our own can_cast_to() function.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16072)
<!-- Reviewable:end -->
