### PR TITLE
feat(http): expose queries queue length to /v1/status

### DIFF
--- a/src/query/service/src/servers/admin/v1/instance_status.rs
+++ b/src/query/service/src/servers/admin/v1/instance_status.rs
@@ -19,12 +19,15 @@ use poem::IntoResponse;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::sessions::QueriesQueueManager;
 use crate::sessions::SessionManager;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct InstanceStatus {
     // the active sessions count with running queries
     pub running_queries_count: u64,
+    // the length of query queue
+    pub queuing_queries_count: u64,
     // the active sessions count, have active connections, but may not have any query running
     pub active_sessions_count: u64,
     // the timestamp on last query started
@@ -43,10 +46,12 @@ pub struct InstanceStatus {
 #[async_backtrace::framed]
 pub async fn instance_status_handler() -> poem::Result<impl IntoResponse> {
     let session_manager = SessionManager::instance();
+    let queue_manager = QueriesQueueManager::instance();
     let status = session_manager.get_current_session_status();
     let status = InstanceStatus {
         running_queries_count: status.running_queries_count,
         active_sessions_count: status.active_sessions_count,
+        queuing_queries_count: queue_manager.length() as u64,
         last_query_started_at: status.last_query_started_at.map(unix_timestamp_secs),
         last_query_finished_at: status.last_query_finished_at.map(unix_timestamp_secs),
         instance_started_at: unix_timestamp_secs(status.instance_started_at),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

I'm writing a controller which may use the queue length as the key indicator to auto scale the cluster. it'd be helpful to have this metric visible in the /v1/status api.

## Tests

- [x] No Test - it simply exposes a metric to the status api

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16112)
<!-- Reviewable:end -->
