### PR TITLE
fix: When Replacing column mask, old `name->id->value` should be completely deleted

### DIFF
--- a/src/meta/api/src/data_mask_api.rs
+++ b/src/meta/api/src/data_mask_api.rs
@@ -14,10 +14,11 @@
 
 use databend_common_meta_app::data_mask::CreateDatamaskReply;
 use databend_common_meta_app::data_mask::CreateDatamaskReq;
-use databend_common_meta_app::data_mask::DropDatamaskReply;
-use databend_common_meta_app::data_mask::DropDatamaskReq;
-use databend_common_meta_app::data_mask::GetDatamaskReply;
-use databend_common_meta_app::data_mask::GetDatamaskReq;
+use databend_common_meta_app::data_mask::DataMaskId;
+use databend_common_meta_app::data_mask::DataMaskNameIdent;
+use databend_common_meta_app::data_mask::DatamaskMeta;
+use databend_common_meta_types::MetaError;
+use databend_common_meta_types::SeqV;
 
 use crate::kv_app_error::KVAppError;
 
@@ -28,7 +29,15 @@ pub trait DatamaskApi: Send + Sync {
         req: CreateDatamaskReq,
     ) -> Result<CreateDatamaskReply, KVAppError>;
 
-    async fn drop_data_mask(&self, req: DropDatamaskReq) -> Result<DropDatamaskReply, KVAppError>;
+    /// On success, returns the dropped id and data mask.
+    /// Returning None, means nothing is removed.
+    async fn drop_data_mask(
+        &self,
+        name_ident: &DataMaskNameIdent,
+    ) -> Result<Option<(SeqV<DataMaskId>, SeqV<DatamaskMeta>)>, KVAppError>;
 
-    async fn get_data_mask(&self, req: GetDatamaskReq) -> Result<GetDatamaskReply, KVAppError>;
+    async fn get_data_mask(
+        &self,
+        name_ident: &DataMaskNameIdent,
+    ) -> Result<Option<SeqV<DatamaskMeta>>, MetaError>;
 }

--- a/src/meta/api/src/kv_app_error.rs
+++ b/src/meta/api/src/kv_app_error.rs
@@ -18,6 +18,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::app_error::TenantIsEmpty;
 use databend_common_meta_stoerr::MetaStorageError;
+use databend_common_meta_types::InvalidArgument;
 use databend_common_meta_types::InvalidReply;
 use databend_common_meta_types::MetaAPIError;
 use databend_common_meta_types::MetaClientError;
@@ -84,6 +85,13 @@ impl From<MetaNetworkError> for KVAppError {
     fn from(e: MetaNetworkError) -> Self {
         let meta_err = MetaError::from(e);
         Self::MetaError(meta_err)
+    }
+}
+
+impl From<InvalidArgument> for KVAppError {
+    fn from(value: InvalidArgument) -> Self {
+        let network_error = MetaNetworkError::from(value);
+        Self::MetaError(MetaError::from(network_error))
     }
 }
 

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -36,7 +36,6 @@ use databend_common_meta_app::data_mask::CreateDatamaskReq;
 use databend_common_meta_app::data_mask::DataMaskIdIdent;
 use databend_common_meta_app::data_mask::DataMaskNameIdent;
 use databend_common_meta_app::data_mask::DatamaskMeta;
-use databend_common_meta_app::data_mask::DropDatamaskReq;
 use databend_common_meta_app::data_mask::MaskPolicyTableIdListIdent;
 use databend_common_meta_app::data_mask::MaskpolicyTableIdList;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
