### PR TITLE
fix: table lock flaky test

### DIFF
--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -1371,11 +1371,7 @@ impl TableContext for QueryContext {
         let tbl = catalog
             .get_table(&self.get_tenant(), db_name, tbl_name)
             .await?;
-        if tbl.engine() != "FUSE" || tbl.is_read_only() {
-            return Ok(None);
-        }
-
-        if tbl.is_temp() {
+        if tbl.engine() != "FUSE" || tbl.is_read_only() || tbl.is_temp() {
             return Ok(None);
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 List lock revisions are returned in big-endian order, we need to sort them in ascending numeric order.
```
a4074603-bd1b-404e-bfc3-9a9617ff529b 2024-09-10T11:54:05.238526+08:00  WARN 
databend_query::locks::lock_manager: lock_manager.rs:135 list_lock_revisions reply: 
[(103, LockMeta { user: "root", node: "j3MoOFeUWV7kdHDgmWxxR2", query_id: "e67d5d9a-3e7f-466b-b923-2264077ce8ae", created_on: 2024-09-10T03:54:05.195603634Z, acquired_on: Some(2024-09-10T03:54:05.204791839Z), lock_type: TABLE, extra_info: {} }), 
(106, LockMeta { user: "root", node: "j3MoOFeUWV7kdHDgmWxxR2", query_id: "a4074603-bd1b-404e-bfc3-9a9617ff529b", created_on: 2024-09-10T03:54:05.228411910Z, acquired_on: None, lock_type: TABLE, extra_info: {} }), 
(97, LockMeta { user: "root", node: "j3MoOFeUWV7kdHDgmWxxR2", query_id: "81b42e53-23b2-44b6-b215-9c45bed02c6c", created_on: 2024-09-10T03:54:05.165842784Z, acquired_on: Some(2024-09-10T03:54:05.177124526Z), lock_type: TABLE, extra_info: {} }), 
(99, LockMeta { user: "root", node: "j3MoOFeUWV7kdHDgmWxxR2", query_id: "29fe86a8-e31a-4884-b098-01dec0625614", created_on: 2024-09-10T03:54:05.173372779Z, acquired_on: None, lock_type: TABLE, extra_info: {} })]
```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16429)
<!-- Reviewable:end -->
