### PR TITLE
feat: login and renew return session_token_validity_in_secs too.

### DIFF
--- a/src/query/service/src/servers/http/v1/session/login_handler.rs
+++ b/src/query/service/src/servers/http/v1/session/login_handler.rs
@@ -25,6 +25,7 @@ use poem::IntoResponse;
 use crate::servers::http::error::QueryError;
 use crate::servers::http::v1::session::client_session_manager::ClientSessionManager;
 use crate::servers::http::v1::session::client_session_manager::REFRESH_TOKEN_VALIDITY;
+use crate::servers::http::v1::session::client_session_manager::SESSION_TOKEN_VALIDITY;
 use crate::servers::http::v1::HttpQueryContext;
 
 #[derive(Deserialize, Clone)]
@@ -42,6 +43,7 @@ pub enum LoginResponse {
         session_id: String,
         session_token: String,
         refresh_token: String,
+        session_token_validity_in_secs: u64,
         refresh_token_validity_in_secs: u64,
     },
     Error {
@@ -101,6 +103,7 @@ pub async fn login_handler(
             session_id,
             session_token: token_pair.session,
             refresh_token: token_pair.refresh,
+            session_token_validity_in_secs: SESSION_TOKEN_VALIDITY.as_secs(),
             refresh_token_validity_in_secs: REFRESH_TOKEN_VALIDITY.as_secs(),
         })),
         Err(e) => Ok(Json(LoginResponse::Error {

--- a/src/query/service/src/servers/http/v1/session/renew_handler.rs
+++ b/src/query/service/src/servers/http/v1/session/renew_handler.rs
@@ -51,7 +51,7 @@ pub async fn renew_handler(
     let refresh_token = ctx
         .databend_token
         .as_ref()
-        .expect("/session/renew should be authed by databend token")
+        .expect("/session/renew should be authed by refresh token")
         .clone();
     match ClientSessionManager::instance()
         .new_token_pair(

--- a/src/query/service/src/servers/http/v1/session/renew_handler.rs
+++ b/src/query/service/src/servers/http/v1/session/renew_handler.rs
@@ -22,6 +22,7 @@ use crate::servers::http::error::QueryError;
 use crate::servers::http::v1::session::client_session_manager::ClientSessionManager;
 use crate::servers::http::v1::session::client_session_manager::TokenPair;
 use crate::servers::http::v1::session::client_session_manager::REFRESH_TOKEN_VALIDITY;
+use crate::servers::http::v1::session::client_session_manager::SESSION_TOKEN_VALIDITY;
 use crate::servers::http::v1::HttpQueryContext;
 
 #[derive(Deserialize, Clone)]
@@ -35,6 +36,7 @@ pub enum RenewResponse {
     Ok {
         session_token: String,
         refresh_token: String,
+        session_token_validity_in_secs: u64,
         refresh_token_validity_in_secs: u64,
     },
     Error {
@@ -66,6 +68,7 @@ pub async fn renew_handler(
         Ok((_, token_pair)) => Ok(Json(RenewResponse::Ok {
             session_token: token_pair.session,
             refresh_token: token_pair.refresh,
+            session_token_validity_in_secs: SESSION_TOKEN_VALIDITY.as_secs(),
             refresh_token_validity_in_secs: REFRESH_TOKEN_VALIDITY.as_secs(),
         })),
         Err(e) => Ok(Json(RenewResponse::Error {

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -78,9 +78,9 @@ pub struct SessionContext {
     txn_mgr: Mutex<TxnManagerRef>,
     temp_tbl_mgr: Mutex<TempTblMgrRef>,
     /// The uniq id for session from the perspective of client.
-    /// for HTTP handler, client session lives longer then the `Session` object. the uniq id is
-    /// http handler: should set the id in session token, if token is not used, session id is not available,
-    ///
+    /// for HTTP handler, client session lives longer then the `Session` object, the id is generated in response of /v1/session/login,
+    /// and carried in session and refresh token. If token is not used, client session id is not available,
+    /// some features like temp table will be unavailable.
     /// for mysql handler: simple use set id of `Session`
     client_session_id: RwLock<Option<String>>,
 }

--- a/tests/suites/1_stateful/09_http_handler/09_0007_token.result
+++ b/tests/suites/1_stateful/09_http_handler/09_0007_token.result
@@ -4,6 +4,7 @@
  'refresh_token_validity_in_secs',
  'session_id',
  'session_token',
+ 'session_token_validity_in_secs',
  'version']
 14400
 ---- do_query('select 1',)
@@ -25,7 +26,10 @@
 {'code': 5103, 'message': 'session token not found'}
 ---- do_renew(1,)
 200
-['refresh_token', 'refresh_token_validity_in_secs', 'session_token']
+['refresh_token',
+ 'refresh_token_validity_in_secs',
+ 'session_token',
+ 'session_token_validity_in_secs']
 14400
 ---- do_query('select 6',)
 200


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

so client can choose to try renew before request, in case some requests is not easy to retry (e.g.  upload a a stream as a file).

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16313)
<!-- Reviewable:end -->