@@ -2866,22 +2865,28 @@ impl SchemaApiTestSuite {
             let req = CreateDatamaskReq {
                 create_option: CreateOption::CreateIfNotExists,
                 name: DataMaskNameIdent::new(tenant.clone(), mask_name_1.to_string()),
-                args: vec![],
-                return_type: "".to_string(),
-                body: "".to_string(),
-                comment: None,
-                create_on: created_on,
+                data_mask_meta: DatamaskMeta {
+                    args: vec![],
+                    return_type: "".to_string(),
+                    body: "".to_string(),
+                    comment: None,
+                    create_on: created_on,
+                    update_on: None,
+                },
             };
             mt.create_data_mask(req).await?;
 
             let req = CreateDatamaskReq {
                 create_option: CreateOption::CreateIfNotExists,
                 name: DataMaskNameIdent::new(tenant.clone(), mask_name_2.to_string()),
-                args: vec![],
-                return_type: "".to_string(),
-                body: "".to_string(),
-                comment: None,
-                create_on: created_on,
+                data_mask_meta: DatamaskMeta {
+                    args: vec![],
+                    return_type: "".to_string(),
+                    body: "".to_string(),
+                    comment: None,
+                    create_on: created_on,
+                    update_on: None,
+                },
             };
             mt.create_data_mask(req).await?;
         }
