### PR TITLE
refactor: Add item count check to `KVPbApi::get_pb_stream()`

### DIFF
--- a/src/meta/api/src/kv_pb_api/errors/mod.rs
+++ b/src/meta/api/src/kv_pb_api/errors/mod.rs
@@ -23,4 +23,5 @@ pub use self::decode_error::PbDecodeError;
 pub use self::encode_error::PbEncodeError;
 pub use self::read_error::NoneValue;
 pub use self::read_error::PbApiReadError;
+pub use self::read_error::StreamReadEof;
 pub use self::write_error::PbApiWriteError;

--- a/src/meta/api/src/name_id_value_api.rs
+++ b/src/meta/api/src/name_id_value_api.rs
@@ -281,7 +281,6 @@ where
                 id.into_t_ident(tenant)
             });
 
-            #[allow(deprecated)]
             let strm = self.get_pb_values(id_idents).await?;
             let seq_metas = strm.try_collect::<Vec<_>>().await?;
 

--- a/src/meta/api/src/name_id_value_api.rs
+++ b/src/meta/api/src/name_id_value_api.rs
@@ -22,9 +22,7 @@ use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_kvapi::kvapi::KVApi;
-use databend_common_meta_types::anyerror::AnyError;
 use databend_common_meta_types::Change;
-use databend_common_meta_types::InvalidReply;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::Operation;
@@ -283,18 +281,6 @@ where
 
             let strm = self.get_pb_values(id_idents).await?;
             let seq_metas = strm.try_collect::<Vec<_>>().await?;
-
-            if seq_metas.len() != name_ids.len() {
-                return Err(InvalidReply::new(
-                    "seq_metas.len() {} != name_ids.len() {}",
-                    &AnyError::error(format!(
-                        "seq_metas.len() {} != name_ids.len() {}",
-                        seq_metas.len(),
-                        name_ids.len()
-                    )),
-                )
-                .into());
-            }
 
             let name_id_values =
                 name_ids

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -3782,7 +3782,6 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
 
         // Batch get all catalog-metas.
         // - A catalog-meta may be already deleted. It is Ok. Just ignore it.
-        #[allow(deprecated)]
         let seq_metas = self.get_pb_values(kv_keys.clone()).await?;
         let seq_metas = seq_metas.try_collect::<Vec<_>>().await?;
 

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -185,7 +185,6 @@ use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_kvapi::kvapi::Key;
-use databend_common_meta_types::anyerror::AnyError;
 use databend_common_meta_types::protobuf as pb;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::seq_value::SeqValue;
@@ -3784,19 +3783,6 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         // - A catalog-meta may be already deleted. It is Ok. Just ignore it.
         let seq_metas = self.get_pb_values(kv_keys.clone()).await?;
         let seq_metas = seq_metas.try_collect::<Vec<_>>().await?;
-
-        if seq_metas.len() != kv_keys.len() {
-            let err = InvalidReply::new(
-                "list_catalogs",
-                &AnyError::error(format!(
-                    "mismatched catalog-meta count: got: {}, expect: {}",
-                    seq_metas.len(),
-                    kv_keys.len()
-                )),
-            );
-            let meta_net_err = MetaNetworkError::from(err);
-            return Err(KVAppError::MetaError(meta_net_err.into()));
-        }
 
         let mut catalog_infos = Vec::with_capacity(kv_keys.len());
 

--- a/src/meta/types/src/errors/meta_network_errors.rs
+++ b/src/meta/types/src/errors/meta_network_errors.rs
@@ -119,7 +119,7 @@ impl InvalidArgument {
 }
 
 #[derive(thiserror::Error, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
-#[error("InvalidReply: {msg} source: {source}")]
+#[error("InvalidReply: {msg}; source: {source}")]
 pub struct InvalidReply {
     msg: String,
     #[source]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: Add item count check to `KVPbApi::get_pb_stream()`

If a `mget()` operation such as `get_pb_stream()` or `get_pb_values()`
returns less item than the input keys, it returns an error rather than
silently close the stream. This helps the caller to detect early closed
stream error.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16377)
<!-- Reviewable:end -->
