### PR TITLE
refactor: tweak `table_statistics` of trait Table

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -278,9 +278,10 @@ pub trait Table: Sync + Send {
     async fn table_statistics(
         &self,
         ctx: Arc<dyn TableContext>,
+        require_fresh: bool,
         change_type: Option<ChangeType>,
     ) -> Result<Option<TableStatistics>> {
-        let (_, _) = (ctx, change_type);
+        let (_, _, _) = (ctx, require_fresh, change_type);
 
         Ok(None)
     }

--- a/src/query/service/src/table_functions/numbers/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers/numbers_table.rs
@@ -210,6 +210,7 @@ impl Table for NumbersTable {
     async fn table_statistics(
         &self,
         _ctx: Arc<dyn TableContext>,
+        _require_fresh: bool,
         _change_type: Option<ChangeType>,
     ) -> Result<Option<TableStatistics>> {
         Ok(Some(TableStatistics {

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -154,7 +154,7 @@ async fn test_compact_segment_resolvable_conflict() -> Result<()> {
     let latest = table.refresh(ctx.as_ref()).await?;
     let latest_fuse_table = FuseTable::try_from_table(latest.as_ref())?;
     let table_statistics = latest_fuse_table
-        .table_statistics(ctx.clone(), None)
+        .table_statistics(ctx.clone(), true, None)
         .await?
         .unwrap();
 

--- a/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
@@ -562,7 +562,7 @@ async fn adjust_bloom_runtime_filter(
         let table_entry = metadata.read().table(table_index).clone();
         let change_type = get_change_type(table_entry.alias_name());
         let table = table_entry.table();
-        if let Some(stats) = table.table_statistics(ctx.clone(), change_type).await? {
+        if let Some(stats) = table.table_statistics(ctx.clone(), true, change_type).await? {
             if let Some(num_rows) = stats.num_rows {
                 let join_cardinality = RelExpr::with_s_expr(s_expr)
                     .derive_cardinality()?

--- a/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_hash_join.rs
@@ -562,7 +562,10 @@ async fn adjust_bloom_runtime_filter(
         let table_entry = metadata.read().table(table_index).clone();
         let change_type = get_change_type(table_entry.alias_name());
         let table = table_entry.table();
-        if let Some(stats) = table.table_statistics(ctx.clone(), true, change_type).await? {
+        if let Some(stats) = table
+            .table_statistics(ctx.clone(), true, change_type)
+            .await?
+        {
             if let Some(num_rows) = stats.num_rows {
                 let join_cardinality = RelExpr::with_s_expr(s_expr)
                     .derive_cardinality()?

--- a/src/query/sql/src/planner/optimizer/statistics/collect_statistics.rs
+++ b/src/query/sql/src/planner/optimizer/statistics/collect_statistics.rs
@@ -65,7 +65,7 @@ impl CollectStatisticsOptimizer {
                     .column_statistics_provider(self.table_ctx.clone())
                     .await?;
                 let table_stats = table
-                    .table_statistics(self.table_ctx.clone(), scan.change_type.clone())
+                    .table_statistics(self.table_ctx.clone(), true, scan.change_type.clone())
                     .await?;
 
                 let mut column_stats = HashMap::new();

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -740,6 +740,7 @@ impl Table for FuseTable {
     async fn table_statistics(
         &self,
         ctx: Arc<dyn TableContext>,
+        require_fresh: bool,
         change_type: Option<ChangeType>,
     ) -> Result<Option<TableStatistics>> {
         if let Some(desc) = &self.changes_desc {
@@ -750,7 +751,7 @@ impl Table for FuseTable {
         }
 
         let stats = match self.table_type {
-            FuseTableType::Attached => {
+            FuseTableType::Attached if require_fresh => {
                 let snapshot = self.read_table_snapshot().await?.ok_or_else(|| {
                     // For table created with "ATTACH TABLE ... READ_ONLY"statement, this should be unreachable:
                     // IO or Deserialization related error should have already been thrown, thus

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -431,7 +431,7 @@ impl FuseTable {
         change_type: ChangeType,
     ) -> Result<Option<TableStatistics>> {
         let Some(base_location) = base_location else {
-            return self.table_statistics(ctx, None).await;
+            return self.table_statistics(ctx, true, None).await;
         };
 
         let (base_snapshot, _) =

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -407,8 +407,7 @@ impl HiveTable {
         if partition_num < 100000 {
             trace!(
                 "get {} partitions from hive metastore:{:?}",
-                partition_num,
-                partition_names
+                partition_num, partition_names
             );
         } else {
             trace!("get {} partitions from hive metastore", partition_num);

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -407,7 +407,8 @@ impl HiveTable {
         if partition_num < 100000 {
             trace!(
                 "get {} partitions from hive metastore:{:?}",
-                partition_num, partition_names
+                partition_num,
+                partition_names
             );
         } else {
             trace!("get {} partitions from hive metastore", partition_num);
@@ -621,6 +622,7 @@ impl Table for HiveTable {
     async fn table_statistics(
         &self,
         _ctx: Arc<dyn TableContext>,
+        _require_fresh: bool,
         _change_type: Option<ChangeType>,
     ) -> Result<Option<TableStatistics>> {
         Ok(None)

--- a/src/query/storages/orc/src/table.rs
+++ b/src/query/storages/orc/src/table.rs
@@ -179,6 +179,7 @@ impl Table for OrcTable {
     async fn table_statistics(
         &self,
         _ctx: Arc<dyn TableContext>,
+        _require_fresh: bool,
         _change_type: Option<ChangeType>,
     ) -> Result<Option<TableStatistics>> {
         Ok(None)

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/table.rs
@@ -310,6 +310,7 @@ impl Table for ParquetRSTable {
     async fn table_statistics(
         &self,
         _ctx: Arc<dyn TableContext>,
+        _require_fresh: bool,
         _change_type: Option<ChangeType>,
     ) -> Result<Option<TableStatistics>> {
         // Unwrap safety: no other thread will hold this lock.

--- a/src/query/storages/stream/src/stream_table.rs
+++ b/src/query/storages/stream/src/stream_table.rs
@@ -290,6 +290,7 @@ impl Table for StreamTable {
     async fn table_statistics(
         &self,
         ctx: Arc<dyn TableContext>,
+        _require_fresh: bool,
         change_type: Option<ChangeType>,
     ) -> Result<Option<TableStatistics>> {
         let table = self.source_table(ctx.clone()).await?;

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -238,7 +238,15 @@ pub(crate) async fn dump_tables(
     push_downs: Option<PushDownInfo>,
 ) -> Result<Vec<(String, Vec<Arc<dyn Table>>)>> {
     let tenant = ctx.get_tenant();
-    let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
+
+    // For performance considerations, we do not require the most up-to-date table information here:
+    // - for regular tables, the data is certainly fresh
+    // - for read-only attached tables, the data may be outdated
+
+    let catalog = ctx
+        .get_catalog(CATALOG_DEFAULT)
+        .await?
+        .disable_table_info_refresh()?;
 
     let mut tables: Vec<String> = Vec::new();
     let mut databases: Vec<String> = Vec::new();

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -444,7 +444,9 @@ where TablesTable<T, U>: HistoryAware
 
         if U {
             for tbl in &database_tables {
-                let stats = match tbl.table_statistics(ctx.clone(), None).await {
+                // For performance considerations, allows using stale statistics data.
+                let require_fresh = false;
+                let stats = match tbl.table_statistics(ctx.clone(), require_fresh, None).await {
                     Ok(stats) => stats,
                     Err(err) => {
                         let msg = format!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


- Tweak method `table_statistics` of trait Table

Allows retrieving stale table statistics. 

For read-only attached tables, this means there is no need to read snapshots from the attached location to get fresh statistics. There are no changes for other types of tables.


- `system.columns`

Disabled the table information refreshment in the catalog used during table dumping

- `system.tables`

Allows using stale statistics  while gathering statistics from tables.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16152)
<!-- Reviewable:end -->
