### PR TITLE
chore: simplify get_sequence() and get_sequence_next_value()

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -5602,8 +5602,9 @@ impl SchemaApiTestSuite {
                 ident: SequenceIdent::new(&tenant, sequence_name),
             };
             let resp = mt.get_sequence(req).await?;
-            assert_eq!(resp.meta.comment, Some("seq".to_string()));
-            assert_eq!(resp.meta.current, 1);
+            let resp = resp.unwrap().data;
+            assert_eq!(resp.comment, Some("seq".to_string()));
+            assert_eq!(resp.current, 1);
         }
 
         info!("--- get sequence nextval");
@@ -5624,8 +5625,9 @@ impl SchemaApiTestSuite {
             };
 
             let resp = mt.get_sequence(req).await?;
-            assert_eq!(resp.meta.comment, Some("seq".to_string()));
-            assert_eq!(resp.meta.current, 11);
+            let resp = resp.unwrap().data;
+            assert_eq!(resp.comment, Some("seq".to_string()));
+            assert_eq!(resp.current, 11);
         }
 
         info!("--- replace sequence");
@@ -5644,8 +5646,9 @@ impl SchemaApiTestSuite {
             };
 
             let resp = mt.get_sequence(req).await?;
-            assert_eq!(resp.meta.comment, Some("seq1".to_string()));
-            assert_eq!(resp.meta.current, 1);
+            let resp = resp.unwrap().data;
+            assert_eq!(resp.comment, Some("seq1".to_string()));
+            assert_eq!(resp.current, 1);
         }
 
         {
@@ -5660,8 +5663,8 @@ impl SchemaApiTestSuite {
                 ident: SequenceIdent::new(&tenant, sequence_name),
             };
 
-            let resp = mt.get_sequence(req).await;
-            assert!(resp.is_err());
+            let resp = mt.get_sequence(req).await?;
+            assert!(resp.is_none());
         }
 
         Ok(())

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -80,7 +80,6 @@ use databend_common_meta_app::schema::ExtendLockRevReq;
 use databend_common_meta_app::schema::GcDroppedTableReq;
 use databend_common_meta_app::schema::GetDatabaseReq;
 use databend_common_meta_app::schema::GetSequenceNextValueReq;
-use databend_common_meta_app::schema::GetSequenceReq;
 use databend_common_meta_app::schema::GetTableCopiedFileReq;
 use databend_common_meta_app::schema::GetTableReq;
 use databend_common_meta_app::schema::IcebergCatalogOption;
