### PR TITLE
fix: flaky test 09_0036_merge_into_without_dist

### DIFF
--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0036_merge_into_without_distributed_enable.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0036_merge_into_without_distributed_enable.test
@@ -612,20 +612,55 @@ create table source_test(a int,b string,delete_flag bool) cluster by(a,b);
 statement ok
 insert into source_test values(1,'d',true),(2,'e',true),(3,'f',false),(4,'e',true),(5,'f',false);
 
+###############################################################################
+# To avoid flakiness, using different stage names for http and mysql handlers #
+# testing of these 2 handlers may be run concurrently, and conflict with each #
+# other, leading to flaky tests.                                              #
+###############################################################################
+
+onlyif mysql
 statement ok
 drop stage if exists source_parquet;
 
+onlyif mysql
 statement ok
 create stage source_parquet file_format = (type = parquet);
 
+onlyif mysql
 statement ok
 remove @source_parquet;
 
+onlyif mysql
 statement ok
 copy into @source_parquet from (select * from source_test);
 
+onlyif mysql
 query TTT
 merge into `target_test` as tt using (select `a`,`b`,`delete_flag` from @source_parquet (pattern => '.*[.]parquet')) as ss on (ss.`a` = tt.`a`) 
+when matched and ss.`delete_flag` = true then delete when matched then update * when not matched and ss.`delete_flag` = false then insert *;
+----
+1 1 2
+
+
+onlyif http
+statement ok
+drop stage if exists source_parquet_http;
+
+onlyif http
+statement ok
+create stage source_parquet_http file_format = (type = parquet);
+
+onlyif http
+statement ok
+remove @source_parquet_http;
+
+onlyif http
+statement ok
+copy into @source_parquet_http from (select * from source_test);
+
+onlyif http
+query TTT
+merge into `target_test` as tt using (select `a`,`b`,`delete_flag` from @source_parquet_http (pattern => '.*[.]parquet')) as ss on (ss.`a` = tt.`a`)
 when matched and ss.`delete_flag` = true then delete when matched then update * when not matched and ss.`delete_flag` = false then insert *;
 ----
 1 1 2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


fix flaky test `tests/sqllogictests/suites/base/09_fuse_engine/09_0036_merge_into_without_distributed_enable.test`, by using different stage names for http/mysql handlers

- fixes: #16456

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16457)
<!-- Reviewable:end -->
