### PR TITLE
refactor: support unset session|global

### DIFF
--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -540,7 +540,7 @@ impl Display for Statement {
                 write!(f, "UNSET ")?;
                 match *unset_type {
                     SetType::SettingsSession => write!(f, "SESSION ")?,
-                    SetType::SettingsGlobal => {}
+                    SetType::SettingsGlobal => write!(f, "GLOBAL ")?,
                     SetType::Variable => write!(f, "VARIABLE ")?,
                 }
                 if identifiers.len() == 1 {

--- a/src/query/ast/src/parser/common.rs
+++ b/src/query/ast/src/parser/common.rs
@@ -250,7 +250,7 @@ pub fn unset_type(i: Input) -> IResult<SetType> {
                 TokenKind::VARIABLE => SetType::Variable,
                 _ => unreachable!(),
             },
-            None => SetType::SettingsGlobal,
+            None => SetType::SettingsSession,
         },
     )(i)
 }

--- a/src/query/ast/tests/it/testdata/statement.txt
+++ b/src/query/ast/tests/it/testdata/statement.txt
@@ -15854,10 +15854,10 @@ SetStmt {
 ---------- Input ----------
 UNSET max_threads;
 ---------- Output ---------
-UNSET max_threads
+UNSET SESSION max_threads
 ---------- AST ------------
 UnSetStmt {
-    unset_type: SettingsGlobal,
+    unset_type: SettingsSession,
     identifiers: [
         Identifier {
             span: Some(
@@ -15894,10 +15894,10 @@ UnSetStmt {
 ---------- Input ----------
 UNSET (max_threads, sql_dialect);
 ---------- Output ---------
-UNSET (max_threads, sql_dialect)
+UNSET SESSION (max_threads, sql_dialect)
 ---------- AST ------------
 UnSetStmt {
-    unset_type: SettingsGlobal,
+    unset_type: SettingsSession,
     identifiers: [
         Identifier {
             span: Some(

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -343,7 +343,6 @@ impl RoleApi for RoleMgr {
             let grant_object = convert_to_grant_obj(object);
 
             let owner_key = self.ownership_object_ident(object);
-
             let owner_value = serialize_struct(
                 &OwnershipInfo {
                     object: object.clone(),

--- a/tests/sqllogictests/suites/base/05_ddl/05_0026_ddl_unset_settings.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0026_ddl_unset_settings.test
@@ -1,84 +1,114 @@
+onlyif http
 query TTTT
 SELECT name, value, default, level from system.settings where name in ('sql_dialect', 'timezone')
 ----
 sql_dialect PostgreSQL PostgreSQL DEFAULT
 timezone UTC UTC DEFAULT
 
+onlyif http
 statement ok
 SET GLOBAL sql_dialect='MySQL'
 
+onlyif http
 statement ok
 SET GLOBAL timezone='Asia/Shanghai'
 
+onlyif http
 query TTTT
 SELECT name, value, default, level from system.settings where name in ('sql_dialect', 'timezone')
 ----
 sql_dialect  MySQL  PostgreSQL  GLOBAL
 timezone  Asia/Shanghai  UTC  GLOBAL
 
+onlyif http
 statement ok
-UNSET (timezone)
+UNSET GLOBAL (timezone)
 
+onlyif http
 statement error 2801
 SET stl_dialect='MySQL'
 
+onlyif http
 statement ok
 UNSET stl_dialect
 
+onlyif http
 statement ok
-UNSET sql_dialect
+UNSET GLOBAL sql_dialect
 
+onlyif http
 query TTTT
 SELECT name, value, default, level from system.settings where name in ('sql_dialect', 'timezone')
 ----
 sql_dialect PostgreSQL PostgreSQL DEFAULT
 timezone UTC UTC DEFAULT
 
+onlyif http
 statement ok
 set DATA_RETENTION_TIME_IN_DAYS=20;
 
+onlyif http
 query TTTTTTT
 show settings like 'DATA_RETENTION_TIME_IN_DAYS';
 ----
 data_retention_time_in_days 20 1 [0, 90] SESSION Sets the data retention time in days. UInt64
 
+onlyif http
 statement ok
 unset data_retention_time_in_days;
 
+onlyif http
 query TTTTTTT
 show settings like 'DATA_RETENTION_TIME_IN_DAYS';
 ----
 data_retention_time_in_days 1 1 [0, 90] DEFAULT Sets the data retention time in days. UInt64
 
+onlyif http
 statement ok
 set global load_file_metadata_expire_hours=12;
 
+onlyif http
 query TT
 show settings like 'load_file_metadata_expire_hours';
 ----
 load_file_metadata_expire_hours 12 24 [0, 18446744073709551615] GLOBAL Sets the hours that the metadata of files you load data from with COPY INTO will expire in. UInt64
 
+onlyif http
 statement ok
 set load_file_metadata_expire_hours=13;
 
+onlyif http
 query TTTTTTT
 show settings like 'load_file_metadata_expire_hours';
 ----
 load_file_metadata_expire_hours 13 24 [0, 18446744073709551615] SESSION Sets the hours that the metadata of files you load data from with COPY INTO will expire in. UInt64
 
+onlyif http
 statement ok
 unset session load_file_metadata_expire_hours;
 
+onlyif http
 query TTTTTTT
 show settings like 'load_file_metadata_expire_hours';
 ----
 load_file_metadata_expire_hours 12 24 [0, 18446744073709551615] GLOBAL Sets the hours that the metadata of files you load data from with COPY INTO will expire in. UInt64
 
+onlyif http
 statement ok
 unset load_file_metadata_expire_hours
 
+onlyif http
+query TTTTTTT
+show settings like 'load_file_metadata_expire_hours';
+----
+load_file_metadata_expire_hours 12 24 [0, 18446744073709551615] GLOBAL Sets the hours that the metadata of files you load data from with COPY INTO will expire in. UInt64
+
+onlyif http
+statement ok
+unset global load_file_metadata_expire_hours
+
+onlyif http
 query TTTTTTT
 show settings like 'load_file_metadata_expire_hours';
 ----
 load_file_metadata_expire_hours 24 24 [0, 18446744073709551615] DEFAULT Sets the hours that the metadata of files you load data from with COPY INTO will expire in. UInt64
-

--- a/tests/sqllogictests/suites/query/set.test
+++ b/tests/sqllogictests/suites/query/set.test
@@ -22,7 +22,7 @@ select value, default = value  from system.settings where name in ('max_threads'
 56 0
 
 statement ok
-UNSET (max_threads, storage_io_min_bytes_for_seek);
+UNSET GLOBAL (max_threads, storage_io_min_bytes_for_seek);
 
 query TT
 select  default = value from system.settings where name in ('max_threads', 'storage_io_min_bytes_for_seek');


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

default unset settings is unset session level setting. Same with set setting

**Note:**

Now unset settings is unset session settings;

If you wants to unset global setting, must call query `UNSET GLOBAL <setting_name>`.
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16214)
<!-- Reviewable:end -->
