### PR TITLE
fix: vacuum dropped table in parallel

### DIFF
--- a/src/query/ee/src/storages/fuse/mod.rs
+++ b/src/query/ee/src/storages/fuse/mod.rs
@@ -16,6 +16,6 @@ pub mod io;
 pub mod operations;
 
 pub use io::snapshots::get_snapshot_referenced_segments;
-pub use operations::vacuum_drop_tables::do_vacuum_drop_tables;
+pub use operations::vacuum_drop_tables::vacuum_drop_tables;
 pub use operations::vacuum_table::do_vacuum;
 pub use operations::virtual_columns::do_refresh_virtual_column;

--- a/src/query/ee/src/storages/fuse/operations/handler.rs
+++ b/src/query/ee/src/storages/fuse/operations/handler.rs
@@ -27,8 +27,8 @@ use databend_enterprise_vacuum_handler::VacuumHandler;
 use databend_enterprise_vacuum_handler::VacuumHandlerWrapper;
 
 use crate::storages::fuse::do_vacuum;
-use crate::storages::fuse::do_vacuum_drop_tables;
 use crate::storages::fuse::operations::vacuum_temporary_files::do_vacuum_temporary_files;
+use crate::storages::fuse::vacuum_drop_tables;
 
 pub struct RealVacuumHandler {}
 
@@ -50,7 +50,7 @@ impl VacuumHandler for RealVacuumHandler {
         tables: Vec<Arc<dyn Table>>,
         dry_run_limit: Option<usize>,
     ) -> Result<Option<Vec<VacuumDropFileInfo>>> {
-        do_vacuum_drop_tables(threads_nums, tables, dry_run_limit).await
+        vacuum_drop_tables(threads_nums, tables, dry_run_limit).await
     }
 
     async fn do_vacuum_temporary_files(

--- a/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
@@ -124,8 +124,6 @@ pub async fn vacuum_drop_tables_by_table_info(
         )
         .await?;
 
-        // Return error if any error happens during invocations of `do_vacuum_drop_table`.
-        //
         // Note that Errs should NOT be swallowed if any target is not successfully deleted.
         // Otherwise, the caller site may proceed to purge meta-data from meta-server with
         // some table data un-vacuumed, and the `vacuum` action of those dropped tables can no


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

During the deletion of objects from a dropped table (in parallel), errors from `remove_all` should be propagated instead of being swallowed.

If errors are not propagated, the vacuum operation might proceed to purge metadata from the meta-server while some table data remains unpurged. This would make it impossible to fully complete the `vacuum` action for those dropped tables.

-------

- For the convenience of testing, the `do_vacuum_drop_tables` function has been split into two functions: `vacuum_drop_tables_by_table_info` and `vacuum_drop_tables`

- Properly propagates errors encountered during the parallel deletion of objects of target tables.

- Test `vacuum_drop_tables_by_table_info` using a customized `Operator` that injects faults into the delete operation. This covers the scenario where deletion fails during the parallel deletion of table data.




## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16139)
<!-- Reviewable:end -->
