### PR TITLE
refactor: change `DatabaseInfo.meta` to `SeqV<DatabaseMeta>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3680,6 +3680,7 @@ dependencies = [
  "num-traits",
  "opendal",
  "paste",
+ "prost 0.12.6",
  "serde",
  "serde_json",
  "sha1",

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -95,7 +95,6 @@ use databend_common_meta_app::schema::DBIdTableName;
 use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DatabaseIdHistoryIdent;
 use databend_common_meta_app::schema::DatabaseIdToName;
-use databend_common_meta_app::schema::DatabaseIdent;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DatabaseInfoFilter;
 use databend_common_meta_app::schema::DatabaseMeta;
@@ -736,14 +735,10 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
 
         let name_key = &req.inner;
 
-        let (_, db_id, db_meta_seq, db_meta) =
-            get_db_or_err(self, name_key, "get_database").await?;
+        let (_, db_id, db_meta) = get_db_or_err(self, name_key, "get_database").await?;
 
         let db = DatabaseInfo {
-            ident: DatabaseIdent {
-                db_id,
-                seq: db_meta_seq,
-            },
+            database_id: DatabaseId::new(db_id),
             name_ident: name_key.clone(),
             meta: db_meta,
         };
@@ -814,12 +809,9 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                         }
 
                         let db = DatabaseInfo {
-                            ident: DatabaseIdent {
-                                db_id,
-                                seq: db_meta_seq,
-                            },
+                            database_id: DatabaseId::new(db_id),
                             name_ident: DatabaseNameIdent::new_from(db_id_list_key.clone()),
-                            meta: db_meta,
+                            meta: SeqV::new(db_meta_seq, db_meta),
                         };
 
                         db_info_list.push(Arc::new(db));
@@ -833,15 +825,15 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             // if `include_drop_db` is true, return all db info which not exist in db_info_list
             let db_id_set: HashSet<u64> = db_info_list
                 .iter()
-                .map(|db_info| db_info.ident.db_id)
+                .map(|db_info| db_info.database_id.db_id)
                 .collect();
 
             let all_dbs = self.list_databases(req).await?;
             for db_info in all_dbs {
-                if !db_id_set.contains(&db_info.ident.db_id) {
+                if !db_id_set.contains(&db_info.database_id.db_id) {
                     warn!(
                         "get db history db:{:?}, db_id:{:?} has no DbIdListKey",
-                        db_info.name_ident, db_info.ident.db_id
+                        db_info.name_ident, db_info.database_id.db_id
                     );
                     db_info_list.push(db_info);
                 }
@@ -850,22 +842,22 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             // if `include_drop_db` is false, filter out db which drop_on time out of retention time
             let db_id_set: HashSet<u64> = db_info_list
                 .iter()
-                .map(|db_info| db_info.ident.db_id)
+                .map(|db_info| db_info.database_id.db_id)
                 .collect();
 
             let all_dbs = self.list_databases(req).await?;
             let mut add_dbinfo_map = HashMap::new();
             let mut db_id_list = Vec::new();
             for db_info in all_dbs {
-                if !db_id_set.contains(&db_info.ident.db_id) {
+                if !db_id_set.contains(&db_info.database_id.db_id) {
                     warn!(
                         "get db history db:{:?}, db_id:{:?} has no DbIdListKey",
-                        db_info.name_ident, db_info.ident.db_id
+                        db_info.name_ident, db_info.database_id.db_id
                     );
                     db_id_list.push(DatabaseId {
-                        db_id: db_info.ident.db_id,
+                        db_id: db_info.database_id.db_id,
                     });
-                    add_dbinfo_map.insert(db_info.ident.db_id, db_info);
+                    add_dbinfo_map.insert(db_info.database_id.db_id, db_info);
                 }
             }
             let inner_keys: Vec<String> = db_id_list
@@ -891,7 +883,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                     if let Some(db_info) = add_dbinfo_map.get(&db_id) {
                         warn!(
                             "get db history db:{:?}, db_id:{:?} has no DbIdListKey",
-                            db_info.name_ident, db_info.ident.db_id
+                            db_info.name_ident, db_info.database_id.db_id
                         );
                         db_info_list.push(db_info.clone());
                     }
@@ -935,15 +927,12 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 let db_meta: DatabaseMeta = deserialize_struct(&seq_meta.data)?;
 
                 let db_info = DatabaseInfo {
-                    ident: DatabaseIdent {
-                        db_id: db_ids[i],
-                        seq: seq_meta.seq,
-                    },
+                    database_id: DatabaseId::new(db_ids[i]),
                     name_ident: DatabaseNameIdent::new(
                         name_key.tenant(),
                         tenant_dbnames[i].database_name(),
                     ),
-                    meta: db_meta,
+                    meta: SeqV::new(seq_meta.seq, db_meta),
                 };
                 db_infos.push(Arc::new(db_info));
             } else {
@@ -1895,11 +1884,10 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
 
             // Get db by name to ensure presence
 
-            let (_, db_id, db_meta_seq, db_meta) =
-                get_db_or_err(self, &tenant_dbname, "rename_table").await?;
+            let (_, db_id, db_meta) = get_db_or_err(self, &tenant_dbname, "rename_table").await?;
 
             // cannot operate on shared database
-            if let Some(from_share) = db_meta.from_share {
+            if let Some(from_share) = &db_meta.from_share {
                 return Err(KVAppError::AppError(AppError::ShareHasNoGrantedPrivilege(
                     ShareHasNoGrantedPrivilege::new(from_share.tenant_name(), from_share.name()),
                 )));
@@ -1978,7 +1966,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             // Get the renaming target db to ensure presence.
 
             let tenant_newdbname = DatabaseNameIdent::new(tenant_dbname.tenant(), &req.new_db_name);
-            let (_, new_db_id, new_db_meta_seq, new_db_meta) =
+            let (_, new_db_id, new_db_meta) =
                 get_db_or_err(self, &tenant_newdbname, "rename_table: new db").await?;
 
             // Get the renaming target table to ensure absence
@@ -2022,8 +2010,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                     condition: vec![
                         // db has not to change, i.e., no new table is created.
                         // Renaming db is OK and does not affect the seq of db_meta.
-                        txn_cond_seq(&DatabaseId { db_id }, Eq, db_meta_seq),
-                        txn_cond_seq(&DatabaseId { db_id: new_db_id }, Eq, new_db_meta_seq),
+                        txn_cond_seq(&DatabaseId { db_id }, Eq, db_meta.seq),
+                        txn_cond_seq(&DatabaseId { db_id: new_db_id }, Eq, new_db_meta.seq),
                         // table_name->table_id does not change.
                         // Updating the table meta is ok.
                         txn_cond_seq(&dbid_tbname, Eq, tb_id_seq),
@@ -2038,7 +2026,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                         txn_op_put(&newdbid_newtbname, serialize_u64(table_id)?), /* (db_id, new_tb_name) -> tb_id */
                         // Changing a table in a db has to update the seq of db_meta,
                         // to block the batch-delete-tables when deleting a db.
-                        txn_op_put(&DatabaseId { db_id }, serialize_struct(&db_meta)?), /* (db_id) -> db_meta */
+                        txn_op_put(&DatabaseId { db_id }, serialize_struct(&*db_meta)?), /* (db_id) -> db_meta */
                         txn_op_put(&dbid_tbname_idlist, serialize_struct(&tb_id_list)?), /* _fd_table_id_list/db_id/old_table_name -> tb_id_list */
                         txn_op_put(&new_dbid_tbname_idlist, serialize_struct(&new_tb_id_list)?), /* _fd_table_id_list/db_id/new_table_name -> tb_id_list */
                         txn_op_put(&table_id_to_name_key, serialize_struct(&db_id_table_name)?), /* __fd_table_id_to_name/db_id/table_name -> DBIdTableName */
@@ -2050,7 +2038,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                     txn.if_then.push(
                         txn_op_put(
                             &DatabaseId { db_id: new_db_id },
-                            serialize_struct(&new_db_meta)?,
+                            serialize_struct(&*new_db_meta)?,
                         ), // (db_id) -> db_meta
                     );
                 }
@@ -2150,7 +2138,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         )
         .await;
 
-        let (_db_id_seq, db_id, _db_meta_seq, db_meta) = match res {
+        let (_db_id_seq, db_id, db_meta) = match res {
             Ok(x) => x,
             Err(e) => {
                 return Err(e);
@@ -2242,7 +2230,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         )
         .await;
 
-        let (_db_id_seq, db_id, _db_meta_seq, _db_meta) = match res {
+        let (_db_id_seq, db_id, _db_meta) = match res {
             Ok(x) => x,
             Err(e) => {
                 return Err(e);
@@ -2370,17 +2358,17 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         )
         .await;
 
-        let (_db_id_seq, db_id, _db_meta_seq, db_meta) = match res {
+        let (_db_id_seq, db_id, db_meta) = match res {
             Ok(x) => x,
             Err(e) => {
                 return Err(e);
             }
         };
 
-        let tb_infos = match db_meta.from_share {
+        let tb_infos = match &db_meta.from_share {
             None => list_tables_from_unshare_db(self, db_id, tenant_dbname).await?,
             Some(share) => {
-                let share_ident = share.to_tident(());
+                let share_ident = share.clone().to_tident(());
                 error!(
                     "list_tables {:?} from share {:?}",
                     tenant_dbname, share_ident,
@@ -3185,7 +3173,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             )))
         } else {
             // up layer will retry
-            Ok(std::result::Result::Err(mismatched_tbs))
+            Ok(Err(mismatched_tbs))
         }
     }
 
@@ -3540,7 +3528,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                     // if limit is Some, append DroppedId::Db only when table_infos is empty
                     if drop_db && table_infos.is_empty() {
                         drop_ids.push(DroppedId::Db(
-                            db_info.ident.db_id,
+                            db_info.database_id.db_id,
                             db_info.name_ident.database_name().to_string(),
                         ));
                     }
@@ -3568,7 +3556,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                     );
                     if drop_db {
                         drop_ids.push(DroppedId::Db(
-                            db_info.ident.db_id,
+                            db_info.database_id.db_id,
                             db_info.name_ident.database_name().to_string(),
                         ));
                     }
@@ -3591,7 +3579,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         )
         .await;
 
-        let (_db_id_seq, db_id, db_meta_seq, db_meta) = match res {
+        let (_db_id_seq, db_id, db_meta) = match res {
             Ok(x) => x,
             Err(e) => {
                 return Err(e);
@@ -3607,10 +3595,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         }
 
         let db_info = Arc::new(DatabaseInfo {
-            ident: DatabaseIdent {
-                db_id,
-                seq: db_meta_seq,
-            },
+            database_id: DatabaseId::new(db_id),
             name_ident: req.inner.clone(),
             meta: db_meta,
         });
@@ -4752,7 +4737,7 @@ async fn drop_database_meta(
     )
     .await;
 
-    let (db_id_seq, db_id, db_meta_seq, mut db_meta) = match res {
+    let (db_id_seq, db_id, mut db_meta) = match res {
         Ok(x) => x,
         Err(e) => {
             if let KVAppError::AppError(AppError::UnknownDatabase(_)) = e {
@@ -4859,10 +4844,10 @@ async fn drop_database_meta(
             db_meta.drop_on = Some(Utc::now());
 
             txn.condition
-                .push(txn_cond_seq(&db_id_key, Eq, db_meta_seq));
+                .push(txn_cond_seq(&db_id_key, Eq, db_meta.seq));
 
             txn.if_then
-                .push(txn_op_put(&db_id_key, serialize_struct(&db_meta)?)); // (db_id) -> db_meta
+                .push(txn_op_put(&db_id_key, serialize_struct(&*db_meta)?)); // (db_id) -> db_meta
         }
 
         // add DbIdListKey if not exists
@@ -4987,7 +4972,7 @@ pub(crate) async fn get_db_or_err(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     name_key: &DatabaseNameIdent,
     msg: impl Display,
-) -> Result<(u64, u64, u64, DatabaseMeta), KVAppError> {
+) -> Result<(u64, u64, SeqV<DatabaseMeta>), KVAppError> {
     let (db_id_seq, db_id) = get_u64_value(kv_api, name_key).await?;
     db_has_to_exist(db_id_seq, name_key, &msg)?;
 
@@ -4999,9 +4984,8 @@ pub(crate) async fn get_db_or_err(
     Ok((
         db_id_seq,
         db_id,
-        db_meta_seq,
         // Safe unwrap(): db_meta_seq > 0 implies db_meta is not None.
-        db_meta.unwrap(),
+        SeqV::new(db_meta_seq, db_meta.unwrap()),
     ))
 }
 
@@ -5254,7 +5238,7 @@ async fn batch_filter_table_info(
             catalog_info: Default::default(),
         };
 
-        filter_tb_infos.push((Arc::new(tb_info), db_info.ident.db_id));
+        filter_tb_infos.push((Arc::new(tb_info), db_info.database_id.db_id));
     }
 
     Ok(())
@@ -5338,7 +5322,7 @@ async fn do_get_table_history(
         TableIdHistoryIdent,
     )> = vec![];
     let (filter, db_info) = db_filter;
-    let db_id = db_info.ident.db_id;
+    let db_id = db_info.database_id.db_id;
 
     // List tables by tenant, db_id, table_name.
     let dbid_tbname_idlist = TableIdHistoryIdent {
@@ -5362,7 +5346,7 @@ async fn do_get_table_history(
         .iter()
         .map(|(_, db_info, table_id_list_key)| {
             TableIdHistoryIdent {
-                database_id: db_info.ident.db_id,
+                database_id: db_info.database_id.db_id,
                 table_name: table_id_list_key.table_name.clone(),
             }
             .to_string_key()
@@ -5851,7 +5835,7 @@ pub(crate) trait UndropTableStrategy {
     async fn refresh_target_db_meta<'a>(
         &'a self,
         kv_api: &'a (impl kvapi::KVApi<Error = MetaError> + ?Sized),
-    ) -> Result<(u64, u64, DatabaseMeta), KVAppError>;
+    ) -> Result<(u64, SeqV<DatabaseMeta>), KVAppError>;
 
     fn extract_and_validate_table_id(
         &self,
@@ -5870,11 +5854,11 @@ impl UndropTableStrategy for UndropTableReq {
     async fn refresh_target_db_meta<'a>(
         &'a self,
         kv_api: &'a (impl kvapi::KVApi<Error = MetaError> + ?Sized),
-    ) -> Result<(u64, u64, DatabaseMeta), KVAppError> {
+    ) -> Result<(u64, SeqV<DatabaseMeta>), KVAppError> {
         // for plain un-drop table (by name), database meta is refreshed by name
-        let (_, db_id, db_meta_seq, db_meta) =
+        let (_, db_id, db_meta) =
             get_db_or_err(kv_api, &self.name_ident.db_name_ident(), "undrop_table").await?;
-        Ok((db_id, db_meta_seq, db_meta))
+        Ok((db_id, db_meta))
     }
 
     fn extract_and_validate_table_id(
@@ -5907,11 +5891,11 @@ impl UndropTableStrategy for UndropTableByIdReq {
     async fn refresh_target_db_meta<'a>(
         &'a self,
         kv_api: &'a (impl kvapi::KVApi<Error = MetaError> + ?Sized),
-    ) -> Result<(u64, u64, DatabaseMeta), KVAppError> {
+    ) -> Result<(u64, SeqV<DatabaseMeta>), KVAppError> {
         // for un-drop table by id, database meta is refreshed by database id
         let (db_meta_seq, db_meta) =
             get_db_by_id_or_err(kv_api, self.db_id, "undrop_table_by_id").await?;
-        Ok((self.db_id, db_meta_seq, db_meta))
+        Ok((self.db_id, SeqV::new(db_meta_seq, db_meta)))
     }
 
     fn extract_and_validate_table_id(
@@ -5942,10 +5926,10 @@ async fn handle_undrop_table(
 
         // Get db by name to ensure presence
 
-        let (db_id, db_meta_seq, db_meta) = req.refresh_target_db_meta(kv_api).await?;
+        let (db_id, db_meta) = req.refresh_target_db_meta(kv_api).await?;
 
         // cannot operate on shared database
-        if let Some(from_share) = db_meta.from_share {
+        if let Some(from_share) = &db_meta.from_share {
             return Err(KVAppError::AppError(AppError::ShareHasNoGrantedPrivilege(
                 ShareHasNoGrantedPrivilege::new(from_share.tenant_name(), from_share.name()),
             )));
@@ -6015,7 +5999,7 @@ async fn handle_undrop_table(
                 condition: vec![
                     // db has not to change, i.e., no new table is created.
                     // Renaming db is OK and does not affect the seq of db_meta.
-                    txn_cond_seq(&DatabaseId { db_id }, Eq, db_meta_seq),
+                    txn_cond_seq(&DatabaseId { db_id }, Eq, db_meta.seq),
                     // still this table id
                     txn_cond_seq(&dbid_tbname, Eq, dbid_tbname_seq),
                     // table is not changed
@@ -6024,7 +6008,7 @@ async fn handle_undrop_table(
                 if_then: vec![
                     // Changing a table in a db has to update the seq of db_meta,
                     // to block the batch-delete-tables when deleting a db.
-                    txn_op_put(&DatabaseId { db_id }, serialize_struct(&db_meta)?), /* (db_id) -> db_meta */
+                    txn_op_put(&DatabaseId { db_id }, serialize_struct(&*db_meta)?), /* (db_id) -> db_meta */
                     txn_op_put(&dbid_tbname, serialize_u64(table_id)?), /* (tenant, db_id, tb_name) -> tb_id */
                     // txn_op_put(&dbid_tbname_idlist, serialize_struct(&tb_id_list)?)?, // _fd_table_id_list/db_id/table_name -> tb_id_list
                     txn_op_put(&tbid, serialize_struct(&tb_meta)?), /* (tenant, db_id, tb_id) -> tb_meta */

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -668,7 +668,7 @@ impl SchemaApiTestSuite {
                 .await;
             debug!("get present database res: {:?}", res);
             let res = res?;
-            assert_eq!(1, res.ident.db_id, "db1 id is 1");
+            assert_eq!(1, res.database_id.db_id, "db1 id is 1");
             assert_eq!("db1", res.name_ident.database_name(), "db1.db is db1");
         }
 
@@ -752,7 +752,7 @@ impl SchemaApiTestSuite {
             assert_ne!(res.meta.engine, new_engine.to_string());
 
             let orig_db_id: u64 = get_kv_u64_data(mt.as_kv_api(), &db_name).await?;
-            assert_eq!(orig_db_id, res.ident.db_id);
+            assert_eq!(orig_db_id, res.database_id.db_id);
             let db_id_name_key = DatabaseIdToName { db_id: orig_db_id };
             let ret_db_name_ident: DatabaseNameIdentRaw =
                 get_kv_data(mt.as_kv_api(), &db_id_name_key).await?;
@@ -776,7 +776,7 @@ impl SchemaApiTestSuite {
             assert_eq!(res.meta.engine, new_engine.to_string());
 
             let db_id: u64 = get_kv_u64_data(mt.as_kv_api(), &db_name).await?;
-            assert_eq!(db_id, res.ident.db_id);
+            assert_eq!(db_id, res.database_id.db_id);
             let db_id_name_key = DatabaseIdToName { db_id };
             let ret_db_name_ident: DatabaseNameIdentRaw =
                 get_kv_data(mt.as_kv_api(), &db_id_name_key).await?;
@@ -918,7 +918,7 @@ impl SchemaApiTestSuite {
                 .await;
             debug!("get present database res: {:?}", res);
             let res = res?;
-            assert_eq!(1, res.ident.db_id, "db1 id is 1");
+            assert_eq!(1, res.database_id.db_id, "db1 id is 1");
             assert_eq!("db1", res.name_ident.database_name(), "db1.db is db1");
         }
 
@@ -1004,13 +1004,13 @@ impl SchemaApiTestSuite {
                 })
                 .await?;
 
-            let got = dbs.iter().map(|x| x.ident.db_id).collect::<Vec<_>>();
+            let got = dbs.iter().map(|x| x.database_id.db_id).collect::<Vec<_>>();
             assert_eq!(db_ids, got);
 
             for (i, db_info) in dbs.iter().enumerate() {
                 assert_eq!(tenant.tenant_name(), db_info.name_ident.tenant_name());
                 assert_eq!(db_names[i], db_info.name_ident.database_name());
-                assert_eq!(db_ids[i], db_info.ident.db_id);
+                assert_eq!(db_ids[i], db_info.database_id.db_id);
                 assert_eq!(engines[i], db_info.meta.engine);
             }
         }
@@ -1048,7 +1048,7 @@ impl SchemaApiTestSuite {
                     filter: None,
                 })
                 .await?;
-            let got = dbs.iter().map(|x| x.ident.db_id).collect::<Vec<_>>();
+            let got = dbs.iter().map(|x| x.database_id.db_id).collect::<Vec<_>>();
             assert_eq!(db_ids, got)
         }
 
@@ -1061,7 +1061,7 @@ impl SchemaApiTestSuite {
                 })
                 .await?;
             let want: Vec<u64> = vec![db_id_3];
-            let got = dbs.iter().map(|x| x.ident.db_id).collect::<Vec<_>>();
+            let got = dbs.iter().map(|x| x.database_id.db_id).collect::<Vec<_>>();
             assert_eq!(want, got)
         }
 
@@ -1154,7 +1154,7 @@ impl SchemaApiTestSuite {
                 .await;
             debug!("get present database res: {:?}", res);
             let res = res?;
-            assert_eq!(1, res.ident.db_id, "db3 id is 1");
+            assert_eq!(1, res.database_id.db_id, "db3 id is 1");
             assert_eq!("db3", res.name_ident.database_name(), "db3.db is db3");
 
             info!("--- get old database after rename");
@@ -1727,7 +1727,7 @@ impl SchemaApiTestSuite {
                 let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
                 let res = mt.create_table(req.clone()).await?;
                 let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-                assert!(old_db.ident.seq < cur_db.ident.seq);
+                assert!(old_db.meta.seq < cur_db.meta.seq);
                 assert!(res.table_id >= 1, "table id >= 1");
 
                 let tb_id = res.table_id;
@@ -1823,7 +1823,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let res = mt.create_table(req.clone()).await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
             assert!(
                 res.table_id > tb_ident_2.table_id,
                 "table id > {}",
@@ -2003,7 +2003,7 @@ impl SchemaApiTestSuite {
 
             // - verify other states are as expected
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
             assert!(create_table_as_dropped_resp.table_id >= 1, "table id >= 1");
 
             // -- verify this table is committpable
@@ -2188,7 +2188,7 @@ impl SchemaApiTestSuite {
             // check if get_database_history return db_id
             let mut found = false;
             for db_info in res {
-                if db_info.ident.db_id == util.db_id {
+                if db_info.database_id.db_id == util.db_id {
                     found = true;
                     break;
                 }
@@ -2320,7 +2320,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db1_name)).await?;
             mt.create_table(create_tb2_req.clone()).await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db1_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let req = GetTableReq::new(&tenant, db1_name, tb2_name);
             let got = mt.get_table(req).await?;
@@ -2332,7 +2332,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db1_name)).await?;
             mt.rename_table(rename_db1tb2_to_db1tb3(false)).await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db1_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let req = GetTableReq::new(&tenant, db1_name, tb3_name);
             let got = mt.get_table(req).await?;
@@ -2382,7 +2382,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db1_name)).await?;
             mt.create_table(create_tb2_req.clone()).await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db1_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let got = mt
                 .get_table((tenant_name, db1_name, tb2_name).into())
@@ -2469,8 +2469,8 @@ impl SchemaApiTestSuite {
             mt.rename_table(req.clone()).await?;
             let cur_db1 = mt.get_database(Self::req_get_db(&tenant, db1_name)).await?;
             let cur_db2 = mt.get_database(Self::req_get_db(&tenant, db2_name)).await?;
-            assert!(old_db1.ident.seq < cur_db1.ident.seq);
-            assert!(old_db2.ident.seq < cur_db2.ident.seq);
+            assert!(old_db1.meta.seq < cur_db1.meta.seq);
+            assert!(old_db2.meta.seq < cur_db2.meta.seq);
 
             let got = mt
                 .get_table((tenant_name, db2_name, tb3_name).into())
@@ -2548,7 +2548,7 @@ impl SchemaApiTestSuite {
                 let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
                 let res = mt.create_table(req.clone()).await?;
                 let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-                assert!(old_db.ident.seq < cur_db.ident.seq);
+                assert!(old_db.meta.seq < cur_db.meta.seq);
                 assert!(res.table_id >= 1, "table id >= 1");
                 let tb_id = res.table_id;
 
@@ -3193,7 +3193,7 @@ impl SchemaApiTestSuite {
                 let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
                 let res = mt.create_table(req.clone()).await?;
                 let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-                assert!(old_db.ident.seq < cur_db.ident.seq);
+                assert!(old_db.meta.seq < cur_db.meta.seq);
                 assert!(res.table_id >= 1, "table id >= 1");
                 let tb_id = res.table_id;
 
@@ -4003,7 +4003,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let res = mt.create_table(req.clone()).await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
             let table_id = res.table_id;
             assert!(table_id >= 1, "table id >= 1");
 
@@ -4654,7 +4654,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let res = mt.create_table(req.clone()).await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
@@ -4683,13 +4683,13 @@ impl SchemaApiTestSuite {
             mt.drop_table_by_id(DropTableByIdReq {
                 if_exists: false,
                 tenant: tbl_name_ident.tenant.clone(),
-                db_id: old_db.ident.db_id,
+                db_id: old_db.database_id.db_id,
                 table_name: tbl_name_ident.table_name.clone(),
                 tb_id,
             })
             .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
                 .get_table_history(ListTableReq::new(&tenant, db_name))
@@ -4711,7 +4711,7 @@ impl SchemaApiTestSuite {
             };
             mt.undrop_table(plan).await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
                 .get_table_history(ListTableReq::new(&tenant, db_name))
@@ -4734,13 +4734,13 @@ impl SchemaApiTestSuite {
             mt.drop_table_by_id(DropTableByIdReq {
                 if_exists: false,
                 tenant: tenant.clone(),
-                db_id: old_db.ident.db_id,
+                db_id: old_db.database_id.db_id,
                 table_name: tbl_name.to_string(),
                 tb_id,
             })
             .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
                 .get_table_history(ListTableReq::new(&tenant, db_name))
@@ -4766,7 +4766,7 @@ impl SchemaApiTestSuite {
                 })
                 .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
@@ -4791,13 +4791,13 @@ impl SchemaApiTestSuite {
             mt.drop_table_by_id(DropTableByIdReq {
                 if_exists: false,
                 tenant: tenant.clone(),
-                db_id: old_db.ident.db_id,
+                db_id: old_db.database_id.db_id,
                 table_name: tbl_name.to_string(),
                 tb_id: tb_info.ident.table_id,
             })
             .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
                 .get_table_history(ListTableReq::new(&tenant, db_name))
@@ -4818,7 +4818,7 @@ impl SchemaApiTestSuite {
             })
             .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
                 .get_table_history(ListTableReq::new(&tenant, db_name))
@@ -4861,7 +4861,7 @@ impl SchemaApiTestSuite {
                 .get_table_history(ListTableReq::new(&tenant, db_name))
                 .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {
@@ -4892,7 +4892,7 @@ impl SchemaApiTestSuite {
             let drop_plan = DropTableByIdReq {
                 if_exists: false,
                 tenant: tenant.clone(),
-                db_id: cur_db.ident.db_id,
+                db_id: cur_db.database_id.db_id,
                 table_name: tbl_name.to_string(),
                 tb_id: new_tb_info.ident.table_id,
             };
@@ -4900,7 +4900,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             mt.drop_table_by_id(drop_plan.clone()).await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
                 .get_table_history(ListTableReq::new(&tenant, db_name))
@@ -4937,7 +4937,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let _got = mt.rename_table(rename_dbtb_to_dbtb1(false)).await;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
                 .get_table_history(ListTableReq::new(&tenant, db_name))
@@ -5434,7 +5434,7 @@ impl SchemaApiTestSuite {
                 let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
                 let res = mt.create_table(req.clone()).await?;
                 let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-                assert!(old_db.ident.seq < cur_db.ident.seq);
+                assert!(old_db.meta.seq < cur_db.meta.seq);
                 assert!(res.table_id >= 1, "table id >= 1");
                 let tb_id = res.table_id;
 
@@ -5554,7 +5554,7 @@ impl SchemaApiTestSuite {
 
                 let db = mt.get_database(plan).await.unwrap();
 
-                let got = mt.get_db_name_by_id(db.ident.db_id).await?;
+                let got = mt.get_db_name_by_id(db.database_id.db_id).await?;
 
                 assert_eq!(got, db_name.to_string());
             }
@@ -5922,7 +5922,7 @@ impl SchemaApiTestSuite {
                 let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
                 let res = mt.create_table(req.clone()).await?;
                 let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-                assert!(old_db.ident.seq < cur_db.ident.seq);
+                assert!(old_db.meta.seq < cur_db.meta.seq);
                 assert!(res.table_id >= 1, "table id >= 1");
 
                 let tb_id1 = res.table_id;
@@ -5931,7 +5931,7 @@ impl SchemaApiTestSuite {
                 let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
                 let res = mt.create_table(req.clone()).await?;
                 let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
-                assert!(old_db.ident.seq < cur_db.ident.seq);
+                assert!(old_db.meta.seq < cur_db.meta.seq);
                 assert!(res.table_id > tb_id1, "table id > tb_id1: {}", tb_id1);
                 let tb_id2 = res.table_id;
 
@@ -6911,7 +6911,7 @@ impl SchemaApiTestSuite {
                 .await;
             debug!("get present database res: {:?}", res);
             let res = res?;
-            assert_eq!(1, res.ident.db_id, "db1 id is 1");
+            assert_eq!(1, res.database_id.db_id, "db1 id is 1");
             assert_eq!("db1", res.name_ident.database_name(), "db1.db is db1");
         }
 
@@ -6972,9 +6972,9 @@ impl SchemaApiTestSuite {
             debug!("get database list: {:?}", res);
             let res = res?;
             assert_eq!(2, res.len(), "database list len is 2");
-            assert_eq!(db_ids[0], res[0].ident.db_id, "db1 id");
+            assert_eq!(db_ids[0], res[0].database_id.db_id, "db1 id");
             assert_eq!("db1", res[0].name_ident.database_name(), "db1.name is db1");
-            assert_eq!(db_ids[1], res[1].ident.db_id, "db3 id");
+            assert_eq!(db_ids[1], res[1].database_id.db_id, "db3 id");
             assert_eq!("db3", res[1].name_ident.database_name(), "db3.name is db3");
         }
 
@@ -7037,7 +7037,7 @@ impl SchemaApiTestSuite {
                 let cur_db = node_a
                     .get_database(Self::req_get_db(&tenant, db_name))
                     .await?;
-                assert!(old_db.ident.seq < cur_db.ident.seq);
+                assert!(old_db.meta.seq < cur_db.meta.seq);
                 tb_ids.push(res.table_id);
             }
         }
@@ -7113,7 +7113,7 @@ impl SchemaApiTestSuite {
             let cur_db = node_a
                 .get_database(Self::req_get_db(&tenant, db_name))
                 .await?;
-            assert!(old_db.ident.seq < cur_db.ident.seq);
+            assert!(old_db.meta.seq < cur_db.meta.seq);
             res.table_id
         };
 
@@ -7386,7 +7386,7 @@ impl SchemaApiTestSuite {
             inner: db_name_ident.clone(),
         };
         let db_info = mt.get_database(get_db_req).await?;
-        let db_id = db_info.ident.db_id;
+        let db_id = db_info.database_id.db_id;
 
         let schema = || {
             Arc::new(TableSchema::new(vec![

--- a/src/meta/api/src/share_api_impl.rs
+++ b/src/meta/api/src/share_api_impl.rs
@@ -1780,7 +1780,7 @@ async fn get_share_object_seq_and_id(
     match obj_name {
         ShareGrantObjectName::Database(db_name) => {
             let name_key = DatabaseNameIdent::new(tenant.clone(), db_name);
-            let (_db_id_seq, db_id, db_meta_seq, db_meta) = get_db_or_err(
+            let (_db_id_seq, db_id, db_meta) = get_db_or_err(
                 kv_api,
                 &name_key,
                 format!("get_share_object_seq_and_id: {}", name_key.display()),
@@ -1798,7 +1798,7 @@ async fn get_share_object_seq_and_id(
                 ));
             }
             Ok((
-                ShareGrantObjectSeqAndId::Database(db_meta_seq, db_id, db_meta),
+                ShareGrantObjectSeqAndId::Database(db_meta.seq, db_id, db_meta.data),
                 ShareObject::Database(db_name.to_owned(), db_id),
             ))
         }

--- a/src/meta/app/Cargo.toml
+++ b/src/meta/app/Cargo.toml
@@ -32,6 +32,7 @@ num-derive = "0.3.3"
 num-traits = "0.2.15"
 opendal = { workspace = true }
 paste = { workspace = true }
+prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha1 = "0.10.5"

--- a/src/meta/app/src/primitive.rs
+++ b/src/meta/app/src/primitive.rs
@@ -14,9 +14,7 @@
 
 use std::ops::Deref;
 
-use databend_common_io::prelude::BufMut;
 use databend_common_meta_kvapi::kvapi;
-use prost::bytes::Buf;
 
 /// The identifier of an internal record used in an application upon [`kvapi::KVApi`],
 /// e.g. TableId, DatabaseId as a value.
@@ -131,7 +129,7 @@ mod prost_message_impl {
         #[test]
         fn test_id_as_protobuf_message() {
             let mut v: u64 = 1;
-            for i in 0..200 {
+            for _i in 0..200 {
                 v = v.wrapping_mul(7);
 
                 let id = Id(v);

--- a/src/meta/app/src/primitive.rs
+++ b/src/meta/app/src/primitive.rs
@@ -14,11 +14,18 @@
 
 use std::ops::Deref;
 
+use databend_common_io::prelude::BufMut;
 use databend_common_meta_kvapi::kvapi;
+use prost::bytes::Buf;
 
-/// The identifier of a internal record used in an application upon kvapi::KVApi.
+/// The identifier of an internal record used in an application upon [`kvapi::KVApi`],
+/// e.g. TableId, DatabaseId as a value.
 ///
-/// E.g. TableId, DatabaseId.
+/// When an id is used as a key in a key-value store,
+/// it is serialized in another way to keep order.
+///
+/// `Id` implements `prost::Message` so that it can be used as a protobuf message.
+/// Although internally it uses JSON encoding.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id(pub u64);
 
@@ -47,5 +54,95 @@ impl Deref for Id {
 impl kvapi::Value for Id {
     fn dependency_keys(&self) -> impl IntoIterator<Item = String> {
         []
+    }
+}
+
+/// Implement `prost::Message` for `Id`, but internally use JSON encoding.
+///
+/// This enables `Id` to be used as a protobuf message,
+/// so that the upper level code can be simplified to using just one trait `prost::Message` to access meta-service data.
+mod prost_message_impl {
+    use prost::bytes::Buf;
+    use prost::bytes::BufMut;
+    use prost::encoding::DecodeContext;
+    use prost::encoding::WireType;
+    use prost::DecodeError;
+
+    use crate::primitive::Id;
+
+    impl prost::Message for Id {
+        fn encode_raw<B>(&self, buf: &mut B)
+        where
+            B: BufMut,
+            Self: Sized,
+        {
+            serde_json::to_writer(buf.writer(), &self.0).unwrap();
+        }
+
+        fn decode<B>(mut buf: B) -> Result<Self, DecodeError>
+        where
+            B: Buf,
+            Self: Default,
+        {
+            let mut b = [0; 64];
+            let len = buf.remaining();
+            if len > b.len() {
+                return Err(DecodeError::new(format!(
+                    "buffer(len={}) is too large, max={}",
+                    len,
+                    b.len()
+                )));
+            }
+
+            buf.copy_to_slice(&mut b[..len]);
+            let id = serde_json::from_slice(&b[..len])
+                .map_err(|e| DecodeError::new(format!("failed to decode u64 as json: {}", e)))?;
+            Ok(Id::new(id))
+        }
+
+        fn merge_field<B>(
+            &mut self,
+            _tag: u32,
+            _wire_type: WireType,
+            _buf: &mut B,
+            _ctx: DecodeContext,
+        ) -> Result<(), DecodeError>
+        where
+            B: Buf,
+            Self: Sized,
+        {
+            unimplemented!("`decode()` is implemented so we do not need this")
+        }
+
+        fn encoded_len(&self) -> usize {
+            format!("{}", self.0).len()
+        }
+
+        fn clear(&mut self) {
+            self.0 = 0;
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+
+        use crate::primitive::Id;
+
+        #[test]
+        fn test_id_as_protobuf_message() {
+            let mut v: u64 = 1;
+            for i in 0..200 {
+                v = v.wrapping_mul(7);
+
+                let id = Id(v);
+                let mut buf = Vec::new();
+                prost::Message::encode(&id, &mut buf).unwrap();
+                let expected = format!("{}", v);
+                assert_eq!(buf, expected.as_bytes());
+
+                let id2: Id = prost::Message::decode(buf.as_ref()).unwrap();
+                assert_eq!(id, id2);
+            }
+        }
     }
 }

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -21,6 +21,7 @@ use std::ops::Deref;
 
 use chrono::DateTime;
 use chrono::Utc;
+use databend_common_meta_types::SeqV;
 
 use super::CreateOption;
 use crate::schema::database_name_ident::DatabaseNameIdent;
@@ -35,15 +36,9 @@ use crate::KeyWithTenant;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DatabaseInfo {
-    pub ident: DatabaseIdent,
+    pub database_id: DatabaseId,
     pub name_ident: DatabaseNameIdent,
-    pub meta: DatabaseMeta,
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct DatabaseIdent {
-    pub db_id: u64,
-    pub seq: u64,
+    pub meta: SeqV<DatabaseMeta>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
@@ -145,6 +140,17 @@ impl Display for DatabaseMeta {
 impl DatabaseInfo {
     pub fn engine(&self) -> &str {
         &self.meta.engine
+    }
+
+    /// Create a new database info without id or meta seq.
+    ///
+    /// Usually such an instance is used for an external database, whose metadata is not stored in databend meta-service.
+    pub fn without_id_seq(name_ident: DatabaseNameIdent, meta: DatabaseMeta) -> Self {
+        Self {
+            database_id: DatabaseId::new(0),
+            name_ident,
+            meta: SeqV::new(0, meta),
+        }
     }
 }
 

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -40,7 +40,7 @@ pub struct DatabaseInfo {
     pub meta: DatabaseMeta,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatabaseIdent {
     pub db_id: u64,
     pub seq: u64,

--- a/src/meta/app/src/schema/mod.rs
+++ b/src/meta/app/src/schema/mod.rs
@@ -46,7 +46,6 @@ pub use database::CreateDatabaseReply;
 pub use database::CreateDatabaseReq;
 pub use database::DatabaseId;
 pub use database::DatabaseIdToName;
-pub use database::DatabaseIdent;
 pub use database::DatabaseInfo;
 pub use database::DatabaseInfoFilter;
 pub use database::DatabaseMeta;

--- a/src/meta/types/src/seq_value.rs
+++ b/src/meta/types/src/seq_value.rs
@@ -14,6 +14,8 @@
 
 use std::convert::TryInto;
 use std::fmt::Formatter;
+use std::ops::Deref;
+use std::ops::DerefMut;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -97,6 +99,20 @@ pub struct SeqV<T = Vec<u8>> {
     pub seq: u64,
     pub meta: Option<KVMeta>,
     pub data: T,
+}
+
+impl<T> Deref for SeqV<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<T> DerefMut for SeqV<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
 }
 
 impl<V> SeqValue<V> for SeqV<V> {

--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -183,7 +183,7 @@ impl StreamHandler for RealStreamHandler {
                     tenant,
                     table_name: stream_name.clone(),
                     tb_id: table.get_id(),
-                    db_id: db.get_db_info().ident.db_id,
+                    db_id: db.get_db_info().database_id.db_id,
                 })
                 .await
         } else if plan.if_exists {

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -346,7 +346,7 @@ impl Catalog for DatabaseCatalog {
             .list_databases(tenant)
             .await?
             .iter()
-            .map(|sys_db| sys_db.get_db_info().ident.db_id)
+            .map(|sys_db| sys_db.get_db_info().database_id.db_id)
             .collect();
 
         let mut_db_ids: Vec<MetaId> = db_ids

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -218,9 +218,9 @@ impl Catalog for ImmutableCatalog {
     }
 
     async fn get_db_name_by_id(&self, db_id: MetaId) -> Result<String> {
-        if self.sys_db.get_db_info().ident.db_id == db_id {
+        if self.sys_db.get_db_info().database_id.db_id == db_id {
             Ok("system".to_string())
-        } else if self.info_schema_db.get_db_info().ident.db_id == db_id {
+        } else if self.info_schema_db.get_db_info().database_id.db_id == db_id {
             Ok("information_schema".to_string())
         } else {
             Err(ErrorCode::UnknownDatabaseId(format!(
@@ -237,9 +237,9 @@ impl Catalog for ImmutableCatalog {
     ) -> Result<Vec<Option<String>>> {
         let mut res = Vec::new();
         for id in db_ids {
-            if self.sys_db.get_db_info().ident.db_id == *id {
+            if self.sys_db.get_db_info().database_id.db_id == *id {
                 res.push(Some("system".to_string()));
-            } else if self.info_schema_db.get_db_info().ident.db_id == *id {
+            } else if self.info_schema_db.get_db_info().database_id.db_id == *id {
                 res.push(Some("information_schema".to_string()));
             }
         }

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -43,7 +43,7 @@ use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::CreateVirtualColumnReply;
 use databend_common_meta_app::schema::CreateVirtualColumnReq;
-use databend_common_meta_app::schema::DatabaseIdent;
+use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::schema::DatabaseType;
@@ -266,12 +266,10 @@ impl Catalog for MutableCatalog {
 
         // Initial the database after creating.
         let db_info = Arc::new(DatabaseInfo {
-            ident: DatabaseIdent {
-                db_id: res.db_id,
-                seq: 0, // TODO
-            },
+            database_id: DatabaseId::new(res.db_id),
             name_ident: req.name_ident.clone(),
-            meta: req.meta.clone(),
+            // TODO create_database should return meta seq
+            meta: SeqV::new(0, req.meta.clone()),
         });
         let database = self.build_db_instance(&db_info)?;
         database.init_database(req.name_ident.tenant_name()).await?;

--- a/src/query/service/src/catalogs/share/share_catalog.rs
+++ b/src/query/service/src/catalogs/share/share_catalog.rs
@@ -48,7 +48,6 @@ use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::CreateVirtualColumnReply;
 use databend_common_meta_app::schema::CreateVirtualColumnReq;
-use databend_common_meta_app::schema::DatabaseIdent;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::schema::DatabaseType;
@@ -242,15 +241,14 @@ impl ShareCatalog {
         let share_endpoint = &share_option.share_endpoint;
         let provider = &share_option.provider;
 
-        DatabaseInfo {
-            ident: DatabaseIdent::default(),
-            name_ident: DatabaseNameIdent::new(
+        DatabaseInfo::without_id_seq(
+            DatabaseNameIdent::new(
                 Tenant {
                     tenant: provider.to_owned(),
                 },
                 &database.name,
             ),
-            meta: DatabaseMeta {
+            DatabaseMeta {
                 engine: "SHARE".to_string(),
                 engine_options: BTreeMap::new(),
                 options: BTreeMap::new(),
@@ -263,7 +261,7 @@ impl ShareCatalog {
                 using_share_endpoint: Some(share_endpoint.to_owned()),
                 from_share_db_id: Some(ShareDbId::Usage(database.id)),
             },
-        }
+        )
     }
 }
 

--- a/src/query/service/src/databases/information_schema/information_schema_database.rs
+++ b/src/query/service/src/databases/information_schema/information_schema_database.rs
@@ -15,10 +15,11 @@
 use std::sync::Arc;
 
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
-use databend_common_meta_app::schema::DatabaseIdent;
+use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::tenant::Tenant;
+use databend_common_meta_types::SeqV;
 use databend_common_storages_information_schema::ColumnsTable;
 use databend_common_storages_information_schema::KeyColumnUsageTable;
 use databend_common_storages_information_schema::KeywordsTable;
@@ -55,15 +56,12 @@ impl InformationSchemaDatabase {
         }
 
         let db_info = DatabaseInfo {
-            ident: DatabaseIdent {
-                db_id: sys_db_meta.next_db_id(),
-                seq: 0,
-            },
+            database_id: DatabaseId::new(sys_db_meta.next_db_id()),
             name_ident: DatabaseNameIdent::new(Tenant::new_literal("dummy"), db),
-            meta: DatabaseMeta {
+            meta: SeqV::new(0, DatabaseMeta {
                 engine: "SYSTEM".to_string(),
                 ..Default::default()
-            },
+            }),
         };
 
         Self { db_info }

--- a/src/query/service/src/databases/system/system_database.rs
+++ b/src/query/service/src/databases/system/system_database.rs
@@ -17,10 +17,11 @@ use std::sync::Arc;
 
 use databend_common_config::InnerConfig;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
-use databend_common_meta_app::schema::DatabaseIdent;
+use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::tenant::Tenant;
+use databend_common_meta_types::SeqV;
 use databend_common_storages_system::BackgroundJobTable;
 use databend_common_storages_system::BackgroundTaskTable;
 use databend_common_storages_system::BacktraceTable;
@@ -155,15 +156,12 @@ impl SystemDatabase {
         }
 
         let db_info = DatabaseInfo {
-            ident: DatabaseIdent {
-                db_id: sys_db_meta.next_db_id(),
-                seq: 0,
-            },
+            database_id: DatabaseId::new(sys_db_meta.next_db_id()),
             name_ident: DatabaseNameIdent::new(Tenant::new_literal("dummy"), "system"),
-            meta: DatabaseMeta {
+            meta: SeqV::new(0, DatabaseMeta {
                 engine: "SYSTEM".to_string(),
                 ..Default::default()
-            },
+            }),
         };
 
         Self { db_info }

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -112,7 +112,7 @@ impl PrivilegeAccess {
                     .get_database(&tenant, db_name)
                     .await?
                     .get_db_info()
-                    .ident
+                    .database_id
                     .db_id;
                 OwnershipObject::Database {
                     catalog_name: catalog_name.clone(),
@@ -135,7 +135,7 @@ impl PrivilegeAccess {
                     .get_database(&tenant, db_name)
                     .await?
                     .get_db_info()
-                    .ident
+                    .database_id
                     .db_id;
                 let table_id = if !disable_table_info_refresh {
                     self.ctx
@@ -615,7 +615,7 @@ impl PrivilegeAccess {
             .get_database(tenant, database_name)
             .await?
             .get_db_info()
-            .ident
+            .database_id
             .db_id;
         if let Some(table_name) = table_name {
             let table_id = if !disable_table_info_refresh {

--- a/src/query/service/src/interpreters/interpreter_database_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_database_drop.rs
@@ -60,7 +60,7 @@ impl Interpreter for DropDatabaseInterpreter {
             let role_api = UserApiProvider::instance().role_api(&tenant);
             let owner_object = OwnershipObject::Database {
                 catalog_name: self.plan.catalog.clone(),
-                db_id: db.get_db_info().ident.db_id,
+                db_id: db.get_db_info().database_id.db_id,
             };
 
             role_api.revoke_ownership(&owner_object).await?;

--- a/src/query/service/src/interpreters/interpreter_privilege_grant.rs
+++ b/src/query/service/src/interpreters/interpreter_privilege_grant.rs
@@ -60,7 +60,7 @@ impl GrantPrivilegeInterpreter {
                     .get_database(tenant, db_name)
                     .await?
                     .get_db_info()
-                    .ident
+                    .database_id
                     .db_id;
                 Ok(OwnershipObject::Database {
                     catalog_name,
@@ -74,7 +74,7 @@ impl GrantPrivilegeInterpreter {
                     .get_database(tenant, db_name)
                     .await?
                     .get_db_info()
-                    .ident
+                    .database_id
                     .db_id;
                 let table_id = catalog
                     .get_table(tenant, db_name.as_str(), table_name)

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -367,7 +367,7 @@ impl CreateTableInterpreter {
         if let Some(current_role) = self.ctx.get_current_role() {
             let tenant = self.ctx.get_tenant();
             let db = catalog.get_database(&tenant, &self.plan.database).await?;
-            let db_id = db.get_db_info().ident.db_id;
+            let db_id = db.get_db_info().database_id.db_id;
 
             let role_api = UserApiProvider::instance().role_api(&tenant);
             role_api

--- a/src/query/service/src/interpreters/interpreter_table_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop.rs
@@ -123,7 +123,7 @@ impl Interpreter for DropTableInterpreter {
                 tenant: tenant.clone(),
                 table_name: tbl_name.to_string(),
                 tb_id: tbl.get_table_info().ident.table_id,
-                db_id: db.get_db_info().ident.db_id,
+                db_id: db.get_db_info().database_id.db_id,
             })
             .await?;
 
@@ -133,7 +133,7 @@ impl Interpreter for DropTableInterpreter {
         let role_api = UserApiProvider::instance().role_api(&self.plan.tenant);
         let owner_object = OwnershipObject::Table {
             catalog_name: self.plan.catalog.clone(),
-            db_id: db.get_db_info().ident.db_id,
+            db_id: db.get_db_info().database_id.db_id,
             table_id,
         };
 

--- a/src/query/service/src/interpreters/interpreter_view_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_view_drop.rs
@@ -92,7 +92,7 @@ impl Interpreter for DropViewInterpreter {
                     tenant: self.plan.tenant.clone(),
                     table_name: self.plan.view_name.clone(),
                     tb_id: table.get_id(),
-                    db_id: db.get_db_info().ident.db_id,
+                    db_id: db.get_db_info().database_id.db_id,
                 })
                 .await?;
         };

--- a/src/query/service/src/table_functions/show_grants/show_grants_table.rs
+++ b/src/query/service/src/table_functions/show_grants/show_grants_table.rs
@@ -575,7 +575,7 @@ async fn show_object_grant(
                 .get_database(&tenant, db_name)
                 .await?
                 .get_db_info()
-                .ident
+                .database_id
                 .db_id;
             let table_id = catalog.get_table(&tenant, db_name, name).await?.get_id();
             if !visibility_checker.check_table_visibility(
@@ -608,7 +608,7 @@ async fn show_object_grant(
                 .get_database(&tenant, name)
                 .await?
                 .get_db_info()
-                .ident
+                .database_id
                 .db_id;
             if !visibility_checker.check_database_visibility(catalog_name, name, db_id) {
                 return Err(ErrorCode::PermissionDenied(format!(

--- a/src/query/service/tests/it/catalogs/database_catalog.rs
+++ b/src/query/service/tests/it/catalogs/database_catalog.rs
@@ -190,7 +190,7 @@ async fn test_catalogs_table() -> Result<()> {
                 tenant: tenant.clone(),
                 table_name: "test_table".to_string(),
                 tb_id: tbl.get_table_info().ident.table_id,
-                db_id: db.get_db_info().ident.db_id,
+                db_id: db.get_db_info().database_id.db_id,
             })
             .await;
         assert!(res.is_ok());

--- a/src/query/sql/src/planner/binder/ddl/account.rs
+++ b/src/query/sql/src/planner/binder/ddl/account.rs
@@ -108,7 +108,7 @@ impl Binder {
                 // ALL PRIVILEGES have different available privileges set on different grant objects
                 // Now in this case all is always true.
                 let grant_object = self.convert_to_revoke_grant_object(level).await?;
-                // Note if old version `grant all on db.*/db.t to user`, the user will contains ownership privilege.
+                // Note if old version `grant all on db.*/db.t to user`, the user will contain ownership privilege.
                 // revoke all need to revoke it.
                 let principal: PrincipalIdentity = principal.clone().into();
                 let priv_types = match &principal {
@@ -156,7 +156,7 @@ impl Binder {
                     .get_database(&tenant, &database_name)
                     .await?
                     .get_db_info()
-                    .ident
+                    .database_id
                     .db_id;
                 let table_id = catalog
                     .get_table(&tenant, &database_name, table_name)
@@ -172,7 +172,7 @@ impl Binder {
                     .get_database(&tenant, &database_name)
                     .await?
                     .get_db_info()
-                    .ident
+                    .database_id
                     .db_id;
                 Ok(GrantObject::DatabaseById(catalog_name, db_id))
             }
@@ -201,7 +201,7 @@ impl Binder {
                     .get_database(&tenant, &database_name)
                     .await?
                     .get_db_info()
-                    .ident
+                    .database_id
                     .db_id;
                 let table_id = catalog
                     .get_table(&tenant, &database_name, table_name)
@@ -220,7 +220,7 @@ impl Binder {
                     .get_database(&tenant, &database_name)
                     .await?
                     .get_db_info()
-                    .ident
+                    .database_id
                     .db_id;
                 Ok(vec![
                     GrantObject::DatabaseById(catalog_name.clone(), db_id),

--- a/src/query/sql/src/planner/binder/ddl/dynamic_table.rs
+++ b/src/query/sql/src/planner/binder/ddl/dynamic_table.rs
@@ -73,7 +73,7 @@ impl Binder {
             let db = catalog
                 .get_database(&self.ctx.get_tenant(), &database)
                 .await?;
-            let db_id = db.get_db_info().ident.db_id;
+            let db_id = db.get_db_info().database_id.db_id;
             options.insert(OPT_KEY_DATABASE_ID.to_owned(), db_id.to_string());
 
             for table_option in table_options.iter() {

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -586,7 +586,7 @@ impl Binder {
             let db = catalog
                 .get_database(&self.ctx.get_tenant(), &database)
                 .await?;
-            let db_id = db.get_db_info().ident.db_id;
+            let db_id = db.get_db_info().database_id.db_id;
             options.insert(OPT_KEY_DATABASE_ID.to_owned(), db_id.to_string());
 
             let config = GlobalConfig::instance();

--- a/src/query/storages/hive/hive/src/converters.rs
+++ b/src/query/storages/hive/hive/src/converters.rs
@@ -23,7 +23,6 @@ use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
 use databend_common_meta_app::schema::CatalogInfo;
-use databend_common_meta_app::schema::DatabaseIdent;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::schema::TableIdent;
@@ -43,18 +42,17 @@ use crate::hive_table_options::HiveTableOptions;
 impl From<hms::Database> for HiveDatabase {
     fn from(hms_database: hms::Database) -> Self {
         HiveDatabase {
-            database_info: DatabaseInfo {
-                ident: DatabaseIdent { db_id: 0, seq: 0 },
-                name_ident: DatabaseNameIdent::new(
+            database_info: DatabaseInfo::without_id_seq(
+                DatabaseNameIdent::new(
                     Tenant::new_literal("dummy"),
                     hms_database.name.unwrap_or_default().to_string(),
                 ),
-                meta: DatabaseMeta {
+                DatabaseMeta {
                     engine: HIVE_DATABASE_ENGINE.to_owned(),
                     created_on: Utc::now(),
                     ..Default::default()
                 },
-            },
+            ),
         }
     }
 }

--- a/src/query/storages/iceberg/src/database.rs
+++ b/src/query/storages/iceberg/src/database.rs
@@ -22,10 +22,11 @@ use databend_common_catalog::table::Table;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
-use databend_common_meta_app::schema::DatabaseIdent;
+use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::tenant::Tenant;
+use databend_common_meta_types::SeqV;
 
 use crate::table::IcebergTable;
 use crate::IcebergCatalog;
@@ -42,14 +43,14 @@ impl IcebergDatabase {
     pub fn create(ctl: IcebergCatalog, name: &str) -> Self {
         let ident = iceberg::NamespaceIdent::new(name.to_string());
         let info = DatabaseInfo {
-            ident: DatabaseIdent { db_id: 0, seq: 0 },
+            database_id: DatabaseId::new(0),
             name_ident: DatabaseNameIdent::new(Tenant::new_literal("dummy"), name),
-            meta: DatabaseMeta {
+            meta: SeqV::new(0, DatabaseMeta {
                 engine: "iceberg".to_string(),
                 created_on: chrono::Utc::now(),
                 updated_on: chrono::Utc::now(),
                 ..Default::default()
-            },
+            }),
         };
 
         Self { ctl, info, ident }

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -280,7 +280,7 @@ pub(crate) async fn dump_tables(
     if databases.is_empty() {
         let all_databases = catalog.list_databases(&tenant).await?;
         for db in all_databases {
-            let db_id = db.get_db_info().ident.db_id;
+            let db_id = db.get_db_info().database_id.db_id;
             let db_name = db.name();
             if visibility_checker.check_database_visibility(CATALOG_DEFAULT, db_name, db_id) {
                 final_dbs.push((db_name.to_string(), db_id));
@@ -292,7 +292,7 @@ pub(crate) async fn dump_tables(
                 .get_database(&tenant, &db)
                 .await?
                 .get_db_info()
-                .ident
+                .database_id
                 .db_id;
             if visibility_checker.check_database_visibility(CATALOG_DEFAULT, &db, db_id) {
                 final_dbs.push((db.to_string(), db_id));

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -81,7 +81,7 @@ impl AsyncSystemTable for DatabasesTable {
                     visibility_checker.check_database_visibility(
                         &ctl_name,
                         db.name(),
-                        db.get_db_info().ident.db_id,
+                        db.get_db_info().database_id.db_id,
                     )
                 })
                 .collect::<Vec<_>>();
@@ -90,7 +90,7 @@ impl AsyncSystemTable for DatabasesTable {
                 catalog_names.push(ctl_name.clone());
                 let db_name = db.name().to_string();
                 db_names.push(db_name);
-                let id = db.get_db_info().ident.db_id;
+                let id = db.get_db_info().database_id.db_id;
                 db_id.push(id);
                 owners.push(
                     user_api

--- a/src/query/storages/system/src/indexes_table.rs
+++ b/src/query/storages/system/src/indexes_table.rs
@@ -165,7 +165,7 @@ impl IndexesTable {
                     visibility_checker.check_database_visibility(
                         &ctl_name,
                         db.name(),
-                        db.get_db_info().ident.db_id,
+                        db.get_db_info().database_id.db_id,
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -180,7 +180,7 @@ impl IndexesTable {
 
         let mut index_tables = Vec::new();
         for db in dbs {
-            let db_id = db.get_db_info().ident.db_id;
+            let db_id = db.get_db_info().database_id.db_id;
             let db_name = db.name();
 
             let tables = match catalog.list_tables(&tenant, db_name).await {

--- a/src/query/storages/system/src/streams_table.rs
+++ b/src/query/storages/system/src/streams_table.rs
@@ -151,7 +151,7 @@ impl<const T: bool> AsyncSystemTable for StreamsTable<T> {
                     visibility_checker.check_database_visibility(
                         ctl_name,
                         db.name(),
-                        db.get_db_info().ident.db_id,
+                        db.get_db_info().database_id.db_id,
                     )
                 })
                 .collect::<Vec<_>>();
@@ -165,7 +165,7 @@ impl<const T: bool> AsyncSystemTable for StreamsTable<T> {
             let mut source_db_ids = vec![];
             let mut source_tb_ids = vec![];
             for db in final_dbs {
-                let db_id = db.get_db_info().ident.db_id;
+                let db_id = db.get_db_info().database_id.db_id;
                 let db_name = db.name();
                 let tables = match ctl.list_tables(&tenant, db_name).await {
                     Ok(tables) => tables,

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -376,7 +376,7 @@ where TablesTable<WITH_HISTORY, WITHOUT_VIEW>: HistoryAware
                     visibility_checker.check_database_visibility(
                         ctl_name,
                         db.name(),
-                        db.get_db_info().ident.db_id,
+                        db.get_db_info().database_id.db_id,
                     )
                 })
                 .collect::<Vec<_>>();
@@ -387,7 +387,7 @@ where TablesTable<WITH_HISTORY, WITHOUT_VIEW>: HistoryAware
                 HashMap::new()
             };
             for db in final_dbs {
-                let db_id = db.get_db_info().ident.db_id;
+                let db_id = db.get_db_info().database_id.db_id;
                 let db_name = db.name();
                 let tables = if tables_names.is_empty()
                     || tables_names.len() > 10


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: change `DatabaseInfo.meta` to `SeqV<DatabaseMeta>`

This commit updates `DatabaseInfo.meta` from `DatabaseMeta` to
`SeqV<DatabaseMeta>` to store the sequence number alongside the
instance. This change improves code clarity and reduces the potential
for errors.


##### chore: DatabaseIdent does not need to be serde


##### feat: make Id a prost::Message so that it can be used a meta-service Value

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)


- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16295)
<!-- Reviewable:end -->
