### PR TITLE
chore: add setting auto_compaction_segments_limit

### DIFF
--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -94,8 +94,9 @@ async fn do_hook_compact(
             // for mutations other than Insertions, we use an empirical value of 3 segments as the
             // limit for compaction. to be refined later.
                 {
+                    let auto_compaction_segments_limit = ctx.get_settings().get_auto_compaction_segments_limit()?;
                     CompactionLimits {
-                        segment_limit: Some(3),
+                        segment_limit: Some(auto_compaction_segments_limit as usize),
                         block_limit: None,
                     }
                 }

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -577,6 +577,12 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
+                ("auto_compaction_segments_limit", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(3),
+                    desc: "The maximum number of segments that can be compacted automatically triggered after write(replace-into/merge-into).",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(2..=u64::MAX)),
+                }),
                 ("use_parquet2", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "This setting is deprecated",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -508,6 +508,10 @@ impl Settings {
         self.try_set_u64("auto_compaction_imperfect_blocks_threshold", val)
     }
 
+    pub fn get_auto_compaction_segments_limit(&self) -> Result<u64> {
+        self.try_get_u64("auto_compaction_segments_limit")
+    }
+
     pub fn get_use_parquet2(&self) -> Result<bool> {
         Ok(self.try_get_u64("use_parquet2")? != 0)
     }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0040_auto_compaction_issue_15760.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0040_auto_compaction_issue_15760.test
@@ -43,9 +43,22 @@ statement ok
 insert into t values(1);
 
 
+# fourth block(after compaction)
+statement ok
+set auto_compaction_segments_limit = 2;
+
+statement ok
+insert into t values(1);
+
+statement ok
+replace into t on(c) values(2);
+
 query III
 select segment_count , block_count , row_count from fuse_snapshot('i15760', 't') limit 20;
 ----
+2 4 11
+3 5 11
+2 4 10
 1 3 9
 4 5 9
 3 4 8


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`auto_compaction_segments_limit`: default is 3. The maximum number of segments that can be compacted automatically triggered after write(replace-into/merge-into).

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16298)
<!-- Reviewable:end -->
