### PR TITLE
feat(storage): add table function clustering_statistics

### DIFF
--- a/scripts/ci/deploy/databend-query-share.sh
+++ b/scripts/ci/deploy/databend-query-share.sh
@@ -16,7 +16,7 @@ echo "current directory:"
 pwd
 
 echo "build share endpoint"
-ls 
+ls
 mv share-endpoint ../tmp-share-endpoint
 cd ../tmp-share-endpoint
 cargo build --release

--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -19,6 +19,7 @@ use databend_common_catalog::table_args::TableArgs;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_types::MetaId;
+use databend_common_storages_fuse::table_functions::ClusteringStatisticsTable;
 use databend_common_storages_fuse::table_functions::FuseAmendTable;
 use databend_common_storages_fuse::table_functions::FuseColumnTable;
 use databend_common_storages_fuse::table_functions::FuseEncodingTable;
@@ -159,6 +160,10 @@ impl TableFunctionFactory {
         creators.insert(
             "clustering_information".to_string(),
             (next_id(), Arc::new(ClusteringInformationTable::create)),
+        );
+        creators.insert(
+            "clustering_statistics".to_string(),
+            (next_id(), Arc::new(ClusteringStatisticsTable::create)),
         );
 
         creators.insert(

--- a/src/query/storages/fuse/src/table_functions/clustering_statistics/clustering_stat.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_statistics/clustering_stat.rs
@@ -1,0 +1,198 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_catalog::table::Table;
+use databend_common_exception::Result;
+use databend_common_expression::types::string::StringColumnBuilder;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::Int32Type;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::StringType;
+use databend_common_expression::BlockEntry;
+use databend_common_expression::Column;
+use databend_common_expression::DataBlock;
+use databend_common_expression::FromData;
+use databend_common_expression::Scalar;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::TableSchema;
+use databend_common_expression::TableSchemaRefExt;
+use databend_common_expression::Value;
+use databend_storages_common_table_meta::meta::SegmentInfo;
+use databend_storages_common_table_meta::meta::TableSnapshot;
+
+use crate::io::SegmentsIO;
+use crate::sessions::TableContext;
+use crate::FuseTable;
+
+pub struct ClusteringStatistics<'a> {
+    pub ctx: Arc<dyn TableContext>,
+    pub table: &'a FuseTable,
+    pub limit: Option<usize>,
+    pub cluster_key_id: u32,
+}
+
+impl<'a> ClusteringStatistics<'a> {
+    pub fn new(
+        ctx: Arc<dyn TableContext>,
+        table: &'a FuseTable,
+        limit: Option<usize>,
+        cluster_key_id: u32,
+    ) -> Self {
+        Self {
+            ctx,
+            table,
+            limit,
+            cluster_key_id,
+        }
+    }
+
+    #[async_backtrace::framed]
+    pub async fn get_blocks(&self) -> Result<DataBlock> {
+        let tbl = self.table;
+        let maybe_snapshot = tbl.read_table_snapshot().await?;
+        if let Some(snapshot) = maybe_snapshot {
+            return self.to_block(snapshot).await;
+        }
+
+        Ok(DataBlock::empty_with_schema(Arc::new(
+            Self::schema().into(),
+        )))
+    }
+
+    #[async_backtrace::framed]
+    async fn to_block(&self, snapshot: Arc<TableSnapshot>) -> Result<DataBlock> {
+        let limit = self.limit.unwrap_or(usize::MAX);
+        let len = std::cmp::min(snapshot.summary.block_count as usize, limit);
+
+        let mut segment_name = Vec::with_capacity(len);
+        let mut block_name = StringColumnBuilder::with_capacity(len, len);
+        let mut max = Vec::with_capacity(len);
+        let mut min = Vec::with_capacity(len);
+        let mut level = Vec::with_capacity(len);
+        let mut pages = Vec::with_capacity(len);
+
+        let segments_io = SegmentsIO::create(
+            self.ctx.clone(),
+            self.table.operator.clone(),
+            self.table.schema(),
+        );
+
+        let mut row_num = 0;
+        let mut end_flag = false;
+        let chunk_size =
+            std::cmp::min(self.ctx.get_settings().get_max_threads()? as usize * 4, len).max(1);
+
+        let format_vec = |v: &[Scalar]| -> String {
+            format!(
+                "[{}]",
+                v.iter()
+                    .map(|item| format!("{}", item))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        };
+        'FOR: for chunk in snapshot.segments.chunks(chunk_size) {
+            let segments = segments_io
+                .read_segments::<SegmentInfo>(chunk, true)
+                .await?;
+            for (i, segment) in segments.into_iter().enumerate() {
+                let segment = segment?;
+                segment_name
+                    .extend(std::iter::repeat(chunk[i].0.clone()).take(segment.blocks.len()));
+
+                for block in segment.blocks.iter() {
+                    let block = block.as_ref();
+                    block_name.put_str(&block.location.0);
+                    block_name.commit_row();
+
+                    let cluster_stats = block.cluster_stats.as_ref();
+                    let clustered = block
+                        .cluster_stats
+                        .as_ref()
+                        .map_or(false, |v| v.cluster_key_id == self.cluster_key_id);
+                    if clustered {
+                        // Safe to unwrap
+                        let cluster_stats = cluster_stats.unwrap();
+                        min.push(Some(format_vec(cluster_stats.min())));
+                        max.push(Some(format_vec(cluster_stats.max())));
+                        level.push(Some(cluster_stats.level));
+                        pages.push(cluster_stats.pages.as_ref().map(|v| format_vec(v)));
+                    } else {
+                        min.push(None);
+                        max.push(None);
+                        level.push(None);
+                        pages.push(None);
+                    }
+
+                    row_num += 1;
+                    if row_num >= limit {
+                        end_flag = true;
+                        break;
+                    }
+                }
+
+                if end_flag {
+                    break 'FOR;
+                }
+            }
+        }
+
+        Ok(DataBlock::new(
+            vec![
+                BlockEntry::new(
+                    DataType::String,
+                    Value::Column(StringType::from_data(segment_name)),
+                ),
+                BlockEntry::new(
+                    DataType::String,
+                    Value::Column(Column::String(block_name.build())),
+                ),
+                BlockEntry::new(
+                    DataType::String.wrap_nullable(),
+                    Value::Column(StringType::from_opt_data(min)),
+                ),
+                BlockEntry::new(
+                    DataType::String.wrap_nullable(),
+                    Value::Column(StringType::from_opt_data(max)),
+                ),
+                BlockEntry::new(
+                    DataType::Number(NumberDataType::Int32).wrap_nullable(),
+                    Value::Column(Int32Type::from_opt_data(level)),
+                ),
+                BlockEntry::new(
+                    DataType::String.wrap_nullable(),
+                    Value::Column(StringType::from_opt_data(pages)),
+                ),
+            ],
+            row_num,
+        ))
+    }
+
+    pub fn schema() -> Arc<TableSchema> {
+        TableSchemaRefExt::create(vec![
+            TableField::new("segment_name", TableDataType::String),
+            TableField::new("block_name", TableDataType::String),
+            TableField::new("min", TableDataType::String.wrap_nullable()),
+            TableField::new("max", TableDataType::String.wrap_nullable()),
+            TableField::new(
+                "level",
+                TableDataType::Number(NumberDataType::Int32).wrap_nullable(),
+            ),
+            TableField::new("pages", TableDataType::String.wrap_nullable()),
+        ])
+    }
+}

--- a/src/query/storages/fuse/src/table_functions/clustering_statistics/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_statistics/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod clustering_stat;
+mod clustering_stat_table;
+
+pub use clustering_stat::ClusteringStatistics;
+pub use clustering_stat_table::ClusteringStatisticsTable;

--- a/src/query/storages/fuse/src/table_functions/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/mod.rs
@@ -12,23 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod cache_admin;
 mod clustering_information;
+mod clustering_statistics;
+mod function_template;
+mod fuse_amend;
 mod fuse_blocks;
 mod fuse_columns;
 mod fuse_encodings;
 mod fuse_segments;
 mod fuse_snapshots;
-
-mod cache_admin;
-
-mod function_template;
-mod fuse_amend;
 mod fuse_statistics;
 mod table_args;
 
 pub use cache_admin::SetCacheCapacity;
 pub use clustering_information::ClusteringInformation;
 pub use clustering_information::ClusteringInformationTable;
+pub use clustering_statistics::ClusteringStatistics;
+pub use clustering_statistics::ClusteringStatisticsTable;
 use databend_common_catalog::table_args::TableArgs;
 use databend_common_catalog::table_function::TableFunction;
 pub use function_template::SimpleTableFunc;

--- a/tests/cloud_control_server/simple_server.py
+++ b/tests/cloud_control_server/simple_server.py
@@ -44,9 +44,9 @@ def load_data_from_json():
                 notification_history_data = json.load(f)
                 notification_history = notification_pb2.NotificationHistory()
                 json_format.ParseDict(notification_history_data, notification_history)
-                NOTIFICATION_HISTORY_DB[
-                    notification_history.name
-                ] = notification_history
+                NOTIFICATION_HISTORY_DB[notification_history.name] = (
+                    notification_history
+                )
 
 
 def create_task_request_to_task(id, create_task_request):

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
@@ -22,6 +22,13 @@ select *  from t09_0014 order by b, a
 1 3
 4 4
 
+query TTIT
+select min, max, level, pages from clustering_statistics('default','t09_0014') order by min
+----
+[1, 1] [3, 0] 0 NULL
+[1, 2] [3, 1] 0 NULL
+[4, 4] [4, 4] 0 NULL
+
 query TIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014')
 ----
@@ -37,6 +44,9 @@ ALTER TABLE t09_0014 DROP CLUSTER KEY
 
 statement error 1118
 select * from clustering_information('default','t09_0014')
+
+statement error 1118
+select * from clustering_statistics('default','t09_0014')
 
 query TIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014', '(b, a)')

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
@@ -22,12 +22,12 @@ select *  from t09_0014 order by b, a
 1 3
 4 4
 
-query TTIT
-select min, max, level, pages from clustering_statistics('default','t09_0014') order by min
+query TTI
+select min, max, level from clustering_statistics('default','t09_0014') order by min
 ----
-[1, 1] [3, 0] 0 NULL
-[1, 2] [3, 1] 0 NULL
-[4, 4] [4, 4] 0 NULL
+[1, 1] [3, 0] 0
+[1, 2] [3, 1] 0
+[4, 4] [4, 4] 0
 
 query TIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014')

--- a/tests/suites/0_stateless/18_rbac/18_0006_mysql_auth.py
+++ b/tests/suites/0_stateless/18_rbac/18_0006_mysql_auth.py
@@ -167,4 +167,3 @@ try:
     cursor.execute("select 123;")
 except mysql.connector.errors.OperationalError:
     print("u4 is timeout")
-

--- a/tests/suites/1_stateful/02_query/02_0008_profile.py
+++ b/tests/suites/1_stateful/02_query/02_0008_profile.py
@@ -36,7 +36,7 @@ def judge(profile):
         cpu_time += item["statistics"][0]
 
     print(memory_usage)
-    print(cpu_time>0)
+    print(cpu_time > 0)
     print(error_count)
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Show cluster statistics in every blocks.
```
mysql> create table t09_0014(a int, b int) cluster by(b,a);
Query OK, 0 rows affected (0.16 sec)

mysql> insert into t09_0014 values(0,3),(1,1);
Query OK, 2 rows affected (0.15 sec)

mysql> insert into t09_0014 values(1,3),(2,1);
Query OK, 2 rows affected (0.17 sec)

mysql> insert into t09_0014 values(4,4) ;
Query OK, 1 row affected (0.21 sec)

mysql> select *  from t09_0014 order by b, a;
+------+------+
| a    | b    |
+------+------+
|    1 |    1 |
|    2 |    1 |
|    0 |    3 |
|    1 |    3 |
|    4 |    4 |
+------+------+
5 rows in set (0.15 sec)
Read 5 rows, 46.00 B in 0.062 sec., 80.16 rows/sec., 737.45 B/sec.

mysql> select * from clustering_statistics('default','t09_0014');
+---------------------------------------------------+------------------------------------------------------+--------+--------+-------+-------+
| segment_name                                      | block_name                                           | min    | max    | level | pages |
+---------------------------------------------------+------------------------------------------------------+--------+--------+-------+-------+
| 1/249/_sg/9839d56dd59a430598c8a21836d3b84d_v4.mpk | 1/249/_b/4be0b79301514b88bdf1bda7b56cf5b1_v2.parquet | [4, 4] | [4, 4] |     0 | NULL  |
| 1/249/_sg/9995e76ce7534e239c5d066ba51d0cc1_v4.mpk | 1/249/_b/405fe8c7b9724046a42148141c50d279_v2.parquet | [1, 2] | [3, 1] |     0 | NULL  |
| 1/249/_sg/6c9800eb4b794822897592936e87e31a_v4.mpk | 1/249/_b/6a467eb4f911422a911c93146ec266d7_v2.parquet | [1, 1] | [3, 0] |     0 | NULL  |
+---------------------------------------------------+------------------------------------------------------+--------+--------+-------+-------+
3 rows in set (0.06 sec)
Read 3 rows, 515.00 B in 0.038 sec., 78.42 rows/sec., 13.15 KiB/sec.

mysql> ALTER TABLE t09_0014 DROP CLUSTER KEY;
Query OK, 0 rows affected (0.15 sec)

mysql> select * from clustering_statistics('default','t09_0014');
ERROR 1105 (HY000): UnclusteredTable. Code: 1118, Text = Unclustered table 'default.t09_0014'.
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16081)
<!-- Reviewable:end -->
