### PR TITLE
refactor: simplify SchemaApi::list_indexes(), get_index() list_background_jobs()

### DIFF
--- a/src/meta/api/src/background_api.rs
+++ b/src/meta/api/src/background_api.rs
@@ -29,6 +29,7 @@ use databend_common_meta_app::background::UpdateBackgroundJobReply;
 use databend_common_meta_app::background::UpdateBackgroundJobStatusReq;
 use databend_common_meta_app::background::UpdateBackgroundTaskReply;
 use databend_common_meta_app::background::UpdateBackgroundTaskReq;
+use databend_common_meta_types::SeqV;
 
 use crate::kv_app_error::KVAppError;
 
@@ -58,11 +59,14 @@ pub trait BackgroundApi: Send + Sync {
         &self,
         req: GetBackgroundJobReq,
     ) -> Result<GetBackgroundJobReply, KVAppError>;
+
+    /// Return a list of job name and job info
     async fn list_background_jobs(
         &self,
         req: ListBackgroundJobsReq,
-    ) -> Result<Vec<(u64, String, BackgroundJobInfo)>, KVAppError>;
-    // Return a list of background tasks (task_id, BackgroundInfo)
+    ) -> Result<Vec<(String, SeqV<BackgroundJobInfo>)>, KVAppError>;
+
+    /// Return a list of background tasks (task_id, BackgroundInfo)
     async fn list_background_tasks(
         &self,
         req: ListBackgroundTasksReq,

--- a/src/meta/api/src/background_api_test_suite.rs
+++ b/src/meta/api/src/background_api_test_suite.rs
@@ -332,15 +332,15 @@ impl BackgroundApiTestSuite {
             assert!(res.is_ok());
             let resp = res.unwrap();
             assert_eq!(1, resp.len());
-            assert_eq!(*job_ident.name(), resp[0].1, "expect same ident name");
+            assert_eq!(*job_ident.name(), resp[0].0, "expect same ident name");
             assert_eq!(
                 BackgroundJobState::FAILED,
-                resp[0].2.job_status.clone().unwrap().job_state,
+                resp[0].1.job_status.clone().unwrap().job_state,
                 "first state is started"
             );
             assert_eq!(
                 INTERVAL,
-                resp[0].2.job_params.clone().unwrap().job_type,
+                resp[0].1.job_params.clone().unwrap().job_type,
                 "first state is started"
             );
         }

--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -50,7 +50,6 @@ use databend_common_meta_app::schema::GcDroppedTableReq;
 use databend_common_meta_app::schema::GetDatabaseReq;
 use databend_common_meta_app::schema::GetDictionaryReply;
 use databend_common_meta_app::schema::GetIndexReply;
-use databend_common_meta_app::schema::GetIndexReq;
 use databend_common_meta_app::schema::GetLVTReply;
 use databend_common_meta_app::schema::GetLVTReq;
 use databend_common_meta_app::schema::GetTableCopiedFileReply;
@@ -63,7 +62,6 @@ use databend_common_meta_app::schema::ListDatabaseReq;
 use databend_common_meta_app::schema::ListDictionaryReq;
 use databend_common_meta_app::schema::ListDroppedTableReq;
 use databend_common_meta_app::schema::ListDroppedTableResp;
-use databend_common_meta_app::schema::ListIndexesByIdReq;
 use databend_common_meta_app::schema::ListIndexesReq;
 use databend_common_meta_app::schema::ListLockRevReq;
 use databend_common_meta_app::schema::ListLocksReq;
@@ -151,24 +149,17 @@ pub trait SchemaApi: Send + Sync {
         name_ident: &IndexNameIdent,
     ) -> Result<Option<(SeqV<IndexId>, SeqV<IndexMeta>)>, KVAppError>;
 
-    async fn get_index(&self, req: GetIndexReq) -> Result<GetIndexReply, KVAppError>;
+    async fn get_index(
+        &self,
+        name_ident: &IndexNameIdent,
+    ) -> Result<Option<GetIndexReply>, MetaError>;
 
     async fn update_index(&self, req: UpdateIndexReq) -> Result<UpdateIndexReply, KVAppError>;
 
     async fn list_indexes(
         &self,
         req: ListIndexesReq,
-    ) -> Result<Vec<(u64, String, IndexMeta)>, KVAppError>;
-
-    async fn list_index_ids_by_table_id(
-        &self,
-        req: ListIndexesByIdReq,
-    ) -> Result<Vec<u64>, KVAppError>;
-
-    async fn list_indexes_by_table_id(
-        &self,
-        req: ListIndexesByIdReq,
-    ) -> Result<Vec<(u64, String, IndexMeta)>, KVAppError>;
+    ) -> Result<Vec<(String, IndexId, IndexMeta)>, KVAppError>;
 
     // virtual column
 

