### PR TITLE
feat: explain analyze output partial infos to debug cardinality estimator

### DIFF
--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -44,6 +44,8 @@ pub enum Statement {
         query: Box<Statement>,
     },
     ExplainAnalyze {
+        // if partial is true, only scan/filter/join will be shown.
+        partial: bool,
         query: Box<Statement>,
     },
 
@@ -414,8 +416,12 @@ impl Display for Statement {
                 }
                 write!(f, " {query}")?;
             }
-            Statement::ExplainAnalyze { query } => {
-                write!(f, "EXPLAIN ANALYZE {query}")?;
+            Statement::ExplainAnalyze { partial, query } => {
+                if *partial {
+                    write!(f, "EXPLAIN ANALYZE PARTIAL {query}")?;
+                } else {
+                    write!(f, "EXPLAIN ANALYZE {query}")?;
+                }
             }
             Statement::Query(stmt) => write!(f, "{stmt}")?,
             Statement::Insert(stmt) => write!(f, "{stmt}")?,

--- a/src/query/ast/src/ast/visitors/walk.rs
+++ b/src/query/ast/src/ast/visitors/walk.rs
@@ -411,7 +411,7 @@ pub fn walk_statement<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Statem
             options,
             query,
         } => visitor.visit_explain(kind, options, query),
-        Statement::ExplainAnalyze { query } => visitor.visit_statement(query),
+        Statement::ExplainAnalyze { query, .. } => visitor.visit_statement(query),
         Statement::Query(query) => visitor.visit_query(query),
         Statement::Insert(insert) => visitor.visit_insert(insert),
         Statement::Replace(replace) => visitor.visit_replace(replace),

--- a/src/query/ast/src/ast/visitors/walk_mut.rs
+++ b/src/query/ast/src/ast/visitors/walk_mut.rs
@@ -396,7 +396,7 @@ pub fn walk_statement_mut<V: VisitorMut>(visitor: &mut V, statement: &mut Statem
             options,
             query,
         } => visitor.visit_explain(kind, options, &mut *query),
-        Statement::ExplainAnalyze { query } => visitor.visit_statement(&mut *query),
+        Statement::ExplainAnalyze { query, .. } => visitor.visit_statement(&mut *query),
         Statement::Query(query) => visitor.visit_query(&mut *query),
         Statement::Insert(insert) => visitor.visit_insert(insert),
         Statement::Replace(replace) => visitor.visit_replace(replace),

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -95,9 +95,10 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
     );
     let explain_analyze = map(
         rule! {
-            EXPLAIN ~ ANALYZE ~ #statement
+            EXPLAIN ~ ANALYZE ~ PARTIAL? ~ #statement
         },
-        |(_, _, statement)| Statement::ExplainAnalyze {
+        |(_, _, partial, statement)| Statement::ExplainAnalyze {
+            partial: partial.is_some(),
             query: Box::new(statement.stmt),
         },
     );

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -892,6 +892,8 @@ pub enum TokenKind {
     PURGE,
     #[token("PUT", ignore(ascii_case))]
     PUT,
+    #[token("PARTIAL", ignore(ascii_case))]
+    PARTIAL,
     #[token("QUARTER", ignore(ascii_case))]
     QUARTER,
     #[token("QUERY", ignore(ascii_case))]

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -812,7 +812,7 @@ impl AccessChecker for PrivilegeAccess {
                     }
                 }
             }
-            Plan::ExplainAnalyze { plan } | Plan::Explain { plan, .. } => {
+            Plan::ExplainAnalyze { plan, .. } | Plan::Explain { plan, .. } => {
                 self.check(ctx, plan).await?
             }
 

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -120,24 +120,28 @@ impl InterpreterFactory {
                 *plan.clone(),
                 kind.clone(),
                 config.clone(),
+                false,
             )?)),
             Plan::ExplainAst { formatted_string } => Ok(Arc::new(ExplainInterpreter::try_create(
                 ctx,
                 plan.clone(),
                 ExplainKind::Ast(formatted_string.clone()),
                 ExplainConfig::default(),
+                false,
             )?)),
             Plan::ExplainSyntax { formatted_sql } => Ok(Arc::new(ExplainInterpreter::try_create(
                 ctx,
                 plan.clone(),
                 ExplainKind::Syntax(formatted_sql.clone()),
                 ExplainConfig::default(),
+                false,
             )?)),
