### PR TITLE
feat: transfer leader command for meta-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11085,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.10.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.10.0-alpha.3#94c820c3047aa07da41bb6bd1524f9dc00eeed02"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.10.0-alpha.6#c6f4a779e0bb563788c4187381065162e76ea996"
 dependencies = [
  "anyerror",
  "byte-unit",
@@ -11107,7 +11107,7 @@ dependencies = [
 [[package]]
 name = "openraft-macros"
 version = "0.10.0"
-source = "git+https://github.com/drmingdrmer/openraft?tag=v0.10.0-alpha.3#94c820c3047aa07da41bb6bd1524f9dc00eeed02"
+source = "git+https://github.com/drmingdrmer/openraft?tag=v0.10.0-alpha.6#c6f4a779e0bb563788c4187381065162e76ea996"
 dependencies = [
  "chrono",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,7 @@ opendal = { version = "0.48.0", features = [
     "services-webhdfs",
     "services-huggingface",
 ] }
-openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.10.0-alpha.3", features = [
+openraft = { git = "https://github.com/drmingdrmer/openraft", tag = "v0.10.0-alpha.6", features = [
     "serde",
     "tracing-log",
     "loosen-follower-log-revert", # allows removing all data from a follower and restoring from the leader.

--- a/src/meta/service/src/api/http_service.rs
+++ b/src/meta/service/src/api/http_service.rs
@@ -63,6 +63,10 @@ impl HttpService {
                 get(super::http::v1::ctrl::trigger_snapshot),
             )
             .at(
+                "/v1/ctrl/trigger_transfer_leader",
+                get(super::http::v1::ctrl::trigger_transfer_leader),
+            )
+            .at(
                 "/v1/ctrl/block_write_snapshot",
                 get(super::http::v1::ctrl::block_write_snapshot),
             )

--- a/src/meta/service/src/meta_service/raft_service_impl.rs
+++ b/src/meta/service/src/meta_service/raft_service_impl.rs
@@ -26,13 +26,16 @@ use databend_common_meta_raft_store::sm_v003::adapter::upgrade_snapshot_data_v00
 use databend_common_meta_raft_store::sm_v003::open_snapshot::OpenSnapshot;
 use databend_common_meta_raft_store::sm_v003::received::Received;
 use databend_common_meta_sled_store::openraft::MessageSummary;
+use databend_common_meta_types::protobuf as pb;
 use databend_common_meta_types::protobuf::raft_service_server::RaftService;
+use databend_common_meta_types::protobuf::Empty;
 use databend_common_meta_types::protobuf::RaftReply;
 use databend_common_meta_types::protobuf::RaftRequest;
 use databend_common_meta_types::protobuf::SnapshotChunkRequest;
 use databend_common_meta_types::protobuf::SnapshotChunkRequestV003;
 use databend_common_meta_types::protobuf::SnapshotResponseV003;
 use databend_common_meta_types::protobuf::StreamItem;
+use databend_common_meta_types::raft_types::TransferLeaderRequest;
 use databend_common_meta_types::snapshot_db::DB;
 use databend_common_meta_types::AppendEntriesRequest;
 use databend_common_meta_types::GrpcHelper;
@@ -382,6 +385,32 @@ impl RaftService for RaftServiceImpl {
         }
         .in_span(root)
         .await
+    }
+
+    async fn transfer_leader(
+        &self,
+        request: Request<pb::TransferLeaderRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let root = databend_common_tracing::start_trace_for_remote_request(full_name!(), &request);
+        let fu = async {
+            let req = request.into_inner();
+            let req: TransferLeaderRequest = req.try_into()?;
+
+            let req_str = req.to_string();
+
+            info!("RaftServiceImpl::{}: start: {}", func_name!(), req_str);
+
+            let raft = &self.meta_node.raft;
+
+            raft.handle_transfer_leader(req)
+                .await
+                .map_err(GrpcHelper::internal_err)?;
+
+            info!("RaftServiceImpl::{}: done: {}", func_name!(), req_str);
+
+            Ok(Response::new(pb::Empty {}))
+        };
+        fu.in_span(root).await
     }
 }
 

--- a/src/meta/service/tests/it/api/http/transfer_leader.rs
+++ b/src/meta/service/tests/it/api/http/transfer_leader.rs
@@ -1,0 +1,85 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use databend_common_base::base::tokio;
+use databend_common_base::base::tokio::time::Instant;
+use databend_common_base::base::Stoppable;
+use databend_common_meta_sled_store::openraft::async_runtime::watch::WatchReceiver;
+use databend_meta::api::HttpService;
+use log::info;
+use pretty_assertions::assert_eq;
+use test_harness::test;
+
+use crate::testing::meta_service_test_harness;
+use crate::tests::start_metasrv_cluster;
+
+/// Start a cluster of 3 nodes,
+/// and send transfer leader command to the leader
+/// to force it to transfer leadership to node 2.
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_transfer_leader() -> anyhow::Result<()> {
+    let tcs = start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let meta0 = tcs[0].grpc_srv.as_ref().unwrap().get_meta_node();
+    let metrics = meta0.raft.metrics().borrow_watched().clone();
+    assert_eq!(metrics.current_leader, Some(0));
+
+    let mut srv = HttpService::create(tcs[0].config.clone(), meta0.clone());
+    srv.start().await.expect("HTTP: admin api error");
+
+    let transfer_url = || {
+        format!(
+            "http://{}/v1/ctrl/trigger_transfer_leader?to=2",
+            &tcs[0].config.admin_api_address
+        )
+    };
+
+    let client = reqwest::Client::builder().build().unwrap();
+
+    info!("--- retry until service is ready or timeout ---");
+    {
+        let timeout_at = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < timeout_at {
+            let resp = client.get(transfer_url()).send().await;
+            info!("transfer_leader resp: {:?}", resp);
+
+            if resp.is_ok() {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let metrics = meta0.raft.metrics().borrow_watched().clone();
+    assert_eq!(metrics.current_leader, Some(2));
+
+    {
+        let meta1 = tcs[1].grpc_srv.as_ref().unwrap().get_meta_node();
+        let metrics = meta1.raft.metrics().borrow_watched().clone();
+        assert_eq!(metrics.current_leader, Some(2));
+    }
+    {
+        let meta2 = tcs[2].grpc_srv.as_ref().unwrap().get_meta_node();
+        let metrics = meta2.raft.metrics().borrow_watched().clone();
+        assert_eq!(metrics.current_leader, Some(2));
+    }
+
+    Ok(())
+}

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -21,8 +21,8 @@ use databend_common_meta_sled_store::openraft::storage::RaftLogReaderExt;
 use databend_common_meta_sled_store::openraft::storage::RaftLogStorage;
 use databend_common_meta_sled_store::openraft::storage::RaftLogStorageExt;
 use databend_common_meta_sled_store::openraft::storage::RaftStateMachine;
+use databend_common_meta_sled_store::openraft::testing::log::StoreBuilder;
 use databend_common_meta_sled_store::openraft::testing::log_id;
-use databend_common_meta_sled_store::openraft::testing::StoreBuilder;
 use databend_common_meta_sled_store::openraft::RaftLogReader;
 use databend_common_meta_sled_store::openraft::RaftSnapshotBuilder;
 use databend_common_meta_types::new_log_id;
@@ -37,8 +37,6 @@ use databend_meta::meta_service::meta_node::LogStore;
 use databend_meta::meta_service::meta_node::SMStore;
 use databend_meta::store::RaftStore;
 use databend_meta::Opened;
-use fastrace::full_name;
-use fastrace::prelude::*;
 use futures::TryStreamExt;
 use log::debug;
 use log::info;
@@ -47,7 +45,6 @@ use pretty_assertions::assert_eq;
 use test_harness::test;
 
 use crate::testing::meta_service_test_harness;
-use crate::testing::meta_service_test_harness_sync;
 use crate::tests::service::MetaSrvTestContext;
 
 struct MetaStoreBuilder {}
@@ -62,13 +59,11 @@ impl StoreBuilder<TypeConfig, LogStore, SMStore, MetaSrvTestContext> for MetaSto
     }
 }
 
-#[test(harness = meta_service_test_harness_sync)]
+#[test(harness = meta_service_test_harness)]
 #[fastrace::trace]
-fn test_impl_raft_storage() -> anyhow::Result<()> {
-    let root = Span::root(full_name!(), SpanContext::random());
-    let _guard = root.set_local_parent();
-
-    databend_common_meta_sled_store::openraft::testing::Suite::test_all(MetaStoreBuilder {})?;
+async fn test_impl_raft_storage() -> anyhow::Result<()> {
+    databend_common_meta_sled_store::openraft::testing::log::Suite::test_all(MetaStoreBuilder {})
+        .await?;
 
     Ok(())
 }

--- a/src/meta/service/tests/it/testing.rs
+++ b/src/meta/service/tests/it/testing.rs
@@ -40,6 +40,7 @@ where
     shutdown_test();
 }
 
+#[allow(dead_code)]
 pub fn meta_service_test_harness_sync<F>(test: F)
 where F: FnOnce() -> anyhow::Result<()> + 'static {
     setup_test();

--- a/src/meta/types/build.rs
+++ b/src/meta/types/build.rs
@@ -29,6 +29,7 @@ fn build_proto() {
 
     let proto_dir = Path::new(&manifest_dir).join("proto");
     let protos = [
+        &Path::new(&proto_dir).join(Path::new("raft.proto")),
         &Path::new(&proto_dir).join(Path::new("meta.proto")),
         &Path::new(&proto_dir).join(Path::new("request.proto")),
     ];

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package meta;
 
+import "raft.proto";
 import "request.proto";
 
 message Empty {}
@@ -27,6 +28,12 @@ message RaftRequest {
 message RaftReply {
   string data = 1;
   string error = 2;
+}
+
+message TransferLeaderRequest {
+  Vote from = 1;
+  uint64 to = 2;
+  LogId last_log_id = 3;
 }
 
 message MemberListRequest { string data = 1; }
@@ -252,6 +259,7 @@ service RaftService {
   rpc InstallSnapshotV1(SnapshotChunkRequest) returns (RaftReply);
   rpc InstallSnapshotV003(stream SnapshotChunkRequestV003) returns (SnapshotResponseV003);
   rpc Vote(RaftRequest) returns (RaftReply);
+  rpc TransferLeader(TransferLeaderRequest) returns (Empty);
 }
 
 service MetaService {

--- a/src/meta/types/proto/raft.proto
+++ b/src/meta/types/proto/raft.proto
@@ -12,7 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod cluster_state_test;
-pub mod config;
-pub mod metrics;
-pub mod transfer_leader;
+syntax = "proto3";
+
+package meta;
+
+// A quorum granted or not granted Leader.
+message LeaderId {
+  uint64 term = 1;
+  uint64 node_id = 2;
+}
+
+// The vote for RequestVote etc.
+message Vote {
+  uint64 term = 1;
+  uint64 node_id = 2;
+  bool committed = 3;
+}
+
+// The log id
+message LogId {
+  uint64 term = 1;
+  uint64 node_id = 2;
+  uint64 index = 3;
+}

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -31,7 +31,7 @@ mod non_empty;
 mod operation;
 mod raft_snapshot_data;
 mod raft_txid;
-mod raft_types;
+pub mod raft_types;
 mod seq_errors;
 mod seq_num;
 mod seq_value;

--- a/src/meta/types/src/proto_ext/mod.rs
+++ b/src/meta/types/src/proto_ext/mod.rs
@@ -14,7 +14,9 @@
 
 //! Extend protobuf generated code with some useful methods.
 
+mod raft_types_ext;
 mod seq_v_ext;
 mod snapshot_chunk_request_ext;
 mod stream_item_ext;
+mod transfer_leader_request_ext;
 mod txn_ext;

--- a/src/meta/types/src/proto_ext/raft_types_ext.rs
+++ b/src/meta/types/src/proto_ext/raft_types_ext.rs
@@ -1,0 +1,65 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod vote_impls {
+
+    use crate::protobuf as pb;
+    use crate::raft_types;
+
+    impl From<raft_types::Vote> for pb::Vote {
+        fn from(vote: raft_types::Vote) -> Self {
+            pb::Vote {
+                term: vote.leader_id.term,
+                node_id: vote.leader_id.node_id,
+                committed: vote.is_committed(),
+            }
+        }
+    }
+
+    impl From<pb::Vote> for raft_types::Vote {
+        fn from(vote: pb::Vote) -> Self {
+            if vote.committed {
+                raft_types::Vote::new_committed(vote.term, vote.node_id)
+            } else {
+                raft_types::Vote::new(vote.term, vote.node_id)
+            }
+        }
+    }
+}
+
+mod log_id_impls {
+
+    use crate::protobuf as pb;
+    use crate::raft_types;
+    use crate::CommittedLeaderId;
+
+    impl From<raft_types::LogId> for pb::LogId {
+        fn from(log_id: raft_types::LogId) -> Self {
+            pb::LogId {
+                term: log_id.leader_id.term,
+                node_id: log_id.leader_id.node_id,
+                index: log_id.index,
+            }
+        }
+    }
+
+    impl From<pb::LogId> for raft_types::LogId {
+        fn from(log_id: pb::LogId) -> Self {
+            raft_types::LogId::new(
+                CommittedLeaderId::new(log_id.term, log_id.node_id),
+                log_id.index,
+            )
+        }
+    }
+}

--- a/src/meta/types/src/proto_ext/transfer_leader_request_ext.rs
+++ b/src/meta/types/src/proto_ext/transfer_leader_request_ext.rs
@@ -1,0 +1,45 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tonic::Status;
+
+use crate::protobuf as pb;
+use crate::raft_types::TransferLeaderRequest;
+use crate::Vote;
+
+impl From<TransferLeaderRequest> for pb::TransferLeaderRequest {
+    fn from(req: TransferLeaderRequest) -> Self {
+        pb::TransferLeaderRequest {
+            from: Some(pb::Vote::from(*req.from_leader())),
+            to: *req.to_node_id(),
+            last_log_id: req.last_log_id().copied().map(pb::LogId::from),
+        }
+    }
+}
+
+impl TryFrom<pb::TransferLeaderRequest> for TransferLeaderRequest {
+    /// Converting pb to rust type is done when receiving a request,
+    /// thus we just return a tonic status error.
+    type Error = Status;
+
+    fn try_from(req: pb::TransferLeaderRequest) -> Result<Self, Status> {
+        let from = req
+            .from
+            .ok_or_else(|| Status::invalid_argument("missing from"))?;
+
+        let r =
+            TransferLeaderRequest::new(Vote::from(from), req.to, req.last_log_id.map(|x| x.into()));
+        Ok(r)
+    }
+}

--- a/src/meta/types/src/raft_types.rs
+++ b/src/meta/types/src/raft_types.rs
@@ -82,6 +82,7 @@ pub type InstallSnapshotError = openraft::error::InstallSnapshotError;
 pub type SnapshotMismatch = openraft::error::SnapshotMismatch;
 pub type VoteRequest = openraft::raft::VoteRequest<TypeConfig>;
 pub type VoteResponse = openraft::raft::VoteResponse<TypeConfig>;
+pub type TransferLeaderRequest = openraft::raft::TransferLeaderRequest<TypeConfig>;
 
 pub fn new_log_id(term: u64, node_id: NodeId, index: u64) -> LogId {
     LogId::new(CommittedLeaderId::new(term, node_id), index)


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: transfer leader command for meta-service

This commit introduce a new admin API(at `admin_api_address`, by default
`127.0.0.1:28002`) to force the current Leader to transfer leadership to
another node.  The url of this command is
"/v1/ctrl/trigger_transfer_leader?to=<new_leader_node_id>".

Such request returns nothing no matter leadership is successfully
transferred or not.

If the node receives this request is not the leader it does nothing.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)






## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16198)
<!-- Reviewable:end -->
