### PR TITLE
fix: uri path used as both path and root.

### DIFF
--- a/src/query/sql/src/planner/binder/location.rs
+++ b/src/query/sql/src/planner/binder/location.rs
@@ -220,7 +220,7 @@ fn parse_ipfs_params(l: &mut UriLocation, root: String) -> Result<StorageParams>
         .unwrap_or_else(|| STORAGE_IPFS_DEFAULT_ENDPOINT.to_string());
     let sp = StorageParams::Ipfs(StorageIpfsConfig {
         endpoint_url: secure_omission(endpoint),
-        root: "/ipfs/".to_string() + root.as_str(),
+        root: "/ipfs".to_string() + root.as_str(),
     });
 
     l.connection

--- a/src/query/sql/tests/location.rs
+++ b/src/query/sql/tests/location.rs
@@ -53,8 +53,8 @@ async fn test_parse_uri_location() -> Result<()> {
             "secure scheme by default",
             UriLocation::new(
                 "ipfs".to_string(),
+                "".to_string(),
                 "too-naive".to_string(),
-                "/".to_string(),
                 "".to_string(),
                 vec![("endpoint_url", "ipfs.filebase.io")]
                     .into_iter()
@@ -64,9 +64,9 @@ async fn test_parse_uri_location() -> Result<()> {
             (
                 StorageParams::Ipfs(StorageIpfsConfig {
                     endpoint_url: "https://ipfs.filebase.io".to_string(),
-                    root: "/ipfs/too-naive".to_string(),
+                    root: "/ipfs/".to_string(),
                 }),
-                "/".to_string(),
+                "too-naive".to_string(),
             ),
         ),
         (
@@ -124,25 +124,25 @@ async fn test_parse_uri_location() -> Result<()> {
             "ipfs-default-endpoint",
             UriLocation::new(
                 "ipfs".to_string(),
+                "".to_string(),
                 "too-simple".to_string(),
-                "/".to_string(),
                 "".to_string(),
                 BTreeMap::new(),
             ),
             (
                 StorageParams::Ipfs(StorageIpfsConfig {
                     endpoint_url: STORAGE_IPFS_DEFAULT_ENDPOINT.to_string(),
-                    root: "/ipfs/too-simple".to_string(),
+                    root: "/ipfs/".to_string(),
                 }),
-                "/".to_string(),
+                "too-simple".to_string(),
             ),
         ),
         (
             "ipfs-change-endpoint",
             UriLocation::new(
                 "ipfs".to_string(),
+                "".to_string(),
                 "too-naive".to_string(),
-                "/".to_string(),
                 "".to_string(),
                 vec![("endpoint_url", "https://ipfs.filebase.io")]
                     .into_iter()
@@ -152,9 +152,9 @@ async fn test_parse_uri_location() -> Result<()> {
             (
                 StorageParams::Ipfs(StorageIpfsConfig {
                     endpoint_url: "https://ipfs.filebase.io".to_string(),
-                    root: "/ipfs/too-naive".to_string(),
+                    root: "/ipfs/".to_string(),
                 }),
-                "/".to_string(),
+                "too-naive".to_string(),
             ),
         ),
         (


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


https://github.com/datafuselabs/databend/issues/16304

@Xuanwo is this a mistake or for some reason?  It is surprising that this bug didn’t cause any issues before.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16321)
<!-- Reviewable:end -->