-            Plan::ExplainAnalyze { plan } => Ok(Arc::new(ExplainInterpreter::try_create(
+            Plan::ExplainAnalyze { partial, plan } => Ok(Arc::new(ExplainInterpreter::try_create(
                 ctx,
                 *plan.clone(),
                 ExplainKind::AnalyzePlan,
                 ExplainConfig::default(),
+                *partial,
             )?)),
 
             Plan::CopyIntoTable(copy_plan) => Ok(Arc::new(CopyIntoTableInterpreter::try_create(

--- a/src/query/service/src/sessions/queue_mgr.rs
+++ b/src/query/service/src/sessions/queue_mgr.rs
@@ -364,7 +364,7 @@ impl QueryEntry {
                 }
             }
 
-            Plan::ExplainAnalyze { plan }
+            Plan::ExplainAnalyze { plan, .. }
             | Plan::Explain {
                 kind: ExplainKind::AnalyzePlan,
                 plan,

--- a/src/query/sql/src/executor/mod.rs
+++ b/src/query/sql/src/executor/mod.rs
@@ -23,9 +23,9 @@ mod util;
 
 pub mod table_read_plan;
 
+pub use format::format_partial_tree;
 pub use physical_plan::PhysicalPlan;
 pub use physical_plan_builder::MutationBuildInfo;
 pub use physical_plan_builder::PhysicalPlanBuilder;
 pub use physical_plan_visitor::PhysicalPlanReplacer;
 pub use util::*;
-pub use format::format_partial_tree;

--- a/src/query/sql/src/executor/mod.rs
+++ b/src/query/sql/src/executor/mod.rs
@@ -28,3 +28,4 @@ pub use physical_plan_builder::MutationBuildInfo;
 pub use physical_plan_builder::PhysicalPlanBuilder;
 pub use physical_plan_visitor::PhysicalPlanReplacer;
 pub use util::*;
+pub use format::format_partial_tree;

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -185,9 +185,9 @@ impl<'a> Binder {
                 self.bind_explain(bind_context, kind, options, query).await?
             }
 
-            Statement::ExplainAnalyze { query } => {
+            Statement::ExplainAnalyze {partial, query } => {
                 let plan = self.bind_statement(bind_context, query).await?;
-                Plan::ExplainAnalyze { plan: Box::new(plan) }
+                Plan::ExplainAnalyze { partial: *partial, plan: Box::new(plan) }
             }
 
             Statement::ShowFunctions { show_options } => {

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -208,7 +208,8 @@ pub async fn optimize(opt_ctx: OptimizerContext, plan: Plan) -> Result<Plan> {
                 }
             }
         },
-        Plan::ExplainAnalyze { plan } => Ok(Plan::ExplainAnalyze {
+        Plan::ExplainAnalyze { plan, partial } => Ok(Plan::ExplainAnalyze {
+            partial,
             plan: Box::new(Box::pin(optimize(opt_ctx, *plan)).await?),
         }),
         Plan::CopyIntoLocation(CopyIntoLocationPlan { stage, path, from }) => {

--- a/src/query/sql/src/planner/plans/plan.rs
+++ b/src/query/sql/src/planner/plans/plan.rs
@@ -179,6 +179,7 @@ pub enum Plan {
         formatted_sql: String,
     },
     ExplainAnalyze {
+        partial: bool,
         plan: Box<Plan>,
     },
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze_partial.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze_partial.test
@@ -1,0 +1,112 @@
+statement ok
+create or replace table t2 as select number as b from numbers(10);
+
+statement ok
+create or replace table t1 as select number as a from numbers(10);
+
+query T
+explain analyze partial select * from t1 join t2 on t1.a = t2.b;
+----
+HashJoin
+├── estimated rows: 10.00
+├── output rows: 10
+├── TableScan
+│   ├── table: default.default.t2
+│   ├── estimated rows: 10.00
+│   └── output rows: 10
+└── TableScan
+    ├── table: default.default.t1
+    ├── estimated rows: 10.00
+    └── output rows: 10
+
+query T
+explain analyze partial select * from t1 where t1.a > 1;
+----
+Filter
+├── filters: [t1.a (#0) > 1]
+├── estimated rows: 8.00
+├── output rows: 8
+└── TableScan
+    ├── table: default.default.t1
+    ├── estimated rows: 10.00
+    └── output rows: 10
+
+query T
+explain analyze partial select * from t1 join t2 on t1.a = t2.b  union all select * from t2 join t1 on t1.a = t2.b;
+----
+UnionAll
+├── Left
+│   └── HashJoin
+│       ├── estimated rows: 10.00
+│       ├── output rows: 10
+│       ├── TableScan
+│       │   ├── table: default.default.t2
+│       │   ├── estimated rows: 10.00
+│       │   └── output rows: 10
+│       └── TableScan
+│           ├── table: default.default.t1
+│           ├── estimated rows: 10.00
+│           └── output rows: 10
+└── Right
+    └── HashJoin
+        ├── estimated rows: 10.00
+        ├── output rows: 10
+        ├── TableScan
+        │   ├── table: default.default.t1
+        │   ├── estimated rows: 10.00
+        │   └── output rows: 10
+        └── TableScan
+            ├── table: default.default.t2
+            ├── estimated rows: 10.00
+            └── output rows: 10
+
+
+query T
+explain analyze partial select * from t1 join t2 on t1.a = t2.b where t1.a > 1;
+----
+HashJoin
+├── estimated rows: 8.00
+├── output rows: 8
+├── Filter
+│   ├── filters: [t2.b (#1) > 1]
+│   ├── estimated rows: 8.00
+│   ├── output rows: 8
+│   └── TableScan
+│       ├── table: default.default.t2
+│       ├── estimated rows: 10.00
+│       └── output rows: 10
+└── Filter
+    ├── filters: [t1.a (#0) > 1]
+    ├── estimated rows: 8.00
+    ├── output rows: 8
+    └── TableScan
+        ├── table: default.default.t1
+        ├── estimated rows: 10.00
+        └── output rows: 10
+
+
+# if the output rows is zero, it will be hidden.
+query T
+explain analyze partial select * from t1 join t2 on t1.a = t2.b where t1.a > 10;
+----
+HashJoin
+├── estimated rows: 0.00
+├── Filter
+│   ├── filters: [t2.b (#1) > 10]
+│   ├── estimated rows: 0.00
+│   └── TableScan
+│       ├── table: default.default.t2
+│       └── estimated rows: 10.00
+└── Filter
+    ├── filters: [t1.a (#0) > 10]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: default.default.t1
+        └── estimated rows: 10.00
+
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
`explain analyze partial` will only output infos about real output rows and estimate rows which is helpful to debug the cardinality estimator.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16185)
<!-- Reviewable:end -->
