### PR TITLE
fix(query): fix alter user set `MUST_CHANGE_PASSWORD`

### DIFF
--- a/src/meta/app/src/principal/user_auth.rs
+++ b/src/meta/app/src/principal/user_auth.rs
@@ -158,7 +158,8 @@ impl AuthInfo {
         AuthInfo::new(auth_type, auth_string, need_change)
     }
 
-    pub fn create_set_need_change(&self, need_change: bool) -> AuthInfo {
+    // create `AuthInfo` and only modify `need_change` field.
+    pub fn create_with_need_change(&self, need_change: bool) -> AuthInfo {
         match self {
             AuthInfo::Password {
                 hash_value,

--- a/src/meta/app/src/principal/user_auth.rs
+++ b/src/meta/app/src/principal/user_auth.rs
@@ -158,6 +158,21 @@ impl AuthInfo {
         AuthInfo::new(auth_type, auth_string, need_change)
     }
 
+    pub fn create_set_need_change(&self, need_change: bool) -> AuthInfo {
+        match self {
+            AuthInfo::Password {
+                hash_value,
+                hash_method,
+                ..
+            } => AuthInfo::Password {
+                hash_value: hash_value.clone(),
+                hash_method: *hash_method,
+                need_change,
+            },
+            _ => self.clone(),
+        }
+    }
+
     pub fn alter(
         &self,
         auth_type: &Option<String>,

--- a/src/query/sql/src/planner/binder/ddl/account.rs
+++ b/src/query/sql/src/planner/binder/ddl/account.rs
@@ -308,15 +308,18 @@ impl Binder {
             user_option.apply(option);
         }
 
-        // if `must_change_password` is set, user need to change password first
+        // If `must_change_password` is set, user need to change password first when login.
         let need_change = user_option
             .must_change_password()
             .cloned()
             .unwrap_or_default();
-        // None means no change to make
+
+        // None means auth info is not changed.
         let new_auth_info = if let Some(auth_option) = &auth_option {
-            // if user is changing self password, always set `need_change` as false.
+            // If user is changing self password, always set `need_change` as false,
             // because after this operation, the password is changed.
+            // And if user is changing other user's password,
+            // set `need_change` same as `must_change_password` option.
             let need_change = if user.is_none() { false } else { need_change };
             let auth_info = user_info.auth_info.alter2(
                 &auth_option.auth_type.clone().map(Into::into),
@@ -339,7 +342,8 @@ impl Binder {
                 Some(auth_info)
             }
         } else if need_change != user_info.auth_info.get_need_change() {
-            let new_auth_info = user_info.auth_info.create_set_need_change(need_change);
+            // If password is not changed, set `need_change` same as `must_change_password` option.
+            let new_auth_info = user_info.auth_info.create_with_need_change(need_change);
             Some(new_auth_info)
         } else {
             None

--- a/src/query/sql/src/planner/binder/ddl/account.rs
+++ b/src/query/sql/src/planner/binder/ddl/account.rs
@@ -302,23 +302,22 @@ impl Binder {
                 .await?
         };
 
+        // TODO: Only user with OWNERSHIP privilege can change user options.
         let mut user_option = user_info.option.clone();
         for option in user_options {
             user_option.apply(option);
         }
 
+        // if `must_change_password` is set, user need to change password first
+        let need_change = user_option
+            .must_change_password()
+            .cloned()
+            .unwrap_or_default();
         // None means no change to make
         let new_auth_info = if let Some(auth_option) = &auth_option {
-            // if `must_change_password` is set, user need to change password first,
-            // unless user is changing self password
-            let need_change = if user.is_none() {
-                false
-            } else {
-                user_option
-                    .must_change_password()
-                    .cloned()
-                    .unwrap_or_default()
-            };
+            // if user is changing self password, always set `need_change` as false.
+            // because after this operation, the password is changed.
+            let need_change = if user.is_none() { false } else { need_change };
             let auth_info = user_info.auth_info.alter2(
                 &auth_option.auth_type.clone().map(Into::into),
                 &auth_option.password,
@@ -339,6 +338,9 @@ impl Binder {
             } else {
                 Some(auth_info)
             }
+        } else if need_change != user_info.auth_info.get_need_change() {
+            let new_auth_info = user_info.auth_info.create_set_need_change(need_change);
+            Some(new_auth_info)
         } else {
             None
         };

--- a/tests/suites/0_stateless/18_rbac/18_0006_mysql_auth.py
+++ b/tests/suites/0_stateless/18_rbac/18_0006_mysql_auth.py
@@ -46,7 +46,6 @@ try:
         "alter user u5 with must_change_password = true;"
     )
 except mysql.connector.errors.OperationalError:
-except mysql.connector.errors.OperationalError:
     print("root@127.0.0.1 is timeout")
 
 try:

--- a/tests/suites/0_stateless/18_rbac/18_0006_mysql_auth.py
+++ b/tests/suites/0_stateless/18_rbac/18_0006_mysql_auth.py
@@ -39,6 +39,13 @@ try:
     cursor.execute(
         "create user u4 identified by 'abc123' with must_change_password = true;"
     )
+    cursor.execute(
+        "create user u5 identified by 'abc123';"
+    )
+    cursor.execute(
+        "alter user u5 with must_change_password = true;"
+    )
+except mysql.connector.errors.OperationalError:
 except mysql.connector.errors.OperationalError:
     print("root@127.0.0.1 is timeout")
 
@@ -167,3 +174,26 @@ try:
     cursor.execute("select 123;")
 except mysql.connector.errors.OperationalError:
     print("u4 is timeout")
+
+try:
+    mydb = mysql.connector.connect(
+        host="127.0.0.1", user="u5", passwd="abc123", port="3307", connection_timeout=3
+    )
+    cursor = mydb.cursor()
+    try:
+        cursor.execute("select 123;")
+    except mysql.connector.errors.DatabaseError as err:
+        print("can't execute with error: {}".format(str(err)))
+
+    cursor.execute("alter user user() identified by 'abc456';")
+except mysql.connector.errors.OperationalError:
+    print("u5 is timeout")
+
+try:
+    mydb = mysql.connector.connect(
+        host="127.0.0.1", user="u5", passwd="abc456", port="3307", connection_timeout=3
+    )
+    cursor = mydb.cursor()
+    cursor.execute("select 123;")
+except mysql.connector.errors.OperationalError:
+    print("u5 is timeout")

--- a/tests/suites/0_stateless/18_rbac/18_0006_mysql_auth.result
+++ b/tests/suites/0_stateless/18_rbac/18_0006_mysql_auth.result
@@ -4,3 +4,4 @@ u1 correct password locked out
 AuthenticateFailure: user u2 is disabled. Not allowed to login
 u3 is blocked by client ip
 can't execute with error: 1105 (HY000): NeedChangePasswordDenied. Code: 1066, Text = Must change password before execute other operations.
+can't execute with error: 1105 (HY000): NeedChangePasswordDenied. Code: 1066, Text = Must change password before execute other operations.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

If the administrator sets `MUST_CHANGE_PASSWORD` as true, the option takes effect immediately. The User must change the password at the next login.

- fixes: #[Link the issue here]


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16243)
<!-- Reviewable:end -->
