### PR TITLE
refactor(query): sort kernel optimization

### DIFF
--- a/src/query/expression/src/kernels/mod.rs
+++ b/src/query/expression/src/kernels/mod.rs
@@ -18,6 +18,7 @@ mod group_by;
 mod group_by_hash;
 mod scatter;
 mod sort;
+mod sort_compare;
 mod take;
 mod take_chunks;
 mod take_compact;
@@ -27,6 +28,7 @@ mod utils;
 
 pub use group_by_hash::*;
 pub use sort::*;
+pub use sort_compare::*;
 pub use take_chunks::*;
 pub use topk::*;
 pub use utils::*;

--- a/src/query/expression/src/kernels/sort.rs
+++ b/src/query/expression/src/kernels/sort.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
-use std::iter::once;
 use std::sync::Arc;
 
 use databend_common_arrow::arrow::array::ord as arrow_ord;

--- a/src/query/expression/src/kernels/sort.rs
+++ b/src/query/expression/src/kernels/sort.rs
@@ -20,13 +20,10 @@ use databend_common_arrow::arrow::array::ord as arrow_ord;
 use databend_common_arrow::arrow::array::ord::DynComparator;
 use databend_common_arrow::arrow::array::Array;
 use databend_common_arrow::arrow::array::PrimitiveArray;
-use databend_common_arrow::arrow::compute::merge_sort as arrow_merge_sort;
-use databend_common_arrow::arrow::compute::merge_sort::build_comparator_impl;
 use databend_common_arrow::arrow::compute::sort as arrow_sort;
 use databend_common_arrow::arrow::datatypes::DataType as ArrowType;
 use databend_common_arrow::arrow::error::Error as ArrowError;
 use databend_common_arrow::arrow::error::Result as ArrowResult;
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 
 use crate::converts::arrow2::ARROW_EXT_TYPE_EMPTY_ARRAY;
@@ -34,10 +31,13 @@ use crate::converts::arrow2::ARROW_EXT_TYPE_EMPTY_MAP;
 use crate::converts::arrow2::ARROW_EXT_TYPE_VARIANT;
 use crate::types::DataType;
 use crate::utils::arrow::column_to_arrow_array;
+use crate::visitor::ValueVisitor;
 use crate::Column;
 use crate::ColumnBuilder;
 use crate::DataBlock;
 use crate::Scalar;
+use crate::SortCompare;
+use crate::Value;
 
 pub type AbortChecker = Arc<dyn CheckAbort + Send + Sync>;
 
@@ -82,6 +82,26 @@ impl DataBlock {
         limit: Option<usize>,
     ) -> Result<DataBlock> {
         let num_rows = block.num_rows();
+        let mut sort_compare = SortCompare::new(descriptions.to_owned(), num_rows, limit);
+
+        for desc in descriptions.iter() {
+            let array = block.get_by_offset(desc.offset).value.clone();
+            sort_compare.visit_value(array)?;
+            sort_compare.increment_column_index();
+        }
+
+        let permutations = sort_compare.take_permutation();
+        DataBlock::take(block, &permutations, &mut None)
+    }
+
+    // TODO remove these
+    #[allow(dead_code)]
+    pub fn sort_old(
+        block: &DataBlock,
+        descriptions: &[SortColumnDescription],
+        limit: Option<usize>,
+    ) -> Result<DataBlock> {
+        let num_rows = block.num_rows();
         if num_rows <= 1 {
             return Ok(block.clone());
         }
@@ -105,115 +125,6 @@ impl DataBlock {
         let indices: PrimitiveArray<u32> =
             arrow_sort::lexsort_to_indices_impl(&order_arrays, limit, &build_compare)?;
         DataBlock::take(block, indices.values(), &mut None)
-    }
-
-    // merge two blocks to one sorted block
-    // require: lhs and rhs have been `convert_to_full`.
-    fn two_way_merge_sort(
-        blocks: &[DataBlock],
-        descriptions: &[SortColumnDescription],
-        limit: Option<usize>,
-    ) -> Result<DataBlock> {
-        assert!(blocks.len() == 2);
-
-        let lhs = &blocks[0];
-        let rhs = &blocks[1];
-
-        let lhs_len = lhs.num_rows();
-        let rhs_len = rhs.num_rows();
-        if lhs_len == 0 {
-            return Ok(rhs.clone());
-        }
-        if rhs_len == 0 {
-            return Ok(lhs.clone());
-        }
-
-        let mut sort_options = Vec::with_capacity(descriptions.len());
-        let sort_arrays = descriptions
-            .iter()
-            .map(|d| {
-                let left = column_to_arrow_array(lhs.get_by_offset(d.offset), lhs_len);
-                let right = column_to_arrow_array(rhs.get_by_offset(d.offset), rhs_len);
-                sort_options.push(arrow_sort::SortOptions {
-                    descending: !d.asc,
-                    nulls_first: d.nulls_first,
-                });
-                vec![left, right]
-            })
-            .collect::<Vec<_>>();
-
-        let sort_dyn_arrays = sort_arrays
-            .iter()
-            .map(|f| vec![f[0].as_ref(), f[1].as_ref()])
-            .collect::<Vec<_>>();
-
-        let sort_options_with_arrays = sort_dyn_arrays
-            .iter()
-            .zip(sort_options.iter())
-            .map(|(arrays, opt)| (arrays as &[&dyn Array], opt))
-            .collect::<Vec<_>>();
-
-        let comparator = build_comparator_impl(&sort_options_with_arrays, &build_compare)?;
-        let lhs_slice = (0, 0, lhs_len);
-        let rhs_slice = (1, 0, rhs_len);
-
-        let slices =
-            arrow_merge_sort::merge_sort_slices(once(&lhs_slice), once(&rhs_slice), &comparator)
-                .to_vec(limit);
-
-        let block = DataBlock::take_by_slices_limit_from_blocks(blocks, &slices, limit);
-        Ok(block)
-    }
-
-    pub fn merge_sort(
-        blocks: &[DataBlock],
-        descriptions: &[SortColumnDescription],
-        limit: Option<usize>,
-        abort_checker: AbortChecker,
-    ) -> Result<DataBlock> {
-        match blocks.len() {
-            0 => Result::Err(ErrorCode::EmptyData("Can't merge empty blocks")),
-            1 => Ok(blocks[0].clone()),
-            2 => {
-                if abort_checker.is_aborting() {
-                    return Err(ErrorCode::AbortedQuery(
-                        "Aborted query, because the server is shutting down or the query was killed.",
-                    ));
-                }
-
-                DataBlock::two_way_merge_sort(blocks, descriptions, limit)
-            }
-            _ => {
-                if abort_checker.is_aborting() {
-                    return Err(ErrorCode::AbortedQuery(
-                        "Aborted query, because the server is shutting down or the query was killed.",
-                    ));
-                }
-                let left = DataBlock::merge_sort(
-                    &blocks[0..blocks.len() / 2],
-                    descriptions,
-                    limit,
-                    abort_checker.clone(),
-                )?;
-                if abort_checker.is_aborting() {
-                    return Err(ErrorCode::AbortedQuery(
-                        "Aborted query, because the server is shutting down or the query was killed.",
-                    ));
-                }
-                let right = DataBlock::merge_sort(
-                    &blocks[blocks.len() / 2..blocks.len()],
-                    descriptions,
-                    limit,
-                    abort_checker.clone(),
-                )?;
-                if abort_checker.is_aborting() {
-                    return Err(ErrorCode::AbortedQuery(
-                        "Aborted query, because the server is shutting down or the query was killed.",
-                    ));
-                }
-                DataBlock::two_way_merge_sort(&[left, right], descriptions, limit)
-            }
-        }
     }
 }
 
