### PR TITLE
refactor(query): Optimize udf js runtime to avoid lock blocking

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/transform_udf_script.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_udf_script.rs
@@ -14,6 +14,8 @@
 
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -40,27 +42,42 @@ static GLOBAL_PYTHON_RUNTIME: std::sync::LazyLock<Arc<RwLock<arrow_udf_python::R
     std::sync::LazyLock::new(|| Arc::new(RwLock::new(arrow_udf_python::Runtime::new().unwrap())));
 
 pub enum ScriptRuntime {
-    JavaScript(Arc<RwLock<arrow_udf_js::Runtime>>),
+    JavaScript(Vec<Arc<RwLock<arrow_udf_js::Runtime>>>),
     WebAssembly(Arc<RwLock<arrow_udf_wasm::Runtime>>),
     Python,
 }
 
 impl ScriptRuntime {
-    pub fn try_create(lang: &str, code: Option<Vec<u8>>) -> Result<Self, ErrorCode> {
+    pub fn try_create(
+        lang: &str,
+        code: Option<Vec<u8>>,
+        runtime_num: usize,
+    ) -> Result<Self, ErrorCode> {
         match lang {
-            "javascript" => arrow_udf_js::Runtime::new()
-                .map(|mut runtime| {
-                    runtime
-                        .converter_mut()
-                        .set_arrow_extension_key(EXTENSION_KEY);
-                    runtime
-                        .converter_mut()
-                        .set_json_extension_name(ARROW_EXT_TYPE_VARIANT);
-                    ScriptRuntime::JavaScript(Arc::new(RwLock::new(runtime)))
-                })
-                .map_err(|err| {
-                    ErrorCode::UDFDataError(format!("Cannot create js runtime: {}", err))
-                }),
+            "javascript" => {
+                // Create multiple runtimes to execute in parallel to avoid blocking caused by js udf runtime locks.
+                let runtimes = (0..runtime_num)
+                    .map(|_| {
+                        arrow_udf_js::Runtime::new()
+                            .map(|mut runtime| {
+                                runtime
+                                    .converter_mut()
+                                    .set_arrow_extension_key(EXTENSION_KEY);
+                                runtime
+                                    .converter_mut()
+                                    .set_json_extension_name(ARROW_EXT_TYPE_VARIANT);
+                                Arc::new(RwLock::new(runtime))
+                            })
+                            .map_err(|err| {
+                                ErrorCode::UDFDataError(format!(
+                                    "Cannot create js runtime: {}",
+                                    err
+                                ))
+                            })
+                    })
+                    .collect::<Result<Vec<Arc<RwLock<arrow_udf_js::Runtime>>>>>()?;
+                Ok(Self::JavaScript(runtimes))
+            }
             "wasm" => Self::create_wasm_runtime(code),
             "python" => Ok(Self::Python),
             _ => Err(ErrorCode::from_string(format!(
@@ -91,19 +108,21 @@ impl ScriptRuntime {
         let arrow_schema = Schema::from(&tmp_schema);
 
         match self {
-            ScriptRuntime::JavaScript(runtime) => {
+            ScriptRuntime::JavaScript(runtimes) => {
                 let code = std::str::from_utf8(code)?;
-                let mut runtime = runtime.write();
-                runtime.add_function_with_handler(
-                    &func.name,
-                    // we pass the field instead of the data type because arrow-udf-js
-                    // now takes the field as an argument here so that it can get any
-                    // metadata associated with the field
-                    arrow_schema.field(0).clone(),
-                    arrow_udf_js::CallMode::ReturnNullOnNullInput,
-                    code,
-                    &func.func_name,
-                )
+                for runtime in runtimes {
+                    let mut runtime = runtime.write();
+                    runtime.add_function_with_handler(
+                        &func.name,
+                        // we pass the field instead of the data type because arrow-udf-js
+                        // now takes the field as an argument here so that it can get any
+                        // metadata associated with the field
+                        arrow_schema.field(0).clone(),
+                        arrow_udf_js::CallMode::ReturnNullOnNullInput,
+                        code,
+                        &func.func_name,
+                    )?;
+                }
             }
             #[cfg(feature = "python-udf")]
             ScriptRuntime::Python => {
@@ -115,7 +134,7 @@ impl ScriptRuntime {
                     arrow_udf_python::CallMode::ReturnNullOnNullInput,
                     code,
                     &func.func_name,
-                )
+                )?;
             }
             #[cfg(not(feature = "python-udf"))]
             ScriptRuntime::Python => {
@@ -124,8 +143,8 @@ impl ScriptRuntime {
                 ));
             }
             // Ignore the execution for WASM context
-            ScriptRuntime::WebAssembly(_) => Ok(()),
-        }?;
+            ScriptRuntime::WebAssembly(_) => {}
+        }
 
         Ok(())
     }
@@ -134,9 +153,13 @@ impl ScriptRuntime {
         &self,
         func: &UdfFunctionDesc,
         input_batch: &RecordBatch,
+        index: usize,
     ) -> Result<RecordBatch> {
         let result_batch = match self {
-            ScriptRuntime::JavaScript(runtime) => {
+            ScriptRuntime::JavaScript(runtimes) => {
+                // Choose a js runtime in order to avoid blocking
+                let idx = index % runtimes.len();
+                let runtime = &runtimes[idx];
                 let runtime = runtime.read();
                 runtime.call(&func.name, input_batch).map_err(|err| {
                     ErrorCode::UDFDataError(format!(
@@ -178,6 +201,7 @@ impl ScriptRuntime {
 pub struct TransformUdfScript {
     funcs: Vec<UdfFunctionDesc>,
     script_runtimes: BTreeMap<String, Arc<ScriptRuntime>>,
+    index_seq: Arc<AtomicUsize>,
 }
 
 unsafe impl Send for TransformUdfScript {}
@@ -187,10 +211,12 @@ impl TransformUdfScript {
         _func_ctx: FunctionContext,
         funcs: Vec<UdfFunctionDesc>,
         script_runtimes: BTreeMap<String, Arc<ScriptRuntime>>,
+        index_seq: Arc<AtomicUsize>,
     ) -> Self {
         Self {
             funcs,
             script_runtimes,
+            index_seq,
         }
     }
 }
@@ -199,6 +225,7 @@ impl Transform for TransformUdfScript {
     const NAME: &'static str = "UDFScriptTransform";
 
     fn transform(&mut self, mut data_block: DataBlock) -> Result<DataBlock> {
+        let index = self.index_seq.fetch_add(1, Ordering::SeqCst);
         for func in &self.funcs {
             let num_rows = data_block.num_rows();
             let block_entries = self.prepare_block_entries(func, &data_block)?;
@@ -206,7 +233,7 @@ impl Transform for TransformUdfScript {
             let runtime_key = Self::get_runtime_key(func)?;
 
             if let Some(runtime) = self.script_runtimes.get(&runtime_key) {
-                let result_batch = runtime.handle_execution(func, &input_batch)?;
+                let result_batch = runtime.handle_execution(func, &input_batch, index)?;
                 self.update_datablock(func, result_batch, &mut data_block)?;
             } else {
                 return Err(ErrorCode::UDFDataError(format!(
@@ -237,6 +264,7 @@ impl TransformUdfScript {
 
     pub fn init_runtime(
         funcs: &[UdfFunctionDesc],
+        runtime_num: usize,
     ) -> Result<BTreeMap<String, Arc<ScriptRuntime>>, ErrorCode> {
         let mut script_runtimes: BTreeMap<String, Arc<ScriptRuntime>> = BTreeMap::new();
 
@@ -251,7 +279,7 @@ impl TransformUdfScript {
             let runtime = match script_runtimes.entry(runtime_key.clone()) {
                 Entry::Occupied(entry) => entry.into_mut().clone(),
                 Entry::Vacant(entry) => {
-                    let new_runtime = ScriptRuntime::try_create(lang.trim(), code_opt)
+                    let new_runtime = ScriptRuntime::try_create(lang.trim(), code_opt, runtime_num)
                         .map(Arc::new)
                         .map_err(|err| {
                             ErrorCode::UDFDataError(format!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Create multiple udf js runtimes to execute in parallel to avoid blocking caused by js udf runtime locks.

Using the internal test sql, the execution time was reduced from 216.769 seconds to 36.534 seconds.


- fixes: #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16174)
<!-- Reviewable:end -->
