### PR TITLE
fix: block_entry.memory_size

### DIFF
--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -26,6 +26,7 @@ use databend_common_exception::Result;
 use crate::schema::DataSchema;
 use crate::types::AnyType;
 use crate::types::DataType;
+use crate::types::ValueType;
 use crate::Column;
 use crate::ColumnBuilder;
 use crate::DataSchemaRef;
@@ -586,7 +587,7 @@ impl TryFrom<DataBlock> for ArrowChunk<ArrayRef> {
 impl BlockEntry {
     pub fn memory_size(&self) -> usize {
         match &self.value {
-            Value::Scalar(s) => std::mem::size_of_val(s),
+            Value::Scalar(s) => AnyType::scalar_memory_size(&AnyType::to_scalar_ref(s)),
             Value::Column(c) => c.memory_size(),
         }
     }

--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -26,7 +26,6 @@ use databend_common_exception::Result;
 use crate::schema::DataSchema;
 use crate::types::AnyType;
 use crate::types::DataType;
-use crate::types::ValueType;
 use crate::Column;
 use crate::ColumnBuilder;
 use crate::DataSchemaRef;
@@ -587,7 +586,7 @@ impl TryFrom<DataBlock> for ArrowChunk<ArrayRef> {
 impl BlockEntry {
     pub fn memory_size(&self) -> usize {
         match &self.value {
-            Value::Scalar(s) => AnyType::scalar_memory_size(&AnyType::to_scalar_ref(s)),
+            Value::Scalar(s) => s.as_ref().memory_size(),
             Value::Column(c) => c.memory_size(),
         }
     }

--- a/src/query/expression/tests/it/block.rs
+++ b/src/query/expression/tests/it/block.rs
@@ -1,12 +1,17 @@
 use databend_common_expression::block_debug::box_render;
+use databend_common_expression::types::number::NumberScalar;
 use databend_common_expression::types::string::StringColumnBuilder;
+use databend_common_expression::types::AnyType;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::types::NumberDataType;
+use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::FromData;
+use databend_common_expression::Scalar;
+use databend_common_expression::Value;
 
 use crate::common::new_block;
 
@@ -55,4 +60,19 @@ fn test_box_render_block() {
 │ (5 shown) │        │
 └────────────────────┘"#;
     assert_eq!(d, expected);
+}
+
+#[test]
+fn test_block_entry_memory_size() {
+    let scalar_u8 = Scalar::Number(NumberScalar::UInt8(1));
+
+    let entry = BlockEntry::new(
+        DataType::Number(NumberDataType::UInt8),
+        Value::<AnyType>::Scalar(scalar_u8),
+    );
+    assert_eq!(1, entry.memory_size());
+
+    let scalar_str = Scalar::String("abc".to_string());
+    let entry = BlockEntry::new(DataType::String, Value::<AnyType>::Scalar(scalar_str));
+    assert_eq!(3, entry.memory_size());
 }

--- a/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_uuid.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_uuid.test
@@ -10,7 +10,7 @@ remove @data/parquet/unload/uuid
 query
 copy into @data/parquet/unload/uuid/ from (select 1 as a)  file_format = (type = parquet)
 ----
-1 64 377
+1 1 377
 
 query error column id doesn't exist
 copy into t_uuid from @data/parquet/unload/uuid file_format = (type = parquet) RETURN_FAILED_ONLY=TRUE
@@ -22,7 +22,7 @@ select * from t_uuid
 query
 copy into @data/parquet/unload/uuid/ from (select 1 as a)  file_format = (type = parquet)
 ----
-1 64 377
+1 1 377
 
 statement ok
 truncate table t_uuid

--- a/tests/suites/0_stateless/05_hints/05_0001_set_var.result
+++ b/tests/suites/0_stateless/05_hints/05_0001_set_var.result
@@ -22,5 +22,5 @@ Asia/Shanghai
 America/Toronto
 2022-02-02 03:00:00
 2022-02-01 14:00:00
-1	64	415
+1	13	415
 Asia/Shanghai

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
@@ -87,7 +87,7 @@ Error: APIError: ResponseError with 1063: Permission denied: privilege READ is r
 Error: APIError: ResponseError with 1063: Permission denied: No privilege on database root_db for user b.
 Error: APIError: ResponseError with 1063: Permission denied: No privilege on table root_table for user b.
 Error: APIError: ResponseError with 1063: Permission denied: No privilege on table root_table for user b.
-1	64	377
+1	1	377
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'t1' for user 'b'@'%' with roles [public]
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE s3 for user 'b'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Select] is required on 'default'.'default'.'t' for user 'b'@'%' with roles [public]

--- a/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
+++ b/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
@@ -17,7 +17,7 @@ Error: APIError: ResponseError with 1063: Permission denied: privilege [Write] i
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE presign_stage for user 'u1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
 000
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Write] is required on STAGE s3 for user 'u1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
-1	64	377
+1	1	377
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Read] is required on STAGE s3 for user 'u1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
 Error: APIError: ResponseError with 1063: Permission denied: privilege READ is required on stage s3 for user 'u1'@'%'
 Error: APIError: ResponseError with 1063: Permission denied: privilege READ is required on stage s3 for user 'u1'@'%'

--- a/tests/suites/1_stateful/07_stage_attachment/07_0000_insert_with_stage.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0000_insert_with_stage.result
@@ -1,7 +1,7 @@
 sample.csv
 Succeeded
 96
-227
+168
 null
 1	'Beijing'	100	China
 2	'Shanghai'	80	China

--- a/tests/suites/1_stateful/07_stage_attachment/07_0001_replace_with_stage.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0001_replace_with_stage.result
@@ -1,6 +1,6 @@
 sample.csv
 96
-227
+168
 null
 1	'Beijing'	100	China
 2	'Shanghai'	80	China

--- a/tests/suites/1_stateful/07_stage_attachment/07_0002_insert_with_stage_deduplicate.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0002_insert_with_stage_deduplicate.result
@@ -1,6 +1,6 @@
 sample.csv
 96
-227
+168
 null
 1	'Beijing'	100	China
 2	'Shanghai'	80	China


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
memory_size of block_entry.value::Scalar is not correct
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16230)
<!-- Reviewable:end -->