@@ -5598,10 +5597,8 @@ impl SchemaApiTestSuite {
 
         info!("--- get sequence");
         {
-            let req = GetSequenceReq {
-                ident: SequenceIdent::new(&tenant, sequence_name),
-            };
-            let resp = mt.get_sequence(req).await?;
+            let req = SequenceIdent::new(&tenant, sequence_name);
+            let resp = mt.get_sequence(&req).await?;
             let resp = resp.unwrap().data;
             assert_eq!(resp.comment, Some("seq".to_string()));
             assert_eq!(resp.current, 1);
@@ -5620,11 +5617,8 @@ impl SchemaApiTestSuite {
 
         info!("--- get sequence after nextval");
         {
-            let req = GetSequenceReq {
-                ident: SequenceIdent::new(&tenant, sequence_name),
-            };
-
-            let resp = mt.get_sequence(req).await?;
+            let req = SequenceIdent::new(&tenant, sequence_name);
+            let resp = mt.get_sequence(&req).await?;
             let resp = resp.unwrap().data;
             assert_eq!(resp.comment, Some("seq".to_string()));
             assert_eq!(resp.current, 11);
@@ -5641,11 +5635,9 @@ impl SchemaApiTestSuite {
 
             let _resp = mt.create_sequence(req).await?;
 
-            let req = GetSequenceReq {
-                ident: SequenceIdent::new(&tenant, sequence_name),
-            };
+            let req = SequenceIdent::new(&tenant, sequence_name);
 
-            let resp = mt.get_sequence(req).await?;
+            let resp = mt.get_sequence(&req).await?;
             let resp = resp.unwrap().data;
             assert_eq!(resp.comment, Some("seq1".to_string()));
             assert_eq!(resp.current, 1);
@@ -5659,11 +5651,8 @@ impl SchemaApiTestSuite {
 
             let _resp = mt.drop_sequence(req).await?;
 
-            let req = GetSequenceReq {
-                ident: SequenceIdent::new(&tenant, sequence_name),
-            };
-
-            let resp = mt.get_sequence(req).await?;
+            let req = SequenceIdent::new(&tenant, sequence_name);
+            let resp = mt.get_sequence(&req).await?;
             assert!(resp.is_none());
         }
 

--- a/src/meta/api/src/sequence_api.rs
+++ b/src/meta/api/src/sequence_api.rs
@@ -18,7 +18,7 @@ use databend_common_meta_app::schema::DropSequenceReply;
 use databend_common_meta_app::schema::DropSequenceReq;
 use databend_common_meta_app::schema::GetSequenceNextValueReply;
 use databend_common_meta_app::schema::GetSequenceNextValueReq;
-use databend_common_meta_app::schema::GetSequenceReq;
+use databend_common_meta_app::schema::SequenceIdent;
 use databend_common_meta_app::schema::SequenceMeta;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::SeqV;
@@ -34,7 +34,7 @@ pub trait SequenceApi: Send + Sync {
 
     async fn get_sequence(
         &self,
-        req: GetSequenceReq,
+        req: &SequenceIdent,
     ) -> Result<Option<SeqV<SequenceMeta>>, MetaError>;
 
     async fn get_sequence_next_value(

--- a/src/meta/api/src/sequence_api.rs
+++ b/src/meta/api/src/sequence_api.rs
@@ -20,6 +20,7 @@ use databend_common_meta_app::schema::GetSequenceNextValueReply;
 use databend_common_meta_app::schema::GetSequenceNextValueReq;
 use databend_common_meta_app::schema::GetSequenceReq;
 use databend_common_meta_app::schema::SequenceMeta;
+use databend_common_meta_types::MetaError;
 use databend_common_meta_types::SeqV;
 
 use crate::kv_app_error::KVAppError;
@@ -34,7 +35,7 @@ pub trait SequenceApi: Send + Sync {
     async fn get_sequence(
         &self,
         req: GetSequenceReq,
-    ) -> Result<Option<SeqV<SequenceMeta>>, KVAppError>;
+    ) -> Result<Option<SeqV<SequenceMeta>>, MetaError>;
 
     async fn get_sequence_next_value(
         &self,

--- a/src/meta/api/src/sequence_api.rs
+++ b/src/meta/api/src/sequence_api.rs
@@ -18,8 +18,9 @@ use databend_common_meta_app::schema::DropSequenceReply;
 use databend_common_meta_app::schema::DropSequenceReq;
 use databend_common_meta_app::schema::GetSequenceNextValueReply;
 use databend_common_meta_app::schema::GetSequenceNextValueReq;
-use databend_common_meta_app::schema::GetSequenceReply;
 use databend_common_meta_app::schema::GetSequenceReq;
+use databend_common_meta_app::schema::SequenceMeta;
+use databend_common_meta_types::SeqV;
 
 use crate::kv_app_error::KVAppError;
 
@@ -30,7 +31,10 @@ pub trait SequenceApi: Send + Sync {
         req: CreateSequenceReq,
     ) -> Result<CreateSequenceReply, KVAppError>;
 
-    async fn get_sequence(&self, req: GetSequenceReq) -> Result<GetSequenceReply, KVAppError>;
+    async fn get_sequence(
+        &self,
+        req: GetSequenceReq,
+    ) -> Result<Option<SeqV<SequenceMeta>>, KVAppError>;
 
     async fn get_sequence_next_value(
         &self,

--- a/src/meta/api/src/sequence_api_impl.rs
+++ b/src/meta/api/src/sequence_api_impl.rs
@@ -24,7 +24,7 @@ use databend_common_meta_app::schema::DropSequenceReply;
 use databend_common_meta_app::schema::DropSequenceReq;
 use databend_common_meta_app::schema::GetSequenceNextValueReply;
 use databend_common_meta_app::schema::GetSequenceNextValueReq;
-use databend_common_meta_app::schema::GetSequenceReq;
+use databend_common_meta_app::schema::SequenceIdent;
 use databend_common_meta_app::schema::SequenceMeta;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_types::MatchSeq;
@@ -85,10 +85,10 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
 
     async fn get_sequence(
         &self,
-        req: GetSequenceReq,
+        name_ident: &SequenceIdent,
     ) -> Result<Option<SeqV<SequenceMeta>>, MetaError> {
-        debug!(req :? =(&req); "SchemaApi: {}", func_name!());
-        let seq_meta = self.get_pb(&req.ident).await?;
+        debug!(req :? =name_ident; "SchemaApi: {}", func_name!());
+        let seq_meta = self.get_pb(name_ident).await?;
         Ok(seq_meta)
     }
 

--- a/src/meta/app/src/schema/sequence.rs
+++ b/src/meta/app/src/schema/sequence.rs
@@ -113,3 +113,34 @@ mod kvapi_impl {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::schema::SequenceIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_sequence_ident() {
+        let tenant = Tenant::new_literal("dummy");
+        let ident = SequenceIdent::new_generic(tenant, "3".to_string());
+
+        let key = ident.to_string_key();
+        assert_eq!(key, "__fd_sequence/dummy/3");
+
+        assert_eq!(ident, SequenceIdent::from_str_key(&key).unwrap());
+    }
+
+    #[test]
+    fn test_sequence_ident_with_key_space() {
+        // TODO(xp): implement this test
+        // let tenant = Tenant::new_literal("test");
+        // let ident = IndexIdIdent::new(tenant, 3);
+        //
+        // let key = ident.to_string_key();
+        // assert_eq!(key, "__fd_catalog_by_id/3");
+        //
+        // assert_eq!(ident, IndexIdIdent::from_str_key(&key).unwrap());
+    }
+}

--- a/src/meta/app/src/schema/sequence.rs
+++ b/src/meta/app/src/schema/sequence.rs
@@ -14,13 +14,13 @@
 
 use chrono::DateTime;
 use chrono::Utc;
-use kvapi_impl::Resource;
+pub use kvapi_impl::SequenceRsc;
 
 use super::CreateOption;
 use crate::tenant_key::ident::TIdent;
 
 /// Defines the meta-service key for sequence.
-pub type SequenceIdent = TIdent<Resource>;
+pub type SequenceIdent = TIdent<SequenceRsc>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SequenceMeta {
@@ -99,8 +99,8 @@ mod kvapi_impl {
     use super::SequenceMeta;
     use crate::tenant_key::resource::TenantResource;
 
-    pub struct Resource;
-    impl TenantResource for Resource {
+    pub struct SequenceRsc;
+    impl TenantResource for SequenceRsc {
         const PREFIX: &'static str = "__fd_sequence";
         const HAS_TENANT: bool = true;
         type ValueType = SequenceMeta;

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -687,7 +687,17 @@ impl Catalog for MutableCatalog {
     }
 
     async fn get_sequence(&self, req: GetSequenceReq) -> Result<GetSequenceReply> {
-        Ok(self.ctx.meta.get_sequence(req).await?)
+        let seq_meta = self.ctx.meta.get_sequence(req).await?;
+
+        let Some(seq_meta) = seq_meta else {
+            return Err(KVAppError::AppError(AppError::SequenceError(
+                req.ident.unknown_error(func_name!()).into(),
+            ))
+            .into());
+        };
+        Ok(GetSequenceReply {
+            meta: seq_meta.data,
+        })
     }
 
     async fn get_sequence_next_value(

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -687,7 +687,7 @@ impl Catalog for MutableCatalog {
     }
 
     async fn get_sequence(&self, req: GetSequenceReq) -> Result<GetSequenceReply> {
-        let seq_meta = self.ctx.meta.get_sequence(req).await?;
+        let seq_meta = self.ctx.meta.get_sequence(&req.ident).await?;
 
         let Some(seq_meta) = seq_meta else {
             return Err(KVAppError::AppError(AppError::SequenceError(


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: simplify get_sequence() and get_sequence_next_value()


##### refactor: simplify get_sequence() API to return Option instead of Result

- Change return type from Result to Option<Sequence>
- Return None when sequence is not found
- This allows callers to easily distinguish between "not found" and other errors


##### chore: replace manually defined `Sequence` error with Unknown/Exist Error with generic


##### chore: add test to `SequenceIdent`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16463)
<!-- Reviewable:end -->
