### PR TITLE
refactor: cleanup logic to get tables to vacuum

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -3396,7 +3396,7 @@ impl SchemaApiTestSuite {
         {
             let req = ListDroppedTableReq {
                 inner: DatabaseNameIdent::new(&tenant, ""),
-                filter: TableInfoFilter::AllDroppedTables(None),
+                filter: TableInfoFilter::DroppedTableOrDroppedDatabase(None),
                 limit: None,
             };
             let resp = mt.get_drop_table_infos(req).await?;
@@ -3606,7 +3606,7 @@ impl SchemaApiTestSuite {
         {
             let req = ListDroppedTableReq {
                 inner: DatabaseNameIdent::new(&tenant, ""),
-                filter: TableInfoFilter::AllDroppedTables(None),
+                filter: TableInfoFilter::DroppedTableOrDroppedDatabase(None),
                 limit: None,
             };
             let resp = mt.get_drop_table_infos(req).await?;
@@ -3803,7 +3803,7 @@ impl SchemaApiTestSuite {
         {
             let req = ListDroppedTableReq {
                 inner: DatabaseNameIdent::new(&tenant, ""),
-                filter: TableInfoFilter::AllDroppedTables(None),
+                filter: TableInfoFilter::DroppedTableOrDroppedDatabase(None),
                 limit: None,
             };
             let resp = mt.get_drop_table_infos(req).await?;
@@ -4316,7 +4316,7 @@ impl SchemaApiTestSuite {
             let now = Utc::now();
             let req = ListDroppedTableReq {
                 inner: DatabaseNameIdent::new(&tenant, ""),
-                filter: TableInfoFilter::AllDroppedTables(Some(now)),
+                filter: TableInfoFilter::DroppedTableOrDroppedDatabase(Some(now)),
                 limit: None,
             };
             let resp = mt.get_drop_table_infos(req).await?;
@@ -4348,7 +4348,7 @@ impl SchemaApiTestSuite {
         {
             let req = ListDroppedTableReq {
                 inner: DatabaseNameIdent::new(&tenant, ""),
-                filter: TableInfoFilter::AllDroppedTables(None),
+                filter: TableInfoFilter::DroppedTableOrDroppedDatabase(None),
                 limit: None,
             };
             let resp = mt.get_drop_table_infos(req).await?;
@@ -4557,7 +4557,7 @@ impl SchemaApiTestSuite {
         for (limit, number, drop_ids) in limit_and_drop_ids {
             let req = ListDroppedTableReq {
                 inner: DatabaseNameIdent::new(&tenant, ""),
-                filter: TableInfoFilter::AllDroppedTables(None),
+                filter: TableInfoFilter::DroppedTableOrDroppedDatabase(None),
                 limit,
             };
             let resp = mt.get_drop_table_infos(req).await?;
@@ -5234,7 +5234,7 @@ impl SchemaApiTestSuite {
             // vacuum drop table
             let req = ListDroppedTableReq {
                 inner: DatabaseNameIdent::new(&tenant, ""),
-                filter: TableInfoFilter::AllDroppedTables(None),
+                filter: TableInfoFilter::DroppedTableOrDroppedDatabase(None),
                 limit: None,
             };
             let resp = mt.get_drop_table_infos(req).await?;

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -897,16 +897,20 @@ impl ListTableReq {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TableInfoFilter {
-    // if datatime is some, filter only dropped tables which drop time before that,
-    // else filter all dropped tables
-    Dropped(Option<DateTime<Utc>>),
-    // filter all dropped tables, including all tables in dropped database and dropped tables in exist dbs,
-    // in this case, `ListTableReq`.db_name will be ignored
-    // return Tables in two cases:
-    //  1) if database drop before date time, then all table in this db will be return;
-    //  2) else, return all the tables drop before data time.
-    AllDroppedTables(Option<DateTime<Utc>>),
-    // return all tables, ignore drop on time.
+    /// Choose only dropped tables.
+    ///
+    /// If the arg `retention_boundary` time is Some, choose only tables dropped before this boundary time.
+    DroppedTables(Option<DateTime<Utc>>),
+    /// Choose dropped table or all table in dropped databases.
+    ///
+    /// In this case, `ListTableReq`.db_name will be ignored.
+    ///
+    /// If the `retention_boundary` time is Some,
+    /// choose the table dropped before this time
+    /// or choose the database before this time.
+    DroppedTableOrDroppedDatabase(Option<DateTime<Utc>>),
+
+    /// return all tables, ignore drop on time.
     All,
 }
 

--- a/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
@@ -128,9 +128,9 @@ impl Interpreter for VacuumDropTablesInterpreter {
         );
         // if database if empty, vacuum all tables
         let filter = if self.plan.database.is_empty() {
-            TableInfoFilter::AllDroppedTables(Some(retention_time))
+            TableInfoFilter::DroppedTableOrDroppedDatabase(Some(retention_time))
         } else {
-            TableInfoFilter::Dropped(Some(retention_time))
+            TableInfoFilter::DroppedTables(Some(retention_time))
         };
 
         let tenant = self.ctx.get_tenant();


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: cleanup logic to get tables to vacuum

- Replace `None` limit with `usize::MAX` to simplify capacity checking
  logic.

- Replace `None` retention time with `DateTime::MAX_UTC`.

- Rename `TableInfoFilter` variants to reflect its purpose more
  precisely.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16450)
<!-- Reviewable:end -->
