### PR TITLE
refactor(query): decrease information_schema.tables call union

### DIFF
--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -285,7 +285,7 @@ async fn test_simple_sql() -> Result<()> {
     assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
     assert_eq!(result.next_uri, Some(final_uri.clone()), "{:?}", result);
     assert_eq!(result.data.len(), 10, "{:?}", result);
-    assert_eq!(result.schema.len(), 20, "{:?}", result);
+    assert_eq!(result.schema.len(), 21, "{:?}", result);
 
     // get state
     let uri = result.stats_uri.unwrap();

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -428,6 +428,8 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'table_schema'                    | 'information_schema' | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'table_schema'                    | 'information_schema' | 'views'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'table_type'                      | 'information_schema' | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'table_type'                      | 'system'             | 'tables'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'table_type'                      | 'system'             | 'tables_with_history'  | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'table_version'                   | 'system'             | 'streams'              | 'Nullable(UInt64)'    | 'BIGINT UNSIGNED'   | ''       | ''       | 'YES'    | ''       |
 | 'tables'                          | 'system'             | 'query_log'            | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'target_features'                 | 'system'             | 'build_options'        | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -193,6 +193,7 @@ impl Binder {
             .with_order_by("name");
 
         select_builder.with_filter(format!("database = '{database}'"));
+        select_builder.with_filter("table_type = 'BASE TABLE'".to_string());
 
         let catalog_name = match catalog {
             None => self.ctx.get_current_catalog(),

--- a/src/query/storages/information_schema/src/tables_table.rs
+++ b/src/query/storages/information_schema/src/tables_table.rs
@@ -52,11 +52,11 @@ impl TablesTable {
     // | TABLE_COMMENT   | text                                                               | YES  |     | NULL    |       |
     // +-----------------+--------------------------------------------------------------------+------+-----+---------+-------+
     pub fn create(table_id: u64) -> Arc<dyn Table> {
-        let query = "SELECT * FROM (SELECT
+        let query = "SELECT
             database AS table_catalog,
             database AS table_schema,
             name AS table_name,
-            'BASE TABLE' AS table_type,
+            table_type AS table_type,
             engine AS engine,
             created_on AS create_time,
             dropped_on AS drop_time,
@@ -67,23 +67,7 @@ impl TablesTable {
             NULL AS table_collation,
             NULL AS data_free,
             comment AS table_comment
-        FROM system.tables union
-        SELECT
-            database AS table_catalog,
-            database AS table_schema,
-            name AS table_name,
-            'VIEW' AS table_type,
-            engine AS engine,
-            created_on AS create_time,
-            dropped_on AS drop_time,
-            0 AS data_length,
-            0 AS index_length,
-            0 AS table_rows,
-            NULL AS auto_increment,
-            NULL AS table_collation,
-            NULL AS data_free,
-            comment AS table_comment
-        FROM system.views) ORDER BY table_schema;";
+        FROM system.tables ORDER BY table_schema;";
 
         let mut options = BTreeMap::new();
         options.insert(QUERY.to_string(), query.to_string());

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -541,10 +541,10 @@ where TablesTable<WITH_HISTORY, WITHOUT_VIEW>: HistoryAware
         let tables_type: Vec<String> = database_tables
             .iter()
             .map(|v| {
-                if v.engine().to_uppercase() == "FUSE" {
-                    "BASE TABLE".to_string()
-                } else {
+                if v.engine().to_uppercase() == "VIEW" {
                     "VIEW".to_string()
+                } else {
+                    "BASE TABLE".to_string()
                 }
             })
             .collect();

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
@@ -77,6 +77,7 @@ number_of_blocks	BIGINT UNSIGNED	YES		NULL	NULL
 number_of_segments	BIGINT UNSIGNED	YES		NULL	NULL
 owner	VARCHAR	YES		NULL	NULL
 table_id	BIGINT UNSIGNED	NO		NULL	NULL
+table_type	VARCHAR	NO		NULL	NULL
 updated_on	TIMESTAMP	NO		NULL	NULL
 Error: APIError: ResponseError with 1063: Permission denied: User 'a'@'%' does not have the required privileges for database 'nogrant'
 1


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. system.tables add a new column `table_type` If table engine is FUSE, value is `BASE TABLE` else value is `VIEW`
2. system.tables store view name, decrease information_schema.tables call union;

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Do not affect existing tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16246)
<!-- Reviewable:end -->
