### PR TITLE
refactor: allow gateway to use "select 1" to verify token in header.

### DIFF
--- a/src/query/service/src/servers/http/middleware.rs
+++ b/src/query/service/src/servers/http/middleware.rs
@@ -89,7 +89,12 @@ impl EndpointKind {
             EndpointKind::Verify => Ok(None),
             EndpointKind::Refresh => Ok(Some(TokenType::Refresh)),
             EndpointKind::StartQuery | EndpointKind::PollQuery | EndpointKind::Logout => {
-                Ok(Some(TokenType::Session))
+                if GlobalConfig::instance().query.management_mode {
+                    // allow gateway to use "select 1" to verify token in request header.
+                    Ok(None)
+                } else {
+                    Ok(Some(TokenType::Session))
+                }
             }
             _ => Err(ErrorCode::AuthenticateFailure(format!(
                 "should not use databend token for {self:?}",


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

if not in management mode, refresh token should only be used when accese `/session/refresh`



## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16512)
<!-- Reviewable:end -->
