### PR TITLE
create dictionary1

### DIFF
--- a/src/query/ast/src/ast/common.rs
+++ b/src/query/ast/src/ast/common.rs
@@ -155,6 +155,29 @@ impl Display for TableRef {
     }
 }
 
+// 引用数据库中的字典
+#[derive(Debug, Clone, PartialEq, Eq, Drive, DriveMut)]
+pub struct DictionaryRef {
+    pub catalog: Option<Identifier>,//目录名
+    pub database: Option<Identifier>,//数据库名
+    pub dictionary: Identifier,//字典名
+    //应该再加一个用于表示数据源的字段
+}
+impl Display for DictionaryRef {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        assert!(self.catalog.is_none() || (self.catalog.is_some() && self.database.is_some()));
+        if let Some(catalog) = &self.catalog {
+            write!(f, "{}.", catalog)?;
+        }
+        if let Some(database) = &self.database {
+            write!(f, "{}.", database)?;
+        }
+        write!(f, "{}", self.dictionary)?;
+        //write!数据源信息
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Drive, DriveMut)]
 pub struct ColumnRef {
     pub database: Option<Identifier>,

--- a/src/query/ast/src/ast/format/syntax/mod.rs
+++ b/src/query/ast/src/ast/format/syntax/mod.rs
@@ -40,6 +40,8 @@ pub fn pretty_statement(stmt: Statement, max_width: usize) -> Result<String> {
         Statement::CreateView(create_view_stmt) => pretty_create_view(create_view_stmt),
         Statement::AlterView(alter_view_stmt) => pretty_alter_view(alter_view_stmt),
         Statement::CreateStream(create_stream_stmt) => pretty_create_stream(create_stream_stmt),
+        // create dictionary,新添加的
+        Statement::CreateDictionary(create_dictionary_stmt) => pretty_create_dictionary(create_dictionary_stmt),
         // Other SQL statements are relatively short and don't need extra format.
         _ => RcDoc::text(stmt.to_string()),
     };

--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -142,6 +142,9 @@ pub enum Statement {
     AnalyzeTable(AnalyzeTableStmt),
     ExistsTable(ExistsTableStmt),
 
+    // Dictionary新添加的枚举类型
+    CreateDictionary(CreateDictionaryStmt),
+
     // Columns
     ShowColumns(ShowColumnsStmt),
 
@@ -520,6 +523,8 @@ impl Display for Statement {
             Statement::ShowDropTables(stmt) => write!(f, "{stmt}")?,
             Statement::AttachTable(stmt) => write!(f, "{stmt}")?,
             Statement::CreateTable(stmt) => write!(f, "{stmt}")?,
+            //dictionary
+            Statement::CreateDictionary(stmt) => write!(f,"{stmt}")?,
             Statement::DropTable(stmt) => write!(f, "{stmt}")?,
             Statement::UndropTable(stmt) => write!(f, "{stmt}")?,
             Statement::AlterTable(stmt) => write!(f, "{stmt}")?,

--- a/src/query/ast/src/ast/visitors/visitor.rs
+++ b/src/query/ast/src/ast/visitors/visitor.rs
@@ -525,6 +525,30 @@ pub trait Visitor<'ast>: Sized {
 
     fn visit_create_table_source(&mut self, _source: &'ast CreateTableSource) {}
 
+     //添加
+     fn visit_create_dictionary(&mut self, stmt: &'ast CreateDictionaryStmt){
+        if let Some(query) = stmt.as_query.as_deref() {
+            self.visit_query(query)
+        }
+    }
+    
+    fn visit_create_dictionary_source(&mut self,_source: &'ast CreateDictionarySource) {}
+    
+    fn visit_dictionary_ref(
+        &mut self,
+        catalog: &'ast Option<Identifier>,
+        database: &'ast Option<Identifier>,
+        dictionary: &'ast Identifier,
+    ){
+        if let Some(catalog) = catalog {
+            walk_identifier(self, catalog);
+        }
+        if let Some(database) = database {
+            walk_identifier(self, database);
+        }
+        walk_identifier(self, &dictionary);
+    }
+
     fn visit_column_definition(&mut self, _column_definition: &'ast ColumnDefinition) {}
 
     fn visit_inverted_index_definition(

--- a/src/query/ast/src/ast/visitors/visitor_mut.rs
+++ b/src/query/ast/src/ast/visitors/visitor_mut.rs
@@ -535,7 +535,15 @@ pub trait VisitorMut: Sized {
         }
     }
 
+    fn visit_create_dictionary(&mut self,stmt: &mut CreateDictionaryStmt) {
+        if let Some(query) = stmt.as_query.as_deref_mut() {
+            self.visit_query(query)
+        }
+    }
+
     fn visit_create_table_source(&mut self, _source: &mut CreateTableSource) {}
+
+    fn visit_create_dictionary_source(&mut self,_source: &mut CreateDictionarySource){}
 
     fn visit_column_definition(&mut self, _column_definition: &mut ColumnDefinition) {}
 

--- a/src/query/ast/src/ast/visitors/walk.rs
+++ b/src/query/ast/src/ast/visitors/walk.rs
@@ -458,6 +458,8 @@ pub fn walk_statement<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Statem
         Statement::ShowTablesStatus(stmt) => visitor.visit_show_tables_status(stmt),
         Statement::ShowDropTables(stmt) => visitor.visit_show_drop_tables(stmt),
         Statement::CreateTable(stmt) => visitor.visit_create_table(stmt),
+        //dictionary
+        Statement::CreateDictionary(stmt) => visitor.visit_create_dictionary(stmt),
         Statement::DropTable(stmt) => visitor.visit_drop_table(stmt),
         Statement::UndropTable(stmt) => visitor.visit_undrop_table(stmt),
         Statement::AlterTable(stmt) => visitor.visit_alter_table(stmt),

--- a/src/query/ast/src/ast/visitors/walk_mut.rs
+++ b/src/query/ast/src/ast/visitors/walk_mut.rs
@@ -453,6 +453,7 @@ pub fn walk_statement_mut<V: VisitorMut>(visitor: &mut V, statement: &mut Statem
         Statement::ShowTablesStatus(stmt) => visitor.visit_show_tables_status(stmt),
         Statement::ShowDropTables(stmt) => visitor.visit_show_drop_tables(stmt),
         Statement::CreateTable(stmt) => visitor.visit_create_table(stmt),
+        Statement::CreateDictionary(stmt) => visitor.visit_create_dictionary(stmt),
         Statement::DropTable(stmt) => visitor.visit_drop_table(stmt),
         Statement::UndropTable(stmt) => visitor.visit_undrop_table(stmt),
         Statement::AlterTable(stmt) => visitor.visit_alter_table(stmt),

--- a/src/query/ast/src/parser/common.rs
+++ b/src/query/ast/src/parser/common.rs
@@ -220,6 +220,16 @@ pub fn table_ref(i: Input) -> IResult<TableRef> {
     })(i)
 }
 
+pub fn dictionary_ref(i: Input) -> IResult<DictionaryRef> {
+    map(dot_separated_idents_1_to_3,|(catalog,database,dictionary)| {
+        DictionaryRef {
+            catalog,
+            database,
+            dictionary,
+        }
+    })(i)
+}
+
 pub fn column_id(i: Input) -> IResult<ColumnID> {
     alt((
         map_res(rule! { ColumnPosition }, |token| {

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -1080,6 +1080,8 @@ pub enum TokenKind {
     #[token("TABLES", ignore(ascii_case))]
     TABLES,
     #[token("TARGET_LAG", ignore(ascii_case))]
+    DICTIONARY,
+    #[token("DICTIONARY",ignore(ascii_case))]
     TARGET_LAG,
     #[token("TEXT", ignore(ascii_case))]
     TEXT,


### PR DESCRIPTION
创建Dictionary语句：

```sql
CREATE DICTIONARY user_info(
  user_id UInt86,
  user_name String,
  user_address String
)
primary key(user_id)
SOURCE(MYSQL(
  host '[localhost](http://localhost/)'
  user 'root'
  password 'root'
  db 'db_name'
  table 'table_name'
));
```

## src/query/ast/src/ast/statements/table.rs

```rust
//create dictionary语句的抽象语法树
#[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
pub struct CreateDictionaryStmt{
    pub create_option: CreateOption,
    pub catalog: Option<Identifier>,
    pub database: Option<Identifier>,
    pub dictionary: Identifier,
    // 创建字典的来源，是直接建立列的定义和索引还是根据已有的字典
    pub source: Option<CreateDictionarySource>,
    //可以加一个数据源字段，这样能够指字典对应的数据来源（MySQL、PostgreSQL、csv、https等）
    //pub data_source: Option<DictionaryDataSource>,//或者设置一个默认的数据源，不对应该是一个必要的选项
    pub engine: Option<Engine>,//存储引擎
    pub uri_location: Option<UriLocation>,
    pub cluster_by: Vec<Expr>,
    pub dictionary_options: BTreeMap<String, String>,//字典选项（这些字典选项应该包括什么），以键值对形式存储
    pub as_query: Option<Box<Query>>,
    pub transient: bool,
}
impl Display for CreateDictionaryStmt {
    fn fmt(&self , f: &mut Formatter) -> std::fmt::Result {
        write!(f, "CREATE ")?;
        if let CreateOption::CreateOrReplace = self.create_option {
            write!(f,"OR REPLACE ")?;
        }
        if self.transient {
            write!(f, "TRANSIENT ")?;
        }
        write!(f, "DICTIONARY ");
        if let CreateOption::CreateIfNotExists = self.create_option {
            write!(f, "IF NOT EXISTS ")?;
        }
        write_dot_separated_list(
            f, 
            self.catalog
                    .iter()
                    .chain(&self.database)
                    .chain(Some(&self.dictionary)),
        )?;
        if let Some(source) = &self.source {
            write!(f, " {source}")?;
        }
        if let Some(engine) = &self.engine {
            write!(f," ENGINE = {engine}")?;
        }
        if let Some(uri_location) = &self.uri_location {
            write!(f," {uri_location}")?;
        }
        if !self.cluster_by.is_empty() {
            write!(f," CLUSTER BY (")?;
            write_comma_separated_list(f, &self.cluster_by)?;
            write!(f,")")?;
        }
        if !self.dictionary_options.is_empty() {
            write!(f," ")?;
            write_space_separated_string_map(f, &self.dictionary_options);
        }
        if let Some(as_query) = &self.as_query {
            write!(f, " AS {as_query}")?;
        }
        Ok(())
    }
}

//创建字典的来源
#[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
pub enum CreateDictionarySource {
    Columns(Vec<ColumnDefinition>, Option<Vec<InvertedIndexDefinition>>),
    Like {
        catalog: Option<Identifier>,
        database: Option<Identifier>,
        dictionary: Identifier,
    },
}
impl Display for CreateDictionarySource {
    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
        match self {
            CreateDictionarySource::Columns(columns, inverted_indexes) => {
                write!(f, "(")?;
                write_comma_separated_list(f, columns)?;
                if let Some(inverted_indexes) = inverted_indexes {
                    write!(f,", ")?;
                    write_comma_separated_list(f, inverted_indexes)?;
                }
                write!(f,")")
            }
            CreateDictionarySource::Like { 
                catalog, 
                database, 
                dictionary 
            } => {
                write!(f,"LIKE ")?;
                write_dot_separated_list(f, catalog.iter().chain(database).chain(Some(dictionary)))
            }
        }
    }
}
```

## src/query/ast/src/ast/format/syntax/ddl.rs

```rust
use crate::ast::CreateDictionaryStmt;
use crate::ast::CreateDictionarySource;
pub(crate) fn pretty_create_dictionary(stmt: CreateDictionaryStmt) -> RcDoc<'static>{
    RcDoc::text("CREATE")
        .append(if let CreateOption::CreateOrReplace = stmt.create_option{
            RcDoc::space().append(RcDoc::text("OR REPLACE"))
        } else {
            RcDoc::nil()
        })
        .append(RcDoc::space().append(RcDoc::text("DICTIONARY")))
        .append(match stmt.create_option {
            CreateOption::Create => RcDoc::nil(),
            CreateOption::CreateIfNotExists => RcDoc::space().append(RcDoc::text("IF NOT EXISTS")),
            CreateOption::CreateOrReplace => RcDoc::nil(),
        })
        .append(
            RcDoc::space()
                    .append(if let Some(catalog) = stmt.catalog {
                        RcDoc::text(catalog.to_string()).append(RcDoc::text("."))
                    } else {
                        RcDoc::nil()
                    })
                    .append(if let Some(database) = stmt.database {
                        RcDoc::text(database.to_string()).append(RcDoc::text("."))
                    } else {
                        RcDoc::nil()
                    })
                    .append(RcDoc::text(stmt.dictionary.to_string())),

        )
        .append(if let Some(source) = stmt.source {
            pretty_dictionary_source(source)
        } else {
            RcDoc::nil()
        })
        .append(if let Some(engine) = stmt.engine {
            RcDoc::space()
                .append(RcDoc::text("ENGINE ="))
                .append(RcDoc::space())
                .append(engine.to_string())
        } else {
            RcDoc::nil()
        })
        .append(if !stmt.cluster_by.is_empty(){
            RcDoc::line()
                .append(RcDoc::text("CLUSTER BY "))
                .append(parenthesized(
                    interweave_comma(stmt.cluster_by.into_iter().map(pretty_expr)).group(),
                ))
        } else {
            RcDoc::nil()
        })
        .append(if !stmt.dictionary_options.is_empty() {
            RcDoc::line()
            .append(interweave_comma(stmt.dictionary_options.iter().map(|(k,v)|{
                RcDoc::text(k.clone())
                        .append(RcDoc::space())
                        .append(RcDoc::text("="))
                        .append(RcDoc::space())
                        .append(RcDoc::text("'"))
                        .append(RcDoc::text(v.clone()))
                        .append(RcDoc::text("'"))
            })))
            .group()
        } else {
            RcDoc::nil()
        })
        .append(if let Some(as_query) = stmt.as_query {
            RcDoc::line().append(RcDoc::text("AS")).append(
                RcDoc::line().nest(NEST_FACTOR)
                .append(pretty_query(*as_query).nest(NEST_FACTOR).group()),
            )
        } else {
            RcDoc::nil()
        })
}
fn pretty_dictionary_source(source: CreateDictionarySource) -> RcDoc<'static>{
    match source {
        CreateDictionarySource::Columns(columns, inverted_indexes) => RcDoc::space()
                .append(parenthesized(
                    interweave_comma(
                        columns.into_iter().map(|column| RcDoc::text(column.to_string())),
                    )
                    .group(),
                ))
                .append(if let Some(inverted_indexes) = inverted_indexes {
                    parenthesized(
                        interweave_comma(
                                inverted_indexes.into_iter().map(|inverted_index| RcDoc::text(inverted_index.to_string())),
                        )
                        .group(),
                    )
                } else {
                    RcDoc::nil()
                }),
        CreateDictionarySource::Like { 
            catalog,
            database, 
            dictionary } => RcDoc::space()
                                        .append(RcDoc::text("LIKE"))
                                        .append(RcDoc::space())
                                        .append(if let Some(catalog) = catalog{
                                            RcDoc::text(catalog.to_string()).append(RcDoc::text("."))
                                        } else {
                                            RcDoc::nil()
                                        })
                                        .append(if let Some(database) = database {
                                            RcDoc::text(database.to_string()).append(RcDoc::text("."))
                                        } else {
                                            RcDoc::nil()
                                        })
                                        .append(RcDoc::text(dictionary.to_string())),
    }
}
```

## src/query/ast/src/ast/statements/statement.rs

```rust
pub enum Statement{
    // Dictionary新添加的枚举类型
    CreateDictionary(CreateDictionaryStmt),
}
impl Display for Statement{
    fn fmt(&self,f: &mut Formatter) -> std::fmt::Result{
        //dictionary
        Statement::CreateDictionary(stmt) => write!(f,"{stmt}")?,
    }
}
```

## src/query/ast/src/ast/format/syntax/mod.rs

```rust
pub fn pretty_statement(stmt: Statement, max_width: usize) -> Result<String> {
    let pretty_stmt = match stmt {
        // create dictionary,新添加的
        Statement::CreateDictionary(create_dictionary_stmt) => pretty_create_dictionary(create_dictionary_stmt),
    }
```

## src/query/ast/src/ast/visitors/visitor.rs

```rust
pub trait Visitor<'ast>: Sized {
    //添加
    fn visit_create_dictionary(&mut self, stmt: &'ast CreateDictionaryStmt){
        if let Some(query) = stmt.as_query.as_deref() {
            self.visit_query(query)
        }
    }
    
    fn visit_create_dictionary_source(&mut self,_source: &'ast CreateDictionarySource) {}
    
    fn visit_dictionary_ref(
        &mut self,
        catalog: &'ast Option<Identifier>,
        database: &'ast Option<Identifier>,
        dictionary: &'ast Identifier,
    ){
        if let Some(catalog) = catalog {
            walk_identifier(self, catalog);
        }
        if let Some(database) = database {
            walk_identifier(self, database);
        }
        walk_identifier(self, &dictionary);
    }
}
```

## src/query/ast/src/ast/format/ast_format.rs

```rust
fn visit_create_dictionary(&mut self, stmt: &'ast CreateDictionaryStmt) {
    let mut children = Vec::new();
    self.visit_dictionary_ref(&stmt.catalog, &stmt.database, &stmt.dictionary);
    children.push(self.children.pop().unwrap());
    if let Some(source) = &stmt.source {
        self.visit_create_dictionary_source(source);
        children.push(self.children.pop().unwrap());
    }
    if let Some(engine) = &stmt.engine {
        let engine_name = format!("DictionaryEngine {}",engine);
        let engine_format_ctx = AstFormatContext::new(engine_name);
        let engine_node = FormatTreeNode::new(engine_format_ctx);
        children.push(engine_node);
    }
    if !stmt.cluster_by.is_empty(){
        let mut cluster_by_children = Vec::with_capacity(stmt.cluster_by.len());
        for cluster_by in stmt.cluster_by.iter(){
            self.visit_expr(cluster_by);
            cluster_by_children.push(self.children.pop().unwrap());
        }
        let cluster_by_name = "ClusterByList".to_string();
        let cluster_by_format_ctx = AstFormatContext::with_children(cluster_by_name, cluster_by_children.len());
        let cluster_by_node = FormatTreeNode::with_children(cluster_by_format_ctx, cluster_by_children);
        children.push(cluster_by_node);
    }
    if !stmt.dictionary_options.is_empty(){
        let mut dictionary_options_children = Vec::with_capacity(stmt.dictionary_options.len());
        for (k,v) in stmt.dictionary_options.iter(){
            let dictionary_option_name = format!("DictionaryOption {} = {:?}",k,v);
            let dictionary_option_format_ctx = AstFormatContext::new(dictionary_option_name);
            let dictionary_option_node = FormatTreeNode::new(dictionary_option_format_ctx);
            dictionary_options_children.push(dictionary_option_node);
        }
        let dictionary_options_format_name = "DictionaryOptions".to_string();
        let dictionary_options_format_ctx = AstFormatContext::with_children(dictionary_options_format_name, dictionary_options_children.len());
        let dictionary_options_node = FormatTreeNode::with_children(dictionary_options_format_ctx, dictionary_options_children);
        children.push(dictionary_options_node);
    }
    if let Some(as_query) = &stmt.as_query {
        self.visit_query(as_query);
        children.push(self.children.pop().unwrap());
    }
    let name = "CreateDictionary".to_string();
    let format_ctx = AstFormatContext::with_children(name, children.len());
    let node = FormatTreeNode::with_children(format_ctx, children);
    self.children.push(node);
}

fn visit_create_dictionary_source(&mut self,_source: &'ast CreateDictionarySource) {
    match _source {
        CreateDictionarySource::Columns(columns, inverted_indexes ) => {
            let mut children = Vec::with_capacity(columns.len());
            for column in columns.iter() {
                self.visit_column_definition(column);
                children.push(self.children.pop().unwrap());
            }
            if let Some(inverted_indexes) = inverted_indexes {
                for inverted_index in inverted_indexes {
                    self.visit_inverted_index_definition(&inverted_index);
                    children.push(self.children.pop().unwrap());
                }
            }
            let name = "ColumnsDefinition".to_string();
            let format_ctx = AstFormatContext::with_children(name, children.len());
            let node = FormatTreeNode::with_children(format_ctx, children);
            self.children.push(node);
        }
        CreateDictionarySource::Like { 
            catalog, 
            database, 
            dictionary
        } => {
            self.visit_dictionary_ref(&catalog, &database, &dictionary);
            let child = self.children.pop().unwrap();
            let name = "LikeDictionary".to_string();
            let format_ctx = AstFormatContext::with_children(name, 1);
            let node = FormatTreeNode::with_children(format_ctx, vec![child]);
            self.children.push(node);
        }
    }
}
fn visit_dictionary_ref(
    &mut self,
    catalog: &'ast Option<Identifier>,
    database: &'ast Option<Identifier>,
    dictionary: &'ast Identifier,
) {
    let mut name = String::new();
    name.push_str("DictionaryIdentifier");
    if let Some(catalog) = catalog {
        name.push_str(&catalog.to_string());
        name.push('.');
    }
    if let Some(database) = database {
        name.push_str(&database.to_string());
        name.push('.');
    }
    name.push_str(&dictionary.to_string());
    let format_ctx = AstFormatContext::new(name);
    let node = FormatTreeNode::new(format_ctx);
    self.children.push(node);
}
```

## src/query/ast/src/ast/visitors/walk.rs

```rust
pub fn walk_statement<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Statement) {
     //dictionary
     Statement::CreateDictionary(stmt) => visitor.visit_create_dictionary(stmt),
}
```

## src/query/ast/src/ast/visitors/walk_mut.rs

```rust
pub fn walk_statement_mut<V: VisitorMut>(visitor: &mut V, statement: &mut Statement) {
     Statement::CreateDictionary(stmt) => visitor.visit_create_dictionary(stmt),
}
```

## src/query/ast/src/ast/visitors/visitor_mut.rs

```rust
pub trait VisitorMut: Sized {
    fn visit_create_dictionary(&mut self,stmt: &mut CreateDictionaryStmt) {
        if let Some(query) = stmt.as_query.as_deref_mut() {
            self.visit_query(query)
        }
    }
}
```

## src/query/ast/src/ast/common.rs

```rust
// 引用数据库中的字典
#[derive(Debug, Clone, PartialEq, Eq, Drive, DriveMut)]
pub struct DictionaryRef {
    pub catalog: Option<Identifier>,//目录名
    pub database: Option<Identifier>,//数据库名
    pub dictionary: Identifier,//字典名
    //应该再加一个用于表示数据源的字段
}
impl Display for DictionaryRef {
    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
        assert!(self.catalog.is_none() || (self.catalog.is_some() && self.database.is_some()));
        if let Some(catalog) = &self.catalog {
            write!(f, "{}.", catalog)?;
        }
        if let Some(database) = &self.database {
            write!(f, "{}.", database)?;
        }
        write!(f, "{}", self.dictionary)?;
        //write!数据源信息
        Ok(())
    }
}
```

## src/query/ast/src/parser/common.rs

```rust
use crate::parser::input::Input;
pub fn dictionary_ref(i: Input) -> IResult<DictionaryRef> {
    map(dot_separated_idents_1_to_3,|(catalog,database,dictionary)| {
        DictionaryRef {
            catalog,
            database,
            dictionary,
        }
    })(i)
}
```

## src/query/ast/src/parser/statement.rs

```rust
pub fn statement_body(i: Input) -> IResult<Statement> {
    //create_dictionary
    let create_dictionary = map_res(
        rule! {
            CREATE ~ ( OR ~ ^REPLACE )? ~ TRANSIENT? ~ DICTIONARY ~ (IF ~ ^NOT ~ ^EXISTS )?
            ~ #dot_separated_idents_1_to_3
            ~ #create_dictionary_source?
            ~ ( #engine )?
            ~ ( #uri_location )?
            ~ ( CLUSTER ~ ^BY ~ ^"(" ~ ^#comma_separated_list1(expr) ~ ^")")?
            ~ ( #dictionary_option )?
            ~ (AS ~ ^#query )?
        },
        |(
            _,
            opt_or_replace,
            opt_transient,
            _,
            opt_if_not_exists,
            (catalog, database, dictionary),
            source,
            engine,
            uri_location,
            opt_cluster_by,
            opt_dictionary_options,
            opt_as_query,
        )| {
            let create_option = parse_create_option(opt_or_replace.is_some(),opt_if_not_exists.is_some())?;
            Ok(Statement::CreateDictionary(CreateDictionaryStmt{
                create_option,
                catalog,
                database,
                dictionary,
                source,
                engine,
                uri_location,
                cluster_by: opt_cluster_by
                        .map(|(_,_,_,exprs,_)|exprs)
                        .unwrap_or_default(),
                dictionary_options:opt_dictionary_options.unwrap_or_default(),
                as_query:opt_as_query.map(|(_,query)| Box::new(query)),
                transient: opt_transient.is_some(),
            }))
        },
    );
}
fn create_dictionary_source(i:Input) -> IResult<CreateDictionarySource> {
    let columns = map(
        rule! {
            "(" ~ ^#comma_separated_list1(create_def) ~ ^")"
        },
        |(_, create_defs, _)| {
            let mut columns = Vec::with_capacity(create_defs.len());
            let mut inverted_indexes = Vec::new();
            for create_def in create_defs {
                match create_def {
                    CreateDefinition::Column(column) => {
                        columns.push(column);
                    }
                    CreateDefinition::InvertedIndex(inverted_index) => {
                        inverted_indexes.push(inverted_index);
                    }
                }
            }
            let opt_inverted_indexes = if !inverted_indexes.is_empty() {
                Some(inverted_indexes)
            } else {
                None
            };
            CreateDictionarySource::Columns(columns, opt_inverted_indexes)
        },
    );
    let like = map(
        rule! {
            LIKE ~ #dot_separated_idents_1_to_3
        },
        |(_, (catalog, database, dictionary))| CreateDictionarySource::Like {
            catalog,
            database,
            dictionary,
        },
    );

    rule!(
        #columns
        | #like
    )(i)
}
pub fn dictionary_option(i: Input) ->IResult<BTreeMap<String,String>> {
    map(
        rule! {
           ( #ident ~ "=" ~ #option_to_string )*
        },
        |opts| {
            BTreeMap::from_iter(
                opts.iter()
                    .map(|(k, _, v)| (k.name.to_lowercase(), v.clone())),
            )
        },
    )(i)
}
```

## src/query/ast/src/parse/token.rs

```rust
//1081行
DICTIONARY,
#[token("DICTIONARY",ignore(ascii_case))]
```

2024/7/23 把src/query/ast/src里凡是create_table出现的地方都一样地加了create_dictionary的结构体或者相关的 方法，但是没有对dictionary具体内容进行一个修改，我觉得还需要添加一个数据源的字段（MySQL、PostSql、本地文件等等）这些应该每个都定义成一个结构体，里面的字段也都应该不一样。

还有我的理解是字典其实是一个特殊的table，那除了数据源字段是多出来的之外，其他的字段应该和普通table是一样的了