### PR TITLE
chore(storage): hook recluster avoid scan all segments

### DIFF
--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -62,8 +62,8 @@ impl BlockThresholds {
     }
 
     #[inline]
-    pub fn check_for_recluster(&self, total_rows: usize, total_bytes: usize) -> bool {
-        total_rows <= self.max_rows_per_block && total_bytes <= self.max_bytes_per_block
+    pub fn check_too_small(&self, row_count: usize, block_size: usize) -> bool {
+        row_count < self.min_rows_per_block / 2 && block_size < self.max_bytes_per_block / 2
     }
 
     #[inline]

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -138,7 +138,12 @@ async fn compact_table(
             &compact_target.table,
         )
         .await?;
+    let settings = ctx.get_settings();
+    // keep the original progress value
+    let progress_value = ctx.get_write_progress_value();
+
     let do_recluster = !table.cluster_keys(ctx.clone()).is_empty();
+    let do_compact = compaction_limits.block_limit.is_some() || !do_recluster;
 
     // evict the table from cache
     ctx.evict_table_from_cache(
@@ -147,61 +152,57 @@ async fn compact_table(
         &compact_target.table,
     )?;
 
-    let mut build_res = if do_recluster {
-        // To ensure that newly ingested blocks are executed.
-        let segment_limit = std::cmp::max(
-            Some(ctx.get_settings().get_auto_compaction_segments_limit()? as usize),
-            compaction_limits.block_limit,
-        );
+    if do_compact {
+        let compact_block = RelOperator::CompactBlock(OptimizeCompactBlock {
+            catalog: compact_target.catalog.clone(),
+            database: compact_target.database.clone(),
+            table: compact_target.table.clone(),
+            limit: compaction_limits.clone(),
+        });
+        let s_expr = SExpr::create_leaf(Arc::new(compact_block));
+        let compact_interpreter = OptimizeCompactBlockInterpreter::try_create(
+            ctx.clone(),
+            s_expr,
+            lock_opt.clone(),
+            false,
+        )?;
+        let mut build_res = compact_interpreter.execute2().await?;
+        // execute the compact pipeline
+        if build_res.main_pipeline.is_complete_pipeline()? {
+            build_res.set_max_threads(settings.get_max_threads()? as usize);
+            let executor_settings = ExecutorSettings::try_create(ctx.clone())?;
+
+            let mut pipelines = build_res.sources_pipelines;
+            pipelines.push(build_res.main_pipeline);
+
+            let complete_executor =
+                PipelineCompleteExecutor::from_pipelines(pipelines, executor_settings)?;
+
+            // Clears previously generated segment locations to avoid duplicate data in the refresh phase
+            ctx.clear_segment_locations()?;
+            ctx.set_executor(complete_executor.get_inner())?;
+            complete_executor.execute()?;
+            drop(complete_executor);
+        }
+    }
+
+    if do_recluster {
         let recluster = RelOperator::Recluster(Recluster {
             catalog: compact_target.catalog,
             database: compact_target.database,
             table: compact_target.table,
             filters: None,
-            limit: segment_limit,
+            limit: Some(settings.get_auto_compaction_segments_limit()? as usize),
         });
         let s_expr = SExpr::create_leaf(Arc::new(recluster));
         let recluster_interpreter =
             ReclusterTableInterpreter::try_create(ctx.clone(), s_expr, lock_opt, false)?;
-        recluster_interpreter.execute2().await?
-    } else {
-        let compact_block = RelOperator::CompactBlock(OptimizeCompactBlock {
-            catalog: compact_target.catalog,
-            database: compact_target.database,
-            table: compact_target.table,
-            limit: compaction_limits,
-        });
-        let s_expr = SExpr::create_leaf(Arc::new(compact_block));
-        let compact_interpreter =
-            OptimizeCompactBlockInterpreter::try_create(ctx.clone(), s_expr, lock_opt, false)?;
-        compact_interpreter.execute2().await?
-    };
-
-    if build_res.main_pipeline.is_empty() {
-        return Ok(());
+        // recluster has been done in ReclusterTableInterpreter.
+        let build_res = recluster_interpreter.execute2().await?;
+        assert!(build_res.main_pipeline.is_empty());
     }
 
-    // execute the compact pipeline (for table with cluster keys, re-cluster will also be executed)
-    let settings = ctx.get_settings();
-    build_res.set_max_threads(settings.get_max_threads()? as usize);
-    let settings = ExecutorSettings::try_create(ctx.clone())?;
-
-    if build_res.main_pipeline.is_complete_pipeline()? {
-        let mut pipelines = build_res.sources_pipelines;
-        pipelines.push(build_res.main_pipeline);
-
-        let complete_executor = PipelineCompleteExecutor::from_pipelines(pipelines, settings)?;
-
-        // keep the original progress value
-        let progress_value = ctx.get_write_progress_value();
-        // Clears previously generated segment locations to avoid duplicate data in the refresh phase
-        ctx.clear_segment_locations()?;
-        ctx.set_executor(complete_executor.get_inner())?;
-        complete_executor.execute()?;
-        drop(complete_executor);
-
-        // reset the progress value
-        ctx.get_write_progress().set(&progress_value);
-    }
+    // reset the progress value
+    ctx.get_write_progress().set(&progress_value);
     Ok(())
 }

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -197,7 +197,7 @@ async fn compact_table(
         let s_expr = SExpr::create_leaf(Arc::new(recluster));
         let recluster_interpreter =
             ReclusterTableInterpreter::try_create(ctx.clone(), s_expr, lock_opt, false)?;
-        // recluster has been done in ReclusterTableInterpreter.
+        // Recluster will be done in `ReclusterTableInterpreter::execute2` directly, we do not need to use `PipelineCompleteExecutor` to execute it
         let build_res = recluster_interpreter.execute2().await?;
         assert!(build_res.main_pipeline.is_empty());
     }

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -197,7 +197,8 @@ async fn compact_table(
         let s_expr = SExpr::create_leaf(Arc::new(recluster));
         let recluster_interpreter =
             ReclusterTableInterpreter::try_create(ctx.clone(), s_expr, lock_opt, false)?;
-        // Recluster will be done in `ReclusterTableInterpreter::execute2` directly, we do not need to use `PipelineCompleteExecutor` to execute it
+        // Recluster will be done in `ReclusterTableInterpreter::execute2` directly,
+        // we do not need to use `PipelineCompleteExecutor` to execute it.
         let build_res = recluster_interpreter.execute2().await?;
         assert!(build_res.main_pipeline.is_empty());
     }

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -176,6 +176,7 @@ impl ReclusterTableInterpreter {
 
         let complete_executor =
             PipelineCompleteExecutor::from_pipelines(pipelines, executor_settings)?;
+        self.ctx.clear_segment_locations()?;
         self.ctx.set_executor(complete_executor.get_inner())?;
         complete_executor.execute()?;
         // make sure the executor is dropped before the next loop.

--- a/src/query/service/src/pipelines/builders/builder_recluster.rs
+++ b/src/query/service/src/pipelines/builders/builder_recluster.rs
@@ -136,7 +136,7 @@ impl PipelineBuilder {
 
                 self.ctx.set_enable_sort_spill(false);
                 let sort_pipeline_builder =
-                    SortPipelineBuilder::create(self.ctx.clone(), schema, Arc::new(sort_descs))
+                    SortPipelineBuilder::create(self.ctx.clone(), schema, Arc::new(sort_descs))?
                         .with_block_size_hit(sort_block_size)
                         .remove_order_col_at_last();
                 sort_pipeline_builder.build_merge_sort_pipeline(&mut self.main_pipeline, false)?;

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -162,6 +162,7 @@ impl ReclusterMutator {
         &self,
         compact_segments: Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>,
     ) -> Result<(u64, ReclusterParts)> {
+        // Sort segments by cluster statistics
         let mut compact_segments = compact_segments;
         compact_segments.sort_by(|a, b| {
             sort_by_cluster_stats(
@@ -171,15 +172,19 @@ impl ReclusterMutator {
             )
         });
 
-        let mut selected_segments = Vec::with_capacity(compact_segments.len());
+        // Prepare for reclustering by collecting segment indices, statistics, and blocks
         let mut selected_segs_idx = Vec::with_capacity(compact_segments.len());
         let mut selected_statistics = Vec::with_capacity(compact_segments.len());
-        compact_segments.into_iter().for_each(|(loc, info)| {
-            selected_statistics.push(info.summary.clone());
-            selected_segments.push(info);
-            selected_segs_idx.push(loc.segment_idx);
-        });
+        let selected_segments = compact_segments
+            .into_iter()
+            .map(|(loc, info)| {
+                selected_statistics.push(info.summary.clone());
+                selected_segs_idx.push(loc.segment_idx);
+                info
+            })
+            .collect::<Vec<_>>();
 
+        // Gather blocks and create a block map categorized by clustering levels
         let blocks = self.gather_blocks(selected_segments).await?;
         let mut blocks_map: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
         for (idx, block) in blocks.iter().enumerate() {
@@ -190,22 +195,21 @@ impl ReclusterMutator {
             }
         }
 
+        // Compute memory threshold and maximum number of blocks allowed for reclustering
         let mem_info = sys_info::mem_info().map_err(ErrorCode::from_std_error)?;
         let recluster_block_size = self.ctx.get_settings().get_recluster_block_size()? as usize;
         let memory_threshold = recluster_block_size.min(mem_info.avail as usize * 1024 * 35 / 100);
+        // specify a rather small value, so that `recluster_block_size` might be tuned to lower value.
+        let max_blocks_num =
+            (memory_threshold / self.block_thresholds.max_bytes_per_block).max(2) * self.max_tasks;
 
-        let max_blocks_num = std::cmp::max(
-            memory_threshold / self.block_thresholds.max_bytes_per_block,
-            // specify a rather small value, so that setting `recluster_block_size`
-            // might be tuned to lower value.
-            2,
-        ) * self.max_tasks;
-
+        // Prepare task generation parameters
         let arrow_schema = self.schema.as_ref().into();
         let column_nodes = ColumnNodes::new_from_schema(&arrow_schema, Some(&self.schema));
 
         let mut tasks = Vec::new();
         let mut selected_blocks_idx = IndexSet::new();
+        // Process blocks for reclustering based on their level
         for (level, indices) in blocks_map.into_iter() {
             if level == -1 || indices.len() < 2 {
                 continue;
@@ -213,31 +217,30 @@ impl ReclusterMutator {
 
             let mut total_rows = 0;
             let mut total_bytes = 0;
-            let mut small_blocks = Vec::new();
+            let mut small_blocks = IndexSet::new();
             let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
-            for i in indices.iter() {
-                if let Some(stats) = &blocks[*i].cluster_stats {
-                    points_map
-                        .entry(stats.min().clone())
-                        .and_modify(|v| v.0.push(*i))
-                        .or_insert((vec![*i], vec![]));
-                    points_map
-                        .entry(stats.max().clone())
-                        .and_modify(|v| v.1.push(*i))
-                        .or_insert((vec![], vec![*i]));
+
+            // Analyze each block's statistics and track min/max points
+            for &i in indices.iter() {
+                let block = &blocks[i];
+                if let Some(stats) = &block.cluster_stats {
+                    points_map.entry(stats.min().clone()).or_default().0.push(i);
+                    points_map.entry(stats.max().clone()).or_default().1.push(i);
                 }
-                // Record block fragments for compact.
-                if self.block_thresholds.check_too_small(
-                    blocks[*i].row_count as usize,
-                    blocks[*i].block_size as usize,
-                ) {
-                    small_blocks.push(*i);
+
+                // Track small blocks for potential compaction
+                if self
+                    .block_thresholds
+                    .check_too_small(block.row_count as usize, block.block_size as usize)
+                {
+                    small_blocks.insert(i);
                 }
-                total_rows += blocks[*i].row_count;
-                total_bytes += blocks[*i].block_size;
+
+                total_rows += block.row_count;
+                total_bytes += block.block_size;
             }
 
-            // If the statistics of blocks are too small, just merge them into one block.
+            // If total rows and bytes are too small, compact the blocks into one
             if self
                 .block_thresholds
                 .check_for_compact(total_rows as usize, total_bytes as usize)
@@ -260,6 +263,7 @@ impl ReclusterMutator {
                 break;
             }
 
+            // Select blocks for reclustering based on depth threshold and max block size
             let mut selected_idx =
                 self.fetch_max_depth(points_map, self.depth_threshold, max_blocks_num)?;
             if selected_idx.is_empty() {
@@ -269,17 +273,19 @@ impl ReclusterMutator {
                 selected_idx = IndexSet::from_iter(small_blocks);
             }
 
+            // Process selected blocks into recluster tasks based on memory threshold
             let mut task_bytes = 0;
             let mut task_rows = 0;
             let mut task_indices = Vec::new();
             let mut selected_blocks = Vec::new();
             for idx in selected_idx {
-                let block_meta = blocks[idx].clone();
-                let block_size = block_meta.block_size as usize;
-                let row_count = block_meta.row_count as usize;
+                let block = blocks[idx].clone();
+                let block_size = block.block_size as usize;
+                let row_count = block.row_count as usize;
+
+                // If memory threshold exceeded, generate a new task and reset accumulators
                 if task_bytes + block_size > memory_threshold && selected_blocks.len() > 1 {
-                    selected_blocks_idx.extend(task_indices.iter());
-                    task_indices.clear();
+                    selected_blocks_idx.extend(std::mem::take(&mut task_indices));
 
                     tasks.push(self.generate_task(
                         &selected_blocks,
@@ -293,6 +299,7 @@ impl ReclusterMutator {
                     task_bytes = 0;
                     selected_blocks.clear();
 
+                    // Break if maximum task limit is reached
                     if tasks.len() >= self.max_tasks {
                         break;
                     }
@@ -301,10 +308,10 @@ impl ReclusterMutator {
                 task_rows += row_count;
                 task_bytes += block_size;
                 task_indices.push(idx);
-                selected_blocks.push((None, block_meta));
+                selected_blocks.push((None, block));
             }
 
-            // the remains.
+            // Add remaining blocks as a final task if any
             if selected_blocks.len() > 1 {
                 selected_blocks_idx.extend(task_indices);
                 tasks.push(self.generate_task(
@@ -318,6 +325,7 @@ impl ReclusterMutator {
             break;
         }
 
+        // Determine if reclustering is needed
         let selected = if selected_blocks_idx.is_empty() {
             let unordered = || {
                 blocks.windows(2).any(|w| {
@@ -333,6 +341,7 @@ impl ReclusterMutator {
             true
         };
 
+        // Generate recluster parts based on selected segments
         let parts = if selected {
             selected_segs_idx.sort_by(|a, b| b.cmp(a));
 
@@ -343,11 +352,10 @@ impl ReclusterMutator {
             });
 
             let blocks_idx: IndexSet<usize> = IndexSet::from_iter(0..blocks.len());
-            let diff = blocks_idx.difference(&selected_blocks_idx);
-            let remained_blocks = diff
-                .into_iter()
-                .map(|v| blocks[*v].clone())
-                .collect::<Vec<_>>();
+            let remained_blocks = blocks_idx
+                .difference(&selected_blocks_idx)
+                .map(|&v| blocks[v].clone())
+                .collect();
 
             ReclusterParts::Recluster {
                 tasks,
@@ -358,6 +366,7 @@ impl ReclusterMutator {
         } else {
             ReclusterParts::new_recluster_parts()
         };
+
         Ok((selected_blocks_idx.len() as u64, parts))
     }
 
@@ -461,10 +470,14 @@ impl ReclusterMutator {
         let mut blocks_num = 0;
         let mut indices = IndexSet::new();
         let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
-        let mut unclustered_sg = IndexSet::new();
+        let mut unclustered_segments = IndexSet::new();
+        let mut small_segments = IndexSet::new();
+
+        // Iterate over all segments
         for (i, (loc, compact_segment)) in compact_segments.iter().enumerate() {
             let mut level = -1;
-            let clustered = compact_segment
+            // Check if the segment is clustered
+            let is_clustered = compact_segment
                 .summary
                 .cluster_stats
                 .as_ref()
@@ -472,22 +485,32 @@ impl ReclusterMutator {
                     level = v.level;
                     v.cluster_key_id == self.cluster_key_id
                 });
-            if !clustered {
+
+            // If not clustered, mark for compaction
+            if !is_clustered {
                 debug!(
-                    "recluster: segment '{}' is unclustered, need to be compacted",
+                    "recluster: segment '{}' is unclustered, needs to be compacted",
                     loc.location.0
                 );
-                unclustered_sg.insert(i);
+                unclustered_segments.insert(i);
                 continue;
             }
 
-            if level < 0 && (compact_segment.summary.block_count as usize) >= self.block_per_seg {
+            // Skip if segment has more blocks than required and no reclustering is needed
+            if level < 0 && compact_segment.summary.block_count as usize >= self.block_per_seg {
                 continue;
             }
 
+            // Process clustered segment
             if let Some(stats) = &compact_segment.summary.cluster_stats {
                 blocks_num += compact_segment.summary.block_count as usize;
+                // Track small segments for special handling later
+                if blocks_num < self.block_per_seg {
+                    small_segments.insert(i);
+                }
+                // Add to indices for potential reclustering
                 indices.insert(i);
+                // Update points_map with min and max points of the segment
                 points_map
                     .entry(stats.min().clone())
                     .and_modify(|v| v.0.push(i))
@@ -499,17 +522,24 @@ impl ReclusterMutator {
             }
         }
 
-        if !unclustered_sg.is_empty() {
-            return Ok((ReclusterMode::Compact, unclustered_sg));
+        // If there are unclustered segments, return early for compaction
+        if !unclustered_segments.is_empty() {
+            return Ok((ReclusterMode::Compact, unclustered_segments));
         }
 
-        let res = if indices.len() > 1 && blocks_num > self.block_per_seg {
-            self.fetch_max_depth(points_map, 1.0, max_len)?
+        let selected_segments = if indices.len() > 1 && blocks_num > self.block_per_seg {
+            let selected = self.fetch_max_depth(points_map, 1.0, max_len)?;
+            if selected.is_empty() && small_segments.len() > 1 {
+                // If no segments were selected but small segments exist, use those.
+                small_segments
+            } else {
+                selected
+            }
         } else {
             indices
         };
 
-        Ok((ReclusterMode::Recluster, res))
+        Ok((ReclusterMode::Recluster, selected_segments))
     }
 
     pub fn segment_can_recluster(&self, summary: &Statistics) -> bool {

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -82,12 +82,12 @@ impl FuseTable {
         let segment_locations = create_segment_location_vector(segment_locations, None);
 
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
-        let limit = limit.unwrap_or(1000);
+        let segment_limit = limit.unwrap_or(1000);
         // The default limit might be too small, which makes
         // the scanning of recluster candidates slow.
-        let chunk_size = limit.max(max_threads * 4);
+        let chunk_size = segment_limit.max(max_threads * 4);
         // The max number of segments to be reclustered.
-        let max_seg_num = limit.min(max_threads * 2);
+        let max_seg_num = segment_limit.min(max_threads * 2);
 
         let mut recluster_seg_num = 0;
         let mut recluster_blocks_count = 0;
@@ -146,7 +146,7 @@ impl FuseTable {
                     .await?;
             }
 
-            if !parts.is_empty() {
+            if !parts.is_empty() || limit.is_some() {
                 recluster_seg_num = selected_seg_num;
                 break;
             }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
@@ -76,9 +76,9 @@ statement ok
 ALTER TABLE t3 RECLUSTER
 
 query FFT
-select average_overlaps, average_depth from clustering_information('db_09_0016','t3')
+select average_overlaps, average_depth, block_depth_histogram from clustering_information('db_09_0016','t3')
 ----
-0.0 1.0
+0.0 1.0 {"00001":2}
 
 # test trim string
 statement ok

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
@@ -7,6 +7,8 @@ use i15760;
 statement ok
 set auto_compaction_imperfect_blocks_threshold = 3;
 
+
+# ISSUE 15760
 statement ok
 create or replace table t (c int) block_per_segment = 10 row_per_block = 3;
 
@@ -71,3 +73,32 @@ select segment_count , block_count , row_count from fuse_snapshot('i15760', 't')
 3 3 3
 2 2 2
 1 1 1
+
+
+#ISSUE 16498
+statement ok
+create table t1(a int) cluster by(a) row_per_block=5;
+
+statement ok
+set auto_compaction_segments_limit = 3;
+
+statement ok
+insert into t1 values(1),(2),(7);
+
+statement ok
+insert into t1 values(3),(5);
+
+statement ok
+insert into t1 values(4),(6),(8);
+
+query III
+select segment_count, block_count, row_count from fuse_snapshot('i15760', 't1') limit 10;
+----
+1 2 8
+1 2 8
+3 3 8
+2 2 5
+1 1 3
+
+statement ok
+drop table t1 all;

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
@@ -80,13 +80,10 @@ statement ok
 create table t1(a int) cluster by(a) row_per_block=5;
 
 statement ok
-set auto_compaction_segments_limit = 3;
-
-statement ok
 insert into t1 values(1),(2),(7);
 
 statement ok
-insert into t1 values(3),(5);
+insert into t1 values(3),(5),(9);
 
 statement ok
 insert into t1 values(4),(6),(8);
@@ -94,10 +91,10 @@ insert into t1 values(4),(6),(8);
 query III
 select segment_count, block_count, row_count from fuse_snapshot('i15760', 't1') limit 10;
 ----
-1 2 8
-1 2 8
-3 3 8
-2 2 5
+1 2 9
+1 2 9
+3 3 9
+2 2 6
 1 1 3
 
 statement ok

--- a/tests/suites/0_stateless/02_ddl/02_0000_create_drop_view.py
+++ b/tests/suites/0_stateless/02_ddl/02_0000_create_drop_view.py
@@ -4,11 +4,17 @@ import sqlalchemy
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+
 def recreate_view(con):
     with con.begin() as c:
         c.execute(sqlalchemy.text("DROP VIEW IF EXISTS v_issue_16188"))
     with con.begin() as c:
-        c.execute(sqlalchemy.text("CREATE OR REPLACE VIEW v_issue_16188 as select a,b from t_issue_16188"))
+        c.execute(
+            sqlalchemy.text(
+                "CREATE OR REPLACE VIEW v_issue_16188 as select a,b from t_issue_16188"
+            )
+        )
+
 
 def main():
     tcp_port = os.getenv("QUERY_MYSQL_HANDLER_PORT")
@@ -21,7 +27,11 @@ def main():
     con = sqlalchemy.create_engine(uri, future=True)
     with con.begin() as c:
         c.execute(sqlalchemy.text("DROP TABLE IF EXISTS t_issue_16188"))
-        c.execute(sqlalchemy.text("CREATE TABLE t_issue_16188 (a int not null, b int not null)"))
+        c.execute(
+            sqlalchemy.text(
+                "CREATE TABLE t_issue_16188 (a int not null, b int not null)"
+            )
+        )
 
     with ThreadPoolExecutor(max_workers=64) as executor:
         futures = []
@@ -31,5 +41,6 @@ def main():
         for future in as_completed(futures):
             future.result()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 1. avoid scan all segments when do hook recluster
 2. recluster will compact the small block and segments.
 3. insert will trigger compact and recluster.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16498)
<!-- Reviewable:end -->
