### PR TITLE
refactor: introduce new method `accurate_columns_ranges` to `Table`

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -296,6 +296,9 @@ pub trait Table: Sync + Send {
         Ok(Box::new(DummyColumnStatisticsProvider))
     }
 
+    /// - Returns `Some(_)`
+    ///    if table has accurate columns ranges information,
+    /// - Otherwise returns `None`.
     #[async_backtrace::framed]
     async fn accurate_columns_ranges(
         &self,

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -297,6 +297,15 @@ pub trait Table: Sync + Send {
     }
 
     #[async_backtrace::framed]
+    async fn accurate_columns_ranges(
+        &self,
+        _ctx: Arc<dyn TableContext>,
+        _column_ids: &[ColumnId],
+    ) -> Result<HashMap<ColumnId, ColumnRange>> {
+        Ok(HashMap::default())
+    }
+
+    #[async_backtrace::framed]
     async fn navigate_to(
         &self,
         navigation: &TimeNavigation,
@@ -607,4 +616,13 @@ impl CompactionLimits {
             block_limit: v,
         }
     }
+}
+
+pub struct Bound {
+    pub value: Scalar,
+    pub may_be_truncated: bool,
+}
+pub struct ColumnRange {
+    pub min: Bound,
+    pub max: Bound,
 }

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -301,8 +301,8 @@ pub trait Table: Sync + Send {
         &self,
         _ctx: Arc<dyn TableContext>,
         _column_ids: &[ColumnId],
-    ) -> Result<HashMap<ColumnId, ColumnRange>> {
-        Ok(HashMap::default())
+    ) -> Result<Option<HashMap<ColumnId, ColumnRange>>> {
+        Ok(None)
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -450,8 +450,8 @@ fn test_ft_stats_block_stats_string_columns_trimming() -> databend_common_except
         let data_value_min = Scalar::String(min_expr.clone());
         let data_value_max = Scalar::String(max_expr.clone());
 
-        let trimmed_min = data_value_min.clone().trim_min(STATS_STRING_PREFIX_LEN);
-        let trimmed_max = data_value_max.clone().trim_max(STATS_STRING_PREFIX_LEN);
+        let trimmed_min = data_value_min.clone().trim_min();
+        let trimmed_max = data_value_max.clone().trim_max();
 
         let meaningless_to_collect_max = is_degenerated_case(max_expr.as_str());
 

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -825,20 +825,20 @@ impl Table for FuseTable {
         &self,
         ctx: Arc<dyn TableContext>,
         column_ids: &[ColumnId],
-    ) -> Result<HashMap<ColumnId, ColumnRange>> {
+    ) -> Result<Option<HashMap<ColumnId, ColumnRange>>> {
         if column_ids.is_empty() {
-            return Ok(HashMap::new());
+            return Ok(Some(HashMap::new()));
         }
 
         let Some(snapshot) = self.read_table_snapshot().await? else {
-            return Ok(HashMap::new());
+            return Ok(Some(HashMap::new()));
         };
 
         let segment_locations = &snapshot.segments;
         let num_segments = snapshot.segments.len();
 
         if num_segments == 0 {
-            return Ok(HashMap::new());
+            return Ok(Some(HashMap::new()));
         }
 
         let column_ids: HashSet<&ColumnId, RandomState> = HashSet::from_iter(column_ids);
@@ -894,7 +894,7 @@ impl Table for FuseTable {
                 })
             })
             .collect();
-        Ok(r)
+        Ok(Some(r))
     }
 
     #[fastrace::trace]

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -15,6 +15,8 @@
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::hash::RandomState;
 use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -27,6 +29,8 @@ use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::ReclusterParts;
 use databend_common_catalog::plan::StreamColumn;
 use databend_common_catalog::table::AppendMode;
+use databend_common_catalog::table::Bound;
+use databend_common_catalog::table::ColumnRange;
 use databend_common_catalog::table::ColumnStatisticsProvider;
 use databend_common_catalog::table::CompactionLimits;
 use databend_common_catalog::table::NavigationDescriptor;
@@ -61,6 +65,7 @@ use databend_common_storage::StorageMetrics;
 use databend_common_storage::StorageMetricsLayer;
 use databend_storages_common_cache::LoadParams;
 use databend_storages_common_table_meta::meta::ClusterKey;
