### PR TITLE
fix: wrong prev snapshot id

### DIFF
--- a/src/query/service/src/interpreters/interpreter_delete.rs
+++ b/src/query/service/src/interpreters/interpreter_delete.rs
@@ -323,7 +323,7 @@ impl DeleteInterpreter {
         }
         let mut plan = PhysicalPlan::CommitSink(Box::new(CommitSink {
             input: Box::new(root),
-            snapshot,
+            snapshot: Some(snapshot),
             table_info,
             mutation_kind: MutationKind::Delete,
             update_stream_meta: vec![],

--- a/src/query/service/src/interpreters/interpreter_merge_into.rs
+++ b/src/query/service/src/interpreters/interpreter_merge_into.rs
@@ -29,10 +29,8 @@ use databend_common_sql::executor::PhysicalPlan;
 use databend_common_sql::executor::PhysicalPlanBuilder;
 use databend_common_sql::optimizer::SExpr;
 use databend_common_sql::plans;
-use databend_common_storages_factory::Table;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::TableContext;
-use databend_storages_common_table_meta::meta::TableSnapshot;
 
 use crate::interpreters::common::dml_build_update_stream_req;
 use crate::interpreters::HookOperator;
@@ -136,13 +134,7 @@ impl MergeIntoInterpreter {
         })?;
 
         // Prepare MergeIntoBuildInfo for PhysicalPlanBuilder to build MergeInto physical plan.
-        let table_info = fuse_table.get_table_info();
-        let table_snapshot = fuse_table.read_table_snapshot().await?.unwrap_or_else(|| {
-            Arc::new(TableSnapshot::new_empty_snapshot(
-                fuse_table.schema().as_ref().clone(),
-                Some(table_info.ident.seq),
-            ))
-        });
+        let table_snapshot = fuse_table.read_table_snapshot().await?;
         let update_stream_meta =
             dml_build_update_stream_req(self.ctx.clone(), &merge_into.meta_data).await?;
         let merge_into_build_info = MergeIntoBuildInfo {

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -45,7 +45,7 @@ use databend_common_sql::ScalarBinder;
 use databend_common_storage::StageFileInfo;
 use databend_common_storages_factory::Table;
 use databend_common_storages_fuse::FuseTable;
-use databend_storages_common_table_meta::meta::TableSnapshot;
+use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshotVisitor;
 use parking_lot::RwLock;
 
 use crate::interpreters::common::check_deduplicate_label;
@@ -164,20 +164,15 @@ impl ReplaceInterpreter {
         })?;
 
         let table_info = fuse_table.get_table_info();
-        let base_snapshot = fuse_table.read_table_snapshot().await?.unwrap_or_else(|| {
-            Arc::new(TableSnapshot::new_empty_snapshot(
-                schema.as_ref().clone(),
-                Some(table_info.ident.seq),
-            ))
-        });
+        let base_snapshot = fuse_table.read_table_snapshot().await?;
 
         let is_multi_node = !self.ctx.get_cluster().is_empty();
         let is_value_source = matches!(self.plan.source, InsertInputSource::Values(_));
         let is_distributed = is_multi_node
             && !is_value_source
             && self.ctx.get_settings().get_enable_distributed_replace()?;
-        let table_is_empty = base_snapshot.segments.is_empty();
-        let table_level_range_index = base_snapshot.summary.col_stats.clone();
+        let table_is_empty = base_snapshot.segments().is_empty();
+        let table_level_range_index = base_snapshot.summary().col_stats;
         let mut purge_info = None;
 
         let ReplaceSourceCtx {
@@ -328,9 +323,9 @@ impl ReplaceInterpreter {
             on_conflicts,
             bloom_filter_column_indexes,
             segments: base_snapshot
-                .segments
-                .clone()
-                .into_iter()
+                .segments()
+                .iter()
+                .cloned()
                 .enumerate()
                 .collect(),
             block_slots: None,

--- a/src/query/service/src/interpreters/interpreter_table_optimize.rs
+++ b/src/query/service/src/interpreters/interpreter_table_optimize.rs
@@ -126,7 +126,7 @@ impl OptimizeTableInterpreter {
         Ok(PhysicalPlan::CommitSink(Box::new(CommitSink {
             input: Box::new(root),
             table_info,
-            snapshot,
+            snapshot: Some(snapshot),
             mutation_kind: MutationKind::Compact,
             update_stream_meta: vec![],
             merge_meta,

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -294,7 +294,7 @@ impl UpdateInterpreter {
         }
         let mut plan = PhysicalPlan::CommitSink(Box::new(CommitSink {
             input: Box::new(root),
-            snapshot,
+            snapshot: Some(snapshot),
             table_info,
             mutation_kind: MutationKind::Update,
             update_stream_meta: vec![],

--- a/src/query/service/src/pipelines/builders/builder_commit.rs
+++ b/src/query/service/src/pipelines/builders/builder_commit.rs
@@ -21,6 +21,7 @@ use databend_common_storages_fuse::operations::MutationGenerator;
 use databend_common_storages_fuse::operations::TableMutationAggregator;
 use databend_common_storages_fuse::operations::TransformMergeCommitMeta;
 use databend_common_storages_fuse::FuseTable;
+use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshotVisitor;
 
 use crate::pipelines::PipelineBuilder;
 
@@ -40,7 +41,7 @@ impl PipelineBuilder {
                 let base_segments = if matches!(plan.mutation_kind, MutationKind::Compact) {
                     vec![]
                 } else {
-                    plan.snapshot.segments.clone()
+                    plan.snapshot.segments().to_vec()
                 };
                 TableMutationAggregator::new(
                     table,

--- a/src/query/service/src/pipelines/builders/builder_recluster.rs
+++ b/src/query/service/src/pipelines/builders/builder_recluster.rs
@@ -211,8 +211,10 @@ impl PipelineBuilder {
             )
         });
 
-        let snapshot_gen =
-            MutationGenerator::new(recluster_sink.snapshot.clone(), MutationKind::Recluster);
+        let snapshot_gen = MutationGenerator::new(
+            Some(recluster_sink.snapshot.clone()),
+            MutationKind::Recluster,
+        );
         self.main_pipeline.add_sink(|input| {
             CommitSink::try_create(
                 table,

--- a/src/query/service/src/test_kits/fuse.rs
+++ b/src/query/service/src/test_kits/fuse.rs
@@ -214,7 +214,8 @@ pub async fn generate_snapshots(fixture: &TestFixture) -> Result<()> {
         None,
     );
     snapshot_1.timestamp = Some(now - Duration::hours(12));
-    snapshot_1.summary = merge_statistics(&snapshot_0.summary, &segments_v3[0].1.summary, None);
+    snapshot_1.summary =
+        merge_statistics(snapshot_0.summary.clone(), &segments_v3[0].1.summary, None);
     let new_snapshot_location = location_gen
         .snapshot_location_from_uuid(&snapshot_1.snapshot_id, TableSnapshot::VERSION)?;
     snapshot_1
@@ -230,7 +231,8 @@ pub async fn generate_snapshots(fixture: &TestFixture) -> Result<()> {
     let mut snapshot_2 = TableSnapshot::from_previous(&snapshot_1, None);
     snapshot_2.segments = locations;
     snapshot_2.timestamp = Some(now);
-    snapshot_2.summary = merge_statistics(&snapshot_1.summary, &segments_v3[1].1.summary, None);
+    snapshot_2.summary =
+        merge_statistics(snapshot_1.summary.clone(), &segments_v3[1].1.summary, None);
     let new_snapshot_location = location_gen
         .snapshot_location_from_uuid(&snapshot_2.snapshot_id, TableSnapshot::VERSION)?;
     snapshot_2

--- a/src/query/service/tests/it/storages/fuse/conflict.rs
+++ b/src/query/service/tests/it/storages/fuse/conflict.rs
@@ -55,7 +55,7 @@ fn test_unresolvable_delete_conflict() {
         merged_statistics: Statistics::default(),
     });
 
-    let mut generator = MutationGenerator::new(Arc::new(base_snapshot), MutationKind::Delete);
+    let mut generator = MutationGenerator::new(Some(Arc::new(base_snapshot)), MutationKind::Delete);
     generator.set_conflict_resolve_context(ctx);
 
     let result = generator.generate_new_snapshot(
@@ -146,7 +146,7 @@ fn test_resolvable_delete_conflict() {
         merged_statistics,
     });
 
-    let mut generator = MutationGenerator::new(Arc::new(base_snapshot), MutationKind::Delete);
+    let mut generator = MutationGenerator::new(Some(Arc::new(base_snapshot)), MutationKind::Delete);
     generator.set_conflict_resolve_context(ctx);
 
     let result = generator.generate_new_snapshot(
@@ -252,7 +252,8 @@ fn test_resolvable_replace_conflict() {
         merged_statistics,
     });
 
-    let mut generator = MutationGenerator::new(Arc::new(base_snapshot), MutationKind::Replace);
+    let mut generator =
+        MutationGenerator::new(Some(Arc::new(base_snapshot)), MutationKind::Replace);
     generator.set_conflict_resolve_context(ctx);
 
     let result = generator.generate_new_snapshot(

--- a/src/query/sql/src/executor/physical_plan_builder.rs
+++ b/src/query/sql/src/executor/physical_plan_builder.rs
@@ -139,6 +139,6 @@ impl PhysicalPlanBuilder {
 
 #[derive(Clone)]
 pub struct MergeIntoBuildInfo {
-    pub table_snapshot: Arc<TableSnapshot>,
+    pub table_snapshot: Option<Arc<TableSnapshot>>,
     pub update_stream_meta: Vec<UpdateStreamMetaReq>,
 }

--- a/src/query/sql/src/executor/physical_plans/physical_commit_sink.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_commit_sink.rs
@@ -27,7 +27,7 @@ use crate::executor::PhysicalPlan;
 pub struct CommitSink {
     pub plan_id: u32,
     pub input: Box<PhysicalPlan>,
-    pub snapshot: Arc<TableSnapshot>,
+    pub snapshot: Option<Arc<TableSnapshot>>,
     pub table_info: TableInfo,
     pub mutation_kind: MutationKind,
     pub update_stream_meta: Vec<UpdateStreamMetaReq>,

--- a/src/query/sql/src/executor/physical_plans/physical_merge_into.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_merge_into.rs
@@ -33,6 +33,7 @@ use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::schema::TableInfo;
 use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::meta::NUM_BLOCK_ID_BITS;
+use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshotVisitor;
 use itertools::Itertools;
 
 use crate::binder::MergeIntoType;
@@ -444,9 +445,9 @@ impl PhysicalPlanBuilder {
         }));
 
         let segments: Vec<_> = base_snapshot
-            .segments
-            .clone()
-            .into_iter()
+            .segments()
+            .iter()
+            .cloned()
             .enumerate()
             .collect();
 

--- a/src/query/storages/common/table_meta/src/readers/snapshot_reader.rs
+++ b/src/query/storages/common/table_meta/src/readers/snapshot_reader.rs
@@ -13,12 +13,17 @@
 // limitations under the License.
 
 use std::io::Read;
+use std::sync::Arc;
 
 use databend_common_exception::Result;
 use databend_common_expression::TableSchema;
 
 use crate::meta::load_json;
+use crate::meta::FormatVersion;
+use crate::meta::Location;
+use crate::meta::SnapshotId;
 use crate::meta::SnapshotVersion;
+use crate::meta::Statistics;
 use crate::meta::TableSnapshot;
 use crate::meta::TableSnapshotV2;
 use crate::meta::TableSnapshotV3;
@@ -46,5 +51,41 @@ impl VersionedReader<TableSnapshot> for SnapshotVersion {
             }
         };
         Ok(r)
+    }
+}
+
+pub trait TableSnapshotVisitor {
+    fn segments(&self) -> &[Location];
+    fn summary(&self) -> Statistics;
+    fn timestamp(&self) -> Option<chrono::DateTime<chrono::Utc>>;
+    fn snapshot_id(&self) -> Option<(SnapshotId, FormatVersion)>;
+    fn table_statistics_location(&self) -> Option<String>;
+}
+
+impl TableSnapshotVisitor for Option<Arc<TableSnapshot>> {
+    fn segments(&self) -> &[Location] {
+        self.as_ref()
+            .map(|snapshot| snapshot.segments.as_ref())
+            .unwrap_or_default()
+    }
+
+    fn summary(&self) -> Statistics {
+        self.as_ref()
+            .map(|snapshot| snapshot.summary.clone())
+            .unwrap_or_default()
+    }
+
+    fn timestamp(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.as_ref().and_then(|snapshot| snapshot.timestamp)
+    }
+
+    fn snapshot_id(&self) -> Option<(SnapshotId, FormatVersion)> {
+        self.as_ref()
+            .map(|snapshot| (snapshot.snapshot_id, snapshot.format_version))
+    }
+
+    fn table_statistics_location(&self) -> Option<String> {
+        self.as_ref()
+            .and_then(|snapshot| snapshot.table_statistics_location.clone())
     }
 }

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -431,7 +431,7 @@ impl FuseTable {
             for result in concurrent_appended_segment_infos.into_iter() {
                 let concurrent_appended_segment = result?;
                 new_statistics = merge_statistics(
-                    &new_statistics,
+                    new_statistics.clone(),
                     &concurrent_appended_segment.summary,
                     default_cluster_key_id,
                 );

--- a/src/query/storages/fuse/src/operations/common/generators/conflict_resolve_context.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/conflict_resolve_context.rs
@@ -51,20 +51,19 @@ impl ConflictResolveContext {
     }
 
     pub fn is_modified_segments_exists_in_latest(
-        base: &TableSnapshot,
-        latest: &TableSnapshot,
+        base_segments: &[Location],
+        latest_segments: &[Location],
         replaced_segments: &HashMap<usize, Location>,
         removed_segments: &[usize],
     ) -> Option<(Vec<usize>, HashMap<usize, Location>)> {
-        let latest_segments = latest
-            .segments
+        let latest_segments = latest_segments
             .iter()
             .enumerate()
             .map(|(i, x)| (x, i))
             .collect::<HashMap<_, usize>>();
         let mut removed = Vec::with_capacity(removed_segments.len());
         for removed_segment in removed_segments {
-            let removed_segment = &base.segments[*removed_segment];
+            let removed_segment = &base_segments[*removed_segment];
             if let Some(position) = latest_segments.get(removed_segment) {
                 removed.push(*position);
             } else {
@@ -74,7 +73,7 @@ impl ConflictResolveContext {
 
         let mut replaced = HashMap::with_capacity(replaced_segments.len());
         for (position, location) in replaced_segments {
-            let origin_segment = &base.segments[*position];
+            let origin_segment = &base_segments[*position];
             if let Some(position) = latest_segments.get(origin_segment) {
                 replaced.insert(*position, location.clone());
             } else {

--- a/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
@@ -22,6 +22,7 @@ use databend_common_metrics::storage::*;
 use databend_common_sql::executor::physical_plans::MutationKind;
 use databend_storages_common_table_meta::meta::ClusterKey;
 use databend_storages_common_table_meta::meta::TableSnapshot;
+use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshotVisitor;
 use log::info;
 use uuid::Uuid;
 
@@ -32,13 +33,13 @@ use crate::statistics::reducers::deduct_statistics_mut;
 
 #[derive(Clone)]
 pub struct MutationGenerator {
-    base_snapshot: Arc<TableSnapshot>,
+    base_snapshot: Option<Arc<TableSnapshot>>,
     conflict_resolve_ctx: ConflictResolveContext,
     mutation_kind: MutationKind,
 }
 
 impl MutationGenerator {
-    pub fn new(base_snapshot: Arc<TableSnapshot>, mutation_kind: MutationKind) -> Self {
+    pub fn new(base_snapshot: Option<Arc<TableSnapshot>>, mutation_kind: MutationKind) -> Self {
         MutationGenerator {
             base_snapshot,
             conflict_resolve_ctx: ConflictResolveContext::None,
@@ -64,25 +65,12 @@ impl SnapshotGenerator for MutationGenerator {
         prev_table_seq: Option<u64>,
     ) -> Result<TableSnapshot> {
         let default_cluster_key_id = cluster_key_meta.clone().map(|v| v.0);
-
-        let empty_snapshot;
-        let previous = match previous {
-            Some(prev) => prev,
-            None => {
-                empty_snapshot = Arc::new(TableSnapshot::new_empty_snapshot(
-                    schema.clone(),
-                    prev_table_seq,
-                ));
-                &empty_snapshot
-            }
-        };
-
         match &self.conflict_resolve_ctx {
             ConflictResolveContext::ModifiedSegmentExistsInLatest(ctx) => {
                 if let Some((removed, replaced)) =
                     ConflictResolveContext::is_modified_segments_exists_in_latest(
-                        &self.base_snapshot,
-                        previous,
+                        self.base_snapshot.segments(),
+                        previous.segments(),
                         &ctx.replaced_segments,
                         &ctx.removed_segment_indexes,
                     )
@@ -90,27 +78,27 @@ impl SnapshotGenerator for MutationGenerator {
                     info!("resolvable conflicts detected");
                     metrics_inc_commit_mutation_modified_segment_exists_in_latest();
                     let new_segments = ConflictResolveContext::merge_segments(
-                        previous.segments.clone(),
+                        previous.segments().to_vec(),
                         ctx.appended_segments.clone(),
                         replaced,
                         removed,
                     );
                     let mut new_summary = merge_statistics(
+                        previous.summary(),
                         &ctx.merged_statistics,
-                        &previous.summary,
                         default_cluster_key_id,
                     );
                     deduct_statistics_mut(&mut new_summary, &ctx.removed_statistics);
                     let new_snapshot = TableSnapshot::new(
                         Uuid::new_v4(),
                         prev_table_seq,
-                        &previous.timestamp,
-                        Some((previous.snapshot_id, previous.format_version)),
+                        &previous.timestamp(),
+                        previous.snapshot_id(),
                         schema,
                         new_summary,
                         new_segments,
                         cluster_key_meta,
-                        previous.table_statistics_location.clone(),
+                        previous.table_statistics_location(),
                     );
 
                     if matches!(self.mutation_kind, MutationKind::Compact) {

--- a/src/query/storages/fuse/src/operations/common/processors/transform_merge_commit_meta.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_merge_commit_meta.rs
@@ -53,7 +53,7 @@ impl TransformMergeCommitMeta {
                         .chain(r.removed_segment_indexes)
                         .collect(),
                     removed_statistics: merge_statistics(
-                        &l.removed_statistics,
+                        l.removed_statistics.clone(),
                         &r.removed_statistics,
                         default_cluster_key_id,
                     ),
@@ -68,7 +68,7 @@ impl TransformMergeCommitMeta {
                         .chain(r.replaced_segments)
                         .collect(),
                     merged_statistics: merge_statistics(
-                        &l.merged_statistics,
+                        l.merged_statistics.clone(),
                         &r.merged_statistics,
                         default_cluster_key_id,
                     ),

--- a/src/query/storages/fuse/src/statistics/reducers.rs
+++ b/src/query/storages/fuse/src/statistics/reducers.rs
@@ -130,13 +130,12 @@ pub fn reduce_cluster_statistics<T: Borrow<Option<ClusterStatistics>>>(
 }
 
 pub fn merge_statistics(
-    l: &Statistics,
+    mut l: Statistics,
     r: &Statistics,
     default_cluster_key_id: Option<u32>,
 ) -> Statistics {
-    let mut new = l.clone();
-    merge_statistics_mut(&mut new, r, default_cluster_key_id);
-    new
+    merge_statistics_mut(&mut l, r, default_cluster_key_id);
+    l
 }
 
 pub fn merge_statistics_mut(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
This issue is caused by logic like `base_snapshot.unwrap_or(TableSnapshot::new_empty())`, which build an incomplete snapshot object when snapshot is None. This PR limits the usage of `TableSnapshot::new_empty()`.
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
