### PR TITLE
feat(query): PartitionsShuffleKind::ConsistentHash support 

### DIFF
--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -138,11 +138,11 @@ impl Partitions {
                 parts.into_iter().map(|x| x.1).collect()
             }
             PartitionsShuffleKind::ConsistentHash => {
-                let mut scale = 1;
+                let mut scale = 0;
                 let num_executors = executors_sorted.len();
                 const EXPECT_NODES: usize = 100;
-                while num_executors * scale < EXPECT_NODES {
-                    scale <<= 1;
+                while num_executors << scale < EXPECT_NODES {
+                    scale += 1;
                 }
 
                 let mut executor_part = executors_sorted
@@ -155,7 +155,7 @@ impl Partitions {
                     .flat_map(|e| {
                         let mut s = DefaultHasher::new();
                         e.hash(&mut s);
-                        (0..scale).map(move |i| {
+                        (0..1 << scale).map(move |i| {
                             i.hash(&mut s);
                             (e, s.finish())
                         })

--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::sync::Arc;
 
 use databend_common_exception::Result;
@@ -90,6 +93,8 @@ pub enum PartitionsShuffleKind {
     Seq,
     // Bind the Partition to executor by partition.hash()%executor_nums order.
     Mod,
+    // Bind the Partition to executor by ConsistentHash(partition.hash()) order.
+    ConsistentHash,
     // Bind the Partition to executor by partition.rand() order.
     Rand,
     // Bind the Partition to executor by broadcast
@@ -132,6 +137,49 @@ impl Partitions {
                 parts.sort_by(|a, b| a.0.cmp(&b.0));
                 parts.into_iter().map(|x| x.1).collect()
             }
+            PartitionsShuffleKind::ConsistentHash => {
+                let mut scale = 1;
+                let num_executors = executors_sorted.len();
+                const EXPECT_NODES: usize = 100;
+                while num_executors * scale < EXPECT_NODES {
+                    scale <<= 1;
+                }
+
+                let mut executor_part = executors_sorted
+                    .iter()
+                    .map(|e| (e.clone(), Partitions::default()))
+                    .collect::<HashMap<_, _>>();
+
+                let mut ring = executors_sorted
+                    .iter()
+                    .flat_map(|e| {
+                        let mut s = DefaultHasher::new();
+                        e.hash(&mut s);
+                        (0..scale).map(move |i| {
+                            i.hash(&mut s);
+                            (e, s.finish())
+                        })
+                    })
+                    .collect::<Vec<_>>();
+
+                ring.sort_by(|&(_, a), &(_, b)| a.cmp(&b));
+
+                for p in self.partitions.iter() {
+                    let k = p.hash();
+                    let idx = match ring.binary_search_by(|&(_, h)| h.cmp(&k)) {
+                        Err(i) => i,
+                        Ok(i) => i,
+                    };
+                    let executor = if idx == ring.len() {
+                        ring[0].0
+                    } else {
+                        ring[idx].0
+                    };
+                    let part = executor_part.get_mut(executor).unwrap();
+                    part.partitions.push(p.clone());
+                }
+                return Ok(executor_part);
+            }
             PartitionsShuffleKind::Rand => {
                 let mut rng = thread_rng();
                 let mut parts = self.partitions.clone();
@@ -139,15 +187,15 @@ impl Partitions {
                 parts
             }
             PartitionsShuffleKind::Broadcast => {
-                let mut executor_part = HashMap::default();
-                for executor in executors_sorted.iter() {
-                    executor_part.insert(
-                        executor.clone(),
-                        Partitions::create(PartitionsShuffleKind::Seq, self.partitions.clone()),
-                    );
-                }
-
-                return Ok(executor_part);
+                return Ok(executors_sorted
+                    .into_iter()
+                    .map(|executor| {
+                        (
+                            executor,
+                            Partitions::create(PartitionsShuffleKind::Seq, self.partitions.clone()),
+                        )
+                    })
+                    .collect());
             }
         };
 

--- a/src/query/catalog/tests/it/partitions.rs
+++ b/src/query/catalog/tests/it/partitions.rs
@@ -186,6 +186,23 @@ fn test_partition_reshuffle() {
     // ConsistentHash.
     {
         let partitions = gen_parts(PartitionsShuffleKind::ConsistentHash, 11);
+        let shuffle = partitions.reshuffle(executors_2.clone()).unwrap();
+
+        writeln!(
+            file,
+            "PartitionsShuffleKind::ConsistentHash : 11 partitions of 2 executors"
+        )
+        .unwrap();
+        let e1_parts = shuffle.get(&executors_2[0]).unwrap();
+        writeln!(file, "{:?}", e1_parts).unwrap();
+
+        let e2_parts = shuffle.get(&executors_2[1]).unwrap();
+        writeln!(file, "{:?}", e2_parts).unwrap();
+    }
+
+    // ConsistentHash.
+    {
+        let partitions = gen_parts(PartitionsShuffleKind::ConsistentHash, 11);
         let shuffle = partitions.reshuffle(executors_3.clone()).unwrap();
 
         writeln!(

--- a/src/query/catalog/tests/it/partitions.rs
+++ b/src/query/catalog/tests/it/partitions.rs
@@ -183,6 +183,26 @@ fn test_partition_reshuffle() {
         writeln!(file, "{:?}", e2_parts).unwrap();
     }
 
+    // ConsistentHash.
+    {
+        let partitions = gen_parts(PartitionsShuffleKind::ConsistentHash, 11);
+        let shuffle = partitions.reshuffle(executors_3.clone()).unwrap();
+
+        writeln!(
+            file,
+            "PartitionsShuffleKind::ConsistentHash : 11 partitions of 3 executors"
+        )
+        .unwrap();
+        let e1_parts = shuffle.get(&executors_3[0]).unwrap();
+        writeln!(file, "{:?}", e1_parts).unwrap();
+
+        let e2_parts = shuffle.get(&executors_3[1]).unwrap();
+        writeln!(file, "{:?}", e2_parts).unwrap();
+
+        let e3_parts = shuffle.get(&executors_3[2]).unwrap();
+        writeln!(file, "{:?}", e3_parts).unwrap();
+    }
+
     // Rand.
     {
         let partitions = gen_parts(PartitionsShuffleKind::Rand, 11);

--- a/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
+++ b/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
@@ -17,6 +17,10 @@ Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fu
 PartitionsShuffleKind::Mod : 11 partitions of 2 executors
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}] }
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
+PartitionsShuffleKind::ConsistentHash : 11 partitions of 3 executors
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}] }
 PartitionsShuffleKind::Rand: 11 partitions of 2 executors
 5
 6

--- a/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
+++ b/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
@@ -17,10 +17,13 @@ Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fu
 PartitionsShuffleKind::Mod : 11 partitions of 2 executors
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}] }
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
+PartitionsShuffleKind::ConsistentHash : 11 partitions of 2 executors
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
 PartitionsShuffleKind::ConsistentHash : 11 partitions of 3 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}] }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"7"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"8"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
 PartitionsShuffleKind::Rand: 11 partitions of 2 executors
 5
 6


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
PartitionsShuffleKind::ConsistentHash support 

`PartitionsShuffleKind::ConsistentHash` has a significant load skew compared to `PartitionsShuffleKind::Mod`, so we need to figure out when `PartitionsShuffleKind::ConsistentHash` is better than `PartitionsShuffleKind::Mod`.

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16094)
<!-- Reviewable:end -->
