### PR TITLE
chore: separate test run for temp_table suite

### DIFF
--- a/scripts/ci/ci-run-sqllogic-tests.sh
+++ b/scripts/ci/ci-run-sqllogic-tests.sh
@@ -19,5 +19,7 @@ fi
 echo "Run suites using argument: $RUN_DIR"
 
 echo "Starting databend-sqllogic tests"
-target/${BUILD_PROFILE}/databend-sqllogictests --handlers "mysql" --run_dir temp_table --enable_sandbox --parallel 8
+if [ -z "$RUN_DIR" ]; then
+    target/${BUILD_PROFILE}/databend-sqllogictests --handlers "mysql" --run_dir temp_table --enable_sandbox --parallel 8
+fi
 target/${BUILD_PROFILE}/databend-sqllogictests --handlers ${TEST_HANDLERS} ${RUN_DIR} --skip_dir management,explain_native,ee,temp_table --enable_sandbox --parallel 8


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
When specific tests to run are specified, the temp table tests should not be executed. 
```
$ ./scripts/ci/ci-run-sqllogic-tests.sh tpcds
Starting standalone DatabendQuery and DatabendMeta
databend-query: no process found
databend-meta: no process found
The databend-query is not killed. force killing.
databend-query: no process found
Start databend-meta...
Waiting on databend-meta 10 seconds...
nohup: appending output to 'nohup.out'
... connecting to :9191
OK :9191 is listening
Start databend-query...
Waiting on databend-query 10 seconds...
nohup: appending output to 'nohup.out'
... connecting to :8000
OK :8000 is listening
Run suites using argument: --run_dir tpcds
Starting databend-sqllogic tests
MySQL client starts to run with: SqlLogicTestArgs { dir: Some("tpcds"), file: None, skipped_dir: Some("management,explain_native,ee,temp_table"), skipped_file: None, handlers: Some(["mysql", "http"]), suites: "tests/sqllogictests/suites", complete: false, no_fail_fast: false, parallel: 8, enable_sandbox: true, debug: false, bench: false, database: "default" }
Calling the script prepare_tpcds_data.sh ...
```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - only modify test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): modify test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16358)
<!-- Reviewable:end -->
