### PR TITLE
feat(catalog): ignore error when listing databases

### DIFF
--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -118,6 +118,7 @@ use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MetaId;
 use fastrace::func_name;
 use log::info;
+use log::warn;
 
 use crate::catalogs::default::catalog_context::CatalogContext;
 use crate::databases::Database;
@@ -250,11 +251,18 @@ impl Catalog for MutableCatalog {
             })
             .await?;
 
-        dbs.iter().try_fold(vec![], |mut acc, item| {
-            let db = self.build_db_instance(item)?;
-            acc.push(db);
-            Ok(acc)
-        })
+        dbs.iter()
+            .try_fold(vec![], |mut acc, item: &Arc<DatabaseInfo>| {
+                let db_result = self.build_db_instance(item);
+                match db_result {
+                    Ok(db) => acc.push(db),
+                    Err(err) => {
+                        // Ignore the error and continue, allow partial failure.
+                        warn!("Failed to build database '{:?}': {:?}", item, err);
+                    }
+                }
+                Ok(acc)
+            })
     }
 
     #[async_backtrace::framed]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR addresses a potential error in the "list databases" functionality, which could disrupt the display of all databases.
Like say we removed `SHARE`, the error will:
<img width="408" alt="image" src="https://github.com/user-attachments/assets/83320e3e-224c-4d5b-a8cf-24dcdf53067a">


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - This change does not affect the core logic of listing databases; it simply ignores certain errors when listing.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/16514)
<!-- Reviewable:end -->
