### PR TITLE
fix(query): cast string to decimal respect numeric_cast_option setting

### DIFF
--- a/src/query/expression/tests/it/decimal.rs
+++ b/src/query/expression/tests/it/decimal.rs
@@ -28,7 +28,7 @@ fn test_decimal_text_exact() -> Result<()> {
     let cases = vec!["", ".e", ".", ".a", "-", "+", "e1", "a", "1e1e1", "1.1.1"];
 
     for s in cases {
-        let r = read_decimal::<i128>(s.as_bytes(), 10, true);
+        let r = read_decimal::<i128>(s.as_bytes(), 10, 5, true);
         assert!(r.is_err(), "{s}: {r:?}");
     }
     Ok(())
@@ -60,7 +60,7 @@ fn test_decimal_text() -> Result<()> {
     ];
 
     for (s, l) in cases {
-        let r = read_decimal::<i128>(s.as_bytes(), 10, false);
+        let r = read_decimal::<i128>(s.as_bytes(), 10, 10, false);
         match r {
             Ok(r) => assert_eq!(l, r, "{s}: {l:?} != {r:?}"),
             Err(e) => panic!("{s}: {l:?} != {e:?}"),
@@ -70,7 +70,7 @@ fn test_decimal_text() -> Result<()> {
     let cases = vec!["", "10000000000#"];
 
     for s in cases {
-        let r = read_decimal::<i128>(s.as_bytes(), 10, false);
+        let r = read_decimal::<i128>(s.as_bytes(), 10, 10, false);
         assert!(r.is_err(), "{s}: {r:?}");
     }
 

--- a/tests/sqllogictests/suites/base/11_data_type/11_0006_data_type_decimal.test
+++ b/tests/sqllogictests/suites/base/11_data_type/11_0006_data_type_decimal.test
@@ -1095,6 +1095,11 @@ select cast(b as int), cast(c as int), cast(d as int) from t
 -1 -1 -1
 -1 -1 -1
 
+query TTT
+select CAST('0.185415880519528430000000000099999993232' AS Decimal(38, 10)),  CAST('0.185415880519528430000000000099999993232' AS Decimal(38, 9));
+----
+0.1854158805 0.185415880
+
 statement ok
 set numeric_cast_option = 'rounding'
 
@@ -1118,6 +1123,11 @@ select cast(b as int), cast(c as int), cast(d as int) from t
 2 2 2
 -1 -1 -1
 -2 -2 -2
+
+query TTT
+select CAST('0.185415880519528430000000000099999993232' AS Decimal(38, 10)),  CAST('0.185415880519528430000000000099999993232' AS Decimal(38, 9));
+----
+0.1854158805 0.185415881
 
 statement ok
 create table decimal_test2(a decimal(28,8), b decimal(24,16));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

cast string to decimal respect numeric_cast_option setting

fixes #16095 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
