### PR TITLE
fix: restore parser backrtace when map_res failed

### DIFF
--- a/src/query/ast/src/parser/common.rs
+++ b/src/query/ast/src/parser/common.rs
@@ -481,11 +481,18 @@ where
 {
     move |input: Input| {
         let i = input;
-        let (input, o1) = parser.parse(input)?;
+        let bt = i.backtrace.clone();
+        let (rest, o1) = parser.parse(input)?;
         match f(o1) {
-            Ok(o2) => Ok((input, o2)),
-            Err(nom::Err::Error(e)) => Err(nom::Err::Error(Error::from_error_kind(i, e))),
-            Err(nom::Err::Failure(e)) => Err(nom::Err::Failure(Error::from_error_kind(i, e))),
+            Ok(o2) => Ok((rest, o2)),
+            Err(nom::Err::Error(e)) => {
+                i.backtrace.restore(bt);
+                Err(nom::Err::Error(Error::from_error_kind(i, e)))
+            }
+            Err(nom::Err::Failure(e)) => {
+                i.backtrace.restore(bt);
+                Err(nom::Err::Failure(Error::from_error_kind(i, e)))
+            }
             Err(nom::Err::Incomplete(_)) => unreachable!(),
         }
     }

--- a/src/query/ast/src/parser/error.rs
+++ b/src/query/ast/src/parser/error.rs
@@ -72,6 +72,14 @@ impl Backtrace {
     pub fn clear(&self) {
         self.inner.replace(None);
     }
+
+    /// Restore the backtrace to a previous state.
+    ///
+    /// This is useful when the furthest-reached error reporting strategy is undesirable,
+    /// particularly when the furthest path is reached but considered invalid.
+    pub fn restore(&self, other: Backtrace) {
+        *self.inner.borrow_mut() = other.inner.into_inner();
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