@@ -3059,12 +3064,9 @@ impl SchemaApiTestSuite {
 
         info!("--- drop mask policy check");
         {
-            let req = DropDatamaskReq {
-                if_exists: true,
-                name: DataMaskNameIdent::new(tenant.clone(), mask_name_1),
-            };
-
-            mt.drop_data_mask(req).await?;
+            let name_ident = DataMaskNameIdent::new(tenant.clone(), mask_name_1);
+            let dropped = mt.drop_data_mask(&name_ident).await?;
+            assert!(dropped.is_some());
 
             // check table meta
             let req = GetTableReq {
@@ -3091,11 +3093,14 @@ impl SchemaApiTestSuite {
             let req = CreateDatamaskReq {
                 create_option: CreateOption::CreateIfNotExists,
                 name: name.clone(),
-                args: vec![],
-                return_type: "".to_string(),
-                body: "".to_string(),
-                comment: Some("before".to_string()),
-                create_on: created_on,
+                data_mask_meta: DatamaskMeta {
+                    args: vec![],
+                    return_type: "".to_string(),
+                    body: "".to_string(),
+                    comment: Some("before".to_string()),
+                    create_on: created_on,
+                    update_on: None,
+                },
             };
             mt.create_data_mask(req).await?;
             let old_id: u64 = get_kv_u64_data(mt.as_kv_api(), &name).await?;
@@ -3108,11 +3113,14 @@ impl SchemaApiTestSuite {
             let req = CreateDatamaskReq {
                 create_option: CreateOption::CreateOrReplace,
                 name: name.clone(),
-                args: vec![],
-                return_type: "".to_string(),
-                body: "".to_string(),
-                comment: Some("after".to_string()),
-                create_on: created_on,
+                data_mask_meta: DatamaskMeta {
+                    args: vec![],
+                    return_type: "".to_string(),
+                    body: "".to_string(),
+                    comment: Some("after".to_string()),
+                    create_on: created_on,
+                    update_on: None,
+                },
             };
             mt.create_data_mask(req).await?;
 

--- a/src/meta/app/src/background/background_job_id_ident.rs
+++ b/src/meta/app/src/background/background_job_id_ident.rs
@@ -12,22 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::data_id::DataId;
+use crate::tenant::ToTenant;
 use crate::tenant_key::ident::TIdent;
 use crate::tenant_key::raw::TIdentRaw;
 
-pub type BackgroundJobIdIdent = TIdent<Resource, u64>;
-pub type BackgroundJobIdIdentRaw = TIdentRaw<Resource, u64>;
+pub type BackgroundJobId = DataId<Resource>;
+
+pub type BackgroundJobIdIdent = TIdent<Resource, BackgroundJobId>;
+pub type BackgroundJobIdIdentRaw = TIdentRaw<Resource, BackgroundJobId>;
 
 pub use kvapi_impl::Resource;
 
 impl BackgroundJobIdIdent {
-    pub fn job_id(&self) -> u64 {
+    pub fn new(tenant: impl ToTenant, job_id: u64) -> Self {
+        Self::new_generic(tenant, BackgroundJobId::new(job_id))
+    }
+
+    pub fn job_id(&self) -> BackgroundJobId {
         *self.name()
     }
 }
 
 impl BackgroundJobIdIdentRaw {
-    pub fn job_id(&self) -> u64 {
+    pub fn job_id(&self) -> BackgroundJobId {
         *self.name()
     }
 }

--- a/src/meta/app/src/background/job_ident.rs
+++ b/src/meta/app/src/background/job_ident.rs
@@ -32,23 +32,24 @@ mod kvapi_impl {
     use databend_common_meta_kvapi::kvapi;
     use databend_common_meta_kvapi::kvapi::Key;
 
-    use crate::background::BackgroundJobIdIdent;
+    use crate::background::background_job_id_ident::BackgroundJobId;
     use crate::background::BackgroundJobIdent;
     use crate::tenant_key::resource::TenantResource;
+    use crate::KeyWithTenant;
 
     pub struct Resource;
     impl TenantResource for Resource {
         const PREFIX: &'static str = "__fd_background_job";
         const TYPE: &'static str = "BackgroundJobIdent";
         const HAS_TENANT: bool = true;
-        type ValueType = BackgroundJobIdIdent;
+        type ValueType = BackgroundJobId;
     }
 
-    impl kvapi::Value for BackgroundJobIdIdent {
+    impl kvapi::Value for BackgroundJobId {
         type KeyType = BackgroundJobIdent;
 
-        fn dependency_keys(&self, _key: &Self::KeyType) -> impl IntoIterator<Item = String> {
-            [self.to_string_key()]
+        fn dependency_keys(&self, key: &Self::KeyType) -> impl IntoIterator<Item = String> {
+            [self.into_t_ident(key.tenant()).to_string_key()]
         }
     }
 

--- a/src/meta/app/src/data_mask/mod.rs
+++ b/src/meta/app/src/data_mask/mod.rs
@@ -23,7 +23,6 @@ use chrono::Utc;
 pub use data_mask_id_ident::DataMaskId;
 pub use data_mask_id_ident::DataMaskIdIdent;
 pub use data_mask_name_ident::DataMaskNameIdent;
-use databend_common_meta_types::SeqV;
 pub use mask_policy_table_id_list_ident::MaskPolicyTableIdListIdent;
 
 use crate::schema::CreateOption;
@@ -39,28 +38,11 @@ pub struct DatamaskMeta {
     pub update_on: Option<DateTime<Utc>>,
 }
 
-impl From<CreateDatamaskReq> for DatamaskMeta {
-    fn from(p: CreateDatamaskReq) -> Self {
-        DatamaskMeta {
-            args: p.args.clone(),
-            return_type: p.return_type.clone(),
-            body: p.body.clone(),
-            comment: p.comment.clone(),
-            create_on: p.create_on,
-            update_on: None,
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateDatamaskReq {
     pub create_option: CreateOption,
     pub name: DataMaskNameIdent,
-    pub args: Vec<(String, String)>,
-    pub return_type: String,
-    pub body: String,
-    pub comment: Option<String>,
-    pub create_on: DateTime<Utc>,
+    pub data_mask_meta: DatamaskMeta,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -74,17 +56,9 @@ pub struct DropDatamaskReq {
     pub name: DataMaskNameIdent,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct DropDatamaskReply {}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GetDatamaskReq {
     pub name: DataMaskNameIdent,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct GetDatamaskReply {
-    pub policy: SeqV<DatamaskMeta>,
 }
 
 /// A list of table ids

--- a/src/meta/app/src/tenant_key/ident.rs
+++ b/src/meta/app/src/tenant_key/ident.rs
@@ -20,6 +20,7 @@ use std::hash::Hasher;
 
 use crate::tenant::Tenant;
 use crate::tenant::ToTenant;
+use crate::tenant_key::errors::ExistError;
 use crate::tenant_key::errors::UnknownError;
 use crate::tenant_key::raw::TIdentRaw;
 use crate::tenant_key::resource::TenantResource;
@@ -137,6 +138,11 @@ impl<R, N> TIdent<R, N> {
     pub fn unknown_error(&self, ctx: impl Display) -> UnknownError<R, N>
     where N: Clone {
         UnknownError::new(self.name.clone(), ctx)
+    }
+
+    pub fn exist_error(&self, ctx: impl Display) -> ExistError<R, N>
+    where N: Clone {
+        ExistError::new(self.name.clone(), ctx)
     }
 }
 

--- a/src/query/ee/src/data_mask/data_mask_handler.rs
+++ b/src/query/ee/src/data_mask/data_mask_handler.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 use databend_common_base::base::GlobalInstance;
 use databend_common_exception::Result;
 use databend_common_meta_api::DatamaskApi;
+use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::data_mask::CreateDatamaskReq;
 use databend_common_meta_app::data_mask::DataMaskNameIdent;
 use databend_common_meta_app::data_mask::DatamaskMeta;
 use databend_common_meta_app::data_mask::DropDatamaskReq;
-use databend_common_meta_app::data_mask::GetDatamaskReq;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_store::MetaStore;
 use databend_enterprise_data_mask_feature::data_mask_handler::DatamaskHandler;
@@ -42,7 +42,14 @@ impl DatamaskHandler for RealDatamaskHandler {
     }
 
     async fn drop_data_mask(&self, meta_api: Arc<MetaStore>, req: DropDatamaskReq) -> Result<()> {
-        let _ = meta_api.drop_data_mask(req).await?;
+        let dropped = meta_api.drop_data_mask(&req.name).await?;
+        if dropped.is_none() {
+            if req.if_exists {
+                // Ok
+            } else {
+                return Err(AppError::from(req.name.unknown_error("drop data mask")).into());
+            }
+        }
 
         Ok(())
     }
@@ -53,12 +60,12 @@ impl DatamaskHandler for RealDatamaskHandler {
         tenant: &Tenant,
         name: String,
     ) -> Result<DatamaskMeta> {
-        let resp = meta_api
-            .get_data_mask(GetDatamaskReq {
-                name: DataMaskNameIdent::new(tenant, name),
-            })
-            .await?;
-        Ok(resp.policy.data)
+        let name_ident = DataMaskNameIdent::new(tenant, name);
+        let seq_meta = meta_api
+            .get_data_mask(&name_ident)
+            .await?
+            .ok_or_else(|| AppError::from(name_ident.unknown_error("get data mask")))?;
+        Ok(seq_meta.data)
     }
 }
 

--- a/src/query/sql/src/planner/plans/data_mask.rs
+++ b/src/query/sql/src/planner/plans/data_mask.rs
@@ -22,6 +22,7 @@ use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
 use databend_common_meta_app::data_mask::CreateDatamaskReq;
 use databend_common_meta_app::data_mask::DataMaskNameIdent;
+use databend_common_meta_app::data_mask::DatamaskMeta;
 use databend_common_meta_app::data_mask::DropDatamaskReq;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
@@ -45,16 +46,19 @@ impl From<CreateDatamaskPolicyPlan> for CreateDatamaskReq {
         CreateDatamaskReq {
             create_option: p.create_option,
             name: DataMaskNameIdent::new(p.tenant.clone(), &p.name),
-            args: p
-                .policy
-                .args
-                .iter()
-                .map(|arg| (arg.arg_name.to_string(), arg.arg_type.to_string()))
-                .collect(),
-            return_type: p.policy.return_type.to_string(),
-            body: p.policy.body.to_string(),
-            comment: p.policy.comment,
-            create_on: Utc::now(),
+            data_mask_meta: DatamaskMeta {
+                args: p
+                    .policy
+                    .args
+                    .iter()
+                    .map(|arg| (arg.arg_name.to_string(), arg.arg_type.to_string()))
+                    .collect(),
+                return_type: p.policy.return_type.to_string(),
+                body: p.policy.body.to_string(),
+                comment: p.policy.comment,
+                create_on: Utc::now(),
+                update_on: None,
+            },
         }
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: When Replacing column mask, old `name->id->value` should be completely deleted

Before this commit, only the `name->id` is removed when replacing column
mask, this would cause column mask records leaked as a junk in
meta-service.

Other changes: simplify data mask and background job API implementation
with KVPbApi routines.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16328)
<!-- Reviewable:end -->
