### PR TITLE
fix(query): if timestamp is some, no need to init parsed

### DIFF
--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -367,21 +367,29 @@ fn string_to_format_timestmap(
             return Err(ErrorCode::BadArguments(format!("{}", e)));
         }
         // Additional checks and adjustments for parsed timestamp
-        if parsed.month.is_none() {
-            parsed.month = Some(1);
-        }
-        if parsed.day.is_none() {
-            parsed.day = Some(1);
-        }
-        if parsed.hour_div_12.is_none() && parsed.hour_mod_12.is_none() {
-            parsed.hour_div_12 = Some(0);
-            parsed.hour_mod_12 = Some(0);
-        }
-        if parsed.minute.is_none() {
-            parsed.minute = Some(0);
-        }
-        if parsed.second.is_none() {
-            parsed.second = Some(0);
+        // If parsed.timestamp is Some no need to pad default year.
+        if parsed.timestamp.is_none() {
+            if parsed.year.is_none() {
+                parsed.year = Some(1970);
+                parsed.year_div_100 = Some(19);
+                parsed.year_mod_100 = Some(70);
+            }
+            if parsed.month.is_none() {
+                parsed.month = Some(1);
+            }
+            if parsed.day.is_none() {
+                parsed.day = Some(1);
+            }
+            if parsed.hour_div_12.is_none() && parsed.hour_mod_12.is_none() {
+                parsed.hour_div_12 = Some(0);
+                parsed.hour_mod_12 = Some(0);
+            }
+            if parsed.minute.is_none() {
+                parsed.minute = Some(0);
+            }
+            if parsed.second.is_none() {
+                parsed.second = Some(0);
+            }
         }
 
         if parse_tz {

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -635,3 +635,25 @@ unset timezone;
 
 statement ok
 unset enable_dst_hour_fix;
+
+statement ok
+set parse_datetime_ignore_remainder = 1;
+
+query T
+select to_datetime('1', '%s')
+----
+1970-01-01 00:00:01.000000
+
+statement error 1006
+select to_timestamp('200,2000', '%s,%Y');
+
+statement ok
+unset parse_datetime_ignore_remainder;
+
+query T
+select to_datetime('1', '%s')
+----
+1970-01-01 00:00:01.000000
+
+statement error 1006
+select to_timestamp('200,2000', '%s,%Y');


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When enable parse_datetime_ignore_remainder if timestamp is some, no need to init any parsed.

- fixes: #16077


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16078)
<!-- Reviewable:end -->
