### PR TITLE
feat: Check essential permissions when creating table with external location 

### DIFF
--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -1693,7 +1693,8 @@ impl Binder {
     }
 }
 
-const VERIFICATION_KEY: &'static str = "_v_d77aa11285c22e0e1d4593a035c98c0d";
+const VERIFICATION_KEY: &str = "_v_d77aa11285c22e0e1d4593a035c98c0d";
+const VERIFICATION_KEY_DEL: &str = "_v_d77aa11285c22e0e1d4593a035c98c0d_del";
 // verify that essential privileges has granted for accessing external location
 async fn verify_external_location_privileges(dal: Operator) -> Result<()> {
     // verify privilege to put
@@ -1710,6 +1711,11 @@ async fn verify_external_location_privileges(dal: Operator) -> Result<()> {
     // verify privilege to list
     if let Err(e) = dal.list(VERIFICATION_KEY).await {
         errors.push(format!("Permission check for [List] failed: {}", e));
+    }
+
+    // verify privilege to delete (del something not exist)
+    if let Err(e) = dal.delete(VERIFICATION_KEY_DEL).await {
+        errors.push(format!("Permission check for [Delete] failed: {}", e));
     }
 
     if errors.is_empty() {

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -469,7 +469,9 @@ impl Binder {
                     "".to_string()
                 };
 
-                // verify essential privileges
+                // Verify essential privileges.
+                // The permission check might fail for reasons other than the permissions themselves,
+                // such as network communication issues.
                 verify_external_location_privileges(data_operator.operator()).await?;
                 (Some(sp), fp)
             }

--- a/tests/sqllogictests/suites/base/06_show/06_0001_show_create_table.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0001_show_create_table.test
@@ -44,13 +44,16 @@ SHOW CREATE TABLE `test`.`c`
 ----
 c CREATE TABLE c ( a INT NOT NULL ) ENGINE=FUSE CLUSTER BY (a, a % 3) COMPRESSION='lz4' STORAGE_FORMAT='parquet'
 
+statement error 4000
+CREATE TABLE test.should_fail (a int not null) ENGINE=FUSE 's3://load/files/' CONNECTION=(access_key_id='1a2b3c' aws_secret_key='4x5y6z') CLUSTER BY (a, a % 3) COMPRESSION='lz4' STORAGE_FORMAT='parquet'
+
 statement ok
-CREATE TABLE test.d (a int not null) ENGINE=FUSE 's3://load/files/' CONNECTION=(access_key_id='1a2b3c' aws_secret_key='4x5y6z') CLUSTER BY (a, a % 3) COMPRESSION='lz4' STORAGE_FORMAT='parquet'
+CREATE TABLE test.d (a int not null) ENGINE=FUSE 'fs:///tmp/load/files/' CONNECTION=(access_key_id='1a2b3c' aws_secret_key='4x5y6z') CLUSTER BY (a, a % 3) COMPRESSION='lz4' STORAGE_FORMAT='parquet'
 
 query TT
 SHOW CREATE TABLE `test`.`d`
 ----
-d CREATE TABLE d ( a INT NOT NULL ) ENGINE=FUSE CLUSTER BY (a, a % 3) COMPRESSION='lz4' STORAGE_FORMAT='parquet' LOCATION = 's3 | bucket=load,root=/files/,endpoint=https://s3.amazonaws.com'
+d CREATE TABLE d ( a INT NOT NULL ) ENGINE=FUSE CLUSTER BY (a, a % 3) COMPRESSION='lz4' STORAGE_FORMAT='parquet' LOCATION = 'fs | root=/tmp/load/files/'
 
 query TT
 SHOW CREATE TABLE `test`.`c`

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_ctas.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_ctas.test
@@ -55,8 +55,11 @@ statement ok
 create stage ctas_stage url='fs:///tmp/ctas/';
 
 
-# the data of dropped table should be purged:
-# list the stage, an empty result-set should be return
+# The data of the dropped table should be purged:
+# Listing the stage should return an empty result set,
+# except for the verification key '_v_d77aa11285c22e0e1d4593a035c98c0d',
+# which is 1 byte in size.
+
 query TT
 SELECT name, size FROM LIST_STAGE(location => '@ctas_stage')
 ----

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_ctas.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_ctas.test
@@ -57,8 +57,10 @@ create stage ctas_stage url='fs:///tmp/ctas/';
 
 # the data of dropped table should be purged:
 # list the stage, an empty result-set should be return
-query T
-list @ctas_stage;
+query TT
+SELECT name, size FROM LIST_STAGE(location => '@ctas_stage')
+----
+_v_d77aa11285c22e0e1d4593a035c98c0d 1
 
 statement ok
 drop database ctas_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Check essential permissions(put/get/list/del/stat) when creating table with external location.

### Note:

- The permission check might fail due to reasons other than the permissions themselves
  
  Such as network communication issues that could not be resolved in time. In such cases, it will still be considered a permission checking failure.

- A specified verification key `_v_d77aa11285c22e0e1d4593a035c98c0d` will be left at the external location.   
  
  Please note that running `vacuum drop table` will **not** remove this key from the external location.  There might be multiple tables under the sample external location.

   

- fixes: #16293

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16315)
<!-- Reviewable:end -->
