### PR TITLE
refactor: adopt `get_pb()` for get_background_task

### DIFF
--- a/src/meta/api/src/share_api_impl.rs
+++ b/src/meta/api/src/share_api_impl.rs
@@ -1780,14 +1780,14 @@ async fn get_share_object_seq_and_id(
     match obj_name {
         ShareGrantObjectName::Database(db_name) => {
             let name_key = DatabaseNameIdent::new(tenant.clone(), db_name);
-            let (_db_id_seq, db_id, db_meta) = get_db_or_err(
+            let (seq_db_id, seq_db_meta) = get_db_or_err(
                 kv_api,
                 &name_key,
                 format!("get_share_object_seq_and_id: {}", name_key.display()),
             )
             .await?;
 
-            if grant && db_meta.from_share.is_some() {
+            if grant && seq_db_meta.from_share.is_some() {
                 return Err(KVAppError::AppError(
                     AppError::CannotShareDatabaseCreatedFromShare(
                         CannotShareDatabaseCreatedFromShare::new(
@@ -1798,8 +1798,12 @@ async fn get_share_object_seq_and_id(
                 ));
             }
             Ok((
-                ShareGrantObjectSeqAndId::Database(db_meta.seq, db_id, db_meta.data),
-                ShareObject::Database(db_name.to_owned(), db_id),
+                ShareGrantObjectSeqAndId::Database(
+                    seq_db_meta.seq,
+                    *seq_db_id.data,
+                    seq_db_meta.data,
+                ),
+                ShareObject::Database(db_name.to_owned(), *seq_db_id.data),
             ))
         }
 

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -183,7 +183,7 @@ where
     K::ValueType: FromToProto,
 {
     let res = kv_api.get_pb(k).await?;
-    Ok((res.seq(), res.value()))
+    Ok((res.seq(), res.into_value()))
 }
 
 /// Batch get values that are encoded with FromToProto.

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -84,6 +84,7 @@ use databend_common_meta_types::MetaError;
 use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::SeqV;
+use databend_common_meta_types::SeqValue;
 use databend_common_meta_types::TxnCondition;
 use databend_common_meta_types::TxnGetResponse;
 use databend_common_meta_types::TxnOp;
@@ -181,13 +182,8 @@ where
     K: kvapi::Key,
     K::ValueType: FromToProto,
 {
-    let res = kv_api.get_kv(&k.to_string_key()).await?;
-
-    if let Some(seq_v) = res {
-        Ok((seq_v.seq, Some(deserialize_struct(&seq_v.data)?)))
-    } else {
-        Ok((0, None))
-    }
+    let res = kv_api.get_pb(k).await?;
+    Ok((res.seq(), res.value()))
 }
 
 /// Batch get values that are encoded with FromToProto.

--- a/src/meta/raft-store/src/marked/mod.rs
+++ b/src/meta/raft-store/src/marked/mod.rs
@@ -83,6 +83,17 @@ impl<T> SeqValue<T> for Marked<T> {
         }
     }
 
+    fn into_value(self) -> Option<T> {
+        match self {
+            Marked::TombStone { internal_seq: _ } => None,
+            Marked::Normal {
+                internal_seq: _,
+                value,
+                meta: _,
+            } => Some(value),
+        }
+    }
+
     fn meta(&self) -> Option<&KVMeta> {
         match self {
             Marked::TombStone { .. } => None,

--- a/src/meta/types/src/seq_value.rs
+++ b/src/meta/types/src/seq_value.rs
@@ -27,6 +27,7 @@ use crate::EvalExpireTime;
 pub trait SeqValue<V = Vec<u8>> {
     fn seq(&self) -> u64;
     fn value(&self) -> Option<&V>;
+    fn into_value(self) -> Option<V>;
     fn meta(&self) -> Option<&KVMeta>;
 
     /// Return the expire time in millisecond since 1970.
@@ -124,6 +125,10 @@ impl<V> SeqValue<V> for SeqV<V> {
         Some(&self.data)
     }
 
+    fn into_value(self) -> Option<V> {
+        Some(self.data)
+    }
+
     fn meta(&self) -> Option<&KVMeta> {
         self.meta.as_ref()
     }
@@ -136,6 +141,10 @@ impl<V> SeqValue<V> for Option<SeqV<V>> {
 
     fn value(&self) -> Option<&V> {
         self.as_ref().and_then(|v| v.value())
+    }
+
+    fn into_value(self) -> Option<V> {
+        self.map(|v| v.data)
     }
 
     fn meta(&self) -> Option<&KVMeta> {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: adopt `get_pb()` for get_background_task


##### refactor: get_db_or_error returns SeqV<T>

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16308)
<!-- Reviewable:end -->
