### PR TITLE
fix(query): fix in operator convert to subquery cast failed

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -2797,7 +2797,7 @@ impl<'a> TypeChecker<'a> {
             }
         }
 
-        let mut data_type = output_context.columns[0].data_type.clone();
+        let box mut data_type = output_context.columns[0].data_type.clone();
 
         let rel_expr = RelExpr::with_s_expr(&s_expr);
         let rel_prop = rel_expr.derive_relational_prop()?;
@@ -2805,12 +2805,16 @@ impl<'a> TypeChecker<'a> {
         let mut child_scalar = None;
         if let Some(expr) = child_expr {
             assert_eq!(output_context.columns.len(), 1);
-            let box (scalar, _) = self.resolve(&expr)?;
+            let box (scalar, expr_ty) = self.resolve(&expr)?;
             child_scalar = Some(Box::new(scalar));
+            // wrap nullable to make sure expr and list values have common type.
+            if expr_ty.is_nullable() {
+                data_type = data_type.wrap_nullable();
+            }
         }
 
         if typ.eq(&SubqueryType::Scalar) {
-            data_type = Box::new(data_type.wrap_nullable());
+            data_type = data_type.wrap_nullable();
         }
         let subquery_expr = SubqueryExpr {
             span: subquery.span,
@@ -2819,7 +2823,7 @@ impl<'a> TypeChecker<'a> {
             compare_op,
             output_column: output_context.columns[0].clone(),
             projection_index: None,
-            data_type: data_type.clone(),
+            data_type: Box::new(data_type),
             typ,
             outer_columns: rel_prop.outer_columns.clone(),
             contain_agg,
@@ -3946,10 +3950,14 @@ impl<'a> TypeChecker<'a> {
             Arc::new(const_scan),
         );
 
-        let data_type = ctx.columns[0].data_type.clone();
+        let box mut data_type = ctx.columns[0].data_type.clone();
         let rel_expr = RelExpr::with_s_expr(&distinct_const_scan);
         let rel_prop = rel_expr.derive_relational_prop()?;
-        let box (scalar, _) = self.resolve(expr)?;
+        let box (scalar, expr_ty) = self.resolve(expr)?;
+        // wrap nullable to make sure expr and list values have common type.
+        if expr_ty.is_nullable() {
+            data_type = data_type.wrap_nullable();
+        }
         let child_scalar = Some(Box::new(scalar));
         let subquery_expr = SubqueryExpr {
             span: None,
@@ -3958,7 +3966,7 @@ impl<'a> TypeChecker<'a> {
             compare_op: Some(ComparisonOp::Equal),
             output_column: ctx.columns[0].clone(),
             projection_index: None,
-            data_type: data_type.clone(),
+            data_type: Box::new(data_type),
             typ: SubqueryType::Any,
             outer_columns: rel_prop.outer_columns.clone(),
             contain_agg: None,

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -397,7 +397,7 @@ Exchange
 └── HashJoin
     ├── output columns: [t1.a (#0), t1.b (#1)]
     ├── join type: INNER
-    ├── build keys: [CAST(subquery_2 (#2) AS Int32 NULL)]
+    ├── build keys: [CAST(CAST(subquery_2 (#2) AS UInt8 NULL) AS Int32 NULL)]
     ├── probe keys: [t1.a (#0)]
     ├── filters: []
     ├── estimated rows: 2.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1290,7 +1290,7 @@ HashJoin
 ├── output columns: [t1.a (#0), t1.b (#1)]
 ├── join type: INNER
 ├── build keys: [t1.a (#0)]
-├── probe keys: [CAST(subquery_2 (#2) AS Int32 NULL)]
+├── probe keys: [CAST(CAST(subquery_2 (#2) AS UInt16 NULL) AS Int32 NULL)]
 ├── filters: []
 ├── estimated rows: 3.00
 ├── TableScan(Build)
@@ -1328,6 +1328,7 @@ Filter
     ├── join type: LEFT MARK
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [CAST(subquery_2 (#2) AS Int32 NULL)]
+    ├── probe keys: [CAST(CAST(subquery_2 (#2) AS UInt16 NULL) AS Int32 NULL)]
     ├── filters: []
     ├── estimated rows: 3.00
     ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1327,7 +1327,6 @@ Filter
     ├── output columns: [t1.a (#0), t1.b (#1), marker (#3)]
     ├── join type: LEFT MARK
     ├── build keys: [t1.a (#0)]
-    ├── probe keys: [CAST(subquery_2 (#2) AS Int32 NULL)]
     ├── probe keys: [CAST(CAST(subquery_2 (#2) AS UInt16 NULL) AS Int32 NULL)]
     ├── filters: []
     ├── estimated rows: 3.00

--- a/tests/sqllogictests/suites/query/select.test
+++ b/tests/sqllogictests/suites/query/select.test
@@ -195,8 +195,37 @@ select * from t1 where a in (1, 2) order by a;
 1 2
 2 3
 
+# fix: https://github.com/datafuselabs/databend/issues/16143
+statement ok
+drop table if exists t2;
+
+statement ok
+create table t2 (id int, payload variant);
+
+statement ok
+insert into t2 values (1, '{"test":10,"test2":"ab"}'), (2, '{"test":20,"test2":"cd"}');
+
+query IT
+select * from t2 where payload:test in (10, 11)
+----
+1 {"test":10,"test2":"ab"}
+
+query IT
+select * from t2 where payload:test2 in ('ab', 'cd')
+----
+1 {"test":10,"test2":"ab"}
+2 {"test":20,"test2":"cd"}
+
+query IT
+select * from t2 where payload:test in (select 20)
+----
+2 {"test":20,"test2":"cd"}
+
 statement ok
 drop table t1;
+
+statement ok
+drop table t2;
 
 statement ok
 unset inlist_to_join_threshold


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix in operator convert to subquery cast failed, list values data type wrap nullable so that expression and list values can have common data type.

- fixes: #16143

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16159)
<!-- Reviewable:end -->
