### PR TITLE
refactor(query): If table_id is specified, use it directly

### DIFF
--- a/benchmark/clickbench/internal/queries/00.sql
+++ b/benchmark/clickbench/internal/queries/00.sql
@@ -10,3 +10,4 @@ from system.databases
 union all
 select name
 from system.functions ignore_result;
+select name from system.tables where name='t_1';

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -260,6 +260,7 @@ pub(crate) async fn dump_tables(
                         }
                     }
                 }
+                Ok(())
             });
         }
     }

--- a/src/query/storages/system/src/locks_table.rs
+++ b/src/query/storages/system/src/locks_table.rs
@@ -87,6 +87,7 @@ impl AsyncSystemTable for LocksTable {
                                 }
                             }
                         }
+                        Ok(())
                     });
                 }
             }

--- a/src/query/storages/system/src/notification_history_table.rs
+++ b/src/query/storages/system/src/notification_history_table.rs
@@ -118,6 +118,7 @@ impl AsyncSystemTable for NotificationHistoryTable {
                             notification_name = Some(s.clone());
                         }
                     }
+                    Ok(())
                 });
             }
         }

--- a/src/query/storages/system/src/streams_table.rs
+++ b/src/query/storages/system/src/streams_table.rs
@@ -116,6 +116,7 @@ impl<const T: bool> AsyncSystemTable for StreamsTable<T> {
                                 }
                             }
                         }
+                        Ok(())
                     });
                     for db in db_name {
                         match ctl.get_database(&tenant, db.as_str()).await {

--- a/src/query/storages/system/src/task_history_table.rs
+++ b/src/query/storages/system/src/task_history_table.rs
@@ -158,6 +158,7 @@ impl AsyncSystemTable for TaskHistoryTable {
                             task_name = Some(s.clone());
                         }
                     }
+                    Ok(())
                 });
                 find_lt_filter(&expr, &mut |col_name, scalar| {
                     if col_name == "scheduled_time" {

--- a/src/query/storages/system/src/util.rs
+++ b/src/query/storages/system/src/util.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_exception::Result;
 use databend_common_expression::Expr;
 use databend_common_expression::Scalar;
 
-pub fn find_eq_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scalar)) {
+pub fn find_eq_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scalar) -> Result<()>) {
     match expr {
         Expr::Constant { .. } | Expr::ColumnRef { .. } => {}
         Expr::Cast { expr, .. } => find_eq_filter(expr, visitor),
@@ -27,7 +28,7 @@ pub fn find_eq_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scala
                 match args.as_slice() {
                     [Expr::ColumnRef { id, .. }, Expr::Constant { scalar, .. }]
                     | [Expr::Constant { scalar, .. }, Expr::ColumnRef { id, .. }] => {
-                        visitor(id, scalar);
+                        let _ = visitor(id, scalar);
                     }
                     _ => {}
                 }

--- a/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
@@ -5,3 +5,6 @@ query T
 select * from (select name from system.tables where database='system') where name='tables'
 ----
 tables
+
+statement error 1006
+select name from system.tables where database='system' or table_id='xx'

--- a/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
@@ -7,4 +7,4 @@ select * from (select name from system.tables where database='system') where nam
 tables
 
 statement error 1006
-select name from system.tables where database='system' or table_id='xx'
+select name from system.tables where database='system' and table_id='xx'

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_ctas.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_ctas.test
@@ -16,7 +16,7 @@ statement error 1006
 create or replace table t (c int) 'fs:///tmp/ctas/' as select number / (number-3999999) from numbers(4000000);
 
 # there should be no table ctas_test.t
-query I
+query T
 select count() from system.tables_with_history where database = 'ctas_test' and name = 't';
 ----
 0
@@ -31,7 +31,7 @@ vacuum drop table from ctas_test;
 
 
 # the dropped table ctas_test.t should be vacuumed
-query I
+query T
 select count() from system.tables_with_history where database = 'ctas_test' and name = 't';
 ----
 0

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_ctas.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_ctas.test
@@ -16,7 +16,7 @@ statement error 1006
 create or replace table t (c int) 'fs:///tmp/ctas/' as select number / (number-3999999) from numbers(4000000);
 
 # there should be no table ctas_test.t
-query T
+query I
 select count() from system.tables_with_history where database = 'ctas_test' and name = 't';
 ----
 0
@@ -31,7 +31,7 @@ vacuum drop table from ctas_test;
 
 
 # the dropped table ctas_test.t should be vacuumed
-query T
+query I
 select count() from system.tables_with_history where database = 'ctas_test' and name = 't';
 ----
 0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Note:

If len of table_ids gt 10, also use list_table

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16098)
<!-- Reviewable:end -->