--- a/src/meta/app/src/app_error.rs
+++ b/src/meta/app/src/app_error.rs
@@ -830,20 +830,6 @@ impl DropIndexWithDropTime {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("GetIndexWithDropTime: get {index_name} with drop time")]
-pub struct GetIndexWithDropTime {
-    index_name: String,
-}
-
-impl GetIndexWithDropTime {
-    pub fn new(index_name: impl Into<String>) -> Self {
-        Self {
-            index_name: index_name.into(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("DuplicatedIndexColumnId: {column_id} is duplicated with index {index_name}")]
 pub struct DuplicatedIndexColumnId {
     column_id: u32,
@@ -1156,9 +1142,6 @@ pub enum AppError {
     DropIndexWithDropTime(#[from] DropIndexWithDropTime),
 
     #[error(transparent)]
-    GetIndexWithDropTime(#[from] GetIndexWithDropTime),
-
-    #[error(transparent)]
     DuplicatedIndexColumnId(#[from] DuplicatedIndexColumnId),
 
     #[error(transparent)]
@@ -1171,10 +1154,10 @@ pub enum AppError {
     UnknownDataMask(#[from] UnknownError<data_mask_name_ident::Resource>),
 
     #[error(transparent)]
-    BackgroundJobAlreadyExists(#[from] ExistError<job_ident::Resource>),
+    BackgroundJobAlreadyExists(#[from] ExistError<job_ident::BackgroundJobName>),
 
     #[error(transparent)]
-    UnknownBackgroundJob(#[from] UnknownError<job_ident::Resource>),
+    UnknownBackgroundJob(#[from] UnknownError<job_ident::BackgroundJobName>),
 
     #[error(transparent)]
     UnmatchColumnDataType(#[from] UnmatchColumnDataType),
@@ -1521,12 +1504,6 @@ impl AppErrorMessage for DropIndexWithDropTime {
     }
 }
 
-impl AppErrorMessage for GetIndexWithDropTime {
-    fn message(&self) -> String {
-        format!("Get Index '{}' with drop time", self.index_name)
-    }
-}
-
 impl AppErrorMessage for DuplicatedIndexColumnId {
     fn message(&self) -> String {
         format!(
@@ -1731,7 +1708,6 @@ impl From<AppError> for ErrorCode {
             AppError::IndexAlreadyExists(err) => ErrorCode::IndexAlreadyExists(err.message()),
             AppError::UnknownIndex(err) => ErrorCode::UnknownIndex(err.message()),
             AppError::DropIndexWithDropTime(err) => ErrorCode::DropIndexWithDropTime(err.message()),
-            AppError::GetIndexWithDropTime(err) => ErrorCode::GetIndexWithDropTime(err.message()),
             AppError::DuplicatedIndexColumnId(err) => {
                 ErrorCode::DuplicatedIndexColumnId(err.message())
             }

--- a/src/meta/app/src/background/job_ident.rs
+++ b/src/meta/app/src/background/job_ident.rs
@@ -16,10 +16,10 @@ use crate::tenant_key::ident::TIdent;
 use crate::tenant_key::raw::TIdentRaw;
 
 /// Defines the meta-service key for background job.
-pub type BackgroundJobIdent = TIdent<Resource>;
-pub type BackgroundJobIdentRaw = TIdentRaw<Resource>;
+pub type BackgroundJobIdent = TIdent<BackgroundJobName>;
+pub type BackgroundJobIdentRaw = TIdentRaw<BackgroundJobName>;
 
-pub use kvapi_impl::Resource;
+pub use kvapi_impl::BackgroundJobName;
 
 impl BackgroundJobIdent {
     pub fn job_name(&self) -> &str {
@@ -37,8 +37,8 @@ mod kvapi_impl {
     use crate::tenant_key::resource::TenantResource;
     use crate::KeyWithTenant;
 
-    pub struct Resource;
-    impl TenantResource for Resource {
+    pub struct BackgroundJobName;
+    impl TenantResource for BackgroundJobName {
         const PREFIX: &'static str = "__fd_background_job";
         const TYPE: &'static str = "BackgroundJobIdent";
         const HAS_TENANT: bool = true;

--- a/src/meta/app/src/tenant_key/resource.rs
+++ b/src/meta/app/src/tenant_key/resource.rs
@@ -23,7 +23,7 @@ use crate::tenant_key::ident::TIdent;
 ///
 /// It includes a prefix to store the `ValueType`.
 /// This trait is used to define a concrete [`TIdent`] can be used as a `kvapi::Key`.
-pub trait TenantResource {
+pub trait TenantResource: 'static {
     /// The key prefix to store in meta-service.
     const PREFIX: &'static str;
 

--- a/src/meta/kvapi/src/kvapi/mod.rs
+++ b/src/meta/kvapi/src/kvapi/mod.rs
@@ -50,6 +50,7 @@ pub use message::MGetKVReq;
 pub use message::UpsertKVReply;
 pub use message::UpsertKVReq;
 pub use pair::Pair;
+pub use pair::SeqPair;
 pub use prefix::prefix_to_range;
 pub use test_suite::TestSuite;
 pub use value::Value;

--- a/src/meta/kvapi/src/kvapi/pair.rs
+++ b/src/meta/kvapi/src/kvapi/pair.rs
@@ -17,4 +17,68 @@ use databend_common_meta_types::SeqV;
 use crate::kvapi;
 
 /// A Key-Value pair for type Key. The value has a seq number.
-pub type Pair<K> = (K, SeqV<<K as kvapi::Key>::ValueType>);
+pub struct Pair<K>
+where K: kvapi::Key
+{
+    key: K,
+    seq_v: SeqV<K::ValueType>,
+}
+
+impl<K> Pair<K>
+where K: kvapi::Key
+{
+    pub fn new(key: K, seq_v: SeqV<K::ValueType>) -> Self {
+        Self { key, seq_v }
+    }
+
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    pub fn seq_value(&self) -> &SeqV<K::ValueType> {
+        &self.seq_v
+    }
+}
+
+/// Same as `Pair`, but the key is a `SeqV` and also have a seq number.
+pub struct SeqPair<K>
+where K: kvapi::Key
+{
+    key: SeqV<K>,
+    seq_v: SeqV<K::ValueType>,
+}
+
+impl<K> SeqPair<K>
+where K: kvapi::Key
+{
+    pub fn new(key: SeqV<K>, seq_v: SeqV<K::ValueType>) -> Self {
+        Self { key, seq_v }
+    }
+
+    pub fn seq_key(&self) -> &SeqV<K> {
+        &self.key
+    }
+
+    pub fn seq_value(&self) -> &SeqV<K::ValueType> {
+        &self.seq_v
+    }
+
+    pub fn into_pair(self) -> Pair<K> {
+        Pair {
+            key: self.key.data,
+            seq_v: self.seq_v,
+        }
+    }
+
+    pub fn unpack(self) -> (SeqV<K>, SeqV<K::ValueType>) {
+        (self.key, self.seq_v)
+    }
+}
+
+impl<K> From<SeqPair<K>> for Pair<K>
+where K: kvapi::Key
+{
+    fn from(sp: SeqPair<K>) -> Self {
+        sp.into_pair()
+    }
+}

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -308,7 +308,9 @@ impl Catalog for MutableCatalog {
 
     #[async_backtrace::framed]
     async fn get_index(&self, req: GetIndexReq) -> Result<GetIndexReply> {
-        Ok(self.ctx.meta.get_index(req).await?)
+        let got = self.ctx.meta.get_index(&req.name_ident).await?;
+        let got = got.ok_or_else(|| AppError::from(req.name_ident.unknown_error("get_index")))?;
+        Ok(got)
     }
 
     #[async_backtrace::framed]
@@ -318,12 +320,19 @@ impl Catalog for MutableCatalog {
 
     #[async_backtrace::framed]
     async fn list_indexes(&self, req: ListIndexesReq) -> Result<Vec<(u64, String, IndexMeta)>> {
-        Ok(self.ctx.meta.list_indexes(req).await?)
+        let name_id_values = self.ctx.meta.list_indexes(req).await?;
+        Ok(name_id_values
+            .into_iter()
+            .map(|(name, id, v)| (*id, name, v))
+            .collect())
     }
 
     #[async_backtrace::framed]
     async fn list_index_ids_by_table_id(&self, req: ListIndexesByIdReq) -> Result<Vec<u64>> {
-        Ok(self.ctx.meta.list_index_ids_by_table_id(req).await?)
+        let req = ListIndexesReq::new(req.tenant, Some(req.table_id));
+        let name_id_values = self.ctx.meta.list_indexes(req).await?;
+
+        Ok(name_id_values.into_iter().map(|(_, id, _)| *id).collect())
     }
 
     #[async_backtrace::framed]
@@ -331,7 +340,8 @@ impl Catalog for MutableCatalog {
         &self,
         req: ListIndexesByIdReq,
     ) -> Result<Vec<(u64, String, IndexMeta)>> {
-        Ok(self.ctx.meta.list_indexes_by_table_id(req).await?)
+        let req = ListIndexesReq::new(req.tenant, Some(req.table_id));
+        self.list_indexes(req).await
     }
 
     // Virtual column

--- a/src/query/storages/system/src/background_jobs_table.rs
+++ b/src/query/storages/system/src/background_jobs_table.rs
@@ -75,8 +75,10 @@ impl AsyncSystemTable for BackgroundJobTable {
         let mut last_updated = Vec::with_capacity(jobs.len());
         let mut creator = Vec::with_capacity(jobs.len());
         let mut create_time = Vec::with_capacity(jobs.len());
-        for (_, name, job) in jobs {
+        for (name, seq_job) in jobs {
             names.push(name);
+            let (_seq, job) = (seq_job.seq, seq_job.data);
+
             let job_type = job.job_params.as_ref().map(|x| x.job_type.clone());
             if let Some(job_type) = job_type {
                 job_types.push(Some(job_type.to_string()));


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: simplify SchemaApi::list_indexes(), get_index() list_background_jobs()

Add `BaseApi::get_id_value()` and `BaseApi::list_id_value()` to
implement generic get and list for `name->id->value` meta data.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16357)
<!-- Reviewable:end -->
