### PR TITLE
fix: meta-service: data inconsistency risk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11081,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.10.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.10.0-alpha.2#55f4e5a541eda9e7cefbd5138b42cdd92c697d17"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.10.0-alpha.3#94c820c3047aa07da41bb6bd1524f9dc00eeed02"
 dependencies = [
  "anyerror",
  "byte-unit",
@@ -11103,7 +11103,7 @@ dependencies = [
 [[package]]
 name = "openraft-macros"
 version = "0.10.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.10.0-alpha.2#55f4e5a541eda9e7cefbd5138b42cdd92c697d17"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.10.0-alpha.3#94c820c3047aa07da41bb6bd1524f9dc00eeed02"
 dependencies = [
  "chrono",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,7 @@ opendal = { version = "0.48.0", features = [
     "services-webhdfs",
     "services-huggingface",
 ] }
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.10.0-alpha.2", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.10.0-alpha.3", features = [
     "serde",
     "tracing-log",
     "loosen-follower-log-revert", # allows removing all data from a follower and restoring from the leader.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### Fix: meta-service: data inconsistency risk

Openraft v0.10.0-alpha.2 introduced a bug that when a Leader sees higher
vote, it update its local vote and this updated vote will be considered
as **granted** to a future candidate, resulting in that a candidate that
does not have up to date log can become the Leader and cause data loss.

This bug is fixed in:
- https://github.com/datafuselabs/openraft/pull/1220

Upgrading should be done ASAP.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16175)
<!-- Reviewable:end -->
