### PR TITLE
chore: disable table info refreshing for `ai_to_sql`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5395,7 +5395,6 @@ dependencies = [
  "databend-storages-common-index",
  "databend-storages-common-table-meta",
  "log",
- "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/src/query/service/src/table_functions/openai/ai_to_sql.rs
+++ b/src/query/service/src/table_functions/openai/ai_to_sql.rs
@@ -185,7 +185,14 @@ impl AsyncSource for GPT2SQLSource {
         // SELECT
         let database = self.ctx.get_current_database();
         let tenant = self.ctx.get_tenant();
-        let catalog = self.ctx.get_catalog(CATALOG_DEFAULT).await?;
+
+        // Disable table info refreshing.
+        // Attached tables may not be able to refresh table info successfully.
+        let catalog = self
+            .ctx
+            .get_catalog(CATALOG_DEFAULT)
+            .await?
+            .disable_table_info_refresh()?;
 
         let mut template = vec![];
         template.push("### Postgres SQL tables, with their properties:".to_string());

--- a/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.result
@@ -1,2 +1,1 @@
 expects no error(nothing outputs)
-expects ai_to_sql works

--- a/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.result
@@ -1,1 +1,2 @@
 expects no error(nothing outputs)
+expects ai_to_sql works

--- a/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.sh
@@ -17,3 +17,6 @@ echo "set data_retention_time_in_days=0;vacuum drop table from issue_16121;" | $
 
 echo "expects no error(nothing outputs)"
 echo "drop table issue_16121.attach_read_only" | $BENDSQL_CLIENT_CONNECT
+
+echo "expects ai_to_sql works"
+echo "SELECT* FROM  ai_to_sql ('current time') IGNORE_RESULT" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.sh
@@ -18,5 +18,6 @@ echo "set data_retention_time_in_days=0;vacuum drop table from issue_16121;" | $
 echo "expects no error(nothing outputs)"
 echo "drop table issue_16121.attach_read_only" | $BENDSQL_CLIENT_CONNECT
 
-echo "expects ai_to_sql works"
-echo "SELECT* FROM  ai_to_sql ('current time') IGNORE_RESULT" | $BENDSQL_CLIENT_CONNECT
+# AI configurations (provider url, ak/sk) are not ready for CI, thus the following test case is commented out
+#echo "expects ai_to_sql works"
+#echo "SELECT* FROM  ai_to_sql ('current time') IGNORE_RESULT" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Disable table info refreshing during execution of `ai_to_sql`. Attached tables may not be able to refresh table info successfully.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - ai functions are not ready to be test in CI yet

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16240)
<!-- Reviewable:end -->
