### PR TITLE
chore(executor): more edge detail for executing graph

### DIFF
--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -998,7 +998,16 @@ impl Debug for ExecutingGraph {
         write!(
             f,
             "{:?}",
-            Dot::with_config(&self.graph, &[Config::EdgeNoLabel])
+            Dot::with_attr_getters(
+                &self.graph,
+                &[Config::EdgeNoLabel],
+                &|_, edge| format!(
+                    "{} -> {}",
+                    edge.weight().output_index,
+                    edge.weight().input_index
+                ),
+                &|_, (_, _)| String::new(),
+            )
         )
     }
 }

--- a/src/query/service/tests/it/pipelines/executor/executor_graph.rs
+++ b/src/query/service/tests/it/pipelines/executor/executor_graph.rs
@@ -51,8 +51,8 @@ async fn test_create_simple_pipeline() -> Result<()> {
             \n    0 [ label = \"BlocksSource\" ]\
             \n    1 [ label = \"DummyTransform\" ]\
             \n    2 [ label = \"SyncSenderSink\" ]\
-            \n    0 -> 1 [ ]\
-            \n    1 -> 2 [ ]\
+            \n    0 -> 1 [ 0 -> 0]\
+            \n    1 -> 2 [ 0 -> 0]\
         \n}\n"
     );
 
@@ -73,10 +73,10 @@ async fn test_create_parallel_simple_pipeline() -> Result<()> {
             \n    3 [ label = \"DummyTransform\" ]\
             \n    4 [ label = \"SyncSenderSink\" ]\
             \n    5 [ label = \"SyncSenderSink\" ]\
-            \n    0 -> 2 [ ]\
-            \n    1 -> 3 [ ]\
-            \n    2 -> 4 [ ]\
-            \n    3 -> 5 [ ]\
+            \n    0 -> 2 [ 0 -> 0]\
+            \n    1 -> 3 [ 0 -> 0]\
+            \n    2 -> 4 [ 0 -> 0]\
+            \n    3 -> 5 [ 0 -> 0]\
         \n}\n"
     );
 
@@ -100,15 +100,15 @@ async fn test_create_resize_pipeline() -> Result<()> {
             \n    6 [ label = \"Resize\" ]\
             \n    7 [ label = \"SyncSenderSink\" ]\
             \n    8 [ label = \"SyncSenderSink\" ]\
-            \n    0 -> 1 [ ]\
-            \n    1 -> 2 [ ]\
-            \n    1 -> 3 [ ]\
-            \n    2 -> 4 [ ]\
-            \n    3 -> 4 [ ]\
-            \n    4 -> 5 [ ]\
-            \n    5 -> 6 [ ]\
-            \n    6 -> 7 [ ]\
-            \n    6 -> 8 [ ]\
+            \n    0 -> 1 [ 0 -> 0]\
+            \n    1 -> 2 [ 0 -> 0]\
+            \n    1 -> 3 [ 1 -> 0]\
+            \n    2 -> 4 [ 0 -> 0]\
+            \n    3 -> 4 [ 0 -> 1]\
+            \n    4 -> 5 [ 0 -> 0]\
+            \n    5 -> 6 [ 0 -> 0]\
+            \n    6 -> 7 [ 0 -> 0]\
+            \n    6 -> 8 [ 1 -> 0]\
         \n}\n"
     );
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(executor): more edge detail for executing graph

before:
```
digraph {
    0 [ label = "system.one" ]
    1 [ label = "CompoundBlockOperator(Map)" ]
    2 [ label = "CompoundBlockOperator(Project)" ]
    3 [ label = "PullingExecutorSink" ]
    0 -> 1 [ ]
    1 -> 2 [ ]
    2 -> 3 [ ]
}
```

after
```
digraph {
    0 [ label = "system.one" ]
    1 [ label = "CompoundBlockOperator(Map)" ]
    2 [ label = "CompoundBlockOperator(Project)" ]
    3 [ label = "PullingExecutorSink" ]
    0 -> 1 [ 0 -> 0]
    1 -> 2 [ 0 -> 0]
    2 -> 3 [ 0 -> 0]
}
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - log

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16468)
<!-- Reviewable:end -->
