### PR TITLE
fix: backward compatibility of table statistics

### DIFF
--- a/src/query/storages/common/table_meta/src/meta/v2/segment.rs
+++ b/src/query/storages/common/table_meta/src/meta/v2/segment.rs
@@ -279,15 +279,7 @@ impl ColumnMeta {
 
 impl BlockMeta {
     pub fn from_v0(s: &v0::BlockMeta, fields: &[TableField]) -> Self {
-        let col_stats = s
-            .col_stats
-            .iter()
-            .filter_map(|(k, v)| {
-                let data_type = fields[*k as usize].data_type();
-                let stats = ColumnStatistics::from_v0(v, data_type);
-                stats.map(|s| (*k, s))
-            })
-            .collect();
+        let col_stats = Statistics::convert_column_stats(&s.col_stats, fields);
 
         let col_metas = s
             .col_metas
@@ -312,16 +304,7 @@ impl BlockMeta {
     }
 
     pub fn from_v1(s: &v1::BlockMeta, fields: &[TableField]) -> Self {
-        let col_stats = s
-            .col_stats
-            .iter()
-            .filter_map(|(k, v)| {
-                let t = fields[*k as usize].data_type();
-                let stats = ColumnStatistics::from_v0(v, t);
-                stats.map(|s| (*k, s))
-            })
-            .collect();
-
+        let col_stats = Statistics::convert_column_stats(&s.col_stats, fields);
         let col_metas = s
             .col_metas
             .iter()

--- a/tests/compat_fuse/compat-logictest/base/fuse_compat_read
+++ b/tests/compat_fuse/compat-logictest/base/fuse_compat_read
@@ -117,9 +117,11 @@ select c_variant   FROM fuse_compat_table;
 
 # Modify columns, but keep the version table [meta]data as it is
 statement ok
-ALTER TABLE fuse_compact_table DROP COLUMN c_int;
+ALTER TABLE fuse_compat_table DROP COLUMN c_int;
+
+
 statement ok
-ALTER TABLE fuse_compact_table ADD COLUMN brand_new uint64;
+ALTER TABLE fuse_compat_table ADD COLUMN brand_new uint64;
 
 
 # Let's see if nothing broken
@@ -130,4 +132,5 @@ select count() FROM fuse_compat_table where brand_new = 100;
 
 query T
 select * FROM fuse_compat_table ignore_result;
+----
 

--- a/tests/compat_fuse/compat-logictest/base/fuse_compat_read
+++ b/tests/compat_fuse/compat-logictest/base/fuse_compat_read
@@ -113,3 +113,21 @@ query T
 select c_variant   FROM fuse_compat_table;
 ----
 [1,{"a":1,"b":{"c":2}}]
+
+
+# Modify columns, but keep the version table [meta]data as it is
+statement ok
+ALTER TABLE fuse_compact_table DROP COLUMN c_int;
+statement ok
+ALTER TABLE fuse_compact_table ADD COLUMN brand_new uint64;
+
+
+# Let's see if nothing broken
+query T
+select count() FROM fuse_compat_table where brand_new = 100;
+----
+0
+
+query T
+select * FROM fuse_compat_table ignore_result;
+

--- a/tests/compat_fuse/compat-logictest/base/fuse_compat_write
+++ b/tests/compat_fuse/compat-logictest/base/fuse_compat_write
@@ -21,7 +21,8 @@ CREATE TABLE fuse_compat_table (
         c_varchar VARCHAR,
         c_array VARIANT,
         c_object VARIANT,
-        c_variant VARIANT
+        c_variant VARIANT,
+        c_array_str ARRAY(String)
 ) Engine = Fuse;
 
 statement ok
@@ -38,5 +39,6 @@ INSERT INTO fuse_compat_table VALUES(
         'varchar',
         parse_json('[1,2,3,["a","b","c"]]'),
         parse_json('{"a":1,"b":{"c":2}}'),
-        parse_json('[1,{"a":1,"b":{"c":2}}]')
+        parse_json('[1,{"a":1,"b":{"c":2}}]'),
+        ['item1', 'item2_looooooooooooooooooong_val', 'item3', 'item4']
 );


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Improve backward compatibility of table column statistics.

While converting table column statistics from legacy versions, ignore newly modified fields (instead of panic).


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16200)
<!-- Reviewable:end -->
