### PR TITLE
chore(http): exposes max_running_query_executed_time in /v1/status

### DIFF
--- a/src/query/service/src/servers/admin/v1/instance_status.rs
+++ b/src/query/service/src/servers/admin/v1/instance_status.rs
@@ -30,6 +30,8 @@ pub struct InstanceStatus {
     pub queuing_queries_count: u64,
     // the active sessions count, have active connections, but may not have any query running
     pub active_sessions_count: u64,
+    // the timestamp of earliest running query
+    pub earliest_running_query_started_at: Option<u64>,
     // the timestamp on last query started
     pub last_query_started_at: Option<u64>,
     // the timestamp on last query finished
@@ -54,6 +56,9 @@ pub async fn instance_status_handler() -> poem::Result<impl IntoResponse> {
         queuing_queries_count: queue_manager.length() as u64,
         last_query_started_at: status.last_query_started_at.map(unix_timestamp_secs),
         last_query_finished_at: status.last_query_finished_at.map(unix_timestamp_secs),
+        earliest_running_query_started_at: status
+            .earliest_running_query_started_at
+            .map(unix_timestamp_secs),
         instance_started_at: unix_timestamp_secs(status.instance_started_at),
         instance_timestamp: unix_timestamp_secs(SystemTime::now()),
     };

--- a/src/query/service/src/servers/admin/v1/instance_status.rs
+++ b/src/query/service/src/servers/admin/v1/instance_status.rs
@@ -30,8 +30,8 @@ pub struct InstanceStatus {
     pub queuing_queries_count: u64,
     // the active sessions count, have active connections, but may not have any query running
     pub active_sessions_count: u64,
-    // the timestamp of earliest running query
-    pub earliest_running_query_started_at: Option<u64>,
+    // the time elapsed since the earliest running query started
+    pub max_running_query_executed_secs: u64,
     // the timestamp on last query started
     pub last_query_started_at: Option<u64>,
     // the timestamp on last query finished
@@ -56,9 +56,7 @@ pub async fn instance_status_handler() -> poem::Result<impl IntoResponse> {
         queuing_queries_count: queue_manager.length() as u64,
         last_query_started_at: status.last_query_started_at.map(unix_timestamp_secs),
         last_query_finished_at: status.last_query_finished_at.map(unix_timestamp_secs),
-        earliest_running_query_started_at: status
-            .earliest_running_query_started_at
-            .map(unix_timestamp_secs),
+        max_running_query_executed_secs: status.max_running_query_executed_secs,
         instance_started_at: unix_timestamp_secs(status.instance_started_at),
         instance_timestamp: unix_timestamp_secs(SystemTime::now()),
     };

--- a/src/query/service/src/sessions/session_mgr.rs
+++ b/src/query/service/src/sessions/session_mgr.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Weak;
 use std::time::Duration;
-use std::time::SystemTime;
 
 use databend_common_base::base::tokio;
 use databend_common_base::base::GlobalInstance;
@@ -311,10 +310,7 @@ impl SessionManager {
 
         let mut running_queries_count = 0;
         let mut active_sessions_count = 0;
-        let mut max_running_query_execute_time = 0;
-        let mut earliest_running_query_started_at: Option<SystemTime> = None;
-
-        let now = SystemTime::now();
+        let mut max_running_query_executed_secs = 0;
 
         for session in self.active_sessions_snapshot() {
             if let Some(session_ref) = session.upgrade() {
@@ -326,23 +322,20 @@ impl SessionManager {
                 if process_info.state == ProcessInfoState::Query {
                     running_queries_count += 1;
 
-                    let created_time = process_info.created_time;
-                    earliest_running_query_started_at = earliest_running_query_started_at
-                        .map(|x| std::cmp::min(x, created_time))
-                        .or(Some(created_time));
-                    let executed_time = created_time.duration_since(now);
-                    let execute_time_seconds = executed_time.map(|x| x.as_secs()).unwrap_or(0);
-
-                    max_running_query_execute_time =
-                        std::cmp::max(max_running_query_execute_time, execute_time_seconds);
+                    let query_executed_secs = process_info
+                        .created_time
+                        .elapsed()
+                        .map(|x| x.as_secs())
+                        .unwrap_or(0);
+                    max_running_query_executed_secs =
+                        std::cmp::max(max_running_query_executed_secs, query_executed_secs);
                 }
             }
         }
 
         status_t.running_queries_count = running_queries_count;
         status_t.active_sessions_count = active_sessions_count;
-        status_t.max_running_query_execute_time = max_running_query_execute_time;
-        status_t.earliest_running_query_started_at = earliest_running_query_started_at;
+        status_t.max_running_query_executed_secs = max_running_query_executed_secs;
         status_t
     }
 

--- a/src/query/service/src/sessions/session_mgr_status.rs
+++ b/src/query/service/src/sessions/session_mgr_status.rs
@@ -18,10 +18,9 @@ use std::time::SystemTime;
 pub struct SessionManagerStatus {
     pub running_queries_count: u64,
     pub active_sessions_count: u64,
-    pub max_running_query_execute_time: u64,
+    pub max_running_query_executed_secs: u64,
     pub last_query_started_at: Option<SystemTime>,
     pub last_query_finished_at: Option<SystemTime>,
-    pub earliest_running_query_started_at: Option<SystemTime>,
     pub instance_started_at: SystemTime,
 }
 
@@ -44,10 +43,9 @@ impl Default for SessionManagerStatus {
         SessionManagerStatus {
             running_queries_count: 0,
             active_sessions_count: 0,
-            max_running_query_execute_time: 0,
+            max_running_query_executed_secs: 0,
             last_query_started_at: None,
             last_query_finished_at: None,
-            earliest_running_query_started_at: None,
             instance_started_at: SystemTime::now(),
         }
     }

--- a/src/query/service/src/sessions/session_mgr_status.rs
+++ b/src/query/service/src/sessions/session_mgr_status.rs
@@ -21,6 +21,7 @@ pub struct SessionManagerStatus {
     pub max_running_query_execute_time: u64,
     pub last_query_started_at: Option<SystemTime>,
     pub last_query_finished_at: Option<SystemTime>,
+    pub earliest_running_query_started_at: Option<SystemTime>,
     pub instance_started_at: SystemTime,
 }
 
@@ -46,6 +47,7 @@ impl Default for SessionManagerStatus {
             max_running_query_execute_time: 0,
             last_query_started_at: None,
             last_query_finished_at: None,
+            earliest_running_query_started_at: None,
             instance_started_at: SystemTime::now(),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

this metric may help the controller to make some decision when there's some session is suspected to be leaked.

## Tests

- [x] No Test - _Explain why_: it simply exposed a metric

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16131)
<!-- Reviewable:end -->
