### PR TITLE
fix(query): revert find_eq_and_or_filter

### DIFF
--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -47,7 +47,7 @@ use log::warn;
 
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;
-use crate::util::find_eq_and_or_filter;
+use crate::util::find_eq_filter;
 
 pub struct TablesTable<const WITH_HISTORY: bool, const WITHOUT_VIEW: bool> {
     table_info: TableInfo,
@@ -248,7 +248,7 @@ where TablesTable<T, U>: HistoryAware
         if let Some(push_downs) = &push_downs {
             if let Some(filter) = push_downs.filters.as_ref().map(|f| &f.filter) {
                 let expr = filter.as_expr(&BUILTIN_FUNCTIONS);
-                find_eq_and_or_filter(&expr, &mut |col_name, scalar| {
+                find_eq_filter(&expr, &mut |col_name, scalar| {
                     if col_name == "database" {
                         if let Scalar::String(database) = scalar {
                             if !db_name.contains(database) {

--- a/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
@@ -14,7 +14,7 @@ create or replace table default.tables(id int)
 
 # default.tables, system.tables, system.columns, and other table under system database
 query T
-select count() > 3 from system.tables where database='system' or name in ('tables', 'columns') order by database;
+select count() > 3 from system.tables where database='system' or name in ('tables', 'columns');
 ----
 1
 

--- a/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
@@ -12,11 +12,11 @@ select name from system.tables where database='system' and table_id='xx'
 statement ok
 create or replace table default.tables(id int)
 
+# default.tables, system.tables, system.columns, and other table under system database
 query T
-select * from (select database, name from system.tables where database='system' or name in ('tables', 'columns')) where name in ('tables') order by database;
+select count() > 3 from system.tables where database='system' or name in ('tables', 'columns') order by database;
 ----
-default tables
-system tables
+1
 
 statement ok
 drop table default.tables


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Because of https://github.com/datafuselabs/databend/pull/16144/files#r1696995697, we need revert pr https://github.com/datafuselabs/databend/pull/16144

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16148)
<!-- Reviewable:end -->
