### PR TITLE
refactor: Use global http client to share the connection pool

### DIFF
--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -63,6 +63,12 @@ use crate::StorageConfig;
 static GLOBAL_HICKORY_RESOLVER: LazyLock<Arc<HickoryResolver>> =
     LazyLock::new(|| Arc::new(HickoryResolver::default()));
 
+static GLOBAL_HTTP_CLIENT: LazyLock<HttpClient> = LazyLock::new(|| {
+    new_storage_http_client().unwrap_or_else(|err| {
+        panic!("http client must be created successfully, but failed for {err}")
+    })
+});
+
 /// init_operator will init an opendal operator based on storage config.
 pub fn init_operator(cfg: &StorageParams) -> Result<Operator> {
     let op = match &cfg {
@@ -162,7 +168,7 @@ pub fn init_azblob_operator(cfg: &StorageAzblobConfig) -> Result<impl Builder> {
         // Credential
         .account_name(&cfg.account_name)
         .account_key(&cfg.account_key)
-        .http_client(new_storage_http_client()?);
+        .http_client(GLOBAL_HTTP_CLIENT.clone());
 
     Ok(builder)
 }
@@ -187,7 +193,7 @@ fn init_gcs_operator(cfg: &StorageGcsConfig) -> Result<impl Builder> {
         .bucket(&cfg.bucket)
         .root(&cfg.root)
         .credential(&cfg.credential)
-        .http_client(new_storage_http_client()?);
+        .http_client(GLOBAL_HTTP_CLIENT.clone());
 
     Ok(builder)
 }
@@ -284,7 +290,7 @@ fn init_s3_operator(cfg: &StorageS3Config) -> Result<impl Builder> {
         builder = builder.enable_virtual_host_style();
     }
 
-    builder = builder.http_client(new_storage_http_client()?);
+    builder = builder.http_client(GLOBAL_HTTP_CLIENT.clone());
 
     Ok(builder)
 }
@@ -301,7 +307,7 @@ fn init_obs_operator(cfg: &StorageObsConfig) -> Result<impl Builder> {
         // Credential
         .access_key_id(&cfg.access_key_id)
         .secret_access_key(&cfg.secret_access_key)
-        .http_client(new_storage_http_client()?);
+        .http_client(GLOBAL_HTTP_CLIENT.clone());
 
     Ok(builder)
 }
@@ -317,7 +323,7 @@ fn init_oss_operator(cfg: &StorageOssConfig) -> Result<impl Builder> {
         .root(&cfg.root)
         .server_side_encryption(&cfg.server_side_encryption)
         .server_side_encryption_key_id(&cfg.server_side_encryption_key_id)
-        .http_client(new_storage_http_client()?);
+        .http_client(GLOBAL_HTTP_CLIENT.clone());
 
     Ok(builder)
 }
@@ -350,7 +356,7 @@ fn init_cos_operator(cfg: &StorageCosConfig) -> Result<impl Builder> {
         .secret_key(&cfg.secret_key)
         .bucket(&cfg.bucket)
         .root(&cfg.root)
-        .http_client(new_storage_http_client()?);
+        .http_client(GLOBAL_HTTP_CLIENT.clone());
 
     Ok(builder)
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Utilize a global request client to share the connection pool. This change can prevent users from creating too many short-lived connections, which could exhaust the entire local port range in extreme cases.

NOTE: this is the default behavior of aws-sdk-sdk and we have already uses the same http client in our `DataOperator`. This change makes sure that all stage, external location table can use the same client.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16276)
<!-- Reviewable:end -->
