### PR TITLE
chore(query): optimize tables query speed

### DIFF
--- a/benchmark/clickbench/internal/queries/00.sql
+++ b/benchmark/clickbench/internal/queries/00.sql
@@ -11,3 +11,4 @@ union all
 select name
 from system.functions ignore_result;
 select name from system.tables where name='t_1';
+select name from system.tables where name in ('t_1', 't_2'');

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -47,7 +47,7 @@ use log::warn;
 
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;
-use crate::util::find_eq_filter;
+use crate::util::find_eq_and_or_filter;
 
 pub struct TablesTable<const WITH_HISTORY: bool, const WITHOUT_VIEW: bool> {
     table_info: TableInfo,
@@ -243,7 +243,7 @@ where TablesTable<T, U>: HistoryAware
         if let Some(push_downs) = &push_downs {
             if let Some(filter) = push_downs.filters.as_ref().map(|f| &f.filter) {
                 let expr = filter.as_expr(&BUILTIN_FUNCTIONS);
-                find_eq_filter(&expr, &mut |col_name, scalar| {
+                find_eq_and_or_filter(&expr, &mut |col_name, scalar| {
                     if col_name == "database" {
                         if let Scalar::String(database) = scalar {
                             if !db_name.contains(database) {

--- a/src/query/storages/system/src/util.rs
+++ b/src/query/storages/system/src/util.rs
@@ -108,3 +108,36 @@ pub fn find_lt_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scala
         }
     }
 }
+
+pub fn find_eq_and_or_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scalar) -> Result<()>) {
+    match expr {
+        Expr::Constant { .. } | Expr::ColumnRef { .. } => {}
+        Expr::Cast { expr, .. } => crate::util::find_eq_filter(expr, visitor),
+        Expr::FunctionCall { function, args, .. } => {
+            // Like: select * from (select * from system.tables where database='default') where name='t'
+            // push downs: [filters: [and_filters(and_filters(tables.database (#1) = 'default', tables.name (#2) = 't'), tables.database (#1) = 'default')], limit: NONE]
+            // database generate twice, so when call find_eq_filter, should check uniq.
+            if function.signature.name == "eq" {
+                match args.as_slice() {
+                    [Expr::ColumnRef { id, .. }, Expr::Constant { scalar, .. }]
+                    | [Expr::Constant { scalar, .. }, Expr::ColumnRef { id, .. }] => {
+                        let _ = visitor(id, scalar);
+                    }
+                    _ => {}
+                }
+            } else if function.signature.name == "and_filters" || function.signature.name == "or" {
+                // only support this:
+                // 1. where xx and xx and xx or yy
+                // 2. filter: Column `table`, Column `database` `table_id`
+                for arg in args {
+                    crate::util::find_eq_filter(arg, visitor)
+                }
+            }
+        }
+        Expr::LambdaFunctionCall { args, .. } => {
+            for arg in args {
+                crate::util::find_eq_filter(arg, visitor)
+            }
+        }
+    }
+}

--- a/src/query/storages/system/src/util.rs
+++ b/src/query/storages/system/src/util.rs
@@ -109,7 +109,10 @@ pub fn find_lt_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scala
     }
 }
 
-pub fn find_eq_and_or_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scalar) -> Result<()>) {
+pub fn find_eq_and_or_filter(
+    expr: &Expr<String>,
+    visitor: &mut impl FnMut(&str, &Scalar) -> Result<()>,
+) {
     match expr {
         Expr::Constant { .. } | Expr::ColumnRef { .. } => {}
         Expr::Cast { expr, .. } => crate::util::find_eq_filter(expr, visitor),

--- a/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
@@ -8,3 +8,15 @@ tables
 
 statement error 1006
 select name from system.tables where database='system' and table_id='xx'
+
+statement ok
+create or replace table default.tables(id int)
+
+query T
+select * from (select database, name from system.tables where database='system' or name in ('tables', 'columns')) where name in ('tables') order by database;
+----
+default tables
+system tables
+
+statement ok
+drop table default.tables


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

add new api find_eq_and_or_filter, support visitor or filter

in [databend/src/query/storages/system/src/task_history_table.rs at 022009fb39eb5c367c48814e2e08752239a8](https://github.com/datafuselabs/databend/blob/022009fb39eb5c367c48814e2e08752239a8c826/src/query/storages/system/src/task_history_table.rs#L155) ,

```
find_eq_filter(&expr, &mut |col_name, scalar| {
                    if col_name == "name" {
                        if let Scalar::String(s) = scalar {
                            task_name = Some(s.clone());
                        }
                    }
                    Ok(())
                });
```

So in this pr, if we directly modify find_eq_filter let it support `or filter` will cause this SQL err:

select xx from task_history where name ='t1' or name = 't2';

So we add a new API.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16144)
<!-- Reviewable:end -->
