### PR TITLE
fix: push filter down join with materialized cte

### DIFF
--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
@@ -1,0 +1,51 @@
+statement ok
+create table t1 as select number as a, number as b from numbers(10);
+
+statement ok
+create table t2 as select number as a, number as b from numbers(10);
+
+query T
+explain with A as  materialized (select * from t1 union all select * from t2),
+B as (select * from A),
+C as (select * from B as b1 left outer join B as b2 on b1.a = b2.a where b1.b < b2.b),
+D as (select * from C)
+select * from D;
+----
+MaterializedCTE
+├── output columns: [t1.a (#0), t1.b (#1)]
+├── UnionAll
+│   ├── output columns: [t1.a (#0), t1.b (#1)]
+│   ├── estimated rows: 20.00
+│   ├── TableScan
+│   │   ├── table: default.default.t1
+│   │   ├── output columns: [a (#0), b (#1)]
+│   │   ├── read rows: 10
+│   │   ├── read size: < 1 KiB
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 10.00
+│   └── TableScan
+│       ├── table: default.default.t2
+│       ├── output columns: [a (#2), b (#3)]
+│       ├── read rows: 10
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
+└── HashJoin
+    ├── output columns: [t1.a (#0), t1.b (#1)]
+    ├── join type: INNER
+    ├── build keys: [b2.a (#0)]
+    ├── probe keys: [b1.a (#0)]
+    ├── filters: [b1.b (#1) < b2.b (#1)]
+    ├── estimated rows: 10.00
+    ├── CTEScan(Build)
+    │   ├── CTE index: 0, sub index: 2
+    │   └── estimated rows: 10.00
+    └── CTEScan(Probe)
+        ├── CTE index: 0, sub index: 1
+        └── estimated rows: 10.00


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

test's before plan:
```
-[ EXPLAIN ]-----------------------------------
MaterializedCTE
├── output columns: [t1.a (#0), t1.b (#1)]
├── UnionAll
│   ├── output columns: [t1.a (#0), t1.b (#1)]
│   ├── estimated rows: 20.00
│   ├── TableScan
│   │   ├── table: default.default.t1
│   │   ├── output columns: [a (#0), b (#1)]
│   │   ├── read rows: 10
│   │   ├── read size: < 1 KiB
│   │   ├── partitions total: 1
│   │   ├── partitions scanned: 1
│   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
│   │   ├── push downs: [filters: [], limit: NONE]
│   │   └── estimated rows: 10.00
│   └── TableScan
│       ├── table: default.default.t2
│       ├── output columns: [a (#2), b (#3)]
│       ├── read rows: 10
│       ├── read size: < 1 KiB
│       ├── partitions total: 1
│       ├── partitions scanned: 1
│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
│       ├── push downs: [filters: [], limit: NONE]
│       └── estimated rows: 10.00
└── HashJoin
    ├── output columns: [t1.a (#0), t1.b (#1)]
    ├── join type: RIGHT OUTER
    ├── build keys: []  //(equi condition missing)
    ├── probe keys: []
    ├── filters: []
    ├── estimated rows: 20.00
    ├── Filter(Build)
    │   ├── output columns: [t1.a (#0), t1.b (#1)]
    │   ├── filters: [a.b (#1) < a.b (#1)] // unexpected push down
    │   ├── estimated rows: 2.00
    │   └── CTEScan
    │       ├── CTE index: 0, sub index: 1
    │       └── estimated rows: 10.00
    └── CTEScan(Probe)
        ├── CTE index: 0, sub index: 2
        └── estimated rows: 10.00
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16349)
<!-- Reviewable:end -->
