### PR TITLE
refactor(query): optimize show drop tables

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -78,6 +78,7 @@ use databend_common_meta_app::schema::SetLVTReply;
 use databend_common_meta_app::schema::SetLVTReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
+use databend_common_meta_app::schema::TableId;
 use databend_common_meta_app::schema::TableIdHistoryIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
@@ -97,7 +98,6 @@ use databend_common_meta_app::schema::UpdateVirtualColumnReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
-use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::Change;
 use databend_common_meta_types::MetaError;
@@ -212,12 +212,11 @@ pub trait SchemaApi: Send + Sync {
 
     async fn get_table(&self, req: GetTableReq) -> Result<Arc<TableInfo>, KVAppError>;
 
-    async fn get_table_history(
+    async fn get_table_meta_history(
         &self,
-        tenant: &Tenant,
         database_name: &str,
         table_id_history: &TableIdHistoryIdent,
-    ) -> Result<Vec<Arc<TableInfo>>, KVAppError>;
+    ) -> Result<Vec<(TableId, SeqV<TableMeta>)>, KVAppError>;
 
     async fn get_tables_history(
         &self,

--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -78,6 +78,7 @@ use databend_common_meta_app::schema::SetLVTReply;
 use databend_common_meta_app::schema::SetLVTReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
+use databend_common_meta_app::schema::TableIdHistoryIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TruncateTableReply;
@@ -96,6 +97,7 @@ use databend_common_meta_app::schema::UpdateVirtualColumnReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::Change;
 use databend_common_meta_types::MetaError;
@@ -210,7 +212,12 @@ pub trait SchemaApi: Send + Sync {
 
     async fn get_table(&self, req: GetTableReq) -> Result<Arc<TableInfo>, KVAppError>;
 
-    async fn get_table_history(&self, req: GetTableReq) -> Result<Vec<Arc<TableInfo>>, KVAppError>;
+    async fn get_table_history(
+        &self,
+        tenant: &Tenant,
+        database_name: &str,
+        table_id_history: &TableIdHistoryIdent,
+    ) -> Result<Vec<Arc<TableInfo>>, KVAppError>;
 
     async fn get_tables_history(
         &self,

--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -210,10 +210,7 @@ pub trait SchemaApi: Send + Sync {
 
     async fn get_table(&self, req: GetTableReq) -> Result<Arc<TableInfo>, KVAppError>;
 
-    async fn get_single_table_history(
-        &self,
-        req: GetTableReq,
-    ) -> Result<Arc<TableInfo>, KVAppError>;
+    async fn get_table_history(&self, req: GetTableReq) -> Result<Vec<Arc<TableInfo>>, KVAppError>;
 
     async fn get_tables_history(
         &self,

--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -210,8 +210,15 @@ pub trait SchemaApi: Send + Sync {
 
     async fn get_table(&self, req: GetTableReq) -> Result<Arc<TableInfo>, KVAppError>;
 
-    async fn get_table_history(&self, req: ListTableReq)
-    -> Result<Vec<Arc<TableInfo>>, KVAppError>;
+    async fn get_single_table_history(
+        &self,
+        req: GetTableReq,
+    ) -> Result<Arc<TableInfo>, KVAppError>;
+
+    async fn get_tables_history(
+        &self,
+        req: ListTableReq,
+    ) -> Result<Vec<Arc<TableInfo>>, KVAppError>;
 
     async fn list_tables(&self, req: ListTableReq) -> Result<Vec<Arc<TableInfo>>, KVAppError>;
 

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -1864,7 +1864,7 @@ impl SchemaApiTestSuite {
                     let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
 
                     let got = mt
-                        .get_table_history(&tenant, db_name, &TableIdHistoryIdent {
+                        .get_table_meta_history(db_name, &TableIdHistoryIdent {
                             database_id: cur_db.database_id.db_id,
                             table_name: tbl_name.to_string(),
                         })
@@ -1879,8 +1879,8 @@ impl SchemaApiTestSuite {
                         tenant: tenant_name.to_string(),
                         ..Default::default()
                     };
-                    assert_eq!(got.meta.created_on, want.meta.created_on);
-                    assert!(got.meta.drop_on.is_some());
+                    assert_eq!(got.1.data.created_on, want.meta.created_on);
+                    assert!(got.1.data.drop_on.is_some());
                 }
             }
 

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -1862,7 +1862,7 @@ impl SchemaApiTestSuite {
                 info!("--- get table history after drop");
                 {
                     let req = GetTableReq::new(&tenant, db_name, tbl_name);
-                    let got = mt.get_single_table_history(req).await.unwrap();
+                    let got = mt.get_table_history(req).await.unwrap()[0].clone();
                     let want = TableInfo {
                         ident: tb_ident_2,
                         desc: format!("'{}'.'{}'", db_name, tbl_name),

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -1861,8 +1861,16 @@ impl SchemaApiTestSuite {
 
                 info!("--- get table history after drop");
                 {
-                    let req = GetTableReq::new(&tenant, db_name, tbl_name);
-                    let got = mt.get_table_history(req).await.unwrap()[0].clone();
+                    let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
+
+                    let got = mt
+                        .get_table_history(&tenant, db_name, &TableIdHistoryIdent {
+                            database_id: cur_db.database_id.db_id,
+                            table_name: tbl_name.to_string(),
+                        })
+                        .await
+                        .unwrap()[0]
+                        .clone();
                     let want = TableInfo {
                         ident: tb_ident_2,
                         desc: format!("'{}'.'{}'", db_name, tbl_name),

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -1858,6 +1858,22 @@ impl SchemaApiTestSuite {
                         tbl_name
                     );
                 }
+
+                info!("--- get table history after drop");
+                {
+                    let req = GetTableReq::new(&tenant, db_name, tbl_name);
+                    let got = mt.get_single_table_history(req).await.unwrap();
+                    let want = TableInfo {
+                        ident: tb_ident_2,
+                        desc: format!("'{}'.'{}'", db_name, tbl_name),
+                        name: tbl_name.into(),
+                        meta: table_meta(created_on),
+                        tenant: tenant_name.to_string(),
+                        ..Default::default()
+                    };
+                    assert_eq!(got.meta.created_on, want.meta.created_on);
+                    assert!(got.meta.drop_on.is_some());
+                }
             }
 
             info!("--- drop table with if_exists = false again, error");
@@ -4014,7 +4030,7 @@ impl SchemaApiTestSuite {
             assert!(table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
 
             assert_eq!(res.len(), 1);
@@ -4032,7 +4048,7 @@ impl SchemaApiTestSuite {
             upsert_test_data(mt.as_kv_api(), &tbid, data).await?;
             // assert not return out of retention time data
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
 
             assert_eq!(res.len(), 0);
@@ -4669,7 +4685,7 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4704,7 +4720,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: tbl_name.to_string(),
@@ -4726,7 +4742,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: tbl_name.to_string(),
@@ -4756,7 +4772,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: tbl_name.to_string(),
@@ -4783,7 +4799,7 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4814,7 +4830,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: tbl_name.to_string(),
@@ -4835,7 +4851,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4872,7 +4888,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let _res = mt.create_table(req.clone()).await?;
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             assert!(old_db.meta.seq < cur_db.meta.seq);
@@ -4918,7 +4934,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {
@@ -4955,7 +4971,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_table_history(ListTableReq::new(&tenant, db_name))
+                .get_tables_history(ListTableReq::new(&tenant, db_name))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -253,6 +253,7 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
         table_name: &str,
     ) -> Result<Arc<dyn Table>>;
 
+    // Get one table identified as dropped by db and table name.
     async fn get_single_table_history(
         &self,
         tenant: &Tenant,

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -253,6 +253,13 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
         table_name: &str,
     ) -> Result<Arc<dyn Table>>;
 
+    async fn get_single_table_history(
+        &self,
+        tenant: &Tenant,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<Arc<dyn Table>>;
+
     /// List all tables in a database.This will not list temporary tables.
     async fn list_tables(&self, tenant: &Tenant, db_name: &str) -> Result<Vec<Arc<dyn Table>>>;
 

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -254,12 +254,12 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     ) -> Result<Arc<dyn Table>>;
 
     // Get one table identified as dropped by db and table name.
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         tenant: &Tenant,
         db_name: &str,
         table_name: &str,
-    ) -> Result<Arc<dyn Table>>;
+    ) -> Result<Vec<Arc<dyn Table>>>;
 
     /// List all tables in a database.This will not list temporary tables.
     async fn list_tables(&self, tenant: &Tenant, db_name: &str) -> Result<Vec<Arc<dyn Table>>>;

--- a/src/query/catalog/src/database.rs
+++ b/src/query/catalog/src/database.rs
@@ -95,6 +95,15 @@ pub trait Database: DynClone + Sync + Send {
         )))
     }
 
+    // Get one table history by db and table name.
+    #[async_backtrace::framed]
+    async fn get_single_table_history(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
+        Err(ErrorCode::Unimplemented(format!(
+            "UnImplement get_table in {} Database",
+            self.name()
+        )))
+    }
+
     #[async_backtrace::framed]
     async fn list_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
         Err(ErrorCode::Unimplemented(format!(

--- a/src/query/catalog/src/database.rs
+++ b/src/query/catalog/src/database.rs
@@ -97,7 +97,7 @@ pub trait Database: DynClone + Sync + Send {
 
     // Get one table history by db and table name.
     #[async_backtrace::framed]
-    async fn get_single_table_history(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
+    async fn get_table_history(&self, _table_name: &str) -> Result<Vec<Arc<dyn Table>>> {
         Err(ErrorCode::Unimplemented(format!(
             "UnImplement get_table in {} Database",
             self.name()

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -402,22 +402,22 @@ impl Catalog for DatabaseCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         tenant: &Tenant,
         db_name: &str,
         table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
+    ) -> Result<Vec<Arc<dyn Table>>> {
         let res = self
             .immutable_catalog
-            .get_single_table_history(tenant, db_name, table_name)
+            .get_table_history(tenant, db_name, table_name)
             .await;
         match res {
             Ok(v) => Ok(v),
             Err(e) => {
                 if e.code() == ErrorCode::UNKNOWN_DATABASE {
                     self.mutable_catalog
-                        .get_single_table_history(tenant, db_name, table_name)
+                        .get_table_history(tenant, db_name, table_name)
                         .await
                 } else {
                     Err(e)

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -272,13 +272,13 @@ impl Catalog for ImmutableCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         tenant: &Tenant,
         db_name: &str,
         table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
-        self.get_table(tenant, db_name, table_name).await
+    ) -> Result<Vec<Arc<dyn Table>>> {
+        Ok(vec![self.get_table(tenant, db_name, table_name).await?])
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -272,6 +272,16 @@ impl Catalog for ImmutableCatalog {
     }
 
     #[async_backtrace::framed]
+    async fn get_single_table_history(
+        &self,
+        tenant: &Tenant,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<Arc<dyn Table>> {
+        self.get_table(tenant, db_name, table_name).await
+    }
+
+    #[async_backtrace::framed]
     async fn list_tables(&self, _tenant: &Tenant, db_name: &str) -> Result<Vec<Arc<dyn Table>>> {
         self.sys_db_meta.get_all_tables(db_name)
     }

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -465,6 +465,17 @@ impl Catalog for MutableCatalog {
     }
 
     #[async_backtrace::framed]
+    async fn get_single_table_history(
+        &self,
+        tenant: &Tenant,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<Arc<dyn Table>> {
+        let db = self.get_database(tenant, db_name).await?;
+        db.get_single_table_history(table_name).await
+    }
+
+    #[async_backtrace::framed]
     async fn list_tables(&self, tenant: &Tenant, db_name: &str) -> Result<Vec<Arc<dyn Table>>> {
         let db = self.get_database(tenant, db_name).await?;
         db.list_tables().await

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -465,14 +465,14 @@ impl Catalog for MutableCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         tenant: &Tenant,
         db_name: &str,
         table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
+    ) -> Result<Vec<Arc<dyn Table>>> {
         let db = self.get_database(tenant, db_name).await?;
-        db.get_single_table_history(table_name).await
+        db.get_table_history(table_name).await
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/catalogs/default/session_catalog.rs
+++ b/src/query/service/src/catalogs/default/session_catalog.rs
@@ -368,6 +368,17 @@ impl Catalog for SessionCatalog {
     fn list_temporary_tables(&self) -> Result<Vec<TableInfo>> {
         self.temp_tbl_mgr.lock().list_tables()
     }
+    
+    async fn get_single_table_history(
+        &self,
+        tenant: &Tenant,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<Arc<dyn Table>> {
+        self.inner
+            .get_single_table_history(tenant, db_name, table_name)
+            .await
+    }
 
     async fn list_tables_history(
         &self,

--- a/src/query/service/src/catalogs/default/session_catalog.rs
+++ b/src/query/service/src/catalogs/default/session_catalog.rs
@@ -370,14 +370,14 @@ impl Catalog for SessionCatalog {
     }
 
     // Get one table identified as dropped by db and table name.
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         tenant: &Tenant,
         db_name: &str,
         table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
+    ) -> Result<Vec<Arc<dyn Table>>> {
         self.inner
-            .get_single_table_history(tenant, db_name, table_name)
+            .get_table_history(tenant, db_name, table_name)
             .await
     }
 

--- a/src/query/service/src/catalogs/default/session_catalog.rs
+++ b/src/query/service/src/catalogs/default/session_catalog.rs
@@ -368,7 +368,8 @@ impl Catalog for SessionCatalog {
     fn list_temporary_tables(&self) -> Result<Vec<TableInfo>> {
         self.temp_tbl_mgr.lock().list_tables()
     }
-    
+
+    // Get one table identified as dropped by db and table name.
     async fn get_single_table_history(
         &self,
         tenant: &Tenant,

--- a/src/query/service/src/catalogs/share/share_catalog.rs
+++ b/src/query/service/src/catalogs/share/share_catalog.rs
@@ -499,6 +499,17 @@ impl Catalog for ShareCatalog {
         Ok(table_info_vec)
     }
 
+    async fn get_single_table_history(
+        &self,
+        _tenant: &Tenant,
+        _db_name: &str,
+        _table_name: &str,
+    ) -> Result<Arc<dyn Table>> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied, cannot get table history from a shared database".to_string(),
+        ))
+    }
+
     #[async_backtrace::framed]
     async fn list_tables_history(
         &self,

--- a/src/query/service/src/catalogs/share/share_catalog.rs
+++ b/src/query/service/src/catalogs/share/share_catalog.rs
@@ -499,12 +499,12 @@ impl Catalog for ShareCatalog {
         Ok(table_info_vec)
     }
 
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         _tenant: &Tenant,
         _db_name: &str,
         _table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
+    ) -> Result<Vec<Arc<dyn Table>>> {
         Err(ErrorCode::PermissionDenied(
             "Permission denied, cannot get table history from a shared database".to_string(),
         ))

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -137,11 +137,11 @@ impl Database for DefaultDatabase {
     }
 
     #[async_backtrace::framed]
-    async fn get_single_table_history(&self, table_name: &str) -> Result<Arc<dyn Table>> {
-        let table_info = self
+    async fn get_table_history(&self, table_name: &str) -> Result<Vec<Arc<dyn Table>>> {
+        let table_infos = self
             .ctx
             .meta
-            .get_single_table_history(GetTableReq::new(
+            .get_table_history(GetTableReq::new(
                 self.get_tenant(),
                 self.get_db_name(),
                 table_name,
@@ -149,7 +149,7 @@ impl Database for DefaultDatabase {
             .await?;
 
         // disable refresh in history table
-        self.get_table_by_info(table_info.as_ref())
+        self.load_tables(table_infos)
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -15,8 +15,12 @@
 use std::sync::Arc;
 
 use databend_common_catalog::table::Table;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_meta_api::kv_app_error::KVAppError;
 use databend_common_meta_api::SchemaApi;
+use databend_common_meta_app::app_error::AppError;
+use databend_common_meta_app::app_error::CannotAccessShareTable;
 use databend_common_meta_app::schema::CommitTableMetaReply;
 use databend_common_meta_app::schema::CommitTableMetaReq;
 use databend_common_meta_app::schema::CreateTableReply;
@@ -32,6 +36,7 @@ use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReply;
 use databend_common_meta_app::schema::SetTableColumnMaskPolicyReq;
+use databend_common_meta_app::schema::TableIdHistoryIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TruncateTableReply;
 use databend_common_meta_app::schema::TruncateTableReq;
@@ -41,6 +46,8 @@ use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
 use databend_common_meta_app::schema::UpdateMultiTableMetaResult;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
+use databend_common_meta_app::KeyWithTenant;
+use log::error;
 
 use crate::databases::Database;
 use crate::databases::DatabaseContext;
@@ -138,14 +145,32 @@ impl Database for DefaultDatabase {
 
     #[async_backtrace::framed]
     async fn get_table_history(&self, table_name: &str) -> Result<Vec<Arc<dyn Table>>> {
+        if let Some(ref share_name_ident_raw) = self.db_info.meta.from_share {
+            let share_ident = share_name_ident_raw.clone().to_tident(());
+            error!(
+                "get_table_history {:?} from share {:?}",
+                self.db_info.name_ident, share_ident,
+            );
+            return Err(ErrorCode::from(KVAppError::AppError(
+                AppError::CannotAccessShareTable(CannotAccessShareTable::new(
+                    &self.db_info.name_ident.tenant().tenant,
+                    share_ident.name(),
+                    table_name,
+                )),
+            )));
+        }
+
         let table_infos = self
             .ctx
             .meta
-            .get_table_history(GetTableReq::new(
-                self.get_tenant(),
-                self.get_db_name(),
-                table_name,
-            ))
+            .get_table_history(
+                self.db_info.name_ident.tenant(),
+                self.db_info.name_ident.database_name(),
+                &TableIdHistoryIdent {
+                    database_id: self.db_info.database_id.db_id,
+                    table_name: table_name.to_string(),
+                },
+            )
             .await?;
 
         // disable refresh in history table

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -137,6 +137,22 @@ impl Database for DefaultDatabase {
     }
 
     #[async_backtrace::framed]
+    async fn get_single_table_history(&self, table_name: &str) -> Result<Arc<dyn Table>> {
+        let table_info = self
+            .ctx
+            .meta
+            .get_single_table_history(GetTableReq::new(
+                self.get_tenant(),
+                self.get_db_name(),
+                table_name,
+            ))
+            .await?;
+
+        // disable refresh in history table
+        self.get_table_by_info(table_info.as_ref())
+    }
+
+    #[async_backtrace::framed]
     async fn list_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
         let table_infos = self.list_table_infos().await?;
         self.load_tables(table_infos)
@@ -152,7 +168,7 @@ impl Database for DefaultDatabase {
         let mut dropped = self
             .ctx
             .meta
-            .get_table_history(ListTableReq::new(self.get_tenant(), self.get_db_name()))
+            .get_tables_history(ListTableReq::new(self.get_tenant(), self.get_db_name()))
             .await?
             .into_iter()
             .filter(|i| i.meta.drop_on.is_some())

--- a/src/query/service/src/databases/share/dummy_share_database.rs
+++ b/src/query/service/src/databases/share/dummy_share_database.rs
@@ -82,7 +82,7 @@ impl Database for DummyShareDatabase {
 
     // Get one table history by db and table name.
     #[async_backtrace::framed]
-    async fn get_single_table_history(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
+    async fn get_table_history(&self, _table_name: &str) -> Result<Vec<Arc<dyn Table>>> {
         Err(ErrorCode::PermissionDenied(
             "Permission denied from a dummy shared database".to_string(),
         ))

--- a/src/query/service/src/databases/share/dummy_share_database.rs
+++ b/src/query/service/src/databases/share/dummy_share_database.rs
@@ -80,6 +80,14 @@ impl Database for DummyShareDatabase {
         ))
     }
 
+    // Get one table history by db and table name.
+    #[async_backtrace::framed]
+    async fn get_single_table_history(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied from a dummy shared database".to_string(),
+        ))
+    }
+
     #[async_backtrace::framed]
     async fn list_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
         Err(ErrorCode::PermissionDenied(

--- a/src/query/service/src/databases/share/share_database.rs
+++ b/src/query/service/src/databases/share/share_database.rs
@@ -221,7 +221,7 @@ impl Database for ShareDatabase {
     }
 
     #[async_backtrace::framed]
-    async fn get_single_table_history(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
+    async fn get_table_history(&self, _table_name: &str) -> Result<Vec<Arc<dyn Table>>> {
         Err(ErrorCode::PermissionDenied(
             "Permission denied, cannot get table history from a shared database".to_string(),
         ))

--- a/src/query/service/src/databases/share/share_database.rs
+++ b/src/query/service/src/databases/share/share_database.rs
@@ -221,6 +221,13 @@ impl Database for ShareDatabase {
     }
 
     #[async_backtrace::framed]
+    async fn get_single_table_history(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
+        Err(ErrorCode::PermissionDenied(
+            "Permission denied, cannot get table history from a shared database".to_string(),
+        ))
+    }
+
+    #[async_backtrace::framed]
     async fn list_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
         let share_table_infos = self.list_share_tables().await?;
 

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -231,13 +231,16 @@ impl Catalog for FakedCatalog {
         self.cat.get_table(tenant, db_name, table_name).await
     }
 
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         tenant: &Tenant,
         db_name: &str,
         table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
-        self.cat.get_table(tenant, db_name, table_name).await
+    ) -> Result<Vec<Arc<dyn Table>>> {
+        Ok(Vec::from([self
+            .cat
+            .get_table(tenant, db_name, table_name)
+            .await?]))
     }
 
     async fn list_tables(&self, _tenant: &Tenant, _db_name: &str) -> Result<Vec<Arc<dyn Table>>> {

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -231,6 +231,15 @@ impl Catalog for FakedCatalog {
         self.cat.get_table(tenant, db_name, table_name).await
     }
 
+    async fn get_single_table_history(
+        &self,
+        tenant: &Tenant,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<Arc<dyn Table>> {
+        self.cat.get_table(tenant, db_name, table_name).await
+    }
+
     async fn list_tables(&self, _tenant: &Tenant, _db_name: &str) -> Result<Vec<Arc<dyn Table>>> {
         todo!()
     }

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -967,12 +967,12 @@ impl Catalog for FakedCatalog {
         todo!()
     }
 
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         _tenant: &Tenant,
         _db_name: &str,
         _table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
+    ) -> Result<Vec<Arc<dyn Table>>> {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -967,6 +967,15 @@ impl Catalog for FakedCatalog {
         todo!()
     }
 
+    async fn get_single_table_history(
+        &self,
+        _tenant: &Tenant,
+        _db_name: &str,
+        _table_name: &str,
+    ) -> Result<Arc<dyn Table>> {
+        todo!()
+    }
+
     async fn list_tables(&self, _tenant: &Tenant, _db_name: &str) -> Result<Vec<Arc<dyn Table>>> {
         todo!()
     }

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -460,6 +460,17 @@ impl Catalog for HiveCatalog {
         Ok(tables)
     }
 
+    async fn get_single_table_history(
+        &self,
+        _tenant: &Tenant,
+        _db_name: &str,
+        _table_name: &str,
+    ) -> Result<Arc<dyn Table>> {
+        Err(ErrorCode::Unimplemented(
+            "Cannot get table history in HIVE catalog",
+        ))
+    }
+
     #[async_backtrace::framed]
     async fn list_tables_history(
         &self,

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -460,12 +460,12 @@ impl Catalog for HiveCatalog {
         Ok(tables)
     }
 
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         _tenant: &Tenant,
         _db_name: &str,
         _table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
+    ) -> Result<Vec<Arc<dyn Table>>> {
         Err(ErrorCode::Unimplemented(
             "Cannot get table history in HIVE catalog",
         ))

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -315,12 +315,12 @@ impl Catalog for IcebergCatalog {
         db.list_tables().await
     }
 
-    async fn get_single_table_history(
+    async fn get_table_history(
         &self,
         _tenant: &Tenant,
         _db_name: &str,
         _table_name: &str,
-    ) -> Result<Arc<dyn Table>> {
+    ) -> Result<Vec<Arc<dyn Table>>> {
         unimplemented!()
     }
 

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -315,6 +315,15 @@ impl Catalog for IcebergCatalog {
         db.list_tables().await
     }
 
+    async fn get_single_table_history(
+        &self,
+        _tenant: &Tenant,
+        _db_name: &str,
+        _table_name: &str,
+    ) -> Result<Arc<dyn Table>> {
+        unimplemented!()
+    }
+
     #[async_backtrace::framed]
     async fn list_tables_history(
         &self,

--- a/src/query/storages/system/src/util.rs
+++ b/src/query/storages/system/src/util.rs
@@ -194,6 +194,14 @@ pub fn find_eq_or_filter(
                             }
                         }
                     }
+                    // show drop tables will specific is_not_null(dropped_on)
+                    "is_not_null" => {
+                        if let Expr::ColumnRef { id, .. } = args[0].clone() {
+                            if id != "dropped_on" {
+                                *invalid_optimize = true;
+                            }
+                        }
+                    }
                     _ => {
                         // Any other function makes it invalid.
                         *invalid_optimize = true;

--- a/tests/sqllogictests/suites/base/06_show/06_0019_show_drop_tables.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0019_show_drop_tables.test
@@ -23,4 +23,7 @@ statement ok
 show drop tables from db1 like '%t';
 
 statement ok
+show drop tables from db1 where name='t_never_exist$$$$';
+
+statement ok
 drop database db1;

--- a/tests/sqllogictests/suites/base/06_show/06_0019_show_drop_tables.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0019_show_drop_tables.test
@@ -14,6 +14,12 @@ statement ok
 drop table db1.t;
 
 statement ok
+create table db1.t(id int);
+
+statement ok
+drop table db1.t;
+
+statement ok
 show drop tables from db1;
 
 statement ok
@@ -24,6 +30,11 @@ show drop tables from db1 like '%t';
 
 statement ok
 show drop tables from db1 where name='t_never_exist$$$$';
+
+query T
+select count(name)>=2 from system.tables_with_history where name='t' and database='db1';
+----
+1
 
 statement ok
 drop database db1;

--- a/tests/sqllogictests/suites/base/06_show/06_0019_show_drop_tables.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0019_show_drop_tables.test
@@ -36,5 +36,11 @@ select count(name)>=2 from system.tables_with_history where name='t' and databas
 ----
 1
 
+query T
+select name, database from system.tables_with_history where database='db1' and dropped_on is not null;
+----
+t db1
+t db1
+
 statement ok
 drop database db1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary



1. add get_single_table_history api
2. optimize show drop tables
3. get_table_history -> get_tables_history

Performance

```
==> Running Q2: internal/queries/02.sql
select name from system.tables where name in ('t_1', 't_2');
3
Q2[1] succeeded in 0.045 seconds
Q2[2] succeeded in 0.044 seconds
Q2[3] succeeded in 0.046 seconds

==> Running Q3: internal/queries/03.sql
select name from system.tables_with_history where name in ('t_1', 't_2');
3
Q3[1] succeeded in 0.046 seconds
Q3[2] succeeded in 0.045 seconds
Q3[3] succeeded in 0.046 seconds
```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16370)
<!-- Reviewable:end -->