+use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::SnapshotId;
 use databend_storages_common_table_meta::meta::Statistics as FuseStatistics;
 use databend_storages_common_table_meta::meta::TableSnapshot;
@@ -86,11 +91,14 @@ use uuid::Uuid;
 use crate::fuse_column::FuseTableColumnStatisticsProvider;
 use crate::fuse_type::FuseTableType;
 use crate::io::MetaReaders;
+use crate::io::SegmentsIO;
 use crate::io::TableMetaLocationGenerator;
 use crate::io::TableSnapshotReader;
 use crate::io::WriteSettings;
 use crate::operations::ChangesDesc;
 use crate::operations::TruncateMode;
+use crate::statistics::reduce_block_statistics;
+use crate::statistics::Trim;
 use crate::FuseStorageFormat;
 use crate::NavigationPoint;
 use crate::Table;
@@ -810,6 +818,83 @@ impl Table for FuseTable {
             FuseTableColumnStatisticsProvider::default()
         };
         Ok(Box::new(provider))
+    }
+
+    #[async_backtrace::framed]
+    async fn accurate_columns_ranges(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        column_ids: &[ColumnId],
+    ) -> Result<HashMap<ColumnId, ColumnRange>> {
+        if column_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let Some(snapshot) = self.read_table_snapshot().await? else {
+            return Ok(HashMap::new());
+        };
+
+        let segment_locations = &snapshot.segments;
+        let num_segments = snapshot.segments.len();
+
+        if num_segments == 0 {
+            return Ok(HashMap::new());
+        }
+
+        let column_ids: HashSet<&ColumnId, RandomState> = HashSet::from_iter(column_ids);
+
+        let schema = self.schema();
+        let num_fields = schema.fields.len();
+        let segments_io = SegmentsIO::create(ctx.clone(), self.operator.clone(), schema);
+        let chunk_size = std::cmp::min(
+            ctx.get_settings().get_max_threads()? as usize * 4,
+            num_segments,
+        )
+        .max(1);
+
+        ctx.set_status_info(&format!(
+            "processing {} segments, chunk size {}",
+            num_segments, chunk_size
+        ));
+
+        // Fold column ranges of segments chunk by chunk
+        let mut reduced = HashMap::with_capacity(num_fields);
+
+        for (idx, chunk) in segment_locations.chunks(chunk_size).enumerate() {
+            let segments = segments_io
+                .read_segments::<Arc<CompactSegmentInfo>>(chunk, false)
+                .await?;
+            let mut partial_col_stats = Vec::with_capacity(chunk_size);
+            // 1. Carry the previously reduced ranges
+            partial_col_stats.push(reduced);
+            // 2. Append ranges of this chunk
+            for compacted_seg in segments.into_iter() {
+                let segment = compacted_seg?;
+                let mut cols_stats = segment.summary.col_stats.clone();
+                cols_stats.retain(|k, _| column_ids.contains(k));
+                partial_col_stats.push(cols_stats);
+            }
+            // 3. Reduces them
+            reduced = reduce_block_statistics(&partial_col_stats);
+            ctx.set_status_info(&format!("processed {} segments", (idx + 1) * chunk_size));
+        }
+
+        let r = reduced
+            .into_iter()
+            .map(|(k, v)| {
+                (k, ColumnRange {
+                    min: Bound {
+                        may_be_truncated: v.min.may_be_trimmed(),
+                        value: v.min,
+                    },
+                    max: Bound {
+                        may_be_truncated: v.max.may_be_trimmed(),
+                        value: v.max,
+                    },
+                })
+            })
+            .collect();
+        Ok(r)
     }
 
     #[fastrace::trace]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Introduce a new method `accurate_columns_ranges` to the `Table` trait, which returns the "accurate" ranges of the given columns.

The bounds of the column ranges are derived from the segment information of the given table, making them tight. However, for string-type columns, the bounds may have been truncated, which is indicated by the `may_be_truncated` field in the `Bound` struct.

`accurate_columns_ranges` is intended to be used later in the optimization of queries like `SELECT MIN/MAX(col) FROM t`.




## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16247)
<!-- Reviewable:end -->