@@ -290,20 +201,26 @@ pub fn compare_scalars(rows: Vec<Vec<Scalar>>, data_types: &[DataType]) -> Resul
 
     let order_columns = columns
         .into_iter()
-        .map(|builder| builder.build().as_arrow())
+        .map(|builder| builder.build())
         .collect::<Vec<_>>();
-    let order_arrays = order_columns
+
+    let descriptions = order_columns
         .iter()
-        .map(|array| arrow_sort::SortColumn {
-            values: array.as_ref(),
-            options: Some(arrow_sort::SortOptions {
-                descending: false,
-                nulls_first: false,
-            }),
+        .enumerate()
+        .map(|(idx, array)| SortColumnDescription {
+            offset: idx,
+            asc: true,
+            nulls_first: false,
+            is_nullable: array.data_type().is_nullable(),
         })
         .collect::<Vec<_>>();
-    let indices: PrimitiveArray<u32> =
-        arrow_sort::lexsort_to_indices_impl(&order_arrays, None, &build_compare)?;
 
-    Ok(indices.values().to_vec())
+    let mut sort_compare = SortCompare::new(descriptions, length, None);
+
+    for array in order_columns {
+        sort_compare.visit_value(Value::Column(array))?;
+        sort_compare.increment_column_index();
+    }
+
+    Ok(sort_compare.take_permutation())
 }

--- a/src/query/expression/src/kernels/sort.rs
+++ b/src/query/expression/src/kernels/sort.rs
@@ -81,6 +81,9 @@ impl DataBlock {
         limit: Option<usize>,
     ) -> Result<DataBlock> {
         let num_rows = block.num_rows();
+        if num_rows <= 1 || block.num_columns() == 0 {
+            return Ok(block.clone());
+        }
         let mut sort_compare = SortCompare::new(descriptions.to_owned(), num_rows, limit);
 
         for desc in descriptions.iter() {

--- a/src/query/expression/src/kernels/sort.rs
+++ b/src/query/expression/src/kernels/sort.rs
@@ -94,6 +94,20 @@ impl DataBlock {
     pub fn sort(
         block: &DataBlock,
         descriptions: &[SortColumnDescription],
+        limit: Option<usize>,
+    ) -> Result<DataBlock> {
+        let limit = if let Some(l) = limit {
+            LimitType::LimitRows(l)
+        } else {
+            LimitType::None
+        };
+
+        Self::sort_with_type(block, descriptions, limit)
+    }
+
+    pub fn sort_with_type(
+        block: &DataBlock,
+        descriptions: &[SortColumnDescription],
         limit: LimitType,
     ) -> Result<DataBlock> {
         let num_rows = block.num_rows();

--- a/src/query/expression/src/kernels/sort_compare.rs
+++ b/src/query/expression/src/kernels/sort_compare.rs
@@ -50,7 +50,7 @@ macro_rules! do_sorter {
                             if $ordering_desc.asc {
                                 $c(left, right)
                             } else {
-                                $c(left, right).reverse()
+                                $c(right, left)
                             }
                         }
                         (true, false) => {

--- a/src/query/expression/src/kernels/sort_compare.rs
+++ b/src/query/expression/src/kernels/sort_compare.rs
@@ -1,0 +1,222 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::ops::Range;
+
+use databend_common_arrow::arrow::bitmap::Bitmap;
+use databend_common_arrow::arrow::buffer::Buffer;
+use databend_common_exception::Result;
+use memchr::memchr;
+
+use crate::types::AnyType;
+use crate::types::NullableColumn;
+use crate::types::Number;
+use crate::types::ValueType;
+use crate::visitor::ValueVisitor;
+use crate::SortColumnDescription;
+
+pub struct SortCompare {
+    rows: usize,
+    limit: Option<usize>,
+    permutation: Vec<u32>,
+    ordering_descs: Vec<SortColumnDescription>,
+    current_column_index: usize,
+    validity: Option<Bitmap>,
+    equality_index: Vec<u8>,
+}
+
+macro_rules! generate_comparator {
+    ($value:expr, $validity:expr, $g:expr, $c:expr, $ordering_desc:expr) => {
+        |&a, &b| {
+            let ord = if let Some(valids) = &$validity {
+                match (valids.get_bit(a as _), valids.get_bit(b as _)) {
+                    (true, true) => {
+                        let left = $g($value, a);
+                        let right = $g($value, b);
+                        $c(left, right)
+                    }
+                    (true, false) => Ordering::Less,
+                    (false, true) => Ordering::Greater,
+                    (false, false) => Ordering::Equal,
+                }
+            } else {
+                let left = $g($value, a);
+                let right = $g($value, b);
+                $c(left, right)
+            };
+
+            if $ordering_desc.asc {
+                ord
+            } else {
+                ord.reverse()
+            }
+        }
+    };
+}
+
+impl SortCompare {
+    pub fn new(
+        ordering_descs: Vec<SortColumnDescription>,
+        rows: usize,
+        limit: Option<usize>,
+    ) -> Self {
+        let equality_index = if ordering_descs.len() == 1 {
+            vec![]
+        } else {
+            vec![1; rows as _]
+        };
+        Self {
+            rows,
+            limit,
+            permutation: (0..rows as u32).collect(),
+            ordering_descs,
+            current_column_index: 0,
+            validity: None,
+            equality_index,
+        }
+    }
+
+    pub fn increment_column_index(&mut self) {
+        self.current_column_index += 1;
+    }
+
+    pub fn take_permutation(mut self) -> Vec<u32> {
+        let limit = self.limit.unwrap_or(self.rows);
+        self.permutation.truncate(limit);
+        self.permutation
+    }
+
+    fn do_inner_sort<C>(&mut self, c: C, range: Range<usize>)
+    where C: FnMut(&u32, &u32) -> Ordering + Copy {
+        let permutations = &mut self.permutation[range.start..range.end];
+
+        let limit = self.limit.unwrap_or(self.rows);
+        if limit > range.start && limit < range.end {
+            let (p, _, _) = permutations.select_nth_unstable_by(limit - range.start, c);
+            p.sort_unstable_by(c);
+        } else {
+            permutations.sort_unstable_by(c);
+        }
+    }
+
+    fn common_sort<T, V, G, C>(&mut self, value: V, g: G, c: C)
+    where
+        G: Fn(V, u32) -> T + Copy,
+        V: Copy,
+        C: Fn(T, T) -> Ordering + Copy,
+    {
+        let mut validity = self.validity.take();
+        let ordering_desc = self.ordering_descs[self.current_column_index].clone();
+
+        // faster path for only one sort column
+        if self.ordering_descs.len() == 1 {
+            self.do_inner_sort(
+                generate_comparator!(value, validity, g, c, ordering_desc),
+                0..self.rows,
+            );
+        } else {
+            let mut current = 1;
+            let len = self.rows;
+            let need_update_equality_index =
+                self.current_column_index != self.ordering_descs.len() - 1;
+
+            while current < len {
+                // Find the start of the next range of equal elements
+                let start = if let Some(pos) = memchr(1, &self.equality_index[current..len]) {
+                    current + pos
+                } else {
+                    len
+                };
+
+                if start == len {
+                    break;
+                }
+
+                // Find the end of the range of equal elements
+                let end = if let Some(pos) = memchr(0, &self.equality_index[start..len]) {
+                    start + pos
+                } else {
+                    len
+                };
+
+                let range = start - 1..end;
+
+                if let Some(v) = validity.as_mut() {
+                    v.slice(range.start, range.end - range.start);
+                    if v.unset_bits() == 0 {
+                        validity = None;
+                    }
+                }
+                // Perform the inner sort on the found range
+                self.do_inner_sort(
+                    generate_comparator!(value, validity, g, c, ordering_desc),
+                    range,
+                );
+
+                if need_update_equality_index {
+                    // Update equality_index
+                    for i in start..end {
+                        let is_equal = u8::from(
+                            c(
+                                g(value, self.permutation[i]),
+                                g(value, self.permutation[i - 1]),
+                            ) == Ordering::Equal,
+                        );
+                        self.equality_index[i] &= is_equal;
+                    }
+                }
+
+                current = end;
+            }
+        }
+    }
+}
+
+impl ValueVisitor for SortCompare {
+    fn visit_scalar(&mut self, _scalar: crate::Scalar) -> Result<()> {
+        Ok(())
+    }
+
+    // faster path for numeric
+    fn visit_number<T: Number>(&mut self, column: Buffer<T>) -> Result<()> {
+        let values = column.as_slice();
+        self.common_sort(values, |c, idx| c[idx as usize], |a: T, b: T| a.cmp(&b));
+        Ok(())
+    }
+
+    fn visit_timestamp(&mut self, buffer: Buffer<i64>) -> Result<()> {
+        self.visit_number(buffer)
+    }
+
+    fn visit_date(&mut self, buffer: Buffer<i32>) -> Result<()> {
+        self.visit_number(buffer)
+    }
+
+    fn visit_typed_column<T: ValueType>(&mut self, col: T::Column) -> Result<()> {
+        self.common_sort(
+            &col,
+            |c, idx| -> T::ScalarRef<'_> { unsafe { T::index_column_unchecked(&c, idx as _) } },
+            |a, b| T::compare(a, b),
+        );
+        Ok(())
+    }
+
+    fn visit_nullable(&mut self, column: Box<NullableColumn<AnyType>>) -> Result<()> {
+        if column.validity.unset_bits() > 0 {
+            self.validity = Some(column.validity.clone());
+        }
+        self.visit_column(column.column.clone())
+    }
+}

--- a/src/query/expression/src/kernels/sort_compare.rs
+++ b/src/query/expression/src/kernels/sort_compare.rs
@@ -179,7 +179,7 @@ impl SortCompare {
                 let range = start - 1..end;
 
                 // Perform the inner sort on the found range
-                do_sorter!(self, value, temp_v, g, c, ordering_desc, range);
+                do_sorter!(self, value, validity, g, c, ordering_desc, range);
                 if need_update_equality_index {
                     // Update equality_index
                     for i in start..end {

--- a/src/query/expression/src/kernels/sort_compare.rs
+++ b/src/query/expression/src/kernels/sort_compare.rs
@@ -41,34 +41,32 @@ macro_rules! do_sorter {
     ($self: expr, $value:expr, $validity:expr, $g:expr, $c:expr, $ordering_desc:expr, $range: expr) => {
         if let Some(valids) = &$validity {
             $self.do_inner_sort(
-                |&a, &b| {
-                    let order = match (valids.get_bit(a as _), valids.get_bit(b as _)) {
-                        (true, true) => {
-                            let left = $g($value, a);
-                            let right = $g($value, b);
+                |&a, &b| match (valids.get_bit(a as _), valids.get_bit(b as _)) {
+                    (true, true) => {
+                        let left = $g($value, a);
+                        let right = $g($value, b);
 
-                            if $ordering_desc.asc {
-                                $c(left, right)
-                            } else {
-                                $c(right, left)
-                            }
+                        if $ordering_desc.asc {
+                            $c(left, right)
+                        } else {
+                            $c(right, left)
                         }
-                        (true, false) => {
-                            if $ordering_desc.nulls_first {
-                                Ordering::Greater
-                            } else {
-                                Ordering::Less
-                            }
+                    }
+                    (true, false) => {
+                        if $ordering_desc.nulls_first {
+                            Ordering::Greater
+                        } else {
+                            Ordering::Less
                         }
-                        (false, true) => {
-                            if $ordering_desc.nulls_first {
-                                Ordering::Less
-                            } else {
-                                Ordering::Greater
-                            }
+                    }
+                    (false, true) => {
+                        if $ordering_desc.nulls_first {
+                            Ordering::Less
+                        } else {
+                            Ordering::Greater
                         }
-                        (false, false) => Ordering::Equal,
-                    };
+                    }
+                    (false, false) => Ordering::Equal,
                 },
                 $range,
             );

--- a/src/query/expression/src/kernels/sort_compare.rs
+++ b/src/query/expression/src/kernels/sort_compare.rs
@@ -123,7 +123,7 @@ impl SortCompare {
             LimitType::None => self.permutation,
             LimitType::LimitRows(rows) => {
                 self.permutation.truncate(rows);
-                return self.permutation;
+                self.permutation
             }
             LimitType::LimitRank(rank_number) => {
                 let mut unique_count = 0;

--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -44,22 +44,26 @@ use serde::Deserialize;
 use serde::Serialize;
 
 pub use self::any::AnyType;
+pub use self::array::ArrayColumn;
 pub use self::array::ArrayType;
+pub use self::binary::BinaryColumn;
 pub use self::binary::BinaryType;
 pub use self::bitmap::BitmapType;
 pub use self::boolean::BooleanType;
 pub use self::date::DateType;
-pub use self::decimal::DecimalDataType;
-pub use self::decimal::DecimalSize;
+pub use self::decimal::*;
 pub use self::empty_array::EmptyArrayType;
 pub use self::empty_map::EmptyMapType;
 pub use self::generic::GenericType;
+pub use self::geography::GeographyColumn;
 pub use self::geography::GeographyType;
 pub use self::map::MapType;
 pub use self::null::NullType;
+pub use self::nullable::NullableColumn;
 pub use self::nullable::NullableType;
 pub use self::number::*;
 pub use self::number_class::*;
+pub use self::string::StringColumn;
 pub use self::string::StringType;
 pub use self::timestamp::TimestampType;
 pub use self::variant::VariantType;
@@ -387,46 +391,47 @@ pub trait ValueType: Debug + Clone + PartialEq + Sized + 'static {
         Self::column_len(col) * std::mem::size_of::<Self::Scalar>()
     }
 
-    /// Compare two scalars and return the Ordering between them, some data types not support comparison.
+    /// This is default implementation yet it's not efficient.
     #[inline(always)]
-    fn compare(_: Self::ScalarRef<'_>, _: Self::ScalarRef<'_>) -> Option<Ordering> {
-        None
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        Self::upcast_scalar(Self::to_owned_scalar(lhs))
+            .cmp(&Self::upcast_scalar(Self::to_owned_scalar(rhs)))
     }
 
     /// Equal comparison between two scalars, some data types not support comparison.
     #[inline(always)]
     fn equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        matches!(Self::compare(left, right), Some(Ordering::Equal))
+        matches!(Self::compare(left, right), Ordering::Equal)
     }
 
     /// Not equal comparison between two scalars, some data types not support comparison.
     #[inline(always)]
     fn not_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        !matches!(Self::compare(left, right), Some(Ordering::Equal))
+        !matches!(Self::compare(left, right), Ordering::Equal)
     }
 
     /// Greater than comparison between two scalars, some data types not support comparison.
     #[inline(always)]
     fn greater_than(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        matches!(Self::compare(left, right), Some(Ordering::Greater))
+        matches!(Self::compare(left, right), Ordering::Greater)
     }
 
     /// Less than comparison between two scalars, some data types not support comparison.
     #[inline(always)]
     fn less_than(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        matches!(Self::compare(left, right), Some(Ordering::Less))
+        matches!(Self::compare(left, right), Ordering::Less)
     }
 
     /// Greater than or equal comparison between two scalars, some data types not support comparison.
     #[inline(always)]
     fn greater_than_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        !matches!(Self::compare(left, right), Some(Ordering::Less))
+        !matches!(Self::compare(left, right), Ordering::Less)
     }
 
     /// Less than or equal comparison between two scalars, some data types not support comparison.
     #[inline(always)]
     fn less_than_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        !matches!(Self::compare(left, right), Some(Ordering::Greater))
+        !matches!(Self::compare(left, right), Ordering::Greater)
     }
 }
 

--- a/src/query/expression/src/types/any.rs
+++ b/src/query/expression/src/types/any.rs
@@ -149,7 +149,7 @@ impl ValueType for AnyType {
     }
 
     #[inline(always)]
-    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Option<Ordering> {
-        Some(lhs.cmp(&rhs))
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
     }
 }

--- a/src/query/expression/src/types/binary.rs
+++ b/src/query/expression/src/types/binary.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::iter::once;
 use std::marker::PhantomData;
 use std::ops::Range;
@@ -167,6 +168,11 @@ impl ValueType for BinaryType {
 
     fn column_memory_size(col: &Self::Column) -> usize {
         col.data().len() + col.offsets().len() * 8
+    }
+
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(rhs)
     }
 }
 

--- a/src/query/expression/src/types/bitmap.rs
+++ b/src/query/expression/src/types/bitmap.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::ops::Range;
 
 use super::binary::BinaryColumn;
@@ -161,6 +162,11 @@ impl ValueType for BitmapType {
 
     fn column_memory_size(col: &Self::Column) -> usize {
         col.data().len() + col.offsets().len() * 8
+    }
+
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(rhs)
     }
 }
 

--- a/src/query/expression/src/types/boolean.rs
+++ b/src/query/expression/src/types/boolean.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::ops::Range;
 
 use databend_common_arrow::arrow::bitmap::Bitmap;
@@ -162,6 +163,11 @@ impl ValueType for BooleanType {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         assert_eq!(builder.len(), 1);
         builder.get(0)
+    }
+
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
     }
 
     #[inline(always)]

--- a/src/query/expression/src/types/date.rs
+++ b/src/query/expression/src/types/date.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::fmt::Display;
 use std::io::Cursor;
 use std::ops::Range;
@@ -183,6 +184,11 @@ impl ValueType for DateType {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         assert_eq!(builder.len(), 1);
         builder[0]
+    }
+
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
     }
 
     #[inline(always)]

--- a/src/query/expression/src/types/decimal.rs
+++ b/src/query/expression/src/types/decimal.rs
@@ -182,6 +182,11 @@ impl<Num: Decimal> ValueType for DecimalType<Num> {
     }
 
     #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
+    }
+
+    #[inline(always)]
     fn equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
         left == right
     }

--- a/src/query/expression/src/types/empty_array.rs
+++ b/src/query/expression/src/types/empty_array.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::ops::Range;
 
 use crate::property::Domain;
@@ -159,6 +160,11 @@ impl ValueType for EmptyArrayType {
 
     fn column_memory_size(_: &Self::Column) -> usize {
         std::mem::size_of::<usize>()
+    }
+
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
     }
 
     #[inline(always)]

--- a/src/query/expression/src/types/empty_map.rs
+++ b/src/query/expression/src/types/empty_map.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::ops::Range;
 
 use crate::property::Domain;
@@ -159,6 +160,11 @@ impl ValueType for EmptyMapType {
 
     fn column_memory_size(_: &Self::Column) -> usize {
         std::mem::size_of::<usize>()
+    }
+
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
     }
 }
 

--- a/src/query/expression/src/types/generic.rs
+++ b/src/query/expression/src/types/generic.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::ops::Range;
 
 use crate::property::Domain;
@@ -148,6 +149,11 @@ impl<const INDEX: usize> ValueType for GenericType<INDEX> {
 
     fn column_memory_size(col: &Self::Column) -> usize {
         col.memory_size()
+    }
+
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
     }
 }
 

--- a/src/query/expression/src/types/geography.rs
+++ b/src/query/expression/src/types/geography.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Range;
@@ -63,7 +64,7 @@ impl Geography {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GeographyRef<'a>(pub &'a [u8]);
 
 impl<'a> GeographyRef<'a> {
@@ -233,8 +234,9 @@ impl ValueType for GeographyType {
         col.memory_size()
     }
 
-    fn compare(a: Self::ScalarRef<'_>, b: Self::ScalarRef<'_>) -> Option<std::cmp::Ordering> {
-        a.partial_cmp(&b)
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
     }
 }
 

--- a/src/query/expression/src/types/geometry.rs
+++ b/src/query/expression/src/types/geometry.rs
@@ -167,6 +167,11 @@ impl ValueType for GeometryType {
     fn column_memory_size(col: &Self::Column) -> usize {
         col.data().len() + col.offsets().len() * 8
     }
+
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
+    }
 }
 
 impl ArgType for GeometryType {

--- a/src/query/expression/src/types/geometry.rs
+++ b/src/query/expression/src/types/geometry.rs
@@ -170,7 +170,7 @@ impl ValueType for GeometryType {
 
     #[inline(always)]
     fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
-        lhs.cmp(&rhs)
+        lhs.cmp(rhs)
     }
 }
 

--- a/src/query/expression/src/types/null.rs
+++ b/src/query/expression/src/types/null.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::ops::Range;
 
 use super::nullable::NullableDomain;
@@ -166,6 +167,11 @@ impl ValueType for NullType {
 
     fn column_memory_size(_: &Self::Column) -> usize {
         std::mem::size_of::<usize>()
+    }
+
+    #[inline(always)]
+    fn compare(_: Self::ScalarRef<'_>, _: Self::ScalarRef<'_>) -> Ordering {
+        Ordering::Equal
     }
 }
 

--- a/src/query/expression/src/types/nullable.rs
+++ b/src/query/expression/src/types/nullable.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::ops::Range;
 
@@ -221,6 +222,17 @@ impl<T: ValueType> ValueType for NullableType<T> {
 
     fn column_memory_size(col: &Self::Column) -> usize {
         col.memory_size()
+    }
+
+    // Null default lastly
+    #[inline(always)]
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        match (lhs, rhs) {
+            (Some(lhs), Some(rhs)) => T::compare(lhs, rhs),
+            (Some(_), None) => Ordering::Greater,
+            (None, Some(_)) => Ordering::Less,
+            (None, None) => Ordering::Equal,
+        }
     }
 }
 

--- a/src/query/expression/src/types/number.rs
+++ b/src/query/expression/src/types/number.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Range;
@@ -216,6 +217,11 @@ impl<Num: Number> ValueType for NumberType<Num> {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         assert_eq!(builder.len(), 1);
         builder[0]
+    }
+
+    #[inline(always)]
+    fn compare(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> Ordering {
+        left.cmp(&right)
     }
 
     #[inline(always)]

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::iter::once;
 use std::ops::Range;
 
@@ -166,6 +167,11 @@ impl ValueType for StringType {
 
     fn column_memory_size(col: &Self::Column) -> usize {
         col.data().len() + col.offsets().len() * 8
+    }
+
+    #[inline(always)]
+    fn compare(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> Ordering {
+        left.cmp(right)
     }
 
     #[inline(always)]

--- a/src/query/expression/src/types/timestamp.rs
+++ b/src/query/expression/src/types/timestamp.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::fmt::Display;
 use std::io::Cursor;
 use std::ops::Range;
@@ -190,6 +191,11 @@ impl ValueType for TimestampType {
     fn build_scalar(builder: Self::ColumnBuilder) -> Self::Scalar {
         assert_eq!(builder.len(), 1);
         builder[0]
+    }
+
+    #[inline(always)]
+    fn compare(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> Ordering {
+        left.cmp(&right)
     }
 
     #[inline(always)]

--- a/src/query/expression/src/types/variant.rs
+++ b/src/query/expression/src/types/variant.rs
@@ -179,8 +179,8 @@ impl ValueType for VariantType {
     }
 
     #[inline(always)]
-    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Option<Ordering> {
-        Some(jsonb::compare(lhs, rhs).expect("unable to parse jsonb value"))
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        jsonb::compare(lhs, rhs).expect("unable to parse jsonb value")
     }
 }
 

--- a/src/query/expression/src/utils/mod.rs
+++ b/src/query/expression/src/utils/mod.rs
@@ -23,6 +23,7 @@ pub mod filter_helper;
 pub mod serialize;
 pub mod udf_client;
 pub mod variant_transform;
+pub mod visitor;
 
 use databend_common_arrow::arrow::bitmap::Bitmap;
 use databend_common_ast::Span;

--- a/src/query/expression/src/utils/visitor.rs
+++ b/src/query/expression/src/utils/visitor.rs
@@ -1,0 +1,141 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_arrow::arrow::bitmap::Bitmap;
+use databend_common_arrow::arrow::buffer::Buffer;
+use databend_common_exception::Result;
+use decimal::DecimalType;
+use geometry::GeometryType;
+
+use crate::types::*;
+use crate::*;
+
+pub trait ValueVisitor {
+    fn visit_scalar(&mut self, _scalar: Scalar) -> Result<()>;
+
+    fn visit_null(&mut self, len: usize) -> Result<()> {
+        self.visit_typed_column::<NullType>(len)
+    }
+
+    fn visit_empty_array(&mut self, len: usize) -> Result<()> {
+        self.visit_typed_column::<EmptyArrayType>(len)
+    }
+
+    fn visit_empty_map(&mut self, len: usize) -> Result<()> {
+        self.visit_typed_column::<EmptyMapType>(len)
+    }
+
+    fn visit_number<T: Number>(
+        &mut self,
+        column: <NumberType<T> as ValueType>::Column,
+    ) -> Result<()> {
+        self.visit_typed_column::<NumberType<T>>(column)
+    }
+
+    fn visit_decimal<T: Decimal>(&mut self, column: Buffer<T>) -> Result<()> {
+        self.visit_typed_column::<DecimalType<T>>(column)
+    }
+
+    fn visit_boolean(&mut self, bitmap: Bitmap) -> Result<()> {
+        self.visit_typed_column::<BooleanType>(bitmap)
+    }
+
+    fn visit_binary(&mut self, column: BinaryColumn) -> Result<()> {
+        self.visit_typed_column::<BinaryType>(column)
+    }
+
+    fn visit_string(&mut self, column: StringColumn) -> Result<()> {
+        self.visit_typed_column::<StringType>(column)
+    }
+
+    fn visit_timestamp(&mut self, buffer: Buffer<i64>) -> Result<()> {
+        self.visit_typed_column::<TimestampType>(buffer)
+    }
+
+    fn visit_date(&mut self, buffer: Buffer<i32>) -> Result<()> {
+        self.visit_typed_column::<DateType>(buffer)
+    }
+
+    fn visit_array(&mut self, column: Box<ArrayColumn<AnyType>>) -> Result<()> {
+        self.visit_typed_column::<AnyType>(Column::Array(column))
+    }
+
+    fn visit_map(&mut self, column: Box<ArrayColumn<AnyType>>) -> Result<()> {
+        self.visit_typed_column::<AnyType>(Column::Map(column))
+    }
+
+    fn visit_tuple(&mut self, columns: Vec<Column>) -> Result<()> {
+        self.visit_typed_column::<AnyType>(Column::Tuple(columns))
+    }
+
+    fn visit_bitmap(&mut self, column: BinaryColumn) -> Result<()> {
+        self.visit_typed_column::<BitmapType>(column)
+    }
+
+    fn visit_nullable(&mut self, column: Box<NullableColumn<AnyType>>) -> Result<()> {
+        self.visit_typed_column::<AnyType>(Column::Nullable(column))
+    }
+
+    fn visit_variant(&mut self, column: BinaryColumn) -> Result<()> {
+        self.visit_typed_column::<VariantType>(column)
+    }
+
+    fn visit_geometry(&mut self, column: BinaryColumn) -> Result<()> {
+        self.visit_typed_column::<GeometryType>(column)
+    }
+
+    fn visit_geography(&mut self, column: GeographyColumn) -> Result<()> {
+        self.visit_typed_column::<GeographyType>(column)
+    }
+
+    fn visit_typed_column<T: ValueType>(&mut self, column: <T as ValueType>::Column) -> Result<()>;
+
+    fn visit_value(&mut self, value: Value<AnyType>) -> Result<()> {
+        match value {
+            Value::Scalar(c) => self.visit_scalar(c),
+            Value::Column(c) => self.visit_column(c),
+        }
+    }
+
+    fn visit_column(&mut self, column: Column) -> Result<()> {
+        match column {
+            Column::Null { len } => self.visit_null(len),
+            Column::EmptyArray { len } => self.visit_empty_array(len),
+            Column::EmptyMap { len } => self.visit_empty_map(len),
+            Column::Number(column) => {
+                with_number_type!(|NUM_TYPE| match column {
+                    NumberColumn::NUM_TYPE(b) => self.visit_number(b),
+                })
+            }
+            Column::Decimal(column) => {
+                with_decimal_type!(|DECIMAL_TYPE| match column {
+                    DecimalColumn::DECIMAL_TYPE(b, _) => self.visit_decimal(b),
+                })
+            }
+            Column::Boolean(bitmap) => self.visit_boolean(bitmap),
+            Column::Binary(column) => self.visit_binary(column),
+            Column::String(column) => self.visit_string(column),
+            Column::Timestamp(buffer) => self.visit_timestamp(buffer),
+            Column::Date(buffer) => self.visit_date(buffer),
+            Column::Array(column) => self.visit_array(column),
+            Column::Map(column) => self.visit_map(column),
+            Column::Tuple(columns) => self.visit_tuple(columns),
+            Column::Bitmap(column) => self.visit_bitmap(column),
+            Column::Nullable(column) => self.visit_nullable(column),
+            Column::Variant(column) => self.visit_variant(column),
+            Column::Geometry(column) => self.visit_geometry(column),
+            Column::Geography(column) => self.visit_geography(column),
+        }
+    }
+}

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -884,8 +884,26 @@ impl PartialOrd for Column {
             (Column::Geography(col1), Column::Geography(col2)) => {
                 col1.iter().partial_cmp(col2.iter())
             }
-            _ => None,
+            (a, b) => {
+                if a.len() != b.len() {
+                    a.len().partial_cmp(&b.len())
+                } else {
+                    for (l, r) in AnyType::iter_column(a).zip(AnyType::iter_column(b)) {
+                        match l.partial_cmp(&r) {
+                            Some(Ordering::Equal) => {}
+                            other => return other,
+                        }
+                    }
+                    Some(Ordering::Equal)
+                }
+            }
         }
+    }
+}
+
+impl Ord for Column {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap_or(Ordering::Equal)
     }
 }
 

--- a/src/query/expression/tests/it/sort.rs
+++ b/src/query/expression/tests/it/sort.rs
@@ -22,6 +22,7 @@ use databend_common_expression::types::StringType;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
+use databend_common_expression::LimitType;
 use databend_common_expression::SortColumnDescription;
 
 use crate::common::new_block;
@@ -101,6 +102,11 @@ fn test_block_sort() -> Result<()> {
     ];
 
     for (sort_descs, limit, expected) in test_cases {
+        let limit = if let Some(l) = limit {
+            LimitType::LimitRows(l)
+        } else {
+            LimitType::None
+        };
         let res = DataBlock::sort(&block, &sort_descs, limit)?;
 
         for (entry, expect) in res.columns().iter().zip(expected.iter()) {
@@ -187,6 +193,11 @@ fn test_block_sort() -> Result<()> {
     ];
 
     for (sort_descs, limit, expected) in test_cases {
+        let limit = if let Some(l) = limit {
+            LimitType::LimitRows(l)
+        } else {
+            LimitType::None
+        };
         let res = DataBlock::sort(&decimal_block, &sort_descs, limit)?;
 
         for (entry, expect) in res.columns().iter().zip(expected.iter()) {
@@ -201,7 +212,7 @@ fn test_block_sort() -> Result<()> {
 
         // test new sort algorithm
         let res = DataBlock::sort_old(&decimal_block, &sort_descs, Some(decimal_block.num_rows()))?;
-        let res_new = DataBlock::sort(&decimal_block, &sort_descs, None)?;
+        let res_new = DataBlock::sort(&decimal_block, &sort_descs, LimitType::None)?;
         assert_block_value_eq(&res, &res_new);
     }
 

--- a/src/query/expression/tests/it/sort.rs
+++ b/src/query/expression/tests/it/sort.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
 use std::vec;
 
 use databend_common_exception::Result;
@@ -20,8 +19,6 @@ use databend_common_expression::block_debug::assert_block_value_eq;
 use databend_common_expression::types::decimal::*;
 use databend_common_expression::types::number::*;
 use databend_common_expression::types::StringType;
-use databend_common_expression::AbortChecker;
-use databend_common_expression::CheckAbort;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;

--- a/src/query/expression/tests/it/sort.rs
+++ b/src/query/expression/tests/it/sort.rs
@@ -22,7 +22,6 @@ use databend_common_expression::types::StringType;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
-use databend_common_expression::LimitType;
 use databend_common_expression::SortColumnDescription;
 
 use crate::common::new_block;
@@ -102,11 +101,6 @@ fn test_block_sort() -> Result<()> {
     ];
 
     for (sort_descs, limit, expected) in test_cases {
-        let limit = if let Some(l) = limit {
-            LimitType::LimitRows(l)
-        } else {
-            LimitType::None
-        };
         let res = DataBlock::sort(&block, &sort_descs, limit)?;
 
         for (entry, expect) in res.columns().iter().zip(expected.iter()) {
@@ -193,11 +187,6 @@ fn test_block_sort() -> Result<()> {
     ];
 
     for (sort_descs, limit, expected) in test_cases {
-        let limit = if let Some(l) = limit {
-            LimitType::LimitRows(l)
-        } else {
-            LimitType::None
-        };
         let res = DataBlock::sort(&decimal_block, &sort_descs, limit)?;
 
         for (entry, expect) in res.columns().iter().zip(expected.iter()) {
@@ -212,7 +201,7 @@ fn test_block_sort() -> Result<()> {
 
         // test new sort algorithm
         let res = DataBlock::sort_old(&decimal_block, &sort_descs, Some(decimal_block.num_rows()))?;
-        let res_new = DataBlock::sort(&decimal_block, &sort_descs, LimitType::None)?;
+        let res_new = DataBlock::sort(&decimal_block, &sort_descs, None)?;
         assert_block_value_eq(&res, &res_new);
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_sort_spill.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_sort_spill.rs
@@ -622,24 +622,6 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_two_way_merge_sort() -> Result<()> {
-        let fixture = TestFixture::setup().await?;
-        let ctx = fixture.new_query_ctx().await?;
-        let (input, expected) = basic_test_data(None);
-
-        test(ctx, input, expected, 4, 2, false, None).await
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_two_way_merge_sort_with_memory_block() -> Result<()> {
-        let fixture = TestFixture::setup().await?;
-        let ctx = fixture.new_query_ctx().await?;
-        let (input, expected) = basic_test_data(None);
-
-        test(ctx, input, expected, 4, 2, true, None).await
-    }
-
     async fn basic_test(
         ctx: Arc<QueryContext>,
         batch_rows: usize,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. Introduce ColumnVisitor trait and SortCompare
2. Optimize kernel sort performance (Now we are using column vertical sort, which removes virtual call in sort compare functions)


Sort Performance with 2~3 order column test example, gain about 40%~50%

```
select l_partkey, l_returnflag from (select * from tpch_test.lineitem limit 10000000) order by l_partkey desc, l_returnflag asc ignore_result;
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16458)
<!-- Reviewable:end -->
