### PR TITLE
chore(query): limit frames size for capture backtrace

### DIFF
--- a/src/common/tracing/src/crash_hook.rs
+++ b/src/common/tracing/src/crash_hook.rs
@@ -48,7 +48,7 @@ impl CrashHandler {
         write_error(format_args!("Timestamp(Local): {}", chrono::Local::now()));
         write_error(format_args!("QueryId: {:?}", current_query_id));
         write_error(format_args!("{}", signal_message(sig, info, uc)));
-        write_error(format_args!("Backtrace:\n{}", backtrace()));
+        write_error(format_args!("Backtrace:\n{}", backtrace(50)));
     }
 }
 

--- a/src/common/tracing/src/panic_hook.rs
+++ b/src/common/tracing/src/panic_hook.rs
@@ -15,7 +15,9 @@
 use std::panic::PanicInfo;
 use std::sync::atomic::Ordering;
 
+use backtrace::trace;
 use backtrace::Backtrace;
+use backtrace::BacktraceFrame;
 use color_backtrace::BacktracePrinter;
 use databend_common_base::runtime::LimitMemGuard;
 use databend_common_exception::USER_SET_ENABLE_BACKTRACE;
@@ -44,7 +46,7 @@ fn should_backtrace() -> bool {
 }
 
 pub fn log_panic(panic: &PanicInfo) {
-    let backtrace_str = backtrace();
+    let backtrace_str = backtrace(50);
 
     eprintln!("{}", panic);
     eprintln!("{}", backtrace_str);
@@ -62,9 +64,22 @@ pub fn log_panic(panic: &PanicInfo) {
     }
 }
 
-pub fn backtrace() -> String {
+fn captures_frames(size: usize) -> Vec<BacktraceFrame> {
+    let mut frames = Vec::with_capacity(size);
+    trace(|frame| {
+        frames.push(backtrace::BacktraceFrame::from(frame.clone()));
+        frames.len() != frames.capacity()
+    });
+
+    frames
+}
+
+pub fn backtrace(frames: usize) -> String {
     if should_backtrace() {
-        let backtrace = Backtrace::new();
+        let frames = captures_frames(frames);
+        let mut backtrace = Backtrace::from(frames);
+        backtrace.resolve();
+
         let printer = BacktracePrinter::new()
             .message("")
             .lib_verbosity(color_backtrace::Verbosity::Full);
@@ -74,5 +89,28 @@ pub fn backtrace() -> String {
         String::from_utf8_lossy(&strip_ansi_escapes::strip(colored)).into_owned()
     } else {
         String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use backtrace::BacktraceFrame;
+
+    use crate::panic_hook::captures_frames;
+
+    #[test]
+    fn test_captures_frames() {
+        fn recursion_f(i: usize, frames: usize) -> Vec<BacktraceFrame> {
+            match i - 1 {
+                0 => captures_frames(frames),
+                x => recursion_f(x, frames),
+            }
+        }
+
+        assert_eq!(recursion_f(100, 20).len(), 20);
+        assert_eq!(recursion_f(100, 30).len(), 30);
+        let frames_size = recursion_f(100, 1000).len();
+        assert!(frames_size >= 100);
+        assert!(frames_size < 1000);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(query): limit frames size for capture backtrace

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16118)
<!-- Reviewable:end -->
